### PR TITLE
fix(cli): let sync throw in check

### DIFF
--- a/.changeset/twenty-keys-divide.md
+++ b/.changeset/twenty-keys-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Fixes a case where failing content entries in `astro check` would not be surfaced

--- a/.changeset/twenty-keys-divide.md
+++ b/.changeset/twenty-keys-divide.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 Fixes a case where failing content entries in `astro check` would not be surfaced

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -31,11 +31,7 @@ export async function check(flags: Flags) {
 		// NOTE: In the future, `@astrojs/check` can expose a `before lint` hook so that this works during `astro check --watch` too.
 		// For now, we run this once as usually `astro check --watch` is ran alongside `astro dev` which also calls `astro sync`.
 		const { default: sync } = await import('../../core/sync/index.js');
-		try {
-			await sync(flagsToAstroInlineConfig(flags));
-		} catch (_) {
-			return process.exit(1);
-		}
+		await sync(flagsToAstroInlineConfig(flags));
 	}
 
 	const { check: checker, parseArgsAsCheckConfig } = checkPackage;


### PR DESCRIPTION
## Changes

- Removes try/catch around `sync` in `astro check`
- Closes #12724
- Closes PLT-2709

## Testing

Manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
