### PR TITLE
fix: injected route entrypoint

### DIFF
--- a/.changeset/sour-bananas-rule.md
+++ b/.changeset/sour-bananas-rule.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes an issue where an injected route entrypoint wasn't correctly marked because the resolved file path contained a query parameter.
+
+This fixes some edge case where some injected entrypoint were not resolved when using an adapter.

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -115,7 +115,11 @@ function isInPagesDir(file: URL, config: AstroConfig): boolean {
 function isInjectedRoute(file: URL, settings: AstroSettings) {
 	let fileURL = file.toString();
 	for (const route of settings.resolvedInjectedRoutes) {
-		if (route.resolvedEntryPoint && fileURL === route.resolvedEntryPoint.toString()) return true;
+		if (
+			route.resolvedEntryPoint &&
+			removeQueryString(fileURL) === removeQueryString(route.resolvedEntryPoint.toString())
+		)
+			return true;
 	}
 	return false;
 }


### PR DESCRIPTION
## Changes

Myself and @HiDeoo found an issue in his starlight-blog, which I encountered when using the integration in the Biome website.

There are cases now where the resolved paths from rollup contain a query parameter in their `URL`. This breaks some cases, and this was one of them.

[We fixed a similar bug before ](https://github.com/withastro/astro/pull/12712).

## Testing

I tested it with the project where I found the issue. It works now

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
