### PR TITLE
Only parse frontmatter at top of file

### DIFF
--- a/.changeset/ten-moons-brake.md
+++ b/.changeset/ten-moons-brake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Avoids parsing frontmatter that are not at the top of a file

--- a/packages/markdown/remark/src/frontmatter.ts
+++ b/packages/markdown/remark/src/frontmatter.ts
@@ -10,7 +10,7 @@ export function isFrontmatterValid(frontmatter: Record<string, any>) {
 	return typeof frontmatter === 'object' && frontmatter !== null;
 }
 
-const frontmatterRE = /^---(.*?)^---/ms;
+const frontmatterRE = /^\s*---([\s\S]*?\n)---/
 export function extractFrontmatter(code: string): string | undefined {
 	return frontmatterRE.exec(code)?.[1];
 }

--- a/packages/markdown/remark/src/frontmatter.ts
+++ b/packages/markdown/remark/src/frontmatter.ts
@@ -10,7 +10,7 @@ export function isFrontmatterValid(frontmatter: Record<string, any>) {
 	return typeof frontmatter === 'object' && frontmatter !== null;
 }
 
-const frontmatterRE = /^\s*---([\s\S]*?\n)---/
+const frontmatterRE = /^\s*---([\s\S]*?\n)---/;
 export function extractFrontmatter(code: string): string | undefined {
 	return frontmatterRE.exec(code)?.[1];
 }

--- a/packages/markdown/remark/test/frontmatter.test.js
+++ b/packages/markdown/remark/test/frontmatter.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { extractFrontmatter, parseFrontmatter } from '../dist/index.js';
+
+describe('extractFrontmatter', () => {
+	it('works', () => {
+		const yaml = `\nfoo: bar\n`;
+		assert.equal(extractFrontmatter(`---${yaml}---`), yaml);
+		assert.equal(extractFrontmatter(`  ---${yaml}---`), yaml);
+		assert.equal(extractFrontmatter(`\n---${yaml}---`), yaml);
+		assert.equal(extractFrontmatter(`\n  \n---${yaml}---`), yaml);
+		assert.equal(extractFrontmatter(`---${yaml}---\ncontent`), yaml);
+		assert.equal(extractFrontmatter(`\n\n---${yaml}---\n\ncontent`), yaml);
+		assert.equal(extractFrontmatter(`\n  \n---${yaml}---\n\ncontent`), yaml);
+		assert.equal(extractFrontmatter(`text\n---${yaml}---\n\ncontent`), undefined);
+	});
+});
+
+describe('parseFrontmatter', () => {
+	it('works', () => {
+		const yaml = `\nfoo: bar\n`;
+		assert.deepEqual(parseFrontmatter(`---${yaml}---`), {
+			frontmatter: { foo: 'bar' },
+			rawFrontmatter: yaml,
+			content: '',
+		});
+		assert.deepEqual(parseFrontmatter(`  ---${yaml}---`), {
+			frontmatter: { foo: 'bar' },
+			rawFrontmatter: yaml,
+			content: '  ',
+		});
+		assert.deepEqual(parseFrontmatter(`\n---${yaml}---`), {
+			frontmatter: { foo: 'bar' },
+			rawFrontmatter: yaml,
+			content: '\n',
+		});
+		assert.deepEqual(parseFrontmatter(`\n  \n---${yaml}---`), {
+			frontmatter: { foo: 'bar' },
+			rawFrontmatter: yaml,
+			content: '\n  \n',
+		});
+		assert.deepEqual(parseFrontmatter(`---${yaml}---\ncontent`), {
+			frontmatter: { foo: 'bar' },
+			rawFrontmatter: yaml,
+			content: '\ncontent',
+		});
+		assert.deepEqual(parseFrontmatter(`\n\n---${yaml}---\n\ncontent`), {
+			frontmatter: { foo: 'bar' },
+			rawFrontmatter: yaml,
+			content: '\n\n\n\ncontent',
+		});
+		assert.deepEqual(parseFrontmatter(`\n  \n---${yaml}---\n\ncontent`), {
+			frontmatter: { foo: 'bar' },
+			rawFrontmatter: yaml,
+			content: '\n  \n\n\ncontent',
+		});
+		assert.deepEqual(parseFrontmatter(`text\n---${yaml}---\n\ncontent`), {
+			frontmatter: {},
+			rawFrontmatter: '',
+			content: `text\n---${yaml}---\n\ncontent`,
+		});
+	});
+
+	it('frontmatter style', () => {
+		const yaml = `\nfoo: bar\n`;
+		const parse1 = (style) => parseFrontmatter(`---${yaml}---`, { frontmatter: style }).content;
+		assert.deepEqual(parse1('preserve'), `---${yaml}---`);
+		assert.deepEqual(parse1('remove'), '');
+		assert.deepEqual(parse1('empty-with-spaces'), `   \n        \n   `);
+		assert.deepEqual(parse1('empty-with-lines'), `\n\n`);
+
+		const parse2 = (style) =>
+			parseFrontmatter(`\n  \n---${yaml}---\n\ncontent`, { frontmatter: style }).content;
+		assert.deepEqual(parse2('preserve'), `\n  \n---${yaml}---\n\ncontent`);
+		assert.deepEqual(parse2('remove'), '\n  \n\n\ncontent');
+		assert.deepEqual(parse2('empty-with-spaces'), `\n  \n   \n        \n   \n\ncontent`);
+		assert.deepEqual(parse2('empty-with-lines'), `\n  \n\n\n\n\ncontent`);
+	});
+});


### PR DESCRIPTION
## Changes

Updates the regex so it only does so.

We should also update the regex used for astro files frontmatter: https://github.com/withastro/astro/blob/a5b17359c1d866db481b7b76b7eecbc3ae5790a7/packages/astro/src/vite-plugin-astro/utils.ts#L4

But I prefer to follow up on that separately and fix the markdown case first.

## Testing

Added new unit tests to ensure this behaviour.

## Docs

n/a. bug fix.
