### PR TITLE
Clean sourcemaps from static output

### DIFF
--- a/.changeset/tame-spoons-shop.md
+++ b/.changeset/tame-spoons-shop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Clean server sourcemaps from static output

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -205,7 +205,8 @@ class AstroBuilder {
 			key: keyPromise,
 		};
 
-		const { internals, ssrOutputChunkNames, contentFileNames } = await viteBuild(opts);
+		const { internals, ssrOutputChunkNames } =
+			await viteBuild(opts);
 
 		const hasServerIslands = this.settings.serverIslandNameMap.size > 0;
 		// Error if there are server islands but no adapter provided.
@@ -213,7 +214,7 @@ class AstroBuilder {
 			throw new AstroError(AstroErrorData.NoAdapterInstalledServerIslands);
 		}
 
-		await staticBuild(opts, internals, ssrOutputChunkNames, contentFileNames);
+		await staticBuild(opts, internals, ssrOutputChunkNames);
 
 		// Write any additionally generated assets to disk.
 		this.timer.assetsStart = performance.now();

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -167,6 +167,14 @@ describe('Astro basic build', () => {
 		assert.doesNotMatch(otherHtml, /<style/);
 	});
 
+	it('server sourcemaps not included in output', async () => {
+		const files = await fixture.readdir('/');
+		const hasSourcemaps = files.some(fileName => {
+			return fileName.endsWith('.map');
+		});
+		assert.equal(hasSourcemaps, false, 'no sourcemap files in output');
+	});
+
 	describe('preview', () => {
 		it('returns 200 for valid URLs', async () => {
 			const result = await fixture.fetch('/');

--- a/packages/astro/test/fixtures/astro-basic/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-basic/astro.config.mjs
@@ -6,5 +6,10 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
 	integrations: [preact(), mdx()],
 	// make sure CLI flags have precedence
-  server: () => ({ port: 4321 })
+  server: () => ({ port: 4321 }),
+  vite: {
+  	build: {
+  		sourcemap: true,
+  	}
+  }
 });

--- a/packages/astro/test/sourcemap.test.js
+++ b/packages/astro/test/sourcemap.test.js
@@ -17,7 +17,13 @@ describe('Sourcemap', async () => {
 	});
 
 	it('Builds non-empty sourcemap', async () => {
-		const map = await fixture.readFile('renderers.mjs.map');
-		assert.equal(map.includes('"sources":[]'), false);
+		const assets = await fixture.readdir('/_astro');
+		const maps = assets.filter(file => file.endsWith('.map'));
+		assert.ok(maps.length > 0, 'got source maps');
+		for(const mapName of maps) {
+			const filename = `/_astro/${mapName}`;
+			const map = await fixture.readFile(filename);
+			assert.equal(map.includes('"sources":[]'), false);
+		}
 	});
 });


### PR DESCRIPTION
## Changes

- During cleanup be sure to remove any `.map` files created from server JavaScript output. Otherwise these are left in and expose server source code to the client.

## Testing

- Added a new test to our basics fixture.

## Docs

N/A, bug fix