### PR TITLE
fix: use atomic writes for data store file operations

### DIFF
--- a/.changeset/tame-bags-remember.md
+++ b/.changeset/tame-bags-remember.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused errors in dev when editing sites with large numbers of MDX pages

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -198,6 +198,8 @@ export default new Map([\n${lines.join(',\n')}]);
 	async #writeFileAtomic(filePath: PathLike, data: string, depth = 0) {
 		if(depth > MAX_DEPTH) {
 			// If we hit the max depth, we skip a write to prevent the stack from growing too large
+			// In theory this means we may miss the latest data, but in practice this will only happen when the file is being written to very frequently
+			// so it will be saved on the next write. This is unlikely to ever happen in practice, as the writes are debounced. It requires lots of writes to very large files.
 			return;
 		}
 		const fileKey = filePath.toString();

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -6,21 +6,14 @@ import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { IMAGE_IMPORT_PREFIX } from './consts.js';
 import { type DataEntry, ImmutableDataStore } from './data-store.js';
 import { contentModuleToId } from './utils.js';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
 const SAVE_DEBOUNCE_MS = 500;
 
-// Write a file atomically, without triggering the file watcher
+// Write a file atomically
 async function writeFileAtomic(filePath: PathLike, data: string) {
-	const dir = await fs.mkdtemp(tmpdir() + '/astro-');
-	const tempFile = join(dir, 'temp');
+	const tempFile = filePath instanceof URL ? new URL(`${filePath.href}.tmp`) : `${filePath}.tmp`;
 	await fs.writeFile(tempFile, data);
-	try {
-		await fs.rename(tempFile, filePath);
-	} finally {
-		await fs.rmdir(dir).catch(() => {});
-	}
+	await fs.rename(tempFile, filePath);
 }
 
 /**


### PR DESCRIPTION
## Changes

The data store has to write a number of different files to disk, which are in turn watched by the filesystem watcher. In some very large sites this was causing issues where the watcher would report the changed file before it had finished writing to disk.

This PR changes all data store file operations to use atomic writes: files are first written to a tmp dir, and then moved.

Fixes #12702

## Testing

This is hard to reproduce. Tested manually using a reproduction with 50k pages and a deliberately shortened debounce time.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
