### PR TITLE
fix: Reflect the configuration for esbuild

### DIFF
--- a/.changeset/seven-feet-juggle.md
+++ b/.changeset/seven-feet-juggle.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Modified compileAstro to reflect the settings in viteConfig.esbuild
+Allows configuring Astro modules TypeScript compilation with the `vite.esbuild` config

--- a/.changeset/seven-feet-juggle.md
+++ b/.changeset/seven-feet-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Modified compileAstro to reflect the settings in viteConfig.esbuild

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -37,8 +37,8 @@ export async function compileAstro({
 		// Compile all TypeScript to JavaScript.
 		// Also, catches invalid JS/TS in the compiled output before returning.
 		esbuildResult = await transformWithEsbuild(transformResult.code, compileProps.filename, {
+			...compileProps.viteConfig.esbuild,
 			loader: 'ts',
-			target: 'esnext',
 			sourcemap: 'external',
 			tsconfigRaw: {
 				compilerOptions: {

--- a/packages/astro/test/units/vite-plugin-astro/compile.test.js
+++ b/packages/astro/test/units/vite-plugin-astro/compile.test.js
@@ -1,16 +1,15 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { describe, it } from 'node:test';
 import { pathToFileURL } from 'node:url';
 import { init, parse } from 'es-module-lexer';
 import { resolveConfig } from 'vite';
 import { compileAstro } from '../../../dist/vite-plugin-astro/compile.js';
 
-let inlineConfig;
 /**
  * @param {string} source
  * @param {string} id
  */
-async function compile(source, id) {
+async function compile(source, id, inlineConfig = {}) {
 	const viteConfig = await resolveConfig({ configFile: false, ...inlineConfig }, 'serve');
 	return await compileAstro({
 		compileProps: {
@@ -24,10 +23,6 @@ async function compile(source, id) {
 }
 
 describe('astro full compile', () => {
-	before(() => {
-		inlineConfig = {};
-	})
-
 	it('should compile a single file', async () => {
 		const result = await compile(`<h1>Hello World</h1>`, '/src/components/index.astro');
 		assert.ok(result.code);
@@ -86,10 +81,9 @@ using x = {}
 		});
 
 		it('should transform the syntax by esbuild.target', async () => {
-			inlineConfig = {
+			const result = await compile(code, '/src/components/index.astro', {
 				esbuild: { target: 'es2018' },
-			}
-			const result = await compile(code, '/src/components/index.astro');
+			});
 			assert.equal(result.code.includes('using x = {}'), false);
 		});
 	});


### PR DESCRIPTION
## Changes

I modified compileAstro to reflect the settings in viteConfig.esbuild.

This change ensures that when `vite.esbuild.target` is specified in the Astro config, it is reflected during the compilation of Astro files. Previously, while the `vite.build.target` value would affect the `build` command output of an Astro project, it did not impact the `dev` command output. As a result, the esbuild target was effectively fixed to `esnext`. This update addresses and resolves that issue.

For example, by setting the configuration as follows, you can specify the esbuild target during the compilation of Astro files.

```js
// astro.config.mjs
export default {
  vite: {
    esbuild: {
      target: 'es2018',
    },
  },
};
```

Fixes: [The vite.build.target setting does not take effect in dev mode. · Issue #12655](https://github.com/withastro/astro/issues/12655)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added tests with code that includes syntax targeted by esbuild, confirming the following two points:
- No transformation occurs if `esbuild.target` is not present in ViteConfig.
- Transformation occurs if `esbuild.target` is specified as anything other than `esnext` in ViteConfig.
  - Tested with `esbuild.target` set to `es2018`.

## Docs

No documentation changes are necessary.
