### PR TITLE
Adds types for `?url&inline` & `?url&no-inline` import queries

### DIFF
--- a/.changeset/curly-snakes-shave.md
+++ b/.changeset/curly-snakes-shave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds types for `?inline` and `?no-inline` [import queries](https://vite.dev/guide/assets.html#explicit-inline-handling) added in Vite 6

--- a/.changeset/curly-snakes-shave.md
+++ b/.changeset/curly-snakes-shave.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds types for `?inline` and `?no-inline` [import queries](https://vite.dev/guide/assets.html#explicit-inline-handling) added in Vite 6
+Adds types for `?url&inline` and `?url&no-inline` [import queries](https://vite.dev/guide/assets.html#explicit-inline-handling) added in Vite 6

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -535,3 +535,18 @@ declare module '*?inline' {
 	const src: string;
 	export default src;
 }
+
+declare module '*?no-inline' {
+	const src: string;
+	export default src;
+}
+
+declare module '*?url&inline' {
+	const src: string;
+	export default src;
+}
+
+declare module '*?url&no-inline' {
+	const src: string;
+	export default src;
+}

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -536,11 +536,6 @@ declare module '*?inline' {
 	export default src;
 }
 
-declare module '*?no-inline' {
-	const src: string;
-	export default src;
-}
-
 declare module '*?url&inline' {
 	const src: string;
 	export default src;


### PR DESCRIPTION
## Changes

- Vite 6 added import queries to [explicitly control asset inlining behaviour](https://vite.dev/guide/assets.html#explicit-inline-handling)
- Vite [declares types](https://github.com/vitejs/vite/blob/ccd1a4c4145ee1069d7baea56981a0322e7be864/packages/vite/client.d.ts#L249-L262) for these, but we didn’t add them to Astro’s client types when updating to Vite 6

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
