### PR TITLE
fix: invoke vite.build with up to date configuration during astro:bui…

### DIFF
--- a/.changeset/heavy-dots-sip.md
+++ b/.changeset/heavy-dots-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed changes to vite configuration made in the astro:build:setup integration hook having no effect when target is "client"

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -290,7 +290,7 @@ async function clientBuild(
 		base: settings.config.base,
 	};
 
-	await runHookBuildSetup({
+	const updatedViteBuildConfig = await runHookBuildSetup({
 		config: settings.config,
 		pages: internals.pagesByKeys,
 		vite: viteBuildConfig,
@@ -298,7 +298,7 @@ async function clientBuild(
 		logger: opts.logger,
 	});
 
-	const buildResult = await vite.build(viteBuildConfig);
+	const buildResult = await vite.build(updatedViteBuildConfig);
 	return buildResult;
 }
 


### PR DESCRIPTION
…ld:setup hook when target is "client"

## Changes

- Make `astro:build:setup` hook actually consume and use the updated configuration provided by integrations using the `updateConfig` function when building for `client` target.

## Testing

Manual tests only for now.

## Docs

Complementary changes in docs by @ematipico on https://github.com/withastro/docs/pull/10410
 /cc @withastro/maintainers-docs

Closes https://github.com/withastro/astro/issues/12372