### PR TITLE
fix: explicitly set dev mode for data store

### DIFF
--- a/.changeset/purple-pillows-lay.md
+++ b/.changeset/purple-pillows-lay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused empty content collections when running dev with NODE_ENV set

--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -278,8 +278,7 @@ export class ContentLayer {
 		);
 		await fs.mkdir(this.#settings.config.cacheDir, { recursive: true });
 		await fs.mkdir(this.#settings.dotAstroDir, { recursive: true });
-		const cacheFile = getDataStoreFile(this.#settings);
-		await this.#store.writeToDisk(cacheFile);
+		await this.#store.writeToDisk();
 		const assetImportsFile = new URL(ASSET_IMPORTS_FILE, this.#settings.dotAstroDir);
 		await this.#store.writeAssetImports(assetImportsFile);
 		const modulesImportsFile = new URL(MODULES_IMPORTS_FILE, this.#settings.dotAstroDir);
@@ -379,8 +378,7 @@ export async function simpleLoader<TData extends { id: string }>(
  * During development, this is in the `.astro` directory so that the Vite watcher can see it.
  * In production, it's in the cache directory so that it's preserved between builds.
  */
-export function getDataStoreFile(settings: AstroSettings, isDev?: boolean) {
-	isDev ??= process?.env.NODE_ENV === 'development';
+export function getDataStoreFile(settings: AstroSettings, isDev: boolean) {
 	return new URL(DATA_STORE_FILE, isDev ? settings.dotAstroDir : settings.config.cacheDir);
 }
 

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -180,16 +180,15 @@ export default new Map([\n${lines.join(',\n')}]);
 
 	#saveToDiskDebounced() {
 		this.#dirty = true;
-		// Only save to disk if it has already been saved once
-		if (this.#file) {
-			if (this.#saveTimeout) {
-				clearTimeout(this.#saveTimeout);
-			}
-			this.#saveTimeout = setTimeout(() => {
-				this.#saveTimeout = undefined;
-				this.writeToDisk();
-			}, SAVE_DEBOUNCE_MS);
+		if (this.#saveTimeout) {
+			clearTimeout(this.#saveTimeout);
 		}
+		this.#saveTimeout = setTimeout(() => {
+			this.#saveTimeout = undefined;
+			if (this.#file) {
+				this.writeToDisk();
+			}
+		}, SAVE_DEBOUNCE_MS);
 	}
 
 	#writing = new Set<string>();

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -377,6 +377,8 @@ export default new Map([\n${lines.join(',\n')}]);
 				const store = await MutableDataStore.fromString(data);
 				store.#file = filePath;
 				return store;
+			} else {
+				await fs.mkdir(new URL('./', filePath), { recursive: true });
 			}
 		} catch {}
 		const store = new MutableDataStore();

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -187,7 +187,7 @@ export default new Map([\n${lines.join(',\n')}]);
 			}
 			this.#saveTimeout = setTimeout(() => {
 				this.#saveTimeout = undefined;
-				this.writeToDisk(this.#file!);
+				this.writeToDisk();
 			}, SAVE_DEBOUNCE_MS);
 		}
 	}
@@ -331,13 +331,15 @@ export default new Map([\n${lines.join(',\n')}]);
 		return devalue.stringify(this._collections);
 	}
 
-	async writeToDisk(filePath: PathLike) {
+	async writeToDisk() {
 		if (!this.#dirty) {
 			return;
 		}
+		if (!this.#file) {
+			throw new AstroError(AstroErrorData.UnknownFilesystemError);
+		}
 		try {
-			await this.#writeFileAtomic(filePath, this.toString());
-			this.#file = filePath;
+			await this.#writeFileAtomic(this.#file, this.toString());
 			this.#dirty = false;
 		} catch (err) {
 			throw new AstroError(AstroErrorData.UnknownFilesystemError, { cause: err });
@@ -373,10 +375,14 @@ export default new Map([\n${lines.join(',\n')}]);
 		try {
 			if (existsSync(filePath)) {
 				const data = await fs.readFile(filePath, 'utf-8');
-				return MutableDataStore.fromString(data);
+				const store = await MutableDataStore.fromString(data);
+				store.#file = filePath;
+				return store;
 			}
 		} catch {}
-		return new MutableDataStore();
+		const store = new MutableDataStore();
+		store.#file = filePath;
+		return store;
 	}
 }
 

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -155,6 +155,7 @@ class AstroBuilder {
 			logger,
 			fs,
 			manifest: this.manifest,
+			command: 'build',
 		});
 
 		return { viteConfig };

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -68,7 +68,8 @@ export default async function build(
 	const settings = await createSettings(astroConfig, fileURLToPath(astroConfig.root));
 
 	if (inlineConfig.force) {
-		await clearContentLayerCache({ settings, logger, fs });
+		// isDev is always false, because it's interested in the build command, not the output type
+		await clearContentLayerCache({ settings, logger, fs, isDev: false });
 	}
 
 	const builder = new AstroBuilder(settings, {

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -119,6 +119,7 @@ export async function createContainer({
 		},
 		force: inlineConfig?.force,
 		manifest,
+		command: 'dev',
 	});
 
 	const viteServer = await vite.createServer(viteConfig);

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -1,4 +1,4 @@
-import fs, { existsSync } from 'node:fs';
+import fs from 'node:fs';
 import type http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { performance } from 'node:perf_hooks';
@@ -87,15 +87,15 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 	let store: MutableDataStore | undefined;
 	try {
 		const dataStoreFile = getDataStoreFile(restart.container.settings, true);
-		if (existsSync(dataStoreFile)) {
-			store = await MutableDataStore.fromFile(dataStoreFile);
-		}
+		store = await MutableDataStore.fromFile(dataStoreFile);
 	} catch (err: any) {
 		logger.error('content', err.message);
 	}
-	if (!store) {
-		store = new MutableDataStore();
+
+	if(!store) {
+		throw new Error('Failed to create data store');
 	}
+
 	await attachContentServerListeners(restart.container);
 
 	const config = globalContentConfigObserver.get();

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -93,7 +93,7 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 	}
 
 	if(!store) {
-		throw new Error('Failed to create data store');
+		logger.error('content', 'Failed to create data store');
 	}
 
 	await attachContentServerListeners(restart.container);
@@ -102,7 +102,7 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 	if (config.status === 'error') {
 		logger.error('content', config.error.message);
 	}
-	if (config.status === 'loaded') {
+	if (config.status === 'loaded' && store) {
 		const contentLayer = globalContentLayer.init({
 			settings: restart.container.settings,
 			logger,

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -136,7 +136,8 @@ export async function syncInternal({
 			logger.error('content', err.message);
 		}
 		if (!store) {
-			throw new Error('Failed to load content store');
+			logger.error('content', 'Failed to load content store');
+			return;
 		}
 		const contentLayer = globalContentLayer.init({
 			settings,

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -49,6 +49,7 @@ export type SyncOptions = {
 		cleanup?: boolean;
 	};
 	manifest: ManifestData;
+	command: "build" | "dev" | "sync";
 };
 
 export default async function sync(
@@ -78,6 +79,7 @@ export default async function sync(
 		fs,
 		force: inlineConfig.force,
 		manifest,
+		command: 'sync',
 	});
 }
 
@@ -117,8 +119,9 @@ export async function syncInternal({
 	skip,
 	force,
 	manifest,
+	command,
 }: SyncOptions): Promise<void> {
-	const isDev = mode === 'development';
+	const isDev = command === 'dev';
 	if (force) {
 		await clearContentLayerCache({ settings, logger, fs, isDev });
 	}

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -1,4 +1,4 @@
-import fsMod, { existsSync } from 'node:fs';
+import fsMod from 'node:fs';
 import { dirname, relative } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';

--- a/packages/astro/test/fixtures/content-layer/src/pages/missing.astro
+++ b/packages/astro/test/fixtures/content-layer/src/pages/missing.astro
@@ -1,7 +1,7 @@
 ---
 import { getEntry, render } from "astro:content"
 // Skipping the broken page in production so the build doesn't fail
-if(import.meta.env.PROD) {
+if(import.meta.env.PROD || import.meta.env.MODE === "production") {
 	return new Response(null, { status: 404 })
 }
 


### PR DESCRIPTION
## Changes

The content layer data store is created in a different location according to whether it is running in dev or build, so that it is either cachable or watchable by the fs watcher. These are mutually exclusive for Reasons. 
This needs to be the same locaiton for both writing (during sync) and reading (during runtime). Unfortunately knowing which of these we're running is not as simple as it could be, and there have been some bugs that have emerged due to conflicts. 

We'd mostly fixed these cases in #12640, but it missed the case where dev was run programatically with NODE_ENV set to something other than development (mostly in a test environment). 

Rather than playing whackamole for all of these scenarios, this PR changes the approach so that it never uses NODE_ENV, and always explicitly sets it. Either this is done via the command used (build and sync use production, dev uses development) or at runtime uses Vite's env.command (build uses production, serve uses development). This involved some refactoring around how files are handled by data stores (which was overdue, because it was needlessly complex as it was created when there were different requirements)

Fixes #12652

## Testing

Added some tests to the astro mode suite, which helpfully messes around with these options.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
