### PR TITLE
fix: make adapter the last element of integrations instead of the first

### DIFF
--- a/.changeset/breezy-bottles-glow.md
+++ b/.changeset/breezy-bottles-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix: make adapter the last element of integrations instead of the first

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -142,7 +142,7 @@ export async function runHookConfigSetup({
 }): Promise<AstroSettings> {
 	// An adapter is an integration, so if one is provided add it to the list of integrations.
 	if (settings.config.adapter) {
-		settings.config.integrations.unshift(settings.config.adapter);
+		settings.config.integrations.push(settings.config.adapter);
 	}
 	if (await isActionsFilePresent(fs, settings.config.srcDir)) {
 		settings.config.integrations.push(astroIntegrationActionsRouteHandler({ settings }));


### PR DESCRIPTION
## Change

- Make `adapter` the last element of `integrations` instead of the first
  - This ensures that adapter is called after all integrations are called so that adapter can their job correctly
  - It fixes #12832
- I hope it's not a breaking change, but it might be

## Testing

I tested locally using reproduction repo in #12832 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
