### PR TITLE
Fix frontmatter parsing with utf8 bom

### DIFF
--- a/.changeset/unlucky-wasps-refuse.md
+++ b/.changeset/unlucky-wasps-refuse.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fixes frontmatter parsing if file is encoded in UTF8 with BOM

--- a/packages/markdown/remark/src/frontmatter.ts
+++ b/packages/markdown/remark/src/frontmatter.ts
@@ -11,9 +11,10 @@ export function isFrontmatterValid(frontmatter: Record<string, any>) {
 }
 
 // Capture frontmatter wrapped with `---`, including any characters and new lines within it.
-// Only capture if it exists near the top of the file (whitespaces between the start of file and
-// the start of `---` are allowed)
-const frontmatterRE = /^\s*---([\s\S]*?\n)---/;
+// Only capture if `---` exists near the top of the file, including:
+// 1. Start of file (including if has BOM encoding)
+// 2. Start of file with any whitespace (but `---` must still start on a new line)
+const frontmatterRE = /(?:^\uFEFF?|^\s*\n)---([\s\S]*?\n)---/;
 export function extractFrontmatter(code: string): string | undefined {
 	return frontmatterRE.exec(code)?.[1];
 }


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/12656

The regex didn't account for file encoded in utf8 with bom. The bom character is now part of the regex.

Also, I'm not sure what I was smoking with https://github.com/withastro/astro/pull/12646, but I supported spaces before the `---` which doesn't makes sense as `---` should only be used on new lines. This is also fixed here.

## Testing

Updated tests reflecting changes above.

## Docs

n/a. bug fix.