### PR TITLE
Remove `session.flash`

### DIFF
--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -23,7 +23,7 @@ const VALID_COOKIE_REGEX = /^[\w-]+$/;
 
 interface SessionEntry {
 	data: any;
-	expires?: number | 'flash';
+	expires?: number;
 }
 
 export class AstroSession<TDriver extends SessionDriverName = any> {
@@ -122,7 +122,7 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 	 * Sets a session value. The session is created if it does not exist.
 	 */
 
-	set<T = any>(key: string, value: T, { ttl }: { ttl?: number | 'flash' } = {}) {
+	set<T = any>(key: string, value: T, { ttl }: { ttl?: number } = {}) {
 		if (!key) {
 			throw new AstroError({
 				...SessionStorageSaveError,
@@ -155,10 +155,6 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 			expires,
 		});
 		this.#dirty = true;
-	}
-
-	flash<T = any>(key: string, value: T) {
-		this.set(key, value, { ttl: 'flash' });
 	}
 
 	/**
@@ -320,10 +316,6 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 				const expired = typeof value.expires === 'number' && value.expires < now;
 				if (!this.#data.has(key) && !this.#toDelete.has(key) && !expired) {
 					this.#data.set(key, value);
-					if (value?.expires === 'flash') {
-						this.#toDelete.add(key);
-						this.#dirty = true;
-					}
 				}
 			}
 

--- a/packages/astro/test/fixtures/sessions/src/middleware.ts
+++ b/packages/astro/test/fixtures/sessions/src/middleware.ts
@@ -7,20 +7,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // Skip requests for prerendered pages
   if (context.isPrerendered) return next();
 
-	if(context.url.searchParams.has('setFlash') && context.url.pathname === '/') {
-		context.session.flash('middleware-flash', `Flashed message at ${new Date().toISOString()}`);
-	}
-
-	if(context.url.pathname === '/next-rewrite-middleware') {
-		context.session.flash('middleware-flash', `Flashed rewrite message at ${new Date().toISOString()}`);
-		return next('/');
-	}
-	
-	if(context.url.pathname === '/ctx-rewrite-middleware') {
-		context.session.flash('middleware-flash', `Flashed rewrite message at ${new Date().toISOString()}`);
-		return context.rewrite(new Request(new URL('/', context.url)));
-	}
-
   const { action, setActionResult, serializeActionResult } =
     getActionContext(context);
 

--- a/packages/astro/test/fixtures/sessions/src/pages/flash-rewrite.astro
+++ b/packages/astro/test/fixtures/sessions/src/pages/flash-rewrite.astro
@@ -1,4 +1,0 @@
----
-Astro.session.flash('flash-value', `Flashed value at ${new Date().toISOString()}`);
-return Astro.rewrite('/');
----

--- a/packages/astro/test/fixtures/sessions/src/pages/flash.astro
+++ b/packages/astro/test/fixtures/sessions/src/pages/flash.astro
@@ -1,4 +1,0 @@
----
-Astro.session.flash('flash-value', `Flashed value at ${new Date().toISOString()}`);
-return Astro.redirect('/');
----

--- a/packages/astro/test/fixtures/sessions/src/pages/index.astro
+++ b/packages/astro/test/fixtures/sessions/src/pages/index.astro
@@ -1,7 +1,5 @@
 ---
 const value = await Astro.session.get('value');
-const flash = await Astro.session.get('flash-value');
-const middlewareFlash = await Astro.session.get('middleware-flash');
 ---
 <html lang="en">
 <head>
@@ -11,8 +9,5 @@ const middlewareFlash = await Astro.session.get('middleware-flash');
 
 <h1>Hi</h1>
 <p>{value}</p>
-<p>Flash: {flash}</p>
-<p>middlewareFlash: {middlewareFlash}</p>
-<p><a href="/flash">Set flash</a></p>
 <a href="/cart" style="font-size: 36px">🛒</a>
 </html>

--- a/packages/astro/test/units/sessions/astro-session.test.js
+++ b/packages/astro/test/units/sessions/astro-session.test.js
@@ -167,26 +167,6 @@ test('AstroSession - Data Persistence', async (t) => {
 	});
 
 
-	await t.test('should not write flash session data to storage a second time', async () => {
-		let storedData;
-		const mockStorage = {
-			get: async () => stringify(new Map([['key', { data: 'value', expires: "flash" }]])),
-			setItem: async (_key, value) => {
-				storedData = value;
-			},
-		};
-		const session = createSession(defaultConfig, defaultMockCookies, mockStorage);
-
-		const value = await session.get('key');
-
-		assert.equal(value, 'value');
-
-		await session[PERSIST_SYMBOL]();
-
-		const emptyMap = devalueStringify(new Map());
-		assert.equal(storedData, emptyMap);
-	})
-
 
 });
 


### PR DESCRIPTION
## Changes

Temporarily removes the `session.flash()` feature. The plan is to re-introduce it a bit later once there has been a bit more work on the API

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
