### PR TITLE
chore: fixes the version of astrojs/db

### DIFF
--- a/.changeset/hip-kids-ring.md
+++ b/.changeset/hip-kids-ring.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Fixes the publishing of the package

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrojs/db",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "description": "Add libSQL and Astro Studio support to your Astro site",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Changes

During the merging of the `next` branch the versions got messed up. This PR bumps the version in the package.json to match the latest version in npm. This should then trigger a patch release with the midding changes since then.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
