### PR TITLE
fix:astro-mdx-component-rendering

### DIFF
--- a/.changeset/many-laws-add.md
+++ b/.changeset/many-laws-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': minor
+---
+
+Fixes the React Invalid Hook Call in MDX | React 19

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[javascriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[javascriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/packages/integrations/mdx/src/server.ts
+++ b/packages/integrations/mdx/src/server.ts
@@ -1,7 +1,7 @@
 import { AstroJSX, jsx } from 'astro/jsx-runtime';
 
-import type { NamedSSRLoadedRendererValue } from 'astro';
 import { AstroError } from 'astro/errors';
+import type { NamedSSRLoadedRendererValue } from 'astro';
 import { renderJSX } from 'astro/runtime/server/index.js';
 
 const slotName = (str: string) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w.toUpperCase());
@@ -11,25 +11,29 @@ const slotName = (str: string) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w
 export async function check(
 	Component: any,
 	props: any,
-	{ default: children = null, ...slotted } = {},
-) {
+	{ default: children = null, ...slotted } = {}
+  ) {
 	if (typeof Component !== 'function') return false;
+  
 	const slots: Record<string, any> = {};
 	for (const [key, value] of Object.entries(slotted)) {
-		const name = slotName(key);
-		slots[name] = value;
+	  const name = slotName(key);
+	  slots[name] = value;
 	}
+  
 	try {
-		const vnode = jsx(Component, { ...props, ...slots, children });
-
-		const rendered = await renderJSX(null, vnode);
-
-		return rendered[AstroJSX];
+	  const vnode = jsx(Component, { ...props, ...slots, children });
+	  
+  
+	  const result = { styles: [], scripts: [], links: [] }; 
+	  const rendered = await renderJSX(result, vnode);
+  
+	  return rendered[AstroJSX];
 	} catch (e) {
-		throwEnhancedErrorIfMdxComponent(e as Error, Component);
+	  throwEnhancedErrorIfMdxComponent(e as Error, Component);
 	}
 	return false;
-}
+  }
 
 export async function renderToStaticMarkup(
 	this: any,

--- a/packages/integrations/mdx/src/server.ts
+++ b/packages/integrations/mdx/src/server.ts
@@ -1,7 +1,7 @@
 import { AstroJSX, jsx } from 'astro/jsx-runtime';
 
-import { AstroError } from 'astro/errors';
 import type { NamedSSRLoadedRendererValue } from 'astro';
+import { AstroError } from 'astro/errors';
 import { renderJSX } from 'astro/runtime/server/index.js';
 
 const slotName = (str: string) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w.toUpperCase());
@@ -21,13 +21,13 @@ export async function check(
 	}
 	try {
 		const vnode = jsx(Component, { ...props, ...slots, children });
-	
+
 		const rendered = await renderJSX(null, vnode);
-	
+
 		return rendered[AstroJSX];
-	  } catch (e) {
+	} catch (e) {
 		throwEnhancedErrorIfMdxComponent(e as Error, Component);
-	  }
+	}
 	return false;
 }
 

--- a/packages/integrations/mdx/src/server.ts
+++ b/packages/integrations/mdx/src/server.ts
@@ -1,6 +1,7 @@
-import type { NamedSSRLoadedRendererValue } from 'astro';
-import { AstroError } from 'astro/errors';
 import { AstroJSX, jsx } from 'astro/jsx-runtime';
+
+import { AstroError } from 'astro/errors';
+import type { NamedSSRLoadedRendererValue } from 'astro';
 import { renderJSX } from 'astro/runtime/server/index.js';
 
 const slotName = (str: string) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w.toUpperCase());
@@ -19,11 +20,14 @@ export async function check(
 		slots[name] = value;
 	}
 	try {
-		const result = await Component({ ...props, ...slots, children });
-		return result[AstroJSX];
-	} catch (e) {
+		const vnode = jsx(Component, { ...props, ...slots, children });
+	
+		const rendered = await renderJSX(null, vnode);
+	
+		return rendered[AstroJSX];
+	  } catch (e) {
 		throwEnhancedErrorIfMdxComponent(e as Error, Component);
-	}
+	  }
 	return false;
 }
 


### PR DESCRIPTION
## Changes

- Fixed the **React invalid hook call warning** when using MDX and React integrations together in Astro.  
- Updated the `check` function to correctly render React components using `jsx` and `renderJSX`, ensuring hooks are called within the proper context.  
- Removed the direct component invocation (`Component({...})`), which was causing React hooks to break.  
- Ensured compatibility with both React and MDX components without needing to import React.

## Testing

- Manually tested by navigating between routes to confirm the **React hook warning** no longer appears.  
- Verified that both React and MDX components render correctly with dynamic props and slots.  
- No automated tests added since this is primarily a runtime integration fix, but manual checks cover the issue.

## Docs

- No documentation updates required since this change is internal and does not affect public APIs.  

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
