### PR TITLE
fix: better logs for invalid content config

### DIFF
--- a/.changeset/afraid-sloths-shake.md
+++ b/.changeset/afraid-sloths-shake.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improve warning logs for invalid content config
+Improves warning logs for invalid content collection configuration

--- a/.changeset/afraid-sloths-shake.md
+++ b/.changeset/afraid-sloths-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve warning logs for invalid content config

--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -138,8 +138,14 @@ export class ContentLayer {
 	async #doSync(options: RefreshContentOptions) {
 		const contentConfig = globalContentConfigObserver.get();
 		const logger = this.#logger.forkIntegrationLogger('content');
+
+		if (contentConfig?.status === 'error') {
+			logger.error(`Error loading content config. Skipping sync.\n${contentConfig.error.message}`);
+			return;
+		}
+
 		if (contentConfig?.status !== 'loaded') {
-			logger.debug('Content config not loaded, skipping sync');
+			logger.error('Content config not loaded, skipping sync');
 			return;
 		}
 

--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -144,6 +144,7 @@ export class ContentLayer {
 			return;
 		}
 
+		// It shows as loaded with no collections even if there's no config
 		if (contentConfig?.status !== 'loaded') {
 			logger.error('Content config not loaded, skipping sync');
 			return;

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -111,7 +111,7 @@ export function createGetCollection({
 			console.warn(
 				`The collection ${JSON.stringify(
 					collection,
-				)} does not exist or is empty. Ensure a collection directory with this name exists.`,
+				)} does not exist or is empty. Please check your content config file for errors.`,
 			);
 			return [];
 		}

--- a/packages/astro/test/fixtures/content-layer/src/content.config.ts
+++ b/packages/astro/test/fixtures/content-layer/src/content.config.ts
@@ -177,6 +177,13 @@ const numbers = defineCollection({
 	loader: glob({ pattern: 'src/data/glob-data/*', base: '.' }),
 });
 
+const notADirectory = defineCollection({
+	loader: glob({ pattern: '*', base: 'src/nonexistent' }),
+});
+
+const nothingMatches = defineCollection({
+	loader: glob({ pattern: 'nothingmatches/*', base: 'src/data' }),
+});
 const images = defineCollection({
 	loader: () => [
 		{
@@ -259,4 +266,7 @@ export const collections = {
 	songs,
 	probes,
 	rodents,
+	notADirectory,
+	nothingMatches
 };
+


### PR DESCRIPTION
## Changes

This makes a number of improvements to logging for content layer config errors: 

- warns if glob base dir doesn't exist
- warns if glob matches no files
- updates warning for empty collection to be more accurate in content layer era
- logs a warning if there's an error when loading content config

Fixes #12795

## Testing

Added tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
