### PR TITLE
fix: copy info to clipboard on linux

### DIFF
--- a/.changeset/shy-worms-talk.md
+++ b/.changeset/shy-worms-talk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes astro info copy to clipboard process not returning to prompt in certain cases.

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -66,7 +66,7 @@ export async function copyToClipboard(text: string, force?: boolean) {
 		// Unix: check if a supported command is installed
 
 		const unixCommands: Array<[string, Array<string>]> = [
-			['xclip', ['-sel', 'clipboard', '-l', '1']],
+			['xclip', ['-selection', 'clipboard', '-l', '1']],
 			['wl-copy', []],
 		];
 		for (const [unixCommand, unixArgs] of unixCommands) {
@@ -101,7 +101,7 @@ export async function copyToClipboard(text: string, force?: boolean) {
 	}
 
 	try {
-		const result = spawnSync(command, args, { input: text });
+		const result = spawnSync(command, args, { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
 		if (result.error) {
 			throw result.error;
 		}


### PR DESCRIPTION
`xclip` process on OS Linux made `spawnSync` not [to return](https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options:~:text=with%20the%20exception%20that%20the%20function%20will%20not%20return%20until%20the%20child%20process%20has%20fully%20closed). Further info at [Stack Overflow](https://stackoverflow.com/questions/52169670/node-child-process-execsync-hangs-with-xclip).

Also updated the `xclip` arguments as per man pages for better familiarity, although the used arguments worked.

## Changes

- Fixes [this issue comment](https://github.com/withastro/astro/issues/12639#issuecomment-2520897644).
- Needs review - not sure if it's a legit fix, as it globaly adds new settings to `spawnSync`. Could be changed to apply only for `xclip` if needed.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tested locally, with linux and xclip/X11.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No docs update needed.