### PR TITLE
fix: pass emulated entry to getCollection filter function

### DIFF
--- a/.changeset/rotten-baboons-roll.md
+++ b/.changeset/rotten-baboons-roll.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug in emulated legacy collections where the entry passed to the getCollection filter function did not include the legacy entry fields.

--- a/packages/astro/test/fixtures/legacy-content-collections/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/legacy-content-collections/src/pages/collections.json.js
@@ -9,8 +9,17 @@ export async function GET() {
 	const withUnionSchema = stripAllRenderFn(await getCollection('with-union-schema'));
 	const withSymlinkedContent = stripAllRenderFn(await getCollection('with-symlinked-content'));
 	const withSymlinkedData = stripAllRenderFn(await getCollection('with-symlinked-data'));
+	const filtered = stripAllRenderFn(await getCollection('without-config', (entry) => entry.slug));
 
 	return new Response(
-		devalue.stringify({ withoutConfig, withSchemaConfig, withSlugConfig, withUnionSchema, withSymlinkedContent, withSymlinkedData }),
+		devalue.stringify({
+			withoutConfig,
+			withSchemaConfig,
+			withSlugConfig,
+			withUnionSchema,
+			withSymlinkedContent,
+			withSymlinkedData,
+			filtered,
+		}),
 	);
 }

--- a/packages/astro/test/legacy-content-collections.test.js
+++ b/packages/astro/test/legacy-content-collections.test.js
@@ -55,6 +55,12 @@ describe('Legacy Content Collections', () => {
 				);
 			});
 
+			it('Passes legacy entry to filter function', async () => {
+				assert.ok(json.hasOwnProperty('filtered'));
+				assert.ok(Array.isArray(json.filtered));
+				assert.ok(json.filtered.length > 0);
+			});
+
 			it('Returns `with schema` collection', async () => {
 				assert.ok(json.hasOwnProperty('withSchemaConfig'));
 				assert.equal(Array.isArray(json.withSchemaConfig), true);


### PR DESCRIPTION
## Changes

When emulating legacy collections, entries have extra fields applied, such as `slug` and the render function. Currently `getCollection` filter functions are being passed the non-emulated version of the entry. This PR ensures that the entry is the same one that is returned from the collection.

Fixes #12873

## Testing

Added a test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
