### PR TITLE
fix: don't match all paths when returning empty array from getStaticPaths

### DIFF
--- a/.changeset/gorgeous-cameras-smile.md
+++ b/.changeset/gorgeous-cameras-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused pages that return an empty array from getStaticPath to match every path

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -47,7 +47,6 @@ export async function getProps(opts: GetParamsAndPropsOptions): Promise<Props> {
 		base,
 	});
 
-	if (!staticPaths.length) return {};
 	// The pathname used here comes from the server, which already encoded.
 	// Since we decided to not mess up with encoding anymore, we need to decode them back so the parameters can match
 	// the ones expected from the users

--- a/packages/astro/test/fixtures/routing-priority/src/pages/empty-paths/[...slug].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/empty-paths/[...slug].astro
@@ -1,0 +1,18 @@
+---
+export function getStaticPaths() {
+	return []
+}
+const { slug } = Astro.params
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>{slug}</title>
+	</head>
+	<body>
+		<h1>empty-paths/[...slug].astro</h1>
+		<p>slug: {slug}</p>
+	</body>
+</html>

--- a/packages/astro/test/routing-priority.test.js
+++ b/packages/astro/test/routing-priority.test.js
@@ -108,6 +108,11 @@ const routes = [
 		fourOhFour: true,
 	},
 	{
+		description: 'do not match /empty-paths/hello to empty-paths/[...slug].astro',
+		url: '/empty-paths/hello',
+		fourOhFour: true,
+	},
+	{
 		description: 'matches /api/catch/a.json to api/catch/[...slug].json.ts',
 		url: '/api/catch/a.json',
 		htmlMatch: JSON.stringify({ path: 'a' }),


### PR DESCRIPTION
## Changes

Since #12709, pages that return an empty array from getStaticPaths match every path. This is incorrect, so this PR restores the previous behaviour where an empty list would match no paths.

Fixes #12891

## Testing

Adds test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
