### PR TITLE
chore(deps): update unstorage and use new syntax

### DIFF
--- a/.changeset/poor-mangos-fold.md
+++ b/.changeset/poor-mangos-fold.md
@@ -25,12 +25,12 @@ If you are using the Node.js adapter, you can use the `fs` driver to store sessi
   adapter: node({ mode: 'standalone' }),
   experimental: {
     session: {
-      // Required: the name of the Unstorage driver
+      // Required: the name of the unstorage driver
       driver: "fs",
     },
   },
 }
 ```
-If you are deploying to a serverless environment, you can use drivers such as `redis` or `netlifyBlobs` or `cloudflareKV` and optionally pass additional configuration options.
+If you are deploying to a serverless environment, you can use drivers such as `redis`, `netlify-blobs`, `vercel-kv`, or `cloudflare-kv-binding` and optionally pass additional configuration options.
 
 For more information, including using the session API with other adapters and a full list of supported drivers, see [the docs for experimental session support](https://docs.astro.build/en/reference/experimental-flags/sessions/). For even more details, and to leave feedback and participate in the development of this feature, [the Sessions RFC](https://github.com/withastro/roadmap/pull/1055).

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -166,7 +166,7 @@
     "tsconfck": "^3.1.4",
     "ultrahtml": "^1.5.3",
     "unist-util-visit": "^5.0.0",
-    "unstorage": "^1.12.0",
+    "unstorage": "^1.14.0",
     "vfile": "^6.0.3",
     "vite": "^6.0.1",
     "vitefu": "^1.0.4",

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -372,13 +372,13 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 
 		if (this.#config.driver === 'test') {
 			this.#storage = (this.#config as SessionConfig<'test'>).options.mockStorage;
-			return this.#storage;
+			return this.#storage!;
 		}
-		// Use fsLite rather than fs, because fs can't be bundled. Add a default base path if not provided.
-		if (this.#config.driver === 'fs' || this.#config.driver === 'fsLite') {
+		// Use fs-lite rather than fs, because fs can't be bundled. Add a default base path if not provided.
+		if (this.#config.driver === 'fs' || this.#config.driver === 'fsLite' || this.#config.driver === 'fs-lite') {
 			this.#config.options ??= {};
-			this.#config.driver = 'fsLite';
-			(this.#config.options as BuiltinDriverOptions['fsLite']).base ??= '.astro/session';
+			this.#config.driver = 'fs-lite';
+			(this.#config.options as BuiltinDriverOptions['fs-lite']).base ??= '.astro/session';
 		}
 
 		if (!this.#config?.driver) {

--- a/packages/astro/test/fixtures/sessions/package.json
+++ b/packages/astro/test/fixtures/sessions/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@netlify/blobs": "^8.1.0",
     "astro": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,8 +608,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       unstorage:
-        specifier: ^1.12.0
-        version: 1.13.1
+        specifier: ^1.14.0
+        version: 1.14.0(@netlify/blobs@8.1.0)
       vfile:
         specifier: ^6.0.3
         version: 6.0.3
@@ -3656,6 +3656,9 @@ importers:
 
   packages/astro/test/fixtures/sessions:
     dependencies:
+      '@netlify/blobs':
+        specifier: ^8.1.0
+        version: 8.1.0
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -6853,6 +6856,10 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
+  '@netlify/blobs@8.1.0':
+    resolution: {integrity: sha512-9hIbusvAZjSGBJ42OyFC2AxsEph1LuKQahMWFcPGEIsOqIYHhMRkYA7wSUMhH7naydjNmllpcp3pJLOK4RhFaQ==}
+    engines: {node: ^14.16.0 || >=16.0.0}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -9104,6 +9111,7 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:
@@ -10597,9 +10605,6 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
-
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
@@ -11004,22 +11009,27 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unstorage@1.13.1:
-    resolution: {integrity: sha512-ELexQHUrG05QVIM/iUeQNdl9FXDZhqLJ4yP59fnmn2jGUh0TEulwOgov1ubOb3Gt2ZGK/VMchJwPDNVEGWQpRg==}
+  unstorage@1.14.0:
+    resolution: {integrity: sha512-FjkD8JSdZyktjzPUR9KbR1Pc2tD9b+rEMMNMyvrlpBwQCftL9WgU7iAvb95QDBi5wDL75SQyTovQASBPzt3a9g==}
     peerDependencies:
-      '@azure/app-configuration': ^1.7.0
-      '@azure/cosmos': ^4.1.1
-      '@azure/data-tables': ^13.2.2
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
       '@azure/identity': ^4.5.0
       '@azure/keyvault-secrets': ^4.9.0
-      '@azure/storage-blob': ^12.25.0
-      '@capacitor/preferences': ^6.0.2
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6.0.3
+      '@deno/kv': '>=0.8.4'
       '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0
       '@planetscale/database': ^1.19.0
       '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.0'
       '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
       idb-keyval: ^6.2.1
       ioredis: ^5.4.1
+      uploadthing: ^7.4.1
     peerDependenciesMeta:
       '@azure/app-configuration':
         optional: true
@@ -11035,17 +11045,27 @@ packages:
         optional: true
       '@capacitor/preferences':
         optional: true
+      '@deno/kv':
+        optional: true
       '@netlify/blobs':
         optional: true
       '@planetscale/database':
         optional: true
       '@upstash/redis':
         optional: true
+      '@vercel/blob':
+        optional: true
       '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
         optional: true
       idb-keyval:
         optional: true
       ioredis:
+        optional: true
+      uploadthing:
         optional: true
 
   untun@0.1.3:
@@ -11139,6 +11159,9 @@ packages:
     resolution: {integrity: sha512-M/wqwtOEjgb956/+m5ZrYT/Iq6Hax0OakWbokj8+9PXOnB7b/4AxESHieEtnNEy7ZpjsjYW1/5nK8fATQMmRxw==}
     peerDependencies:
       vue: '>=3.2.13'
+    peerDependenciesMeta:
+      vue:
+        optional: true
 
   vite@5.4.11:
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
@@ -12916,6 +12939,8 @@ snapshots:
       preact: 10.24.3
 
   '@neon-rs/load@0.0.4': {}
+
+  '@netlify/blobs@8.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -15412,7 +15437,7 @@ snapshots:
       mlly: 1.7.3
       node-forge: 1.3.1
       pathe: 1.1.2
-      std-env: 3.7.0
+      std-env: 3.8.0
       ufo: 1.5.4
       untun: 0.1.3
       uqr: 0.1.2
@@ -17326,8 +17351,6 @@ snapshots:
 
   statuses@2.0.1: {}
 
-  std-env@3.7.0: {}
-
   std-env@3.8.0: {}
 
   stream-replace-string@2.0.0: {}
@@ -17791,7 +17814,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unstorage@1.13.1:
+  unstorage@1.14.0(@netlify/blobs@8.1.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 3.6.0
@@ -17803,6 +17826,8 @@ snapshots:
       node-fetch-native: 1.6.4
       ofetch: 1.4.1
       ufo: 1.5.4
+    optionalDependencies:
+      '@netlify/blobs': 8.1.0
 
   untun@0.1.3:
     dependencies:
@@ -17956,6 +17981,7 @@ snapshots:
   vite-svg-loader@5.1.0(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       svgo: 3.3.2
+    optionalDependencies:
       vue: 3.5.13(typescript@5.7.2)
 
   vite@5.4.11(@types/node@18.19.50)(sass@1.82.0):


### PR DESCRIPTION
## Changes

Updates unstorage to `1.14.0`, which adds new drivers. It also now supports kebab-case driver names, so this also updates the code and changesets to use that

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
