### PR TITLE
fix: correctly check isOnline with port

### DIFF
--- a/.changeset/wild-ducks-decide.md
+++ b/.changeset/wild-ducks-decide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/upgrade': patch
+---
+
+Fixes a bug that caused registry URLs that specify a port to be incorrectly detected as offline.

--- a/packages/upgrade/src/actions/verify.ts
+++ b/packages/upgrade/src/actions/verify.ts
@@ -43,8 +43,8 @@ export async function verify(
 }
 
 function isOnline(registry: string): Promise<boolean> {
-	const { host } = new URL(registry);
-	return dns.lookup(host).then(
+	const { hostname } = new URL(registry);
+	return dns.lookup(hostname).then(
 		() => true,
 		() => false,
 	);


### PR DESCRIPTION
## Changes

`@astrojs/upgrade` checks if it's online by doign a DNS lookup for the registry host. This was broken for registries that have a port in the URL (mostly local ones like Verdaccio) because it was using url.host, which includes the port. This PR fixes that by using url.hostname.

Fixes #12660

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
