### PR TITLE
fix(@astrojs/rss): revert incorrect Content-Type header applied for RSS XML file

### DIFF
--- a/.changeset/hot-pumas-attack.md
+++ b/.changeset/hot-pumas-attack.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Revert incorrect Content-Type header applied for RSS XML file

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -89,7 +89,7 @@ export default async function getRssResponse(rssOptions: RSSOptions): Promise<Re
 	const rssString = await getRssString(rssOptions);
 	return new Response(rssString, {
 		headers: {
-			'Content-Type': 'application/rss+xml; charset=utf-8',
+			'Content-Type': 'application/xml',
 		},
 	});
 }

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -62,7 +62,7 @@ describe('rss', () => {
 		assertXmlDeepEqual(str, validXmlResult);
 
 		const contentType = response.headers.get('Content-Type');
-		assert.equal(contentType, 'application/rss+xml; charset=utf-8');
+		assert.equal(contentType, 'application/xml');
 	});
 
 	it('should be the same string as getRssString', async () => {


### PR DESCRIPTION
## Changes
This fixes an issue where the RSS XML file generated by `@astrojs/rss` is displayed in plaintext due to a faulty `Content-Type` header by reverting the https://github.com/withastro/astro/pull/12644 pull request.

For more information, you can view the https://github.com/withastro/astro/issues/12828 issue that I filed.

## Example screenshots

**Before** (current, `Content-Type` header is set to `application/rss+xml; charset=utf-8` since `astro@5.0.3`)

![msedge_t86IuPt0Pq](https://github.com/user-attachments/assets/46110c32-290f-4be0-8294-dc7125d6ee10)

**After** (manually overriding the `Content-Type` header to `application/xml` which was the value used by `@astrojs/rss` before the PR change)

![msedge_pumxsK772k](https://github.com/user-attachments/assets/140c3d09-684f-459d-8e45-7c1f34c9d3fb)

## Testing

A reproducible example can be found here: https://codesandbox.io/p/devbox/kind-hugle-27v5l?on=codesandbox

Or, if you want to reproduce it yourself:
- Go to https://astro.new and find the **Blog** template
- Open the **Blog** template in CodeSandbox
- Visit the `/rss.xml` RSS XML page

You should see the XML page being displayed in plaintext.

## Reproducible example screenshot for the "Blog" Template in CodeSandbox
![msedge_4MsvTN5VE4](https://github.com/user-attachments/assets/e37591d4-ab89-4ef9-80ba-9f91392cd9af)