### PR TITLE
fix: missing log

### DIFF
--- a/.changeset/red-schools-marry.md
+++ b/.changeset/red-schools-marry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where Astro didn't log anything in case a file isn't created during the build.


### PR DESCRIPTION
## Changes

Astro adds a log when a file isn't created when a `Response` has not body

## Testing

<img width="941" alt="Screenshot 2024-12-23 at 11 14 05" src="https://github.com/user-attachments/assets/d19ff0c7-8a58-49cf-b273-15a04b907dab" />


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
