### PR TITLE
Fix i18n current locale

### DIFF
--- a/.changeset/happy-pianos-report.md
+++ b/.changeset/happy-pianos-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Astro.currentLocale returning the incorrect locale when using fallback rewrites in SSR mode

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -599,12 +599,6 @@ export class RenderContext {
 							fallbackRoute.pattern.test(url.pathname),
 						)) ?? routeData;
 			const pathname = route.pathname && !isRoute404or500(route) ? route.pathname : url.pathname;
-			// console.log('route', route);
-			// console.table({
-			// 	routePath: routeData.pathname,
-			// 	is404Or500: isRoute404or500(routeData),
-			// 	urlPathname: url.pathname,
-			// });
 			computedLocale = computeCurrentLocale(pathname, locales, defaultLocale);
 		}
 

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -592,15 +592,16 @@ export class RenderContext {
 			}
 		} else {
 			// For SSG we match the route naively, for dev we handle fallback on 404, for SSR we find route from fallbackRoutes
-			let route = routeData;
-			if (!routeData.pattern.test(url.pathname) && routeData.fallbackRoutes) {
-				// if
-				route =
-					routeData.fallbackRoutes.find((fallbackRoute) =>
-						fallbackRoute.pattern.test(url.pathname),
-					) || routeData;
+			let pathname = routeData.pathname;
+			if (!routeData.pattern.test(url.pathname)) {
+				for (const fallbackRoute of routeData.fallbackRoutes) {
+					if (fallbackRoute.pattern.test(url.pathname)) {
+						pathname = fallbackRoute.pathname;
+						break;
+					}
+				}
 			}
-			const pathname = route.pathname && !isRoute404or500(route) ? route.pathname : url.pathname;
+			pathname = pathname && !isRoute404or500(routeData) ? pathname : url.pathname;
 			computedLocale = computeCurrentLocale(pathname, locales, defaultLocale);
 		}
 

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -591,8 +591,20 @@ export class RenderContext {
 				computedLocale = computeCurrentLocale(referer, locales, defaultLocale);
 			}
 		} else {
-			const pathname =
-				routeData.pathname && !isRoute404or500(routeData) ? routeData.pathname : url.pathname;
+			// For SSG we match the route naively, for dev we handle fallback on 404, for SSR we find route from fallbackRoutes
+			const route =
+				(routeData.pattern.test(url.pathname)
+					? routeData
+					: routeData.fallbackRoutes.find((fallbackRoute) =>
+							fallbackRoute.pattern.test(url.pathname),
+						)) ?? routeData;
+			const pathname = route.pathname && !isRoute404or500(route) ? route.pathname : url.pathname;
+			// console.log('route', route);
+			// console.table({
+			// 	routePath: routeData.pathname,
+			// 	is404Or500: isRoute404or500(routeData),
+			// 	urlPathname: url.pathname,
+			// });
 			computedLocale = computeCurrentLocale(pathname, locales, defaultLocale);
 		}
 

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -592,12 +592,14 @@ export class RenderContext {
 			}
 		} else {
 			// For SSG we match the route naively, for dev we handle fallback on 404, for SSR we find route from fallbackRoutes
-			const route =
-				(routeData.pattern.test(url.pathname)
-					? routeData
-					: routeData.fallbackRoutes.find((fallbackRoute) =>
-							fallbackRoute.pattern.test(url.pathname),
-						)) ?? routeData;
+			let route = routeData;
+			if (!routeData.pattern.test(url.pathname) && routeData.fallbackRoutes) {
+				// if
+				route =
+					routeData.fallbackRoutes.find((fallbackRoute) =>
+						fallbackRoute.pattern.test(url.pathname),
+					) || routeData;
+			}
 			const pathname = route.pathname && !isRoute404or500(route) ? route.pathname : url.pathname;
 			computedLocale = computeCurrentLocale(pathname, locales, defaultLocale);
 		}

--- a/packages/astro/test/fixtures/i18n-routing-fallback/src/pages/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback/src/pages/index.astro
@@ -1,3 +1,6 @@
+---
+const locale = Astro.currentLocale
+---
 <html>
 <head>
 	<title>Astro</title>
@@ -7,6 +10,10 @@
 </head>
 <body>
 	Hello
+	<p>
+
+	locale - {locale}
+	</p>
 </body>
 </html>
 

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1,6 +1,6 @@
+import * as cheerio from 'cheerio';
 import * as assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
-import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 
@@ -2032,6 +2032,7 @@ describe('Fallback rewrite dev server', () => {
 	it('should correctly rewrite to en', async () => {
 		const html = await fixture.fetch('/fr').then((res) => res.text());
 		assert.match(html, /Hello/);
+		assert.match(html, /locale - fr/);
 		// assert.fail()
 	});
 
@@ -2085,6 +2086,7 @@ describe('Fallback rewrite SSG', () => {
 	it('should correctly rewrite to en', async () => {
 		const html = await fixture.readFile('/fr/index.html');
 		assert.match(html, /Hello/);
+		assert.match(html, /locale - fr/);
 		// assert.fail()
 	});
 
@@ -2138,6 +2140,7 @@ describe('Fallback rewrite SSR', () => {
 		const response = await app.render(request);
 		assert.equal(response.status, 200);
 		const html = await response.text();
+		assert.match(html, /locale - fr/);
 		assert.match(html, /Hello/);
 	});
 

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1,6 +1,6 @@
+import * as cheerio from 'cheerio';
 import * as assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
-import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import * as assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 
@@ -2014,13 +2014,13 @@ describe('Fallback rewrite dev server', () => {
 				locales: ['en', 'fr', 'es', 'it', 'pt'],
 				routing: {
 					prefixDefaultLocale: false,
+					fallbackType: 'rewrite',
 				},
 				fallback: {
 					fr: 'en',
 					it: 'en',
 					es: 'pt',
 				},
-				fallbackType: 'rewrite',
 			},
 		});
 		devServer = await fixture.startDevServer();


### PR DESCRIPTION
## Changes

- This will fix the issue with Astro.currentLocale not working correctly in SSR. See issue #12838 

## Testing

Adds similar logic to `computeCurrentLocale` as was used in #12709  to handle SSR manifests with fallback routes. 
Welcome feedback from a maintainer on whether there may be a more elegant solution to solve both of these - I dont have enough background on the decision process behind having such different manifests and i18n implementation between dev/SSR/SSG.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Just corrects a bug and inconsistent behavior across modes. No new docs needed. 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
