### PR TITLE
fix: check if content layer files have changed before writing

### DIFF
--- a/.changeset/light-meals-press.md
+++ b/.changeset/light-meals-press.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Skips updating content layer files if content is unchanged

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -213,6 +213,11 @@ export default new Map([\n${lines.join(',\n')}]);
 
 		const tempFile = filePath instanceof URL ? new URL(`${filePath.href}.tmp`) : `${filePath}.tmp`;
 		try {
+			const oldData = await fs.readFile(filePath, 'utf-8').catch(() => '');
+			if (oldData === data) {
+				// If the data hasn't changed, we can skip the write
+				return;
+			}
 			// Write it to a temporary file first and then move it to prevent partial reads.
 			await fs.writeFile(tempFile, data);
 			await fs.rename(tempFile, filePath);


### PR DESCRIPTION
## Changes

When data has changed in the content layer, the data store needs to write several different files, including the data store itself, asset imports (e.g. images) and module imports (e.g. mdx). These are all in the module graph, so will trigger HMR if changed. #12751 reported that when editing MDX it would reload twice, and the second time would take a long time for large sites. The double reload was because there was initially HMR from the changed MDX module itself. The slow second reload was because it was writing the big imports file itself too, causing Vite to re-parse the whole big graph. This isn't needed, because the imports file itself hasn't changed, just the file it was referring to.

This PR changes the write function to first check the old file content before writing, and skip if it is unchanged.

This does _not_ stop the double-reload in the example. The first update is instant, and is the HMR for the mdx module itself. The second is a full refresh, which is triggered by the data store changing. This in unavoidable, because the data _has_ changed, and may need a full page refresh because we don't know how it's been used. What has been fixed though is that this is much faster, because the big imports file has not been invalidated so I'm going to count this as a fix.

Fixes #12751

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
