### PR TITLE
Adds "blocking" and "disabled" attributes to the TypeScript definition of the HTML link element

### DIFF
--- a/.changeset/four-kangaroos-develop.md
+++ b/.changeset/four-kangaroos-develop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Lets TypeScript know about the "blocking" and "disabled" attributes of the `<link>` element.

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -837,10 +837,12 @@ declare namespace astroHTML.JSX {
 
 	interface LinkHTMLAttributes extends HTMLAttributes {
 		as?: string | undefined | null;
+		blocking?: 'render'	 | undefined | null;
 		crossorigin?: boolean | string | undefined | null;
+		disabled?: boolean | undefined | null;
+		fetchpriority?: 'auto' | 'high' | 'low' | undefined | null;
 		href?: string | URL | undefined | null;
 		hreflang?: string | undefined | null;
-		fetchpriority?: 'auto' | 'high' | 'low' | undefined | null;
 		integrity?: string | undefined | null;
 		media?: string | undefined | null;
 		imagesrcset?: string | undefined | null;


### PR DESCRIPTION
## Changes

I missed the "blocking" attribute of the `<link>` element.
Added it. Came across missing "disabled" attribute. Added that, too.
Started sorting, but did not complete, because I haven't found "charset" at MDN.

## Testing

n/a

## Docs

n/a

Improvements of the changeset are welcome as always.