### PR TITLE
fix(rss): use "application/rss+xml" as default content type and allow…

### DIFF
--- a/.changeset/brave-files-fry.md
+++ b/.changeset/brave-files-fry.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': minor
+---
+
+use standard rss content type

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -28,6 +28,10 @@ export type RSSOptions = {
 	/** Specify custom data in opening of file */
 	customData?: z.infer<typeof rssOptionsValidator>['customData'];
 	trailingSlash?: z.infer<typeof rssOptionsValidator>['trailingSlash'];
+	/**
+	 * Specify the response charset. default is utf-8
+	 */
+	charset?: z.infer<typeof rssOptionsValidator>['charset'];
 };
 
 export type RSSFeedItem = {
@@ -83,13 +87,14 @@ const rssOptionsValidator = z.object({
 	stylesheet: z.union([z.string(), z.boolean()]).optional(),
 	customData: z.string().optional(),
 	trailingSlash: z.boolean().default(true),
+	charset: z.string().optional().default('utf-8')
 });
 
-export default async function getRssResponse(rssOptions: RSSOptions): Promise<Response> {
+export default async function getRssResponse({charset, ...rssOptions}: RSSOptions): Promise<Response> {
 	const rssString = await getRssString(rssOptions);
 	return new Response(rssString, {
 		headers: {
-			'Content-Type': 'application/xml',
+			'Content-Type': `application/rss+xml; charset=${charset}`,
 		},
 	});
 }


### PR DESCRIPTION
… set custom charset

According to https://www.rssboard.org/rss-mime-type-application.txt The MIME type for RSS feed should be "application/rss+xml" It also need to set the charset in content type for non-english content

## Changes

* Set the content type "application/rss+xml"
* Allow user use different charset in content type, `utf-8` is default


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
