### PR TITLE
fix: add support for `react-compiler-runtime`

### DIFF
--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -60,6 +60,7 @@ function getViteConfiguration(
 				'react/jsx-runtime',
 				'react/jsx-dev-runtime',
 				'react-dom',
+				'react-compiler-runtime'
 			],
 			exclude: [reactConfig.server],
 		},


### PR DESCRIPTION
## Changes

Adds support for libraries publishing code pre-compiled with the [React Compiler](https://react.dev/learn/react-compiler#using-react-compiler-with-react-17-or-18)

## Testing

Don't know enough about astro internals to add a test 🤷 

## Docs

Don't think docs need to change, support for `react-compiler-runtime` is just expected to work, same way the `react/jsx-runtime` is.
