### PR TITLE
fix(core): add error log for server islands

### DIFF
--- a/.changeset/khaki-tools-live.md
+++ b/.changeset/khaki-tools-live.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where Astro didn't print error logs when Astro Islands were used in incorrect cases.

--- a/.changeset/silver-cars-confess.md
+++ b/.changeset/silver-cars-confess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where Astro was printing the incorrect output format when running the `astro build` command

--- a/.changeset/spotty-timers-shake.md
+++ b/.changeset/spotty-timers-shake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/underscore-redirects': minor
+---
+
+Adds a new `buildOutput` property to the API `createRedirectsFromAstroRoutes`

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -12,7 +12,7 @@ import {
 	runHookConfigSetup,
 } from '../../integrations/hooks.js';
 import type { AstroSettings, ManifestData } from '../../types/astro.js';
-import type { AstroConfig, AstroInlineConfig, RuntimeMode } from '../../types/public/config.js';
+import type { AstroInlineConfig, RuntimeMode } from '../../types/public/config.js';
 import { resolveConfig } from '../config/config.js';
 import { createNodeLogger } from '../config/logging.js';
 import { createSettings } from '../config/settings.js';
@@ -163,7 +163,7 @@ class AstroBuilder {
 		await runHookBuildStart({ config: this.settings.config, logging: this.logger });
 		this.validateConfig();
 
-		this.logger.info('build', `output: ${blue('"' + this.settings.config.output + '"')}`);
+		this.logger.info('build', `output: ${blue('"' + this.settings.buildOutput + '"')}`);
 		this.logger.info('build', `directory: ${blue(fileURLToPath(this.settings.config.outDir))}`);
 		if (this.settings.adapter) {
 			this.logger.info('build', `adapter: ${green(this.settings.adapter.name)}`);
@@ -283,7 +283,7 @@ class AstroBuilder {
 		logger: Logger;
 		timeStart: number;
 		pageCount: number;
-		buildMode: AstroConfig['output'];
+		buildMode: AstroSettings['buildOutput'];
 	}) {
 		const total = getTimeStat(timeStart, performance.now());
 

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -63,7 +63,7 @@ export async function viteBuild(opts: StaticBuildOptions) {
 	registerAllPlugins(container);
 	// Build your project (SSR application code, assets, client JS, etc.)
 	const ssrTime = performance.now();
-	opts.logger.info('build', `Building ${settings.config.output} entrypoints...`);
+	opts.logger.info('build', `Building ${settings.buildOutput} entrypoints...`);
 	const ssrOutput = await ssrBuild(opts, internals, pageInput, container);
 	opts.logger.info('build', green(`✓ Completed in ${getTimeStat(ssrTime, performance.now())}.`));
 

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -170,7 +170,7 @@ export async function createVite(
 			astroInternationalization({ settings }),
 			vitePluginActions({ fs, settings }),
 			vitePluginUserActions({ settings }),
-			vitePluginServerIslands({ settings }),
+			vitePluginServerIslands({ settings, logger }),
 			astroContainer(),
 			astroHmrReloadPlugin(),
 		],

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -33,6 +33,7 @@ export type LoggerLabel =
 	| 'env'
 	| 'update'
 	| 'adapter'
+	| 'islands'
 	// SKIP_FORMAT: A special label that tells the logger not to apply any formatting.
 	// Useful for messages that are already formatted, like the server start message.
 	| 'SKIP_FORMAT';

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -1,12 +1,12 @@
 import type { ConfigEnv, ViteDevServer, Plugin as VitePlugin } from 'vite';
-import type { AstroSettings } from '../../types/astro.js';
+import type { AstroPluginOptions } from '../../types/astro.js';
 import type { AstroPluginMetadata } from '../../vite-plugin-astro/index.js';
 
 export const VIRTUAL_ISLAND_MAP_ID = '@astro-server-islands';
 export const RESOLVED_VIRTUAL_ISLAND_MAP_ID = '\0' + VIRTUAL_ISLAND_MAP_ID;
 const serverIslandPlaceholder = "'$$server-islands$$'";
 
-export function vitePluginServerIslands({ settings }: { settings: AstroSettings }): VitePlugin {
+export function vitePluginServerIslands({ settings, logger }: AstroPluginOptions): VitePlugin {
 	let command: ConfigEnv['command'] = 'serve';
 	let viteServer: ViteDevServer | null = null;
 	const referenceIdMap = new Map<string, string>();
@@ -37,6 +37,20 @@ export function vitePluginServerIslands({ settings }: { settings: AstroSettings 
 					if (astro?.serverComponents.length) {
 						for (const comp of astro.serverComponents) {
 							if (!settings.serverIslandNameMap.has(comp.resolvedPath)) {
+								if (!settings.adapter) {
+									logger.error(
+										'islands',
+										"You tried to use a server island without an adapter. This an error and your project won't build.",
+									);
+								}
+
+								if (settings.buildOutput !== 'server') {
+									logger.error(
+										'islands',
+										'You tried to use a server island, but your output isn\'t `"server"`. Use an adapter that support server output.',
+									);
+								}
+
 								let name = comp.localName;
 								let idx = 1;
 

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -40,7 +40,7 @@ export function vitePluginServerIslands({ settings, logger }: AstroPluginOptions
 								if (!settings.adapter) {
 									logger.error(
 										'islands',
-										"You tried to use a server island without an adapter. This an error and your project won't build.",
+										"You tried to render a server island without an adapter added to your project. An adapter is required to use the `server: defer` attribute on any component. Your project will fail to build unless you add an adapter or remove the attribute.",
 									);
 								}
 

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -44,13 +44,6 @@ export function vitePluginServerIslands({ settings, logger }: AstroPluginOptions
 									);
 								}
 
-								if (settings.buildOutput !== 'server') {
-									logger.error(
-										'islands',
-										'You tried to use a server island, but your output isn\'t `"server"`. Use an adapter that support server output.',
-									);
-								}
-
 								let name = comp.localName;
 								let idx = 1;
 

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -40,7 +40,7 @@ export function vitePluginServerIslands({ settings, logger }: AstroPluginOptions
 								if (!settings.adapter) {
 									logger.error(
 										'islands',
-										"You tried to render a server island without an adapter added to your project. An adapter is required to use the `server: defer` attribute on any component. Your project will fail to build unless you add an adapter or remove the attribute.",
+										"You tried to render a server island without an adapter added to your project. An adapter is required to use the `server:defer` attribute on any component. Your project will fail to build unless you add an adapter or remove the attribute.",
 									);
 								}
 

--- a/packages/underscore-redirects/src/astro.ts
+++ b/packages/underscore-redirects/src/astro.ts
@@ -18,6 +18,7 @@ interface CreateRedirectsFromAstroRoutesParams {
 	 */
 	routeToDynamicTargetMap: Map<IntegrationRouteData, string>;
 	dir: URL;
+	buildOutput: 'static' | 'server';
 }
 
 /**
@@ -27,6 +28,7 @@ export function createRedirectsFromAstroRoutes({
 	config,
 	routeToDynamicTargetMap,
 	dir,
+	buildOutput,
 }: CreateRedirectsFromAstroRoutesParams) {
 	const base =
 		config.base && config.base !== '/'
@@ -34,7 +36,8 @@ export function createRedirectsFromAstroRoutes({
 				? config.base.slice(0, -1)
 				: config.base
 			: '';
-	const output = config.output;
+	// TODO: the use of `config.output` is deprecated. We need to update the adapters that use this package to pass the new buildOutput
+	const output = buildOutput ?? config.output;
 	const _redirects = new Redirects();
 
 	for (const [route, dynamicTarget = ''] of routeToDynamicTargetMap) {


### PR DESCRIPTION
## Changes

- Adds errors logs when Astro Islands are incorrectly used	
  - Absence of an adapter
  - Incorrect buld output
- Fixes the logs, where the output format was incorrect
- Adds a new parameter to `underscore-redirects` package. Since `config.output` isn't reliable anymore, I added a new field, so we can update the adapters to pass the correct value

## Testing

I tested the logs locally. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs


<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
