### PR TITLE
fix(underscore-redirects): force type

### DIFF
--- a/.changeset/shiny-hornets-relate.md
+++ b/.changeset/shiny-hornets-relate.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/underscore-redirects': patch
+---
+
+Fixes the type of `force`

--- a/packages/underscore-redirects/src/redirects.ts
+++ b/packages/underscore-redirects/src/redirects.ts
@@ -9,7 +9,7 @@ export type RedirectDefinition = {
 	// a priority once inserted.
 	weight: number;
 	status: number;
-	force?: number;
+	force?: boolean;
 };
 
 export class Redirects {


### PR DESCRIPTION
## Changes

- In #11271 I used the wrong type for `force` (copy paste ftw)

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
