### PR TITLE
chore: better warning

### DIFF
--- a/.changeset/fuzzy-pans-cough.md
+++ b/.changeset/fuzzy-pans-cough.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Provides more information when logging a warning for accessing `Astro.request.headers` in prerendered pages

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -437,6 +437,7 @@ async function generatePath(
 		headers: new Headers(),
 		logger,
 		isPrerendered: true,
+		routePattern: route.component
 	});
 	const renderContext = await RenderContext.create({
 		pipeline,

--- a/packages/astro/src/core/request.ts
+++ b/packages/astro/src/core/request.ts
@@ -85,7 +85,7 @@ export function createRequest({
 			get() {
 				logger.warn(
 					null,
-					`\`Astro.request.headers\` was used when rendering the route \`${routePattern}'\`. \`Astro.request.headers\` is not available on prerendered pages. If you need access to request headers, make sure that the page is server rendered using \`export const prerender = false;\` or by setting \`output\` to \`"server"\` in your Astro config to make all your pages server rendered.`,
+					`\`Astro.request.headers\` was used when rendering the route \`${routePattern}'\`. \`Astro.request.headers\` is not available on prerendered pages. If you need access to request headers, make sure that the page is server-rendered using \`export const prerender = false;\` or by setting \`output\` to \`"server"\` in your Astro config to make all your pages server-rendered by default.`,
 				);
 				return _headers;
 			},

--- a/packages/astro/src/core/request.ts
+++ b/packages/astro/src/core/request.ts
@@ -20,6 +20,8 @@ export interface CreateRequestOptions {
 	 * @default false
 	 */
 	isPrerendered?: boolean;
+
+	routePattern: string
 }
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
@@ -41,6 +43,7 @@ export function createRequest({
 	logger,
 	locals,
 	isPrerendered = false,
+	routePattern
 }: CreateRequestOptions): Request {
 	// headers are made available on the created request only if the request is for a page that will be on-demand rendered
 	const headersObj = isPrerendered
@@ -82,7 +85,7 @@ export function createRequest({
 			get() {
 				logger.warn(
 					null,
-					`\`Astro.request.headers\` is not available on prerendered pages. If you need access to request headers, make sure that the page is server rendered using \`export const prerender = false;\` or by setting \`output\` to \`"server"\` in your Astro config to make all your pages server rendered.`,
+					`\`Astro.request.headers\` was used when rendering the route \`${routePattern}'\`. \`Astro.request.headers\` is not available on prerendered pages. If you need access to request headers, make sure that the page is server rendered using \`export const prerender = false;\` or by setting \`output\` to \`"server"\` in your Astro config to make all your pages server rendered.`,
 				);
 				return _headers;
 			},

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -174,6 +174,7 @@ export async function handleRoute({
 		logger,
 		clientAddress: incomingRequest.socket.remoteAddress,
 		isPrerendered: route.prerender,
+		routePattern: route.component
 	});
 
 	// Set user specified headers to response object.


### PR DESCRIPTION
## Changes

This PR adds the `routePattern` to the warning about `Astro.request.headers` being used in pre-rendered pages.

This should give us better information when debugging the annoying warning :)

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
