### PR TITLE
fix(middleware): don't import via entrypoint

### DIFF
--- a/.changeset/bright-crabs-kick.md
+++ b/.changeset/bright-crabs-kick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the middleware was incorrectly imported during the build

--- a/packages/astro/src/core/build/pipeline.ts
+++ b/packages/astro/src/core/build/pipeline.ts
@@ -132,6 +132,7 @@ export class BuildPipeline extends Pipeline {
 
 		const middleware = internals.middlewareEntryPoint
 			? async function () {
+					// @ts-expect-error: the compiler can't understand the previous check
 					const mod = await import(internals.middlewareEntryPoint.toString());
 					return { onRequest: mod.onRequest };
 				}

--- a/packages/astro/src/core/build/pipeline.ts
+++ b/packages/astro/src/core/build/pipeline.ts
@@ -131,11 +131,10 @@ export class BuildPipeline extends Pipeline {
 		const renderers = await import(renderersEntryUrl.toString());
 
 		const middleware = internals.middlewareEntryPoint
-			? await import(internals.middlewareEntryPoint.toString()).then((mod) => {
-					return function () {
-						return { onRequest: mod.onRequest };
-					};
-				})
+			? async function () {
+					const mod = await import(internals.middlewareEntryPoint.toString());
+					return { onRequest: mod.onRequest };
+				}
 			: manifest.middleware;
 
 		if (!renderers) {

--- a/packages/astro/test/fixtures/middleware-full-ssr/package.json
+++ b/packages/astro/test/fixtures/middleware-full-ssr/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/middleware-full-ssr",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/middleware-full-ssr/src/error.js
+++ b/packages/astro/test/fixtures/middleware-full-ssr/src/error.js
@@ -1,0 +1,1 @@
+throw new Error("Shoud not error at build time")

--- a/packages/astro/test/fixtures/middleware-full-ssr/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-full-ssr/src/middleware.js
@@ -1,0 +1,2 @@
+import "./error.js"
+export const onRequest = (_ , next) => next();

--- a/packages/astro/test/fixtures/middleware-full-ssr/src/pages/index.astro
+++ b/packages/astro/test/fixtures/middleware-full-ssr/src/pages/index.astro
@@ -1,0 +1,14 @@
+---
+const data = Astro.locals;
+---
+
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+
+	<span>Index</span>
+	<p>{data?.name}</p>
+</body>
+</html>

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -171,6 +171,21 @@ describe('Middleware in PROD mode, SSG', () => {
 	});
 });
 
+describe('Middleware should not be executed or imported during', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	it('should build the project without errors', async () => {
+		fixture = await loadFixture({
+			root: './fixtures/middleware-full-ssr/',
+			output: 'server',
+			adapter: testAdapter({}),
+		});
+		await fixture.build();
+		assert.ok('Should build');
+	});
+});
+
 describe('Middleware API in PROD mode, SSR', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3324,6 +3324,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/middleware-full-ssr:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/middleware-no-user-middleware:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/12690

The middleware was always imported during the build, even before its execution. 

This PR changes that by assigning a function that does the loading.

## Testing

CI should pass. I created a new test case. In the test case the middleware imports a file that throws an error at runtime. In the test case the middleware isn't used because all pages SSR, so no errors should be thrown.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
