### PR TITLE
fix: make `reference()` a sync transform

### DIFF
--- a/.changeset/fluffy-ants-reflect.md
+++ b/.changeset/fluffy-ants-reflect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression that caused `default()` to not work with `reference()`

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -18,7 +18,7 @@ import {
 	unescapeHTML,
 } from '../runtime/server/index.js';
 import { CONTENT_LAYER_TYPE, IMAGE_IMPORT_PREFIX } from './consts.js';
-import { type DataEntry, globalDataStore, ImmutableDataStore } from './data-store.js';
+import { type DataEntry, type ImmutableDataStore, globalDataStore } from './data-store.js';
 import type { ContentLookupMap } from './utils.js';
 
 type LazyImport = () => Promise<any>;
@@ -604,7 +604,7 @@ async function render({
 }
 
 export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) {
-	// We're handling it like this to avoid needing an async schema. Not ideal, but should 
+	// We're handling it like this to avoid needing an async schema. Not ideal, but should
 	// be safe because the store will already have been loaded by the time this is called.
 	let store: ImmutableDataStore | null = null;
 	globalDataStore.get().then((s) => (store = s));
@@ -622,21 +622,20 @@ export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) 
 				}),
 			])
 			.transform(
-				 (
+				(
 					lookup:
 						| string
 						| { id: string; collection: string }
 						| { slug: string; collection: string },
 					ctx,
 				) => {
-					if(!store) {
+					if (!store) {
 						ctx.addIssue({
 							code: ZodIssueCode.custom,
 							message: `**${ctx.path.join('.')}:** Reference to ${collection} could not be resolved. Store not available.`,
 						});
-						return
+						return;
 					}
-
 
 					const flattenedErrorPath = ctx.path.join('.');
 					const collectionIsInStore = store.hasCollection(collection);

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -632,7 +632,7 @@ export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) 
 					if (!store) {
 						ctx.addIssue({
 							code: ZodIssueCode.custom,
-							message: `**${ctx.path.join('.')}:** Reference to ${collection} could not be resolved. Store not available.`,
+							message: `**${ctx.path.join('.')}:** Reference to ${collection} could not be resolved: store not available.\nThis is an Astro bug, so please file an issue at https://github.com/withastro/astro/issues.`,
 						});
 						return;
 					}

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -18,7 +18,7 @@ import {
 	unescapeHTML,
 } from '../runtime/server/index.js';
 import { CONTENT_LAYER_TYPE, IMAGE_IMPORT_PREFIX } from './consts.js';
-import { type DataEntry, globalDataStore } from './data-store.js';
+import { type DataEntry, globalDataStore, ImmutableDataStore } from './data-store.js';
 import type { ContentLookupMap } from './utils.js';
 
 type LazyImport = () => Promise<any>;
@@ -604,6 +604,10 @@ async function render({
 }
 
 export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) {
+	// We're handling it like this to avoid needing an async schema. Not ideal, but should 
+	// be safe because the store will already have been loaded by the time this is called.
+	let store: ImmutableDataStore | null = null;
+	globalDataStore.get().then((s) => (store = s));
 	return function reference(collection: string) {
 		return z
 			.union([
@@ -618,15 +622,23 @@ export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) 
 				}),
 			])
 			.transform(
-				async (
+				 (
 					lookup:
 						| string
 						| { id: string; collection: string }
 						| { slug: string; collection: string },
 					ctx,
 				) => {
+					if(!store) {
+						ctx.addIssue({
+							code: ZodIssueCode.custom,
+							message: `**${ctx.path.join('.')}:** Reference to ${collection} could not be resolved. Store not available.`,
+						});
+						return
+					}
+
+
 					const flattenedErrorPath = ctx.path.join('.');
-					const store = await globalDataStore.get();
 					const collectionIsInStore = store.hasCollection(collection);
 
 					if (typeof lookup === 'object') {

--- a/packages/astro/test/fixtures/content-layer/src/content.config.ts
+++ b/packages/astro/test/fixtures/content-layer/src/content.config.ts
@@ -152,7 +152,7 @@ const spacecraft = defineCollection({
 			publishedDate: z.coerce.date(),
 			tags: z.array(z.string()),
 			heroImage: image().optional(),
-			cat: reference('cats').optional(),
+			cat: reference('cats').default('siamese'),
 			something: z
 				.string()
 				.optional()


### PR DESCRIPTION
## Changes

Currently the transform used in `reference()` is async. This was a change with content collections to allow the store to be loaded. However this caused an issue during JSON schema generation when combined with `default()`. See https://github.com/withastro/docs/pull/10362 where this reported as part of a docs PR.

This PR updates the transform to instead preload the store and then make the transform itself sync.

## Testing
Updated fixture to use the `reference().default()` syntax that previously broke.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
