### PR TITLE
feat(routing): external redirects

### DIFF
--- a/.changeset/light-pants-smoke.md
+++ b/.changeset/light-pants-smoke.md
@@ -2,7 +2,7 @@
 'astro': minor
 ---
 
-Adds support for external redirects `astro.config.mjs`:
+Adds support for configured external redirects:
 
 ```js 
 // astro.config.mjs

--- a/.changeset/light-pants-smoke.md
+++ b/.changeset/light-pants-smoke.md
@@ -1,0 +1,20 @@
+---
+'astro': minor
+---
+
+Adds support for external redirects `astro.config.mjs`:
+
+```js 
+// astro.config.mjs
+import {defineConfig} from "astro/config"
+
+export default defineConfig({
+  redirects: {
+    "/blog": "https://example.com/blog",
+    "/news": {
+      status: 302,
+      destination: "https://example.com/news" 
+    }
+  }
+})
+```

--- a/.changeset/light-pants-smoke.md
+++ b/.changeset/light-pants-smoke.md
@@ -2,7 +2,9 @@
 'astro': minor
 ---
 
-Adds support for configured external redirects:
+Adds support for redirecting to external sites with the  [`redirects`](https://docs.astro.build/en/reference/configuration-reference/#redirects) configuration option.
+
+Now, you can redirect routes either internally to another path or externally by providing a URL beginning with `http` or `https`:
 
 ```js 
 // astro.config.mjs

--- a/.changeset/light-pants-smoke.md
+++ b/.changeset/light-pants-smoke.md
@@ -2,7 +2,7 @@
 'astro': minor
 ---
 
-Adds support for redirecting to external sites with the  [`redirects`](https://docs.astro.build/en/reference/configuration-reference/#redirects) configuration option.
+Adds support for redirecting to external sites with the [`redirects`](https://docs.astro.build/en/reference/configuration-reference/#redirects) configuration option.
 
 Now, you can redirect routes either internally to another path or externally by providing a URL beginning with `http` or `https`:
 

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1001,12 +1001,12 @@ export const RedirectWithNoLocation = {
  * @see
  * - [Astro.redirect](https://docs.astro.build/en/reference/api-reference/#redirect)
  * @description
- * An external redirect must start with http or https, and must be a valid URL
+ * An external redirect must start with http or https, and must be a valid URL.
  */
 export const UnsupportedExternalRedirect = {
 	name: 'UnsupportedExternalRedirect',
 	title: 'Unsupported or malformed URL.',
-	message: 'An external redirect must start with http or https, and must be a valid URL',
+	message: 'An external redirect must start with http or https, and must be a valid URL.',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -995,6 +995,20 @@ export const RedirectWithNoLocation = {
 	name: 'RedirectWithNoLocation',
 	title: 'A redirect must be given a location with the `Location` header.',
 } satisfies ErrorData;
+
+/**
+ * @docs
+ * @see
+ * - [Astro.redirect](https://docs.astro.build/en/reference/api-reference/#redirect)
+ * @description
+ * An external redirect must start with http or https, and must be a valid URL
+ */
+export const UnsupportedExternalRedirect = {
+	name: 'UnsupportedExternalRedirect',
+	title: 'Unsupported or malformed URL.',
+	message: 'An external redirect must start with http or https, and must be a valid URL',
+} satisfies ErrorData;
+
 /**
  * @docs
  * @see

--- a/packages/astro/src/core/redirects/render.ts
+++ b/packages/astro/src/core/redirects/render.ts
@@ -42,7 +42,6 @@ function redirectRouteGenerate(renderContext: RenderContext): string {
 		if (redirectIsExternal(redirect)) {
 			return redirect;
 		} else {
-			// TODO: this logic is duplicated between here and manifest/create.ts
 			let target = redirect;
 			for (const param of Object.keys(params)) {
 				const paramValue = params[param]!;

--- a/packages/astro/src/core/redirects/render.ts
+++ b/packages/astro/src/core/redirects/render.ts
@@ -3,9 +3,11 @@ import type { RenderContext } from '../render-context.js';
 
 export function redirectIsExternal(redirect: RedirectConfig): boolean {
 	if (typeof redirect === 'string') {
-		return redirect.startsWith('http') || redirect.startsWith('https');
+		return redirect.startsWith('http://') || redirect.startsWith('https://');
 	} else {
-		return redirect.destination.startsWith('http') || redirect.destination.startsWith('https');
+		return (
+			redirect.destination.startsWith('http://') || redirect.destination.startsWith('https://')
+		);
 	}
 }
 

--- a/packages/astro/src/core/redirects/render.ts
+++ b/packages/astro/src/core/redirects/render.ts
@@ -1,4 +1,13 @@
+import type { RedirectConfig } from '../../types/public/index.js';
 import type { RenderContext } from '../render-context.js';
+
+export function redirectIsExternal(redirect: RedirectConfig): boolean {
+	if (typeof redirect === 'string') {
+		return redirect.startsWith('http') || redirect.startsWith('https');
+	} else {
+		return redirect.destination.startsWith('http') || redirect.destination.startsWith('https');
+	}
+}
 
 export async function renderRedirect(renderContext: RenderContext) {
 	const {
@@ -9,6 +18,13 @@ export async function renderRedirect(renderContext: RenderContext) {
 	const status =
 		redirectRoute && typeof redirect === 'object' ? redirect.status : method === 'GET' ? 301 : 308;
 	const headers = { location: encodeURI(redirectRouteGenerate(renderContext)) };
+	if (redirect && redirectIsExternal(redirect)) {
+		if (typeof redirect === 'string') {
+			return Response.redirect(redirect, status);
+		} else {
+			return Response.redirect(redirect.destination, status);
+		}
+	}
 	return new Response(null, { status, headers });
 }
 
@@ -21,13 +37,17 @@ function redirectRouteGenerate(renderContext: RenderContext): string {
 	if (typeof redirectRoute !== 'undefined') {
 		return redirectRoute?.generate(params) || redirectRoute?.pathname || '/';
 	} else if (typeof redirect === 'string') {
-		// TODO: this logic is duplicated between here and manifest/create.ts
-		let target = redirect;
-		for (const param of Object.keys(params)) {
-			const paramValue = params[param]!;
-			target = target.replace(`[${param}]`, paramValue).replace(`[...${param}]`, paramValue);
+		if (redirectIsExternal(redirect)) {
+			return redirect;
+		} else {
+			// TODO: this logic is duplicated between here and manifest/create.ts
+			let target = redirect;
+			for (const param of Object.keys(params)) {
+				const paramValue = params[param]!;
+				target = target.replace(`[${param}]`, paramValue).replace(`[...${param}]`, paramValue);
+			}
+			return target;
 		}
-		return target;
 	} else if (typeof redirect === 'undefined') {
 		return '/';
 	}

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -317,7 +317,6 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Rou
 function createRedirectRoutes(
 	{ settings }: CreateRouteManifestParams,
 	routeMap: Map<string, RouteData>,
-	logger: Logger,
 ): RouteData[] {
 	const { config } = settings;
 	const trailingSlash = config.trailingSlash;
@@ -484,7 +483,7 @@ export async function createRouteManifest(
 		routeMap.set(route.route, route);
 	}
 
-	const redirectRoutes = createRedirectRoutes(params, routeMap, logger);
+	const redirectRoutes = createRedirectRoutes(params, routeMap);
 
 	// we remove the file based routes that were deemed redirects
 	const filteredFiledBasedRoutes = fileBasedRoutes.filter((fileBasedRoute) => {

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -264,16 +264,16 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 * and the value is the path to redirect to.
 	 *
 	 * You can redirect both static and dynamic routes, but only to the same kind of route.
-	 * For example you cannot have a `'/article': '/blog/[...slug]'` redirect.
+	 * For example, you cannot have a `'/article': '/blog/[...slug]'` redirect.
 	 *
 	 *
 	 * ```js
-	 * {
+	 * export default defineConfig({
 	 *   redirects: {
 	 *     '/old': '/new',
 	 *     '/blog/[...slug]': '/articles/[...slug]',
 	 *   }
-	 * }
+	 * })
 	 * ```
 	 *
 	 *
@@ -287,14 +287,28 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 * You can customize the [redirection status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) using an object in the redirect config:
 	 *
 	 * ```js
-	 * {
+	 * export default defineConfig({
 	 *   redirects: {
 	 *     '/other': {
 	 *       status: 302,
 	 *       destination: '/place',
 	 *     },
 	 *   }
-	 * }
+	 * })
+	 * ```
+	 *
+	 * Since **v5.2.0**, the property accepts external URLs:
+	 *
+	 * ```js
+	 * export default defineConfig({
+	 *   redirects: {
+	 *     '/blog': 'https://example.com/blog',
+	 *     '/news': {
+	 *        status: 302,
+	 *        destination: 'https://example.com/news'
+	 *     }
+	 *   }
+	 * })
 	 * ```
 	 */
 	redirects?: Record<string, RedirectConfig>;

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -270,9 +270,14 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 * ```js
 	 * export default defineConfig({
 	 *   redirects: {
-	 *     '/old': '/new',
-	 *     '/blog/[...slug]': '/articles/[...slug]',
-	 *   }
+	 *   	'/old': '/new',
+	 *    '/blog/[...slug]': '/articles/[...slug]',
+	 *    '/about': 'https://example.com/about',
+	 *    '/news': {
+	 *        status: 302,
+	 *        destination: 'https://example.com/news'
+	 *  	}
+	 * 	}
 	 * })
 	 * ```
 	 *
@@ -296,21 +301,6 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 *   }
 	 * })
 	 * ```
-	 *
-	 * Since **v5.2.0**, the property accepts external URLs:
-	 *
-	 * ```js
-	 * export default defineConfig({
-	 *   redirects: {
-	 *     '/blog': 'https://example.com/blog',
-	 *     '/news': {
-	 *        status: 302,
-	 *        destination: 'https://example.com/news'
-	 *     }
-	 *   }
-	 * })
-	 * ```
-	 */
 	redirects?: Record<string, RedirectConfig>;
 
 	/**

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -301,6 +301,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 *   }
 	 * })
 	 * ```
+	 */
 	redirects?: Record<string, RedirectConfig>;
 
 	/**

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -36,13 +36,12 @@ describe('Astro.redirect', () => {
 			assert.equal(response.headers.get('location'), '/login');
 		});
 
-		// ref: https://github.com/withastro/astro/pull/9287#discussion_r1420739810
-		it.skip('Ignores external redirect', async () => {
+		it('Allows external redirect', async () => {
 			const app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/external/redirect');
 			const response = await app.render(request);
-			assert.equal(response.status, 404);
-			assert.equal(response.headers.get('location'), null);
+			assert.equal(response.status, 301);
+			assert.equal(response.headers.get('location'), 'https://example.com/');
 		});
 
 		it('Warns when used inside a component', async () => {
@@ -131,6 +130,7 @@ describe('Astro.redirect', () => {
 						'/more/old/[dynamic]': '/more/[dynamic]',
 						'/more/old/[dynamic]/[route]': '/more/[dynamic]/[route]',
 						'/more/old/[...spread]': '/more/new/[...spread]',
+						'/external/redirect': 'https://example.com/',
 					},
 				});
 				await fixture.build();
@@ -207,6 +207,12 @@ describe('Astro.redirect', () => {
 				const html = await fixture.readFile('/more/old/welcome/world/index.html');
 				assert.equal(html.includes('http-equiv="refresh'), true);
 				assert.equal(html.includes('url=/more/new/welcome/world'), true);
+			});
+
+			it('supports redirecting to an external destination', async () => {
+				const html = await fixture.readFile('/external/redirect/index.html');
+				assert.equal(html.includes('http-equiv="refresh'), true);
+				assert.equal(html.includes('url=https://example.com/'), true);
 			});
 		});
 


### PR DESCRIPTION
## Changes

Closes PLT-2745

This PR adds support for external directs in the `redirects` configuration:
- Added a new error in case the user specify a URL that doesn't start with `http://` or `https://` or the URL isn't parsable
- No special handling for patterns. Astro can't know if the external an Astro site, so it's virtually impossible to handle route patterns e.g. `[...slug]`, `[slug]`
- No particular handling inside `underscore-redirects` (apart from tiny refactors)

## Testing

Added new tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/10704

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
