### PR TITLE
Fix component render in markdoc when `nodes.document.render` is `null`

### DIFF
--- a/.changeset/nasty-pandas-unite.md
+++ b/.changeset/nasty-pandas-unite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fixes rendering components when the `nodes.document.render` Markdoc config is set to `null`

--- a/packages/integrations/markdoc/components/TreeNode.ts
+++ b/packages/integrations/markdoc/components/TreeNode.ts
@@ -40,7 +40,11 @@ export type TreeNode =
 
 function renderTreeNodeToFactoryResult(result: SSRResult, treeNode: TreeNode) {
 	if (Array.isArray(treeNode)) {
-		return Promise.all(treeNode.map((node) => renderTreeNodeToFactoryResult(result, node)));
+		return Promise.all(
+			treeNode.map((node) =>
+				renderComponent(result, 'ComponentNode', ComponentNode, { treeNode: node }),
+			),
+		);
 	}
 
 	if (treeNode.type === 'text') return render`${treeNode.content}`;

--- a/packages/integrations/markdoc/test/fixtures/render-null/markdoc.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-null/markdoc.config.mjs
@@ -1,10 +1,15 @@
-import { defineMarkdocConfig, nodes } from '@astrojs/markdoc/config';
+import { defineMarkdocConfig, nodes, component } from '@astrojs/markdoc/config';
 
 export default defineMarkdocConfig({
 	nodes: {
 		document: {
 			...nodes.document,
 			render: null,
-		}
-	}
-})
+		},
+	},
+	tags: {
+		'div-wrapper': {
+			render: component('./src/components/DivWrapper.astro'),
+		},
+	},
+});

--- a/packages/integrations/markdoc/test/fixtures/render-null/src/components/DivWrapper.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-null/src/components/DivWrapper.astro
@@ -1,0 +1,1 @@
+<div class="div-wrapper"><slot /></div>

--- a/packages/integrations/markdoc/test/fixtures/render-null/src/content/blog/render-null.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/render-null/src/content/blog/render-null.mdoc
@@ -5,3 +5,9 @@ title: Post with render null
 ## Post with render null
 
 This should render the contents inside a fragment!
+
+{% div-wrapper %}
+
+I'm inside a div wrapper
+
+{% /div-wrapper %}

--- a/packages/integrations/markdoc/test/render.test.js
+++ b/packages/integrations/markdoc/test/render.test.js
@@ -137,6 +137,8 @@ function renderNullChecks(html) {
 	const h2 = document.querySelector('h2');
 	assert.equal(h2.textContent, 'Post with render null');
 	assert.equal(h2.parentElement?.tagName, 'BODY');
+	const divWrapper = document.querySelector('.div-wrapper');
+	assert.equal(divWrapper.textContent, "I'm inside a div wrapper");
 }
 
 /** @param {string} html */


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/12964

It seems like `renderTreeNodeToFactoryResult` shouldn't be calling itself, but it should re-create the `ComponentNode` entirely as it handles nested component rendering. Same as how the `const slots` are constructed below the updated code.

## Testing

Added a new test

## Docs

n/a. bug fix