### PR TITLE
fix: session regeneration

### DIFF
--- a/.changeset/hot-baboons-own.md
+++ b/.changeset/hot-baboons-own.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+ensure session regeneration

--- a/.changeset/hot-baboons-own.md
+++ b/.changeset/hot-baboons-own.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-ensure session regeneration
+Fixes a bug where the session ID wasn't correctly regenerated

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -182,9 +182,8 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 		const oldSessionId = this.#sessionID;
 
 		// Create new session
-		this.#sessionID = undefined;
+		this.#sessionID = crypto.randomUUID();
 		this.#data = data;
-		this.#ensureSessionID();
 		await this.#setCookie();
 
 		// Clean up old session asynchronously

--- a/packages/astro/test/sessions.test.js
+++ b/packages/astro/test/sessions.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
+
+describe('Astro.cookies', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/sessions/',
+			output: 'server',
+			adapter: testAdapter(),
+		});
+	});
+
+	describe('Production', () => {
+		let app;
+		before(async () => {
+			await fixture.build();
+			app = await fixture.loadTestAdapterApp();
+		});
+
+		async function fetchResponse(path, requestInit) {
+			const request = new Request('http://example.com' + path, requestInit);
+			const response = await app.render(request);
+			return response;
+		}
+
+		it('can regenerate session cookies upon request', async () => {
+			const firstResponse = await fetchResponse('/regenerate', { method: 'GET' });
+			const firstHeaders = Array.from(app.setCookieHeaders(firstResponse));
+			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
+
+			const secondResponse = await fetchResponse('/regenerate', {
+				method: 'GET',
+				headers: {
+					cookie: `astro-session=${firstSessionId}`,
+				},
+			});
+			const secondHeaders = Array.from(app.setCookieHeaders(secondResponse));
+			const secondSessionId = secondHeaders[0].split(';')[0].split('=')[1];
+			assert.notEqual(firstSessionId, secondSessionId);
+		});
+	});
+});

--- a/packages/astro/test/sessions.test.js
+++ b/packages/astro/test/sessions.test.js
@@ -3,7 +3,7 @@ import { before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 
-describe('Astro.cookies', () => {
+describe('Astro.session', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 


### PR DESCRIPTION
## Changes

- What does this change?

Ensures that session IDs get regenerated when `regenerate()` is called. This fixes #12863.

- [x] Don't forget a changeset! `pnpm exec changeset`

## Testing

Built astro with this change locally and ran it against https://stackblitz.com/edit/github-muwk6ati-gxwf5xkb?file=src%2Fpages%2Findex.astro and it functions as expected (new uuid shown on every refresh).

## Docs

Docs should not be needed - this aligns the code's functionality with the current docs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
