### PR TITLE
docs: fix typos/punctuation

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -561,8 +561,8 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 *
 		 * #### Effect on Astro.url
 		 * Setting `build.format` controls what `Astro.url` is set to during the build. When it is:
-		 * - `directory` - The `Astro.url.pathname` will include a trailing slash to mimic folder behavior; ie `/foo/`.
-		 * - `file` - The `Astro.url.pathname` will include `.html`; ie `/foo.html`.
+		 * - `directory` - The `Astro.url.pathname` will include a trailing slash to mimic folder behavior. (e.g. `/foo/`)
+		 * - `file` - The `Astro.url.pathname` will include `.html`. (e.g. `/foo.html`)
 		 *
 		 * This means that when you create relative URLs using `new URL('./relative', Astro.url)`, you will get consistent behavior between dev and build.
 		 *


### PR DESCRIPTION
## Changes

Fixes docs typos and punctuation in `packages/astro/src/types/public/config.ts`.

## Testing

Docs fixes only.

## Docs

Docs fixes only.