### PR TITLE
fix: clear the content layer cache when the Astro config changes

### DIFF
--- a/.changeset/shaggy-dancers-run.md
+++ b/.changeset/shaggy-dancers-run.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Clears the content layer cache when the Astro config is changed

--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -1,12 +1,10 @@
 import { promises as fs, existsSync } from 'node:fs';
-import { deterministicString } from 'deterministic-object-hash';
 import PQueue from 'p-queue';
 import type { FSWatcher } from 'vite';
 import xxhash from 'xxhash-wasm';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
 import type { AstroSettings } from '../types/astro.js';
-
 import type { ContentEntryType, RefreshContentOptions } from '../types/public/content.js';
 import {
 	ASSET_IMPORTS_FILE,
@@ -21,6 +19,7 @@ import {
 	getEntryConfigByExtMap,
 	getEntryDataAndImages,
 	globalContentConfigObserver,
+	safeStringify,
 } from './utils.js';
 
 export interface ContentLayerOptions {
@@ -152,7 +151,7 @@ export class ContentLayer {
 			...hashableConfig
 		} = this.#settings.config;
 
-		const astroConfigDigest = deterministicString(hashableConfig);
+		const astroConfigDigest = safeStringify(hashableConfig);
 
 		const { digest: currentConfigDigest } = contentConfig.config;
 		this.#lastConfigDigest = currentConfigDigest;

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -832,3 +832,26 @@ export function contentModuleToId(fileName: string) {
 	params.set(CONTENT_MODULE_FLAG, 'true');
 	return `${DEFERRED_MODULE}?${params.toString()}`;
 }
+
+// Based on https://github.com/sindresorhus/safe-stringify
+function safeStringifyReplacer(seen: WeakSet<object>) {
+	return function (_key: string, value: unknown) {
+		if (!(value !== null && typeof value === 'object')) {
+			return value;
+		}
+		if (seen.has(value)) {
+			return '[Circular]';
+		}
+		seen.add(value);
+		const newValue = Array.isArray(value) ? [] : {};
+		for (const [key2, value2] of Object.entries(value)) {
+			(newValue as Record<string, unknown>)[key2] = safeStringifyReplacer(seen)(key2, value2);
+		}
+		seen.delete(value);
+		return newValue;
+	};
+}
+export function safeStringify(value: unknown) {
+	const seen = new WeakSet();
+	return JSON.stringify(value, safeStringifyReplacer(seen));
+}

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -832,26 +832,3 @@ export function contentModuleToId(fileName: string) {
 	params.set(CONTENT_MODULE_FLAG, 'true');
 	return `${DEFERRED_MODULE}?${params.toString()}`;
 }
-
-// Based on https://github.com/sindresorhus/safe-stringify
-function safeStringifyReplacer(seen: WeakSet<object>) {
-	return function (_key: string, value: unknown) {
-		if (!(value !== null && typeof value === 'object')) {
-			return value;
-		}
-		if (seen.has(value)) {
-			return '[Circular]';
-		}
-		seen.add(value);
-		const newValue = Array.isArray(value) ? [] : {};
-		for (const [key2, value2] of Object.entries(value)) {
-			(newValue as Record<string, unknown>)[key2] = safeStringifyReplacer(seen)(key2, value2);
-		}
-		seen.delete(value);
-		return newValue;
-	};
-}
-export function safeStringify(value: unknown) {
-	const seen = new WeakSet();
-	return JSON.stringify(value, safeStringifyReplacer(seen));
-}

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -304,14 +304,13 @@ describe('Content Layer', () => {
 			let newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 1);
 			await fixture.editFile('astro.config.mjs', (prev) => {
-				return prev.replace("Astro content layer", "Astro more content layer");
+				return prev.replace('Astro content layer', 'Astro more content layer');
 			});
 			await fixture.build();
 			newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 1);
 			await fixture.resetAllFiles();
 		});
-
 	});
 
 	describe('Dev', () => {

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -288,7 +288,7 @@ describe('Content Layer', () => {
 			assert.equal(newJson.entryWithReference.data.something?.content, 'transform me');
 		});
 
-		it('clears the store on new build if the config has changed', async () => {
+		it('clears the store on new build if the content config has changed', async () => {
 			let newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 1);
 			await fixture.editFile('src/content.config.ts', (prev) => {
@@ -299,6 +299,19 @@ describe('Content Layer', () => {
 			assert.equal(newJson.increment.data.lastValue, 1);
 			await fixture.resetAllFiles();
 		});
+
+		it('clears the store on new build if the Astro config has changed', async () => {
+			let newJson = devalue.parse(await fixture.readFile('/collections.json'));
+			assert.equal(newJson.increment.data.lastValue, 1);
+			await fixture.editFile('astro.config.mjs', (prev) => {
+				return prev.replace("Astro content layer", "Astro more content layer");
+			});
+			await fixture.build();
+			newJson = devalue.parse(await fixture.readFile('/collections.json'));
+			assert.equal(newJson.increment.data.lastValue, 1);
+			await fixture.resetAllFiles();
+		});
+
 	});
 
 	describe('Dev', () => {

--- a/packages/astro/test/fixtures/content-layer/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-layer/astro.config.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
 	name: 'Astro content layer',
-  integrations: [mdx(), {
+	integrations: [mdx(), {
 		name: '@astrojs/my-integration',
 		hooks: {
 				'astro:server:setup': async ({ server, refreshContent }) => {

--- a/packages/astro/test/fixtures/content-layer/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-layer/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config';
 import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+	name: 'Astro content layer',
   integrations: [mdx(), {
 		name: '@astrojs/my-integration',
 		hooks: {


### PR DESCRIPTION
## Changes

Currently the content layer cache is invalidated if the content config or Astro version changes. However this causes problems if there are changes in the Astro config that also affect the stored data. This can include things like markdown settings, but potentially lots of other things.

The apporach this PR takes is to hash everything except integrations, adapters and vite config. It switches the digest function to use a safe stringify function in case the Astro config includes circular refs.

Closes #12761

## Testing

Adds a test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
