### PR TITLE
Process empty markdown for remark/rehype plugins

### DIFF
--- a/.changeset/pink-years-warn.md
+++ b/.changeset/pink-years-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Processes markdown with empty content as remark and rehype plugins may add additional content or frontmatter

--- a/packages/astro/src/vite-plugin-markdown/content-entry-type.ts
+++ b/packages/astro/src/vite-plugin-markdown/content-entry-type.ts
@@ -20,12 +20,8 @@ export const markdownContentEntryType: ContentEntryType = {
 	async getRenderFunction(config) {
 		const processor = await createMarkdownProcessor(config.markdown);
 		return async function renderToString(entry) {
-			if (!entry.body) {
-				return {
-					html: '',
-				};
-			}
-			const result = await processor.render(entry.body, {
+			// Process markdown even if it's empty as remark/rehype plugins may add content or frontmatter dynamically
+			const result = await processor.render(entry.body ?? '', {
 				frontmatter: entry.data,
 				// @ts-expect-error Internal API
 				fileURL: entry.filePath ? pathToFileURL(entry.filePath) : undefined,

--- a/packages/astro/test/astro-markdown-plugins.test.js
+++ b/packages/astro/test/astro-markdown-plugins.test.js
@@ -135,6 +135,16 @@ describe('Astro Markdown plugins', () => {
 			const $ = cheerio.load(html);
 			assert.equal($('p').text(), 'Not transformed');
 		});
+
+		it('processes empty markdown content with remark plugins', async () => {
+			const html = await fixture.readFile('/empty-content/index.html');
+			const $ = cheerio.load(html);
+			assert.equal($('h1').text(), 'Test Empty Markdown');
+			assert.equal(
+				$('#frontmatter-custom-property').text(),
+				'Generated property via remark plugin!',
+			);
+		});
 	});
 });
 

--- a/packages/astro/test/fixtures/content-layer-remark-plugins/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-layer-remark-plugins/astro.config.mjs
@@ -15,6 +15,14 @@ export default defineConfig({
 					});
         };
       },
+      function addFrontmatter() {
+        return function (tree, file) {
+          if (file.data.astro?.frontmatter) {
+          file.data.astro.frontmatter.customProperty =
+            'Generated property via remark plugin!';
+          }
+        };
+      }
     ],
   },
 });

--- a/packages/astro/test/fixtures/content-layer-remark-plugins/src/content/docs/empty-content.md
+++ b/packages/astro/test/fixtures/content-layer-remark-plugins/src/content/docs/empty-content.md
@@ -1,0 +1,3 @@
+---
+title: Test Empty Markdown
+---

--- a/packages/astro/test/fixtures/content-layer-remark-plugins/src/pages/[...slug].astro
+++ b/packages/astro/test/fixtures/content-layer-remark-plugins/src/pages/[...slug].astro
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 }
 
 const { doc } = Astro.props;
-const { Content } = await render(doc);
+const { Content, remarkPluginFrontmatter } = await render(doc);
 ---
 
 <!DOCTYPE html>
@@ -22,6 +22,7 @@ const { Content } = await render(doc);
 </head>
 <body>
 	<h1>{doc.data.title}</h1>
+  <div id="frontmatter-custom-property">{remarkPluginFrontmatter?.customProperty}</div>
 	<Content />
 </body>
 </html>


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/12800

Process empty markdown content as remark or rehype plugins may add content or frontmatter that may be used by end-users.

## Testing

Added a new test

## Docs

n/a. bug fix