### PR TITLE
fix(routing): don't trigger get of headers

### DIFF
--- a/.changeset/sweet-zoos-move.md
+++ b/.changeset/sweet-zoos-move.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where users could use `Astro.request.headers` during a rewrite inside prerendered routes. This an invalid behaviour, and now Astro will show a warning if this happens.

--- a/.changeset/tame-pianos-approve.md
+++ b/.changeset/tame-pianos-approve.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the use of `Astro.rewrite` would trigger the invalid use of `Astro.request.headers`

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -175,7 +175,14 @@ export class RenderContext {
 				if (payload instanceof Request) {
 					this.request = payload;
 				} else {
-					this.request = copyRequest(newUrl, this.request);
+					this.request = copyRequest(
+						newUrl,
+						this.request,
+						// need to send the flag of the previous routeData
+						routeData.prerender,
+						this.pipeline.logger,
+						this.routeData.route,
+					);
 				}
 				this.isRewriting = true;
 				this.url = new URL(this.request.url);
@@ -290,7 +297,14 @@ export class RenderContext {
 		if (reroutePayload instanceof Request) {
 			this.request = reroutePayload;
 		} else {
-			this.request = copyRequest(newUrl, this.request);
+			this.request = copyRequest(
+				newUrl,
+				this.request,
+				// need to send the flag of the previous routeData
+				routeData.prerender,
+				this.pipeline.logger,
+				this.routeData.route,
+			);
 		}
 		this.url = new URL(this.request.url);
 		this.cookies = new AstroCookies(this.request);

--- a/packages/astro/src/core/request.ts
+++ b/packages/astro/src/core/request.ts
@@ -1,5 +1,4 @@
 import type { IncomingHttpHeaders } from 'node:http';
-import { AstroError, AstroErrorData } from './errors/index.js';
 import type { Logger } from './logger/core.js';
 
 type HeaderType = Headers | Record<string, any> | IncomingHttpHeaders;
@@ -102,33 +101,4 @@ export function createRequest({
 	}
 
 	return request;
-}
-
-/**
- * Utility function that creates a new `Request` with a new URL from an old `Request`.
- *
- * @param newUrl The new `URL`
- * @param oldRequest The old `Request`
- */
-export function copyRequest(newUrl: URL, oldRequest: Request, isPrerendered: boolean): Request {
-	if (oldRequest.bodyUsed) {
-		throw new AstroError(AstroErrorData.RewriteWithBodyUsed);
-	}
-	return new Request(newUrl, {
-		method: oldRequest.method,
-		headers: isPrerendered ? {} : oldRequest.headers,
-		body: oldRequest.body,
-		referrer: oldRequest.referrer,
-		referrerPolicy: oldRequest.referrerPolicy,
-		mode: oldRequest.mode,
-		credentials: oldRequest.credentials,
-		cache: oldRequest.cache,
-		redirect: oldRequest.redirect,
-		integrity: oldRequest.integrity,
-		signal: oldRequest.signal,
-		keepalive: oldRequest.keepalive,
-		// https://fetch.spec.whatwg.org/#dom-request-duplex
-		// @ts-expect-error It isn't part of the types, but undici accepts it and it allows to carry over the body to a new request
-		duplex: 'half',
-	});
 }

--- a/packages/astro/src/core/request.ts
+++ b/packages/astro/src/core/request.ts
@@ -1,15 +1,22 @@
 import type { IncomingHttpHeaders } from 'node:http';
+import { AstroError, AstroErrorData } from './errors/index.js';
 import type { Logger } from './logger/core.js';
 
 type HeaderType = Headers | Record<string, any> | IncomingHttpHeaders;
-type RequestBody = ArrayBuffer | Blob | ReadableStream | URLSearchParams | FormData;
+type RequestBody =
+	| ArrayBuffer
+	| Blob
+	| ReadableStream
+	| URLSearchParams
+	| FormData
+	| ReadableStream<Uint8Array>;
 
 export interface CreateRequestOptions {
 	url: URL | string;
 	clientAddress?: string | undefined;
 	headers: HeaderType;
 	method?: string;
-	body?: RequestBody | undefined;
+	body?: RequestBody | undefined | null;
 	logger: Logger;
 	locals?: object | undefined;
 	/**
@@ -22,6 +29,8 @@ export interface CreateRequestOptions {
 	isPrerendered?: boolean;
 
 	routePattern: string;
+
+	init?: RequestInit;
 }
 
 /**
@@ -39,6 +48,7 @@ export function createRequest({
 	logger,
 	isPrerendered = false,
 	routePattern,
+	init,
 }: CreateRequestOptions): Request {
 	// headers are made available on the created request only if the request is for a page that will be on-demand rendered
 	const headersObj = isPrerendered
@@ -65,6 +75,7 @@ export function createRequest({
 		headers: headersObj,
 		// body is made available only if the request is for a page that will be on-demand rendered
 		body: isPrerendered ? null : body,
+		...init,
 	});
 
 	if (isPrerendered) {
@@ -91,4 +102,33 @@ export function createRequest({
 	}
 
 	return request;
+}
+
+/**
+ * Utility function that creates a new `Request` with a new URL from an old `Request`.
+ *
+ * @param newUrl The new `URL`
+ * @param oldRequest The old `Request`
+ */
+export function copyRequest(newUrl: URL, oldRequest: Request, isPrerendered: boolean): Request {
+	if (oldRequest.bodyUsed) {
+		throw new AstroError(AstroErrorData.RewriteWithBodyUsed);
+	}
+	return new Request(newUrl, {
+		method: oldRequest.method,
+		headers: isPrerendered ? {} : oldRequest.headers,
+		body: oldRequest.body,
+		referrer: oldRequest.referrer,
+		referrerPolicy: oldRequest.referrerPolicy,
+		mode: oldRequest.mode,
+		credentials: oldRequest.credentials,
+		cache: oldRequest.cache,
+		redirect: oldRequest.redirect,
+		integrity: oldRequest.integrity,
+		signal: oldRequest.signal,
+		keepalive: oldRequest.keepalive,
+		// https://fetch.spec.whatwg.org/#dom-request-duplex
+		// @ts-expect-error It isn't part of the types, but undici accepts it and it allows to carry over the body to a new request
+		duplex: 'half',
+	});
 }

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -4,7 +4,9 @@ import type { RouteData } from '../../types/public/internal.js';
 import { shouldAppendForwardSlash } from '../build/util.js';
 import { originPathnameSymbol } from '../constants.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
+import type { Logger } from '../logger/core.js';
 import { appendForwardSlash, removeTrailingForwardSlash } from '../path.js';
+import { createRequest } from '../request.js';
 import { DEFAULT_404_ROUTE } from './astro-designed-error-pages.js';
 
 export type FindRouteToRewrite = {
@@ -80,27 +82,42 @@ export function findRouteToRewrite({
  *
  * @param newUrl The new `URL`
  * @param oldRequest The old `Request`
+ * @param isPrerendered It needs to be the flag of the previous routeData, before the rewrite
+ * @param logger
+ * @param routePattern
  */
-export function copyRequest(newUrl: URL, oldRequest: Request): Request {
+export function copyRequest(
+	newUrl: URL,
+	oldRequest: Request,
+	isPrerendered: boolean,
+	logger: Logger,
+	routePattern: string,
+): Request {
 	if (oldRequest.bodyUsed) {
 		throw new AstroError(AstroErrorData.RewriteWithBodyUsed);
 	}
-	return new Request(newUrl, {
+	return createRequest({
+		url: newUrl,
 		method: oldRequest.method,
-		headers: oldRequest.headers,
 		body: oldRequest.body,
-		referrer: oldRequest.referrer,
-		referrerPolicy: oldRequest.referrerPolicy,
-		mode: oldRequest.mode,
-		credentials: oldRequest.credentials,
-		cache: oldRequest.cache,
-		redirect: oldRequest.redirect,
-		integrity: oldRequest.integrity,
-		signal: oldRequest.signal,
-		keepalive: oldRequest.keepalive,
-		// https://fetch.spec.whatwg.org/#dom-request-duplex
-		// @ts-expect-error It isn't part of the types, but undici accepts it and it allows to carry over the body to a new request
-		duplex: 'half',
+		isPrerendered,
+		logger,
+		headers: isPrerendered ? {} : oldRequest.headers,
+		routePattern,
+		init: {
+			referrer: oldRequest.referrer,
+			referrerPolicy: oldRequest.referrerPolicy,
+			mode: oldRequest.mode,
+			credentials: oldRequest.credentials,
+			cache: oldRequest.cache,
+			redirect: oldRequest.redirect,
+			integrity: oldRequest.integrity,
+			signal: oldRequest.signal,
+			keepalive: oldRequest.keepalive,
+			// https://fetch.spec.whatwg.org/#dom-request-duplex
+			// @ts-expect-error It isn't part of the types, but undici accepts it and it allows to carry over the body to a new request
+			duplex: 'half',
+		},
 	});
 }
 


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/12931
Closes PLT-2736

The issue was that doing `oldRequest.headers` during a rewrite was causing the warning to fire, because it triggers the `.get` method. 

This is fixed now by checking the `isPrerendered` flag.

Also, I updated the method `copyRequest` to use the internal method `copyRequest`, which creates the `headers` object based on `isPrenredererd`. This should fix cases (not caught, probably) where users could have used `Request.headers` during a rewrite.

## Testing

I tested it locally using the reproduction provided. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
