### PR TITLE
feat: improve heading id slug format

### DIFF
--- a/.changeset/tiny-parrots-unite.md
+++ b/.changeset/tiny-parrots-unite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Makes generated heading ID slug values more kebab-case friendly

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -55,13 +55,11 @@ export function rehypeHeadingIds(): ReturnType<RehypePlugin> {
 				}
 			});
 
-			node.properties = node.properties || {};
+			node.properties ??= {};
 			if (typeof node.properties.id !== 'string') {
-				let slug = slugger.slug(text);
-
-				if (slug.endsWith('-')) slug = slug.slice(0, -1);
-
-				node.properties.id = slug;
+				const NBSP = /[\u00A0\u2007\u202F]/g;
+				const EXTRA_HYPHENS = /^-+|(?<=-)-+|-+$/g;
+				node.properties.id = slugger.slug(text.replace(NBSP, ' ')).replace(EXTRA_HYPHENS, '');
 			}
 
 			headings.push({ depth, slug: node.properties.id, text });

--- a/packages/markdown/remark/test/rehype-collect-headings.test.js
+++ b/packages/markdown/remark/test/rehype-collect-headings.test.js
@@ -1,0 +1,68 @@
+import { createMarkdownProcessor } from '../dist/index.js';
+
+import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+
+describe('rehypeHeadingIds()', () => {
+	let processor;
+
+	before(async () => {
+		processor = await createMarkdownProcessor();
+	});
+
+	describe('generated ID slug', () => {
+		it('treats non-breaking space as space', async () => {
+			/**
+			 * NO-BREAK SPACE `&nbsp;`, FIGURE SPACE `&numsp;`, NARROW NO-BREAK SPACE
+			 * */
+			const NON_BREAKING_SPACES = ['&#160;', '&#8199;', '&#8239;'];
+
+			const {
+				metadata: {
+					headings: [heading],
+				},
+			} = await processor.render(markdownHeading());
+
+			assert.equal(heading.slug, expectedSlug());
+
+			/**
+			 * Value function
+			 * @returns {string} markdown heading with defined `NON_BREAKING_SPACES` in text
+			 * */
+			function markdownHeading() {
+				return `## text${NON_BREAKING_SPACES.join('text')}text`;
+			}
+
+			/**
+			 * Value function
+			 * @returns {string} expected slug value of `markdownHeading()`
+			 * */
+			function expectedSlug() {
+				return `text-${NON_BREAKING_SPACES.map(() => 'text').join('-')}`;
+			}
+		});
+
+		it('is in kebab-case', async () => {
+			const EXPECTED_SLUG = 'lorem-ipsum-dolor-sit-amet';
+			const MARKDOWN_HEADING = '## 😄 😄 Lorem 😄 ipsum 😄 😄 😄 dolor ✓ sit &nbsp; amet 😄 😄';
+
+			const {
+				metadata: {
+					headings: [heading],
+				},
+			} = await processor.render(MARKDOWN_HEADING);
+
+			assert.equal(heading.slug, EXPECTED_SLUG);
+		});
+
+		it('has unique value within given set of headings', async () => {
+			const repeatedMarkdownHeadings = `${'## Lorem ipsum dolor sit amet\n\n'.repeat(3)}`;
+
+			const {
+				metadata: { headings },
+			} = await processor.render(repeatedMarkdownHeadings);
+
+			assert.equal(headings.length, new Set(headings.map(({ slug }) => slug)).size);
+		});
+	});
+});

--- a/packages/markdown/remark/test/rehype-collect-headings.test.js
+++ b/packages/markdown/remark/test/rehype-collect-headings.test.js
@@ -63,7 +63,10 @@ describe('rehypeHeadingIds()', () => {
 				metadata: { headings },
 			} = await processor.render(repeatedMarkdownHeadings);
 
-			assert.equal(headings.length, new Set(headings.map(({ slug }) => slug)).size);
+			const numberOfHeadings = headings.length;
+			const numberOfUniqueIdValues = new Set(headings.map(({ slug }) => slug)).size;
+
+			assert.equal(numberOfHeadings, numberOfUniqueIdValues);
 		});
 	});
 });

--- a/packages/markdown/remark/test/rehype-collect-headings.test.js
+++ b/packages/markdown/remark/test/rehype-collect-headings.test.js
@@ -1,7 +1,6 @@
-import { createMarkdownProcessor } from '../dist/index.js';
-
 import * as assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { createMarkdownProcessor } from '../dist/index.js';
 
 describe('rehypeHeadingIds()', () => {
 	let processor;
@@ -21,24 +20,26 @@ describe('rehypeHeadingIds()', () => {
 				metadata: {
 					headings: [heading],
 				},
-			} = await processor.render(markdownHeading());
+			} = await processor.render(markdownHeading(NON_BREAKING_SPACES));
 
-			assert.equal(heading.slug, expectedSlug());
+			assert.equal(heading.slug, expectedSlug(NON_BREAKING_SPACES));
 
 			/**
-			 * Value function
-			 * @returns {string} markdown heading with defined `NON_BREAKING_SPACES` in text
+			 * Helper function
+			 * @param {string[]} nbsp - list of non-breaking spaces
+			 * @returns {string} markdown heading with given `nbsp` list
 			 * */
-			function markdownHeading() {
-				return `## text${NON_BREAKING_SPACES.join('text')}text`;
+			function markdownHeading(nbsp = []) {
+				return `## text${nbsp.join('text')}text`;
 			}
 
 			/**
-			 * Value function
-			 * @returns {string} expected slug value of `markdownHeading()`
+			 * Helper function
+			 * @param {string[]} nbsp - list of non-breaking spaces
+			 * @returns {string} expected slug value of `markdownHeading()` with given `nbsp` list
 			 * */
-			function expectedSlug() {
-				return `text-${NON_BREAKING_SPACES.map(() => 'text').join('-')}`;
+			function expectedSlug(nbsp = []) {
+				return `text-${nbsp.map(() => 'text').join('-')}`;
 			}
 		});
 


### PR DESCRIPTION
## Changes

- Fixes #12970
- Makes slug value account for NBSP spaces as spaces
- Cleans up slugified ID value to be in kebab-case
- Potentially changes so far generated ID values, eg. from `-my---heading-text--` to `my-heading-text`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- Added unit tests on slug formatting. Hope they are up to par.
- Also tested manually.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs change needed.
