### PR TITLE
Remove `buildOutput` re-assign by adapters

### DIFF
--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -327,10 +327,6 @@ export async function runHookConfigDone({
 					setAdapter(adapter) {
 						validateSetAdapter(logger, settings, adapter, integration.name, command);
 
-						if (adapter.adapterFeatures?.buildOutput !== 'static') {
-							settings.buildOutput = 'server';
-						}
-
 						if (!adapter.supportedAstroFeatures) {
 							throw new Error(
 								`The adapter ${adapter.name} doesn't provide a feature map. It is required in Astro 4.0.`,


### PR DESCRIPTION
## Changes

IIUC `adapterFeatures.buildOutput` tells Astro that it supports static output or server output (server output usually also means it can support static output too).

If an adapter says that it supports server output, it shouldn't mutate `config.output` to be `"server"`. `config.output` is used to set if pages are all prerendered or on-demand by default. An adapter that supports server output doesn't need to change the user preference for how pages are rendered by default.

In practice this re-assignment is only internal where it can incorrectly return what the user has configured, but it shouldn't change any user-facing behaviour in practice. (If so it should be a bug in Astro elsewhere)

## Testing

Just testing CI

## Docs

n/a