### PR TITLE
fix(examples): add Starlog example viewport meta tag

### DIFF
--- a/examples/starlog/src/components/BaseHead.astro
+++ b/examples/starlog/src/components/BaseHead.astro
@@ -8,6 +8,7 @@ const { title = SiteTitle, name = SiteTitle, description = SiteDescription, ...s
 ---
 
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
 <SEO {title} {description} {name} {...seo} />
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Changes

The Starlog example was missing a `viewport` meta tag, which was causing issues on mobile devices (media queries not working properly):

![image](https://github.com/user-attachments/assets/7b9098d3-d55d-4dd8-afa4-f68a4a7aae1a)

Adding a default one fixes the issue:

![image](https://github.com/user-attachments/assets/008efbf0-e518-4658-a7f1-25c9c62d7f29)

Note: I haven't included achangeset as it was said they're not needed for examples.

## Testing

By emulating mobile device on Chrome (Toggle device  toolbar in dev tools) and on a personal website 🙂 
No tests added as this is an example template.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No updates or changes required - it affects only Starlog example users on mobile devices.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
