### PR TITLE
fix: delete old entry when frontmatter slug changed

### DIFF
--- a/.changeset/tiny-papayas-develop.md
+++ b/.changeset/tiny-papayas-develop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensures old content collection entry is deleted if a markdown frontmatter slug is changed in dev

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -93,7 +93,7 @@ export function glob(globOptions: GlobOptions): Loader {
 			const isLegacy = (globOptions as any)._legacy;
 			// If global legacy collection handling flag is *not* enabled then this loader is used to emulate them instead
 			const emulateLegacyCollections = !config.legacy.collections;
-			async function syncData(entry: string, base: URL, entryType?: ContentEntryType) {
+			async function syncData(entry: string, base: URL, entryType?: ContentEntryType, oldId?: string) {
 				if (!entryType) {
 					logger.warn(`No entry type found for ${entry}`);
 					return;
@@ -115,6 +115,11 @@ export function glob(globOptions: GlobOptions): Loader {
 				});
 
 				const id = generateId({ entry, base, data });
+
+				if(oldId && oldId !== id) {
+					store.delete(oldId);
+				}
+
 				let legacyId: string | undefined;
 
 				if (isLegacy) {
@@ -320,7 +325,8 @@ export function glob(globOptions: GlobOptions): Loader {
 				}
 				const entryType = configForFile(changedPath);
 				const baseUrl = pathToFileURL(basePath);
-				await syncData(entry, baseUrl, entryType);
+				const oldId = fileToIdMap.get(changedPath);
+				await syncData(entry, baseUrl, entryType, oldId);
 				logger.info(`Reloaded data from ${green(entry)}`);
 			}
 

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -467,6 +467,37 @@ describe('Content Layer', () => {
 			await fixture.resetAllFiles();
 		});
 
+		it('removes old entry when slug is changed', async () => {
+			const rawJsonResponse = await fixture.fetch('/collections.json');
+			const initialJson = devalue.parse(await rawJsonResponse.text());
+
+			assert.ok(initialJson.spacecraft.includes('exomars'));
+			assert.ok(!initialJson.spacecraft.includes('rosalind-franklin-rover'));
+
+			await fixture.editFile('/src/content/space/exomars.md', (prev) => {
+				return prev.replace('# slug', 'slug');
+			});
+
+			await fixture.onNextDataStoreChange();
+			const updatedJsonResponse = await fixture.fetch('/collections.json');
+			const updated = devalue.parse(await updatedJsonResponse.text());
+			assert.ok(!updated.spacecraft.includes('exomars'));
+			assert.ok(updated.spacecraft.includes('rosalind-franklin-rover'));
+
+			await fixture.editFile('/src/content/space/exomars.md', (prev) => {
+				return prev.replace('rosalind-franklin-rover', 'rosalind-franklin');
+			})
+
+			await fixture.onNextDataStoreChange();
+			const updatedJsonResponse2 = await fixture.fetch('/collections.json');
+			const updated2 = devalue.parse(await updatedJsonResponse2.text());
+			assert.ok(!updated2.spacecraft.includes('rosalind-franklin-rover'));
+			assert.ok(updated2.spacecraft.includes('rosalind-franklin'));
+			
+			await fixture.resetAllFiles();
+
+		});
+
 		it('returns an error if we render an undefined entry', async () => {
 			const res = await fixture.fetch('/missing');
 			const text = await res.text();

--- a/packages/astro/test/fixtures/content-layer/src/content/space/exomars.md
+++ b/packages/astro/test/fixtures/content-layer/src/content/space/exomars.md
@@ -1,0 +1,10 @@
+---
+title: Rosalind Franklin Rover
+description: 'Learn about the Rosalind Franklin Rover.'
+publishedDate: '2022-09-19'
+tags: [space, 2020s]
+# slug: rosalind-franklin-rover
+---
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+
+The Rosalind Franklin rover is a planned robotic Mars rover, part of the ExoMars mission led by the European Space Agency and the Russian space agency Roscosmos. The mission is scheduled to launch in September 2022, and the rover is expected to land on Mars in June 2023. The rover is named after the British biophysicist Rosalind Franklin, who made key contributions to the discovery of the structure of DNA.

--- a/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
@@ -15,6 +15,8 @@ export async function GET() {
 	const atlantis = await getEntry('spacecraft', 'atlantis');
 	const referencedEntry = await getEntry(entryWithReference.data.cat);
 
+	const spacecraft = await getCollection('spacecraft');
+
 	const entryWithImagePath = await getEntry('spacecraft', 'lunar-module');
 
 	const increment = await getEntry('increment', 'value');
@@ -50,7 +52,8 @@ export async function GET() {
 			yamlLoader,
 			tomlLoader,
 			nestedJsonLoader,
-			atlantis
+			atlantis,
+			spacecraft: spacecraft.map(({id}) => id).sort((a, b) => a.localeCompare(b)),
 		})
 	);
 }

--- a/packages/astro/test/fixtures/content-layer/src/pages/spacecraft/index.astro
+++ b/packages/astro/test/fixtures/content-layer/src/pages/spacecraft/index.astro
@@ -1,0 +1,17 @@
+---
+import { getCollection } from "astro:content";
+const collection = await getCollection("spacecraft");
+---
+<html>
+	<head>
+		<title>Spacecraft</title>
+	</head>
+	<body>
+		<h1>Spacecraft</h1>
+		<ul>
+			{collection.map((craft) => (
+				<li><a href={`/spacecraft/${craft.id}`}>{ craft.data?.title }</a></li>
+			))}
+		</ul>
+	</body>
+</html>


### PR DESCRIPTION
## Changes

While the glob loader handles deleting or renaming a file, it didn't previously handle the scenario where a slug was changed inside a file. This PR ensures that the old entry is deleted.

Fixes #12668

## Testing

Adds new test cases

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
