### PR TITLE
pass original locals to the 404 page render

### DIFF
--- a/.changeset/famous-gorillas-confess.md
+++ b/.changeset/famous-gorillas-confess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+use same request context for initial request also for 404 page renders (e.g. runtime from adapters)

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -246,7 +246,7 @@ export async function handleRoute({
 		const fourOhFourRoute = await matchRoute('/404', manifestData, pipeline);
 		if (fourOhFourRoute) {
 			renderContext = await RenderContext.create({
-				locals: {},
+				locals,
 				pipeline,
 				pathname,
 				middleware: isDefaultPrerendered404(fourOhFourRoute.route) ? undefined : middleware,


### PR DESCRIPTION
## Changes

- pass the original locals data to the render function of 404 pages

## Docs

- no doc update required because this is probably expected behavior