### PR TITLE
Version transitions in CLI outputs

### DIFF
--- a/.changeset/happy-radios-drive.md
+++ b/.changeset/happy-radios-drive.md
@@ -2,4 +2,4 @@
 '@astrojs/upgrade': patch
 ---
 
-Changed the version string format to show both the source and target versions.
+Updates displayed data to show both source and target versions

--- a/.changeset/happy-radios-drive.md
+++ b/.changeset/happy-radios-drive.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/upgrade': patch
+---
+
+Changed the version string format to show both the source and target versions.

--- a/packages/upgrade/src/actions/install.ts
+++ b/packages/upgrade/src/actions/install.ts
@@ -48,7 +48,7 @@ export async function install(
 	const majors: PackageInfo[] = [];
 	for (const packageInfo of toInstall) {
 		const word = ctx.dryRun ? 'can' : 'will';
-		await upgrade(packageInfo, `${word} be updated to`);
+		await upgrade(packageInfo, `${word} be updated`);
 		if (packageInfo.isMajor) {
 			majors.push(packageInfo);
 		}

--- a/packages/upgrade/src/messages.ts
+++ b/packages/upgrade/src/messages.ts
@@ -109,14 +109,17 @@ export const info = async (prefix: string, text: string, version = '') => {
 		);
 	}
 };
+
 export const upgrade = async (packageInfo: PackageInfo, text: string) => {
-	const { name, isMajor = false, targetVersion } = packageInfo;
+	const { name, isMajor = false, targetVersion, currentVersion } = packageInfo;
 
 	const bg = isMajor ? (v: string) => color.bgYellow(color.black(` ${v} `)) : color.green;
 	const style = isMajor ? color.yellow : color.green;
 	const symbol = isMajor ? '▲' : '●';
+
+	const fromVersion = currentVersion.replace(/^\D+/, '');
 	const toVersion = targetVersion.replace(/^\D+/, '');
-	const version = `v${toVersion}`;
+	const version = `v${fromVersion} → v${toVersion}`;
 
 	const length = 12 + name.length + text.length + version.length;
 	if (length > stdout.columns) {

--- a/packages/upgrade/src/messages.ts
+++ b/packages/upgrade/src/messages.ts
@@ -119,7 +119,7 @@ export const upgrade = async (packageInfo: PackageInfo, text: string) => {
 
 	const fromVersion = currentVersion.replace(/^\D+/, '');
 	const toVersion = targetVersion.replace(/^\D+/, '');
-	const version = `v${fromVersion} → v${toVersion}`;
+	const version = `from v${fromVersion} to v${toVersion}`;
 
 	const length = 12 + name.length + text.length + version.length;
 	if (length > stdout.columns) {

--- a/packages/upgrade/test/install.test.js
+++ b/packages/upgrade/test/install.test.js
@@ -39,7 +39,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('●  astro can be updated v1.0.0 → v1.0.1'), true);
+		assert.equal(fixture.hasMessage('●  astro can be updated from v1.0.0 to v1.0.1'), true);
 	});
 
 	it('minor', async () => {
@@ -54,7 +54,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('●  astro can be updated v1.0.0 → v1.2.0'), true);
+		assert.equal(fixture.hasMessage('●  astro can be updated from v1.0.0 to v1.2.0'), true);
 	});
 
 	it('major (reject)', async () => {
@@ -81,7 +81,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  astro can be updated  v1.0.0 → v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  astro can be updated  from v1.0.0 to v2.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, 0);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), false);
@@ -111,7 +111,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  astro can be updated  v1.0.0 → v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  astro can be updated  from v1.0.0 to v2.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), true);
@@ -149,8 +149,8 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  a can be updated  v1.0.0 → v2.0.0'), true);
-		assert.equal(fixture.hasMessage('▲  b can be updated  v6.0.0 → v7.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  a can be updated  from v1.0.0 to v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  b can be updated  from v6.0.0 to v7.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		const [changelog, a, b] = fixture.messages().slice(-5);
@@ -199,9 +199,9 @@ describe('install', () => {
 		};
 		await install(context);
 		assert.equal(fixture.hasMessage('◼  current is up to date on v1.0.0'), true);
-		assert.equal(fixture.hasMessage('●  patch can be updated v1.0.0 → v1.0.1'), true);
-		assert.equal(fixture.hasMessage('●  minor can be updated v1.0.0 → v1.2.0'), true);
-		assert.equal(fixture.hasMessage('▲  major can be updated  v1.0.0 → v3.0.0'), true);
+		assert.equal(fixture.hasMessage('●  patch can be updated from v1.0.0 to v1.0.1'), true);
+		assert.equal(fixture.hasMessage('●  minor can be updated from v1.0.0 to v1.2.0'), true);
+		assert.equal(fixture.hasMessage('▲  major can be updated  from v1.0.0 to v3.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), true);

--- a/packages/upgrade/test/install.test.js
+++ b/packages/upgrade/test/install.test.js
@@ -39,7 +39,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('●  astro can be updated to v1.0.1'), true);
+		assert.equal(fixture.hasMessage('●  astro can be updated v1.0.0 → v1.0.1'), true);
 	});
 
 	it('minor', async () => {
@@ -54,7 +54,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('●  astro can be updated to v1.2.0'), true);
+		assert.equal(fixture.hasMessage('●  astro can be updated v1.0.0 → v1.2.0'), true);
 	});
 
 	it('major (reject)', async () => {
@@ -81,7 +81,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  astro can be updated to  v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  astro can be updated v1.0.0 → v2.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, 0);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), false);
@@ -111,7 +111,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  astro can be updated to  v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  astro can be updated v1.0.0 → v2.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), true);
@@ -149,8 +149,8 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  a can be updated to  v2.0.0'), true);
-		assert.equal(fixture.hasMessage('▲  b can be updated to  v7.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  a can be updated v1.0.0 → v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  b can be updated v6.0.0 → v7.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		const [changelog, a, b] = fixture.messages().slice(-5);
@@ -199,9 +199,9 @@ describe('install', () => {
 		};
 		await install(context);
 		assert.equal(fixture.hasMessage('◼  current is up to date on v1.0.0'), true);
-		assert.equal(fixture.hasMessage('●  patch can be updated to v1.0.1'), true);
-		assert.equal(fixture.hasMessage('●  minor can be updated to v1.2.0'), true);
-		assert.equal(fixture.hasMessage('▲  major can be updated to  v3.0.0'), true);
+		assert.equal(fixture.hasMessage('●  patch can be updated v1.0.0 → v1.0.1'), true);
+		assert.equal(fixture.hasMessage('●  minor can be updated v1.0.0 → v1.2.0'), true);
+		assert.equal(fixture.hasMessage('▲  major can be updated v1.0.0 → v3.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), true);

--- a/packages/upgrade/test/install.test.js
+++ b/packages/upgrade/test/install.test.js
@@ -81,7 +81,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  astro can be updated v1.0.0 → v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  astro can be updated  v1.0.0 → v2.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, 0);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), false);
@@ -111,7 +111,7 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  astro can be updated v1.0.0 → v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  astro can be updated  v1.0.0 → v2.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), true);
@@ -149,8 +149,8 @@ describe('install', () => {
 			],
 		};
 		await install(context);
-		assert.equal(fixture.hasMessage('▲  a can be updated v1.0.0 → v2.0.0'), true);
-		assert.equal(fixture.hasMessage('▲  b can be updated v6.0.0 → v7.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  a can be updated  v1.0.0 → v2.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  b can be updated  v6.0.0 → v7.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		const [changelog, a, b] = fixture.messages().slice(-5);
@@ -201,7 +201,7 @@ describe('install', () => {
 		assert.equal(fixture.hasMessage('◼  current is up to date on v1.0.0'), true);
 		assert.equal(fixture.hasMessage('●  patch can be updated v1.0.0 → v1.0.1'), true);
 		assert.equal(fixture.hasMessage('●  minor can be updated v1.0.0 → v1.2.0'), true);
-		assert.equal(fixture.hasMessage('▲  major can be updated v1.0.0 → v3.0.0'), true);
+		assert.equal(fixture.hasMessage('▲  major can be updated  v1.0.0 → v3.0.0'), true);
 		assert.equal(prompted, true);
 		assert.equal(exitCode, undefined);
 		assert.equal(fixture.hasMessage('check   Be sure to follow the CHANGELOG.'), true);


### PR DESCRIPTION
## Changes

- Updated the upgrade messaging to show both current and target versions
- Added arrow symbol (→) to visually represent the version change

Before:

```bash
@astrojs/tailwind can be updated to v5.1.3
```

After:

```bash
@astrojs/tailwind can be updated v4.0.0 → v5.1.3
```

## Testing

Updated existing test suite by modifying test assertions to verify new message format

## Docs

Should be self-explanatory

## Additional

Coming from https://github.com/withastro/roadmap/discussions/1069