### PR TITLE
fix: correctly copy to clipboard in `astro info`

### DIFF
--- a/.changeset/angry-pumas-act.md
+++ b/.changeset/angry-pumas-act.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Correctly copy system info to clipboard
+Fixes a bug where `astro info --copy` wasn't working correctly on `macOS` systems.

--- a/.changeset/angry-pumas-act.md
+++ b/.changeset/angry-pumas-act.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Correctly copy system info to clipboard

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -85,7 +85,7 @@ export async function copyToClipboard(text: string, force?: boolean) {
 
 	if (!command) {
 		console.error(colors.red('\nClipboard command not found!'));
-		console.log('Fallback: Please manually copy the text above.');
+		console.log('Please manually copy the text above.');
 		return;
 	}
 

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -85,7 +85,7 @@ export async function copyToClipboard(text: string, force?: boolean) {
 
 	if (!command) {
 		console.error(colors.red('\nClipboard command not found!'));
-		console.log('Please manually copy the text above.');
+		console.info('Please manually copy the text above.');
 		return;
 	}
 
@@ -105,8 +105,8 @@ export async function copyToClipboard(text: string, force?: boolean) {
 		if (result.error) {
 			throw result.error;
 		}
-		console.log(colors.green('Copied to clipboard!'));
-	} catch (err) {
+		console.info(colors.green('Copied to clipboard!'));
+	} catch {
 		console.error(
 			colors.red(`\nSorry, something went wrong!`) + ` Please copy the text above manually.`,
 		);
@@ -187,7 +187,7 @@ function printRow(label: string, value: string | string[], print: boolean) {
 	}
 	plaintext += '\n';
 	if (print) {
-		console.log(richtext);
+		console.info(richtext);
 	}
 	return plaintext;
 }

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { arch, platform } from 'node:os';
 import * as colors from 'kleur/colors';
 import prompts from 'prompts';
@@ -49,61 +49,108 @@ export async function printInfo({ flags }: InfoOptions) {
 	applyPolyfill();
 	const { userConfig } = await resolveConfig(flagsToAstroInlineConfig(flags), 'info');
 	const output = await getInfoOutput({ userConfig, print: true });
-
-	await copyToClipboard(output);
+	await copyToClipboard(output, flags.copy);
 }
 
-async function copyToClipboard(text: string) {
+export async function copyToClipboard(text: string, force?: boolean) {
 	text = text.trim();
 	const system = platform();
 	let command = '';
+	let args: Array<string> = [];
+
 	if (system === 'darwin') {
 		command = 'pbcopy';
 	} else if (system === 'win32') {
 		command = 'clip';
 	} else {
 		// Unix: check if a supported command is installed
-		const unixCommands = [
-			['xclip', '-sel clipboard -l 1'],
-			['wl-copy', '"$0"'],
+
+		const unixCommands: Array<[string, Array<string>]> = [
+			['xclip', ['-sel', 'clipboard', '-l', '1']],
+			['wl-copy', []],
 		];
-		for (const [unixCommand, args] of unixCommands) {
+		for (const [unixCommand, unixArgs] of unixCommands) {
 			try {
-				const output = execSync(`which ${unixCommand}`, { encoding: 'utf8', stdio: 'pipe' });
-				if (output[0] !== '/') {
-					// Did not find a path. Skip!
-					continue;
+				const output = spawnSync('which', [unixCommand], { encoding: 'utf8' });
+				if (output.stdout.trim()) {
+					command = unixCommand;
+					args = unixArgs;
+					break;
 				}
-				command = `${unixCommand} ${args}`;
 			} catch {
-				// Failed to execute which. Skip!
 				continue;
 			}
 		}
-		// Did not find supported command. Bail out!
-		if (!command) return;
 	}
 
-	console.log();
-	const { shouldCopy } = await prompts({
-		type: 'confirm',
-		name: 'shouldCopy',
-		message: 'Copy to clipboard?',
-		initial: true,
-	});
-	if (!shouldCopy) return;
+	if (!command) {
+		console.error(colors.red('\nClipboard command not found!'));
+		console.log('Fallback: Please manually copy the text above.');
+		return;
+	}
+
+	if (!force) {
+		const { shouldCopy } = await prompts({
+			type: 'confirm',
+			name: 'shouldCopy',
+			message: 'Copy to clipboard?',
+			initial: true,
+		});
+
+		if (!shouldCopy) return;
+	}
 
 	try {
-		execSync(command.replaceAll('$0', text), {
-			stdio: 'ignore',
-			input: text,
-			encoding: 'utf8',
-		});
-	} catch {
+		const result = spawnSync(command, args, { input: text });
+		if (result.error) {
+			throw result.error;
+		}
+		console.log(colors.green('Copied to clipboard!'));
+	} catch (err) {
 		console.error(
 			colors.red(`\nSorry, something went wrong!`) + ` Please copy the text above manually.`,
 		);
 	}
+}
+
+export function readFromClipboard() {
+	const system = platform();
+	let command = '';
+	let args: Array<string> = [];
+
+	if (system === 'darwin') {
+			command = 'pbpaste';
+	} else if (system === 'win32') {
+			command = 'powershell';
+			args = ['-command', 'Get-Clipboard'];
+	} else {
+			const unixCommands: Array<[string, Array<string>]>  = [
+					['xclip', ['-sel', 'clipboard', '-o']],
+					['wl-paste', []],
+			];
+			for (const [unixCommand, unixArgs] of unixCommands) {
+					try {
+							const output = spawnSync('which', [unixCommand], { encoding: 'utf8' });
+							if (output.stdout.trim()) {
+									command = unixCommand;
+									args = unixArgs;
+									break;
+							}
+					} catch {
+							continue;
+					}
+			}
+	}
+
+	if (!command) {
+			throw new Error('Clipboard read command not found!');
+	}
+
+	const result = spawnSync(command, args, { encoding: 'utf8' });
+	if (result.error) {
+			throw result.error;
+	}
+	return result.stdout.trim();
 }
 
 const PLATFORM_TO_OS: Partial<Record<ReturnType<typeof platform>, string>> = {

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'node:url';
 import { stripVTControlCharacters } from 'node:util';
 import { cli, cliServerLogSetup, loadFixture, parseCliDevStart } from './test-utils.js';
 import { readFromClipboard } from '../dist/cli/info/index.js';
+import { platform } from 'node:process';
+
 describe('astro cli', () => {
 	const cliServerLogSetupWithFixture = (flags, cmd) => {
 		const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
@@ -82,13 +84,17 @@ describe('astro cli', () => {
 		const proc = await cli('info', '--copy');
 		const pkgURL = new URL('../package.json', import.meta.url);
 		const pkgVersion = await fs.readFile(pkgURL, 'utf8').then((data) => JSON.parse(data).version);
-		assert.ok(proc.stdout.includes('Copied to clipboard!'));
 		assert.ok(proc.stdout.includes(`v${pkgVersion}`));
 		assert.equal(proc.exitCode, 0);
 
-		const clipboardContent = await readFromClipboard();
-
-		assert.ok(clipboardContent.includes(`v${pkgVersion}`));
+		// On Linux we only check if we have Wayland or x11. In Codespaces it falsely reports that it does have x11
+		if(platform === 'linux' && ((!process.env.WAYLAND_DISPLAY && !process.env.DISPLAY) || process.env.CODESPACES)) {
+			assert.ok(proc.stdout.includes('Please manually copy the text above'));
+		} else {
+			assert.ok(proc.stdout.includes('Copied to clipboard!'));
+			const clipboardContent = await readFromClipboard();
+			assert.ok(clipboardContent.includes(`v${pkgVersion}`));
+		}
 
 	});
 

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -7,7 +7,7 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { stripVTControlCharacters } from 'node:util';
 import { cli, cliServerLogSetup, loadFixture, parseCliDevStart } from './test-utils.js';
-
+import { readFromClipboard } from '../dist/cli/info/index.js';
 describe('astro cli', () => {
 	const cliServerLogSetupWithFixture = (flags, cmd) => {
 		const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
@@ -76,6 +76,20 @@ describe('astro cli', () => {
 		const proc = await cli('--version');
 
 		assert.equal(proc.stdout.includes(pkgVersion), true);
+	});
+
+	it('astro info', async () => {
+		const proc = await cli('info', '--copy');
+		const pkgURL = new URL('../package.json', import.meta.url);
+		const pkgVersion = await fs.readFile(pkgURL, 'utf8').then((data) => JSON.parse(data).version);
+		assert.ok(proc.stdout.includes('Copied to clipboard!'));
+		assert.ok(proc.stdout.includes(`v${pkgVersion}`));
+		assert.equal(proc.exitCode, 0);
+
+		const clipboardContent = await readFromClipboard();
+
+		assert.ok(clipboardContent.includes(`v${pkgVersion}`));
+
 	});
 
 	it(


### PR DESCRIPTION
## Changes

`astro info` copy to clipboard has not been working on Mac because piping the input to `pbcopy` using `execSync` seems to not work. This PR fixes that by switching to `spawnSync` instead of `execSync`. It also adds a helper to read from the clipboard so we can check it works across platforms, and adds support for a `--copy` flag to avoid needing to prompt.

Fixes #12639

## Testing

Adds a new test suite.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
