### PR TITLE
fix: pass cookie options to delete

### DIFF
--- a/.changeset/heavy-lemons-tie.md
+++ b/.changeset/heavy-lemons-tie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused cookies to not be deleted when destroying a session

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -63,12 +63,21 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 		}: Exclude<ResolvedSessionConfig<TDriver>, undefined>,
 	) {
 		this.#cookies = cookies;
+		let cookieConfigObject: AstroCookieSetOptions | undefined;
 		if (typeof cookieConfig === 'object') {
-			this.#cookieConfig = cookieConfig;
-			this.#cookieName = cookieConfig.name || DEFAULT_COOKIE_NAME;
+			const { name = DEFAULT_COOKIE_NAME, ...rest } = cookieConfig;
+			this.#cookieName = name;
+			cookieConfigObject = rest;
 		} else {
 			this.#cookieName = cookieConfig || DEFAULT_COOKIE_NAME;
 		}
+		this.#cookieConfig = {
+			sameSite: 'lax',
+			secure: true,
+			path: '/',
+			...cookieConfigObject,
+			httpOnly: true,
+		};
 		this.#config = config;
 	}
 
@@ -259,15 +268,9 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 				message: 'Invalid cookie name. Cookie names can only contain letters, numbers, and dashes.',
 			});
 		}
-		const cookieOptions: AstroCookieSetOptions = {
-			sameSite: 'lax',
-			secure: true,
-			path: '/',
-			...this.#cookieConfig,
-			httpOnly: true,
-		};
+
 		const value = this.#ensureSessionID();
-		this.#cookies.set(this.#cookieName, value, cookieOptions);
+		this.#cookies.set(this.#cookieName, value, this.#cookieConfig);
 	}
 
 	/**
@@ -346,7 +349,7 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 			this.#toDestroy.add(this.#sessionID);
 		}
 		if (this.#cookieName) {
-			this.#cookies.delete(this.#cookieName);
+			this.#cookies.delete(this.#cookieName, this.#cookieConfig);
 		}
 		this.#sessionID = undefined;
 		this.#data = undefined;

--- a/packages/astro/test/units/sessions/astro-session.test.js
+++ b/packages/astro/test/units/sessions/astro-session.test.js
@@ -86,18 +86,20 @@ test('AstroSession - Cookie Management', async (t) => {
 	});
 
 	await t.test('should delete cookie on destroy', async () => {
-		let cookieDeleted = false;
+		let cookieDeletedArgs;
+		let cookieDeletedName;
 		const mockCookies = {
 			...defaultMockCookies,
-			delete: () => {
-				cookieDeleted = true;
+			delete: (name, args) => {
+				cookieDeletedName = name;
+				cookieDeletedArgs = args;
 			},
 		};
 
 		const session = createSession(defaultConfig, mockCookies);
 		session.destroy();
-
-		assert.equal(cookieDeleted, true);
+		assert.equal(cookieDeletedName, 'test-session');
+		assert.equal(cookieDeletedArgs?.path, '/');
 	});
 });
 


### PR DESCRIPTION
## Changes

Currently we're not passing any options to cookie.delete() when destroying a session. This was meaning the cookie wasn't being properly deleted, because when created it passes some default options.

This PR ensures that the same options are passed to both create and delete the cookie.

This bug was reported in a comment on the RFC

## Testing

Added test cases 
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
