### PR TITLE
fix: change partytown organization

### DIFF
--- a/.changeset/rare-suits-approve.md
+++ b/.changeset/rare-suits-approve.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': minor
+---
+
+change partytown organization

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -32,7 +32,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@builder.io/partytown": "^0.10.2",
+    "@qwik.dev/partytown": "^0.11.0",
     "mrmime": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -2,9 +2,9 @@ import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { PartytownConfig } from '@builder.io/partytown/integration';
-import { partytownSnippet } from '@builder.io/partytown/integration';
-import { copyLibFiles, libDirPath } from '@builder.io/partytown/utils';
+import type { PartytownConfig } from '@qwik.dev/partytown/integration';
+import { partytownSnippet } from '@qwik.dev/partytown/integration';
+import { copyLibFiles, libDirPath } from '@qwik.dev/partytown/utils';
 import type { AstroIntegration } from 'astro';
 import sirv from './sirv.js';
 const resolve = createRequire(import.meta.url).resolve;
@@ -19,7 +19,7 @@ function appendForwardSlash(str: string) {
 
 export default function createPlugin(options?: PartytownOptions): AstroIntegration {
 	let partytownSnippetHtml: string;
-	const partytownEntrypoint = resolve('@builder.io/partytown/package.json');
+	const partytownEntrypoint = resolve('@qwik.dev/partytown/package.json');
 	const partytownLibDirectory = path.resolve(partytownEntrypoint, '../lib');
 	return {
 		name: '@astrojs/partytown',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4980,9 +4980,9 @@ importers:
 
   packages/integrations/partytown:
     dependencies:
-      '@builder.io/partytown':
-        specifier: ^0.10.2
-        version: 0.10.2
+      '@qwik.dev/partytown':
+        specifier: ^0.11.0
+        version: 0.11.0
       mrmime:
         specifier: ^2.0.0
         version: 2.0.0
@@ -5932,11 +5932,6 @@ packages:
   '@bluwy/giget-core@0.1.1':
     resolution: {integrity: sha512-0Y6ILl9wJMkALcHGBMtkNDhXVjeFLqSEutwQThYj7jEqKpZ35j+p7QpKEhci+GyY77paMFGETXy1OBU39adWqg==}
     engines: {node: '>=18'}
-
-  '@builder.io/partytown@0.10.2':
-    resolution: {integrity: sha512-A9U+4PREWcS+CCYzKGIPovtGB/PBgnH/8oQyCE6Nr9drDJk6cMPpLQIEajpGPmG9tYF7N3FkRvhXm/AS9+0iKg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   '@changesets/apply-release-plan@7.0.6':
     resolution: {integrity: sha512-TKhVLtiwtQOgMAC0fCJfmv93faiViKSDqr8oMEqrnNs99gtSC1sZh/aEMS9a+dseU1ESZRCK+ofLgGY7o0fw/Q==}
@@ -7008,6 +7003,11 @@ packages:
     peerDependencies:
       preact: ^10.4.0
       vite: '>=2.0.0'
+
+  '@qwik.dev/partytown@0.11.0':
+    resolution: {integrity: sha512-MHime7cxj7KGrapGZ1VqLkXXq5BLNqvjNZndRJVvMkUWn92F2bsezlWW1lKDoFaKCKu2xv9LRUZL99RYOs+ccA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -8217,6 +8217,10 @@ packages:
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
 
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
@@ -9120,6 +9124,7 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:
@@ -12092,8 +12097,6 @@ snapshots:
     dependencies:
       tar: 6.2.1
 
-  '@builder.io/partytown@0.10.2': {}
-
   '@changesets/apply-release-plan@7.0.6':
     dependencies:
       '@changesets/config': 3.0.4
@@ -13122,6 +13125,10 @@ snapshots:
       vite: 6.0.5(@types/node@18.19.50)(jiti@2.4.0)(sass@1.82.0)(yaml@2.5.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@qwik.dev/partytown@0.11.0':
+    dependencies:
+      dotenv: 16.4.7
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -14436,6 +14443,8 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dotenv@16.4.7: {}
 
   dotenv@8.6.0: {}
 


### PR DESCRIPTION
## Changes

- Updated the package from `@builder.io/partytown` to `@qwik.dev/partytown`, so it fixes the following production warning:

<img width="755" alt="Bildschirmfoto 2024-12-24 um 10 54 48" src="https://github.com/user-attachments/assets/c6bced5b-42fc-4149-92de-9da24f6e294a" />

## Testing

- `pnpm build`

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Docs are not affected