### PR TITLE
fix: strip query string before checking md extension

### DIFF
--- a/.changeset/tidy-ligers-tan.md
+++ b/.changeset/tidy-ligers-tan.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug which misidentified pages as markdown if a query string ended in a markdown extension

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -18,9 +18,11 @@ export function isURL(value: unknown): value is URL {
 }
 /** Check if a file is a markdown file based on its extension */
 export function isMarkdownFile(fileId: string, option?: { suffix?: string }): boolean {
+	// Strip query string
+	const id = fileId.split("?")[0];
 	const _suffix = option?.suffix ?? '';
 	for (let markdownFileExtension of SUPPORTED_MARKDOWN_FILE_EXTENSIONS) {
-		if (fileId.endsWith(`${markdownFileExtension}${_suffix}`)) return true;
+		if (id.endsWith(`${markdownFileExtension}${_suffix}`)) return true;
 	}
 	return false;
 }

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { before, describe, it, after } from 'node:test';
 import * as cheerio from 'cheerio';
 import { fixLineEndings, loadFixture } from './test-utils.js';
 
@@ -153,5 +153,26 @@ describe('Astro Markdown', () => {
 			assert.ok(title.includes('import.meta.env.SITE'));
 			assert.ok(title.includes('import.meta.env.TITLE'));
 		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		it('ignores .md extensions on query params', async () => {
+			const res = await fixture.fetch('/false-positive?page=page.md');
+			assert.ok(res.ok);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('p').text(), 'the page is not markdown');
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
 	});
 });

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/false-positive.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/false-positive.astro
@@ -1,0 +1,5 @@
+---
+let page = "not markdown"
+---
+
+<p>the page is {page}</p>


### PR DESCRIPTION
## Changes

Currently the markdown vite plugin just checks if the id ends in a makrdown extension. This breaks if the id includes a query param. This PR strips the query string before checking.

Fixes #12711

## Testing

Added test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
