### PR TITLE
Remove custom optimizeDeps.include in react integration

### DIFF
--- a/.changeset/brown-flies-repeat.md
+++ b/.changeset/brown-flies-repeat.md
@@ -1,5 +1,0 @@
----
-'@astrojs/vue': patch
----
-
-Removes vue-specific entrypoints in `optimizeDeps.include` and rely on `@vitejs/plugin-vue` to add

--- a/.changeset/brown-flies-repeat.md
+++ b/.changeset/brown-flies-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vue': patch
+---
+
+Removes vue-specific entrypoints in `optimizeDeps.include` and rely on `@vitejs/plugin-vue` to add

--- a/.changeset/curvy-pans-share.md
+++ b/.changeset/curvy-pans-share.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/solid-js': patch
+---
+
+Adds the client entrypoint to `optimizeDeps.include`

--- a/.changeset/smart-ties-hear.md
+++ b/.changeset/smart-ties-hear.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Removes react-specific entrypoints in `optimizeDeps.include` and rely on `@vitejs/plugin-react` to add

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -54,20 +54,10 @@ function getViteConfiguration(
 ) {
 	return {
 		optimizeDeps: {
-			include: [
-				reactConfig.client,
-				'react',
-				'react/jsx-runtime',
-				'react/jsx-dev-runtime',
-				'react-dom',
-				'react-compiler-runtime',
-			],
+			include: [reactConfig.client],
 			exclude: [reactConfig.server],
 		},
 		plugins: [react({ include, exclude, babel }), optionsPlugin(!!experimentalReactChildren)],
-		resolve: {
-			dedupe: ['react', 'react-dom', 'react-dom/server'],
-		},
 		ssr: {
 			external: reactConfig.externals,
 			noExternal: [

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -51,6 +51,7 @@ function getViteConfiguration(
 ) {
 	const config: UserConfig = {
 		optimizeDeps: {
+			include: ['@astrojs/solid-js/client.js'],
 			exclude: ['@astrojs/solid-js/server.js'],
 		},
 		plugins: [solid({ include, exclude, ssr: true })],

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -116,7 +116,7 @@ async function getViteConfiguration(
 
 	const config: UserConfig = {
 		optimizeDeps: {
-			include: ['@astrojs/vue/client.js', 'vue'],
+			include: ['@astrojs/vue/client.js'],
 			exclude: ['@astrojs/vue/server.js', VIRTUAL_MODULE_ID],
 		},
 		plugins: [vue(vueOptions), virtualAppEntrypoint(vueOptions)],

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -116,7 +116,9 @@ async function getViteConfiguration(
 
 	const config: UserConfig = {
 		optimizeDeps: {
-			include: ['@astrojs/vue/client.js'],
+			// We add `vue` here as `@vitejs/plugin-vue` doesn't add it and we want to prevent
+			// re-optimization if the `vue` import is only encountered later.
+			include: ['@astrojs/vue/client.js', 'vue'],
 			exclude: ['@astrojs/vue/server.js', VIRTUAL_MODULE_ID],
 		},
 		plugins: [vue(vueOptions), virtualAppEntrypoint(vueOptions)],


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/12896
ref https://github.com/withastro/astro/pull/12735 (revert)

- React: `@vitejs/plugin-react` will add `optimizeDeps.include` [themselves](https://github.com/vitejs/vite-plugin-react/blob/ab12dfafbab3260bfd4904d85375ea2c02c36afe/packages/plugin-react/src/index.ts#L274-L296)
- Vue: Added a comment of why we manually add `vue` to `optimizeDeps.include`
- Solid: Different issue, but I noticed that we don't optimize `@astrojs/solid-js/client.js` by default like how the other integrations do.

I didn't do this for Preact as we're still pinning to an older version, but once we can update to the latest (tracked https://github.com/withastro/astro/issues/12805), we can also do the same here for it.

## Testing

Existing tests should pass

## Docs

n/a. bug fix.