### PR TITLE
chore: fix links in session errors

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -871,7 +871,7 @@ export const AstroResponseHeadersReassigned = {
 /**
  * @docs
  * @see
- * 	- [experimental.session](https://5-0-0-beta.docs.astro.build/en/reference/configuration-reference/#experimentalsession)
+ * 	- [experimental.session](https://docs.astro.build/en/reference/experimental-flags/sessions/)
  * @description
  * Thrown when the session storage could not be initialized.
  */
@@ -880,13 +880,13 @@ export const SessionStorageInitError = {
 	title: 'Session storage could not be initialized.',
 	message: (error: string, driver?: string) =>
 		`Error when initializing session storage${driver ? ` with driver ${driver}` : ''}. ${error ?? ''}`,
-	hint: 'For more information, see https://5-0-0-beta.docs.astro.build/en/reference/configuration-reference/#experimentalsession',
+	hint: 'For more information, see https://docs.astro.build/en/reference/experimental-flags/sessions/',
 } satisfies ErrorData;
 
 /**
  * @docs
  * @see
- * 	- [experimental.session](https://5-0-0-beta.docs.astro.build/en/reference/configuration-reference/#experimentalsession)
+ * 	- [experimental.session](https://docs.astro.build/en/reference/experimental-flags/sessions/)
  * @description
  * Thrown when the session data could not be saved.
  */
@@ -895,7 +895,7 @@ export const SessionStorageSaveError = {
 	title: 'Session data could not be saved.',
 	message: (error: string, driver?: string) =>
 		`Error when saving session data${driver ? ` with driver ${driver}` : ''}. ${error ?? ''}`,
-	hint: 'For more information, see https://5-0-0-beta.docs.astro.build/en/reference/configuration-reference/#experimentalsession',
+	hint: 'For more information, see https://docs.astro.build/en/reference/experimental-flags/sessions/',
 } satisfies ErrorData;
 
 /**


### PR DESCRIPTION
## Changes

Fixes the links in the custom errors to point to the correct docs

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
