### PR TITLE
fix: do not override process.env (take 2)

### DIFF
--- a/.changeset/long-dolls-drop.md
+++ b/.changeset/long-dolls-drop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes usage of `import.meta.env.*` and allow them to be refreshed when updated in `astro:env`

--- a/packages/astro/src/env/runtime-constants.ts
+++ b/packages/astro/src/env/runtime-constants.ts
@@ -1,0 +1,1 @@
+export const ENV_SYMBOL = Symbol.for('astro:env/dev');

--- a/packages/astro/src/env/runtime.ts
+++ b/packages/astro/src/env/runtime.ts
@@ -1,12 +1,16 @@
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { invalidVariablesToError } from './errors.js';
+import { ENV_SYMBOL } from './runtime-constants.js';
 import type { ValidationResultInvalid } from './validators.js';
 export { validateEnvVariable, getEnvFieldType } from './validators.js';
 
 export type GetEnv = (key: string) => string | undefined;
 type OnSetGetEnv = (reset: boolean) => void;
 
-let _getEnv: GetEnv = (key) => process.env[key];
+let _getEnv: GetEnv = (key) => {
+	const env = (globalThis as any)[ENV_SYMBOL] ?? {};
+	return env[key];
+};
 
 export function setGetEnv(fn: GetEnv, reset = false) {
 	_getEnv = fn;

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -9,6 +9,7 @@ import {
 	VIRTUAL_MODULES_IDS_VALUES,
 } from './constants.js';
 import { type InvalidVariable, invalidVariablesToError } from './errors.js';
+import { ENV_SYMBOL } from './runtime-constants.js';
 import type { EnvSchema } from './schema.js';
 import { getEnvFieldType, validateEnvVariable } from './validators.js';
 
@@ -28,11 +29,7 @@ export function astroEnv({ settings, mode, sync }: AstroEnvPluginParams): Plugin
 		enforce: 'pre',
 		buildStart() {
 			const loadedEnv = loadEnv(mode, fileURLToPath(settings.config.root), '');
-			for (const [key, value] of Object.entries(loadedEnv)) {
-				if (value !== undefined) {
-					process.env[key] = value;
-				}
-			}
+			(globalThis as any)[ENV_SYMBOL] = loadedEnv;
 
 			const validatedVariables = validatePublicVariables({
 				schema,


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/12618

same as https://github.com/withastro/astro/pull/12227. it seems like with how adapters now set the envs without a TLA, the order for calling `setOnSetGetEnv` and the actual `setGetEnv` call is correct now and won't cause issues like reported in https://github.com/withastro/astro/issues/12324

Marking as draft for now as I've not thoroughly tested this yet (and won't have time to do so soon). But if there's no problems, this PR can be merged as is.

## Testing

TODO

## Docs

n/a. bug fix.
