### PR TITLE
fix: match index files only by using entire basename

### DIFF
--- a/.changeset/small-maps-give.md
+++ b/.changeset/small-maps-give.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Some non-index files that were incorrectly being treated as index files are now excluded

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -183,7 +183,7 @@ function createFileBasedRoutes(
 			validateSegment(segment, file);
 
 			const parts = getParts(segment, file);
-			const isIndex = isDir ? false : basename.startsWith('index.');
+			const isIndex = isDir ? false : basename.substring(0, basename.lastIndexOf('.')) === "index";
 			const routeSuffix = basename.slice(basename.indexOf('.'), -ext.length);
 			const isPage = validPageExtensions.has(ext);
 


### PR DESCRIPTION
The previous code would cause file names like `index.xml.ts` to be treated as index files, when they aren't (the file basename excluding the extension `.ts` is `index.xml`, and `index` should be the index file). To match index files only, match the entire first half of the basename when splitting by the last occurrence of the period/file extension delimiter.

Pedantically this might not be correct -- i.e. some file extensions actually span multiple delimiters, like `index.tar.gz`. But in that case it's not an index file as well, so I think this is fine.

Fixes #12675

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->

This was tested with my website repository that I'm using to migrate to Astro. This may need more tests to make sure it is not a breaking change.

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->

Possibly -- files that were considered index files may not be and vice versa. Although I think this change should only include files that were previously excluded by the `.startswith("index.")` check.

<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
