### PR TITLE
fix: invalidate data store module when dev server starts

### DIFF
--- a/.changeset/strong-scissors-sip.md
+++ b/.changeset/strong-scissors-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where content collections would sometimes appear empty when first running astro dev

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -70,10 +70,12 @@ export function astroContentVirtualModPlugin({
 			dataStoreFile = getDataStoreFile(settings, env.command === 'serve');
 		},
 		buildStart() {
-			// We defer adding the data store file to the watcher until the server is ready
-			devServer.watcher.add(fileURLToPath(dataStoreFile));
-			// Manually invalidate the data store to avoid a race condition in file watching
-			invalidateDataStore(devServer);
+			if (devServer) {
+				// We defer adding the data store file to the watcher until the server is ready
+				devServer.watcher.add(fileURLToPath(dataStoreFile));
+				// Manually invalidate the data store to avoid a race condition in file watching
+				invalidateDataStore(devServer);
+			}
 		},
 		async resolveId(id) {
 			if (id === VIRTUAL_MODULE_ID) {


### PR DESCRIPTION
## Changes

This is another fix in the saga of data store race conditions. When we changed the dev fs watcher to not start watching the data store file until after the content layer sync was complete, it was meanign that in some scenarios, newly-created data store files were not triggering a module reload. This PR adds a manual module invalidation at the same time as adding the file to the watcher.

Fixes #12866

## Testing

This can't be reproduced when using pnpm (for some unclear reason), but I have manually tested it with the #12866 repro, using npm.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
