### PR TITLE
fix: do not generate a stub for content types

### DIFF
--- a/.changeset/great-hotels-reply.md
+++ b/.changeset/great-hotels-reply.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where `astro:content` types would be erased when restarting the dev server

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -150,17 +150,15 @@ export async function syncInternal({
 		settings.timer.end('Sync content layer');
 	} else {
 		const paths = getContentPaths(settings.config, fs);
-		// Content is synced after writeFiles. That means references are not created
-		// To work around it, we create a stub so the reference is created and content
-		// sync will override the empty file
 		if (
 			paths.config.exists ||
 			// Legacy collections don't require a config file
 			(settings.config.legacy?.collections && fs.existsSync(paths.contentDir))
 		) {
+			// We only create the reference, without a stub to avoid overriding the
+			// already generated types
 			settings.injectedTypes.push({
 				filename: CONTENT_TYPES_FILE,
-				content: '',
 			});
 		}
 	}
@@ -182,7 +180,9 @@ function writeInjectedTypes(settings: AstroSettings, fs: typeof fsMod) {
 	for (const { filename, content } of settings.injectedTypes) {
 		const filepath = fileURLToPath(new URL(filename, settings.dotAstroDir));
 		fs.mkdirSync(dirname(filepath), { recursive: true });
-		fs.writeFileSync(filepath, content, 'utf-8');
+		if (content) {
+			fs.writeFileSync(filepath, content, 'utf-8');
+		}
 		references.push(normalizePath(relative(fileURLToPath(settings.dotAstroDir), filepath)));
 	}
 

--- a/packages/astro/src/types/astro.ts
+++ b/packages/astro/src/types/astro.ts
@@ -64,7 +64,8 @@ export interface AstroSettings {
 	latestAstroVersion: string | undefined;
 	serverIslandMap: NonNullable<SSRManifest['serverIslandMap']>;
 	serverIslandNameMap: NonNullable<SSRManifest['serverIslandNameMap']>;
-	injectedTypes: Array<InjectedType>;
+	// This makes content optional. Internal only so it's optional on InjectedType
+	injectedTypes: Array<Omit<InjectedType, 'content'> & Partial<Pick<InjectedType, 'content'>>>;
 	/**
 	 * Determine if the build output should be a static, dist folder or a adapter-based server output
 	 * undefined when unknown

--- a/packages/astro/src/types/astro.ts
+++ b/packages/astro/src/types/astro.ts
@@ -64,7 +64,7 @@ export interface AstroSettings {
 	latestAstroVersion: string | undefined;
 	serverIslandMap: NonNullable<SSRManifest['serverIslandMap']>;
 	serverIslandNameMap: NonNullable<SSRManifest['serverIslandNameMap']>;
-	// This makes content optional. Internal only so it's optional on InjectedType
+	// This makes content optional. Internal only so it's not optional on InjectedType
 	injectedTypes: Array<Omit<InjectedType, 'content'> & Partial<Pick<InjectedType, 'content'>>>;
 	/**
 	 * Determine if the build output should be a static, dist folder or a adapter-based server output


### PR DESCRIPTION
## Changes

- Closes #12901
- We only generate a reference instead of the stub, which was overriding the generated types in rare cases

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
