### PR TITLE
fix: add render() to stub content type defs

### DIFF
--- a/.changeset/strange-carpets-drop.md
+++ b/.changeset/strange-carpets-drop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds `render()` to stub content types

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -89,29 +89,29 @@ declare module 'astro:content' {
 		input: CollectionConfig<S>,
 	): CollectionConfig<S>;
 
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export const getEntryBySlug: (...args: any[]) => any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export const getDataEntryById: (...args: any[]) => any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export const getCollection: (...args: any[]) => any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export const getEntry: (...args: any[]) => any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export const getEntries: (...args: any[]) => any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export const reference: (...args: any[]) => any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export type CollectionKey = any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	// biome-ignore lint/correctness/noUnusedVariables: stub generic type to match generated type
 	export type CollectionEntry<C> = any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export type ContentCollectionKey = any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export type DataCollectionKey = any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export type ContentConfig = any;
-	/** Run `astro sync` to generate high fidelity types */
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
 	export const render: (entry: any) => any;
 }

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -112,4 +112,6 @@ declare module 'astro:content' {
 	export type DataCollectionKey = any;
 	/** Run `astro sync` to generate high fidelity types */
 	export type ContentConfig = any;
+	/** Run `astro sync` to generate high fidelity types */
+	export const render: (entry: any) => any;
 }


### PR DESCRIPTION
## Changes

The generated `astro:content` runtime includes a `render` function, which has types that are created using typegen. However these types are missing from the stub types used before the first sync. This PR adds a stub declaration.

Fixes #12837 

## Testing
Tested a preview build. It's hard to test in the monorepo because it tends to find random `content.d.ts` files scattered throughout the repo.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
