### PR TITLE
fix(@astrojs/rss): use standard rss content type, add utf-8 charset

### DIFF
--- a/.changeset/loud-cobras-rhyme.md
+++ b/.changeset/loud-cobras-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+use standard rss content type, add charset utf-8

--- a/.changeset/loud-cobras-rhyme.md
+++ b/.changeset/loud-cobras-rhyme.md
@@ -2,4 +2,4 @@
 '@astrojs/rss': patch
 ---
 
-use standard rss content type, add charset utf-8
+Sends the standard RSS content type response header, with UTF-8 charset

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -89,7 +89,7 @@ export default async function getRssResponse(rssOptions: RSSOptions): Promise<Re
 	const rssString = await getRssString(rssOptions);
 	return new Response(rssString, {
 		headers: {
-			'Content-Type': 'application/xml',
+			'Content-Type': 'application/rss+xml; charset=utf-8',
 		},
 	});
 }

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -62,7 +62,7 @@ describe('rss', () => {
 		assertXmlDeepEqual(str, validXmlResult);
 
 		const contentType = response.headers.get('Content-Type');
-		assert.equal(contentType, 'application/xml');
+		assert.equal(contentType, 'application/rss+xml; charset=utf-8');
 	});
 
 	it('should be the same string as getRssString', async () => {


### PR DESCRIPTION
## Changes

According to https://www.rssboard.org/rss-mime-type-application.txt

The default content type for RSS should be `application/rss+xml`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
