### PR TITLE
fix: catch image errors correctly

### DIFF
--- a/.changeset/nine-experts-tan.md
+++ b/.changeset/nine-experts-tan.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Throws a more helpful error when images are missing

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -39,7 +39,7 @@ export function astroContentAssetPropagationPlugin({
 					? fileURLToPath(new URL(importerParam, settings.config.root))
 					: importer;
 
-				const resolved = this.resolve(base, importerPath, { skipSelf: true, ...opts });
+				const resolved = await this.resolve(base, importerPath, { skipSelf: true, ...opts });
 				if (!resolved) {
 					throw new AstroError({
 						...AstroErrorData.ImageNotFound,


### PR DESCRIPTION
## Changes

Currently we're not correctly throwing when images can't be resolved, because we weren't awaiting the result of `this.resolve`. This meant resolution was failing in unexpected ways, leading to reports such as #12682

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
