### PR TITLE
fix: load env earlier

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -14,6 +14,7 @@ import {
 } from '../content/index.js';
 import { createEnvLoader } from '../env/env-loader.js';
 import { astroEnv } from '../env/vite-plugin-env.js';
+import { importMetaEnv } from '../env/vite-plugin-import-meta-env.js';
 import astroInternationalization from '../i18n/vite-plugin-i18n.js';
 import astroPrefetch from '../prefetch/vite-plugin-prefetch.js';
 import astroDevToolbar from '../toolbar/vite-plugin-dev-toolbar.js';
@@ -23,7 +24,6 @@ import astroPostprocessVitePlugin from '../vite-plugin-astro-postprocess/index.j
 import { vitePluginAstroServer } from '../vite-plugin-astro-server/index.js';
 import astroVitePlugin from '../vite-plugin-astro/index.js';
 import configAliasVitePlugin from '../vite-plugin-config-alias/index.js';
-import envVitePlugin from '../vite-plugin-env/index.js';
 import vitePluginFileURL from '../vite-plugin-fileurl/index.js';
 import astroHeadPlugin from '../vite-plugin-head/index.js';
 import astroHmrReloadPlugin from '../vite-plugin-hmr-reload/index.js';
@@ -124,7 +124,7 @@ export async function createVite(
 	});
 
 	const srcDirPattern = glob.convertPathToPattern(fileURLToPath(settings.config.srcDir));
-	const envLoader = createEnvLoader();
+	const envLoader = createEnvLoader(mode, settings.config);
 
 	// Start with the Vite configuration that Astro core needs
 	const commonConfig: vite.InlineConfig = {
@@ -148,8 +148,8 @@ export async function createVite(
 			// The server plugin is for dev only and having it run during the build causes
 			// the build to run very slow as the filewatcher is triggered often.
 			command === 'dev' && vitePluginAstroServer({ settings, logger, fs, manifest, ssrManifest }), // ssrManifest is only required in dev mode, where it gets created before a Vite instance is created, and get passed to this function
-			envVitePlugin({ envLoader }),
-			astroEnv({ settings, mode, sync, envLoader }),
+			importMetaEnv({ envLoader }),
+			astroEnv({ settings, sync, envLoader }),
 			markdownVitePlugin({ settings, logger }),
 			htmlVitePlugin(),
 			astroPostprocessVitePlugin(),

--- a/packages/astro/src/env/README.md
+++ b/packages/astro/src/env/README.md
@@ -1,4 +1,8 @@
-# vite-plugin-env
+# env
+
+The content of this directory is for `astro:env` features, except for `vite-plugin-import-meta-env.ts`.
+
+# vite-plugin-import-meta-env
 
 Improves Vite's [Env Variables](https://vite.dev/guide/env-and-mode.html#env-files) support to include **private** env variables during Server-Side Rendering (SSR) but never in client-side rendering (CSR).
 

--- a/packages/astro/src/env/env-loader.ts
+++ b/packages/astro/src/env/env-loader.ts
@@ -43,17 +43,12 @@ function getPrivateEnv(
 	return privateEnv;
 }
 
-export const createEnvLoader = () => {
-	let privateEnv: Record<string, string> = {};
+export const createEnvLoader = (mode: string, config: AstroConfig) => {
+	const loaded = loadEnv(mode, config.vite.envDir ?? fileURLToPath(config.root), '');
+	const privateEnv = getPrivateEnv(loaded, config);
 	return {
-		load: (mode: string, config: AstroConfig) => {
-			const loaded = loadEnv(mode, config.vite.envDir ?? fileURLToPath(config.root), '');
-			privateEnv = getPrivateEnv(loaded, config);
-			return loaded;
-		},
-		getPrivateEnv: () => {
-			return privateEnv;
-		},
+		get: () => loaded,
+		getPrivateEnv: () => privateEnv,
 	};
 };
 

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -14,12 +14,11 @@ import { getEnvFieldType, validateEnvVariable } from './validators.js';
 
 interface AstroEnvPluginParams {
 	settings: AstroSettings;
-	mode: string;
 	sync: boolean;
 	envLoader: EnvLoader;
 }
 
-export function astroEnv({ settings, mode, sync, envLoader }: AstroEnvPluginParams): Plugin {
+export function astroEnv({ settings, sync, envLoader }: AstroEnvPluginParams): Plugin {
 	const { schema, validateSecrets } = settings.config.env;
 	let isDev: boolean;
 
@@ -32,7 +31,7 @@ export function astroEnv({ settings, mode, sync, envLoader }: AstroEnvPluginPara
 			isDev = command !== 'build';
 		},
 		buildStart() {
-			const loadedEnv = envLoader.load(mode, settings.config);
+			const loadedEnv = envLoader.get();
 
 			if (!isDev) {
 				for (const [key, value] of Object.entries(loadedEnv)) {

--- a/packages/astro/src/env/vite-plugin-import-meta-env.ts
+++ b/packages/astro/src/env/vite-plugin-import-meta-env.ts
@@ -1,7 +1,7 @@
 import { transform } from 'esbuild';
 import MagicString from 'magic-string';
 import type * as vite from 'vite';
-import type { EnvLoader } from '../env/env-loader.js';
+import type { EnvLoader } from './env-loader.js';
 
 interface EnvPluginOptions {
 	envLoader: EnvLoader;
@@ -65,7 +65,7 @@ async function replaceDefine(
 	};
 }
 
-export default function envVitePlugin({ envLoader }: EnvPluginOptions): vite.Plugin {
+export function importMetaEnv({ envLoader }: EnvPluginOptions): vite.Plugin {
 	let privateEnv: Record<string, string>;
 	let defaultDefines: Record<string, string>;
 	let isDev: boolean;

--- a/packages/astro/test/astro-sync.test.js
+++ b/packages/astro/test/astro-sync.test.js
@@ -209,10 +209,15 @@ describe('astro sync', () => {
 				assert.fail();
 			}
 		});
-		it('Does not throw if a virtual module is imported in content.config.ts', async () => {
+		it('Does not throw if a virtual module is imported in content.config.ts or import.meta.env is not loaded', async () => {
 			try {
 				await fixture.load('./fixtures/astro-env-content-collections/');
 				fixture.clean();
+				fs.writeFileSync(
+					new URL('./fixtures/astro-env-content-collections/.env', import.meta.url),
+					'BAR=abc',
+					'utf-8',
+				);
 				await fixture.whenSyncing();
 				assert.ok(true);
 			} catch {

--- a/packages/astro/test/fixtures/astro-env-content-collections/src/content.config.ts
+++ b/packages/astro/test/fixtures/astro-env-content-collections/src/content.config.ts
@@ -1,11 +1,14 @@
 import { defineCollection, z } from "astro:content";
 import { FOO } from "astro:env/client"
 
-console.log({ FOO })
+console.log({ FOO, BAR: import.meta.env.BAR })
 
 export const collections = {
     foo: defineCollection({
-        type: "data",
+        loader: () => [{
+            id: 'x',
+            title: import.meta.env.BAR
+        }],
         schema: z.object({
             title: z.string()
         })


### PR DESCRIPTION
## Changes

- Closes #12952, closes #12968
- Loads env earlier so content layer can access it
- Moves the vite plugin for `import.meta.env`

## Testing

Adds a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
