### PR TITLE
chore: remove unused ts-expect-error directive

### DIFF
--- a/packages/integrations/preact/src/static-html.ts
+++ b/packages/integrations/preact/src/static-html.ts
@@ -16,7 +16,6 @@ type Props = {
 const StaticHtml = ({ value, name, hydrate = true }: Props) => {
 	if (!value) return null;
 	const tagName = hydrate ? 'astro-slot' : 'astro-static-slot';
-	// @ts-expect-error pass `name` as a prop, ignoring type errors
 	return h(tagName, { name, dangerouslySetInnerHTML: { __html: value } });
 };
 


### PR DESCRIPTION
## Changes

This unneeded @ts-expect-error directive is causing lint errors for me
 
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
