### PR TITLE
fix: better handling of resync and restarts in content layer

### DIFF
--- a/.changeset/kind-horses-smile.md
+++ b/.changeset/kind-horses-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug in dev where files would stop being watched if the Astro config file was edited

--- a/.changeset/large-cherries-explain.md
+++ b/.changeset/large-cherries-explain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the content layer would use an outdated version of the Astro config if it was edited in dev

--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -142,7 +142,6 @@ export class ContentLayer {
 		return this.#queue.add(() => this.#doSync(options));
 	}
 
-
 	async #doSync(options: RefreshContentOptions) {
 		let contentConfig = globalContentConfigObserver.get();
 		const logger = this.#logger.forkIntegrationLogger('content');
@@ -185,6 +184,7 @@ export class ContentLayer {
 		} = this.#settings.config;
 
 		const astroConfigDigest = safeStringify(hashableConfig);
+		
 		const { digest: currentConfigDigest } = contentConfig.config;
 		this.#lastConfigDigest = currentConfigDigest;
 

--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -32,10 +32,6 @@ export interface ContentLayerOptions {
 	watcher?: FSWatcher;
 }
 
-export function getAstroConfigDigest(config: AstroConfig) {
-	const { vite, integrations, adapter, ...hashableConfig } = config;
-	return safeStringify(hashableConfig);
-}
 
 export class ContentLayer {
 	#logger: Logger;
@@ -146,9 +142,6 @@ export class ContentLayer {
 		return this.#queue.add(() => this.#doSync(options));
 	}
 
-	configMatches(config: AstroConfig) {
-		return getAstroConfigDigest(config) === getAstroConfigDigest(this.#settings.config);
-	}
 
 	async #doSync(options: RefreshContentOptions) {
 		let contentConfig = globalContentConfigObserver.get();
@@ -184,8 +177,14 @@ export class ContentLayer {
 		}
 
 		logger.info('Syncing content');
-		const astroConfigDigest = getAstroConfigDigest(this.#settings.config);
+		const {
+			vite: _vite,
+			integrations: _integrations,
+			adapter: _adapter,
+			...hashableConfig
+		} = this.#settings.config;
 
+		const astroConfigDigest = safeStringify(hashableConfig);
 		const { digest: currentConfigDigest } = contentConfig.config;
 		this.#lastConfigDigest = currentConfigDigest;
 

--- a/packages/astro/src/content/loaders/file.ts
+++ b/packages/astro/src/content/loaders/file.ts
@@ -101,6 +101,8 @@ export function file(fileName: string, options?: FileOptions): Loader {
 
 			await syncData(filePath, context);
 
+			watcher?.add(filePath);
+
 			watcher?.on('change', async (changedPath) => {
 				if (changedPath === filePath) {
 					logger.info(`Reloading data from ${fileName}`);

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -318,6 +318,8 @@ export function glob(globOptions: GlobOptions): Loader {
 				return;
 			}
 
+			watcher.add(filePath);
+
 			const matchesGlob = (entry: string) =>
 				!entry.startsWith('../') && micromatch.isMatch(entry, globOptions.pattern);
 

--- a/packages/astro/src/content/server-listeners.ts
+++ b/packages/astro/src/content/server-listeners.ts
@@ -25,14 +25,7 @@ export async function attachContentServerListeners({
 }: ContentServerListenerParams) {
 	const contentPaths = getContentPaths(settings.config, fs);
 	if (!settings.config.legacy?.collections) {
-		const contentGenerator = await createContentTypesGenerator({
-			fs,
-			settings,
-			logger,
-			viteServer,
-			contentConfigObserver: globalContentConfigObserver,
-		});
-		await contentGenerator.init();
+		await attachListeners();
 	} else if (fs.existsSync(contentPaths.contentDir)) {
 		logger.debug(
 			'content',
@@ -71,9 +64,9 @@ export async function attachContentServerListeners({
 		viteServer.watcher.on('addDir', (entry) =>
 			contentGenerator.queueEvent({ name: 'addDir', entry }),
 		);
-		viteServer.watcher.on('change', (entry) =>
-			contentGenerator.queueEvent({ name: 'change', entry }),
-		);
+		viteServer.watcher.on('change', (entry) => {
+			contentGenerator.queueEvent({ name: 'change', entry });
+		});
 		viteServer.watcher.on('unlink', (entry) => {
 			contentGenerator.queueEvent({ name: 'unlink', entry });
 		});

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -292,7 +292,14 @@ export async function createContentTypesGenerator({
 			entry: pathToFileURL(rawEvent.entry),
 			name: rawEvent.name,
 		};
-		if (!event.entry.pathname.startsWith(contentPaths.contentDir.pathname)) return;
+
+		if (settings.config.legacy.collections) {
+			if (!event.entry.pathname.startsWith(contentPaths.contentDir.pathname)) {
+				return;
+			}
+		} else if (contentPaths.config.url.pathname !== event.entry.pathname) {
+			return;
+		}
 
 		events.push(event);
 

--- a/packages/astro/src/content/watcher.ts
+++ b/packages/astro/src/content/watcher.ts
@@ -1,0 +1,62 @@
+import type { FSWatcher } from 'vite';
+
+type WatchEventName = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
+type WatchEventCallback = (path: string) => void;
+
+export type WrappedWatcher = FSWatcher & {
+	removeAllTrackedListeners(): void;
+};
+
+// This lets us use the standard Vite FSWatcher, but also track all listeners added by the content loaders
+// We do this so we can remove them all when we re-sync.
+export function createWatcherWrapper(watcher: FSWatcher): WrappedWatcher {
+	const listeners = new Map<WatchEventName, Set<WatchEventCallback>>();
+
+	const handler: ProxyHandler<FSWatcher> = {
+		get(target, prop, receiver) {
+			// Intercept the 'on' method and track the listener
+			if (prop === 'on') {
+				return function (event: WatchEventName, callback: WatchEventCallback) {
+					if (!listeners.has(event)) {
+						listeners.set(event, new Set());
+					}
+
+					// Track the listener
+					listeners.get(event)!.add(callback);
+
+					// Call the original method
+					return Reflect.get(target, prop, receiver).call(target, event, callback);
+				};
+			}
+
+			// Intercept the 'off' method
+			if (prop === 'off') {
+				return function (event: WatchEventName, callback: WatchEventCallback) {
+					// Remove from our tracking
+					listeners.get(event)?.delete(callback);
+
+					// Call the original method
+					return Reflect.get(target, prop, receiver).call(target, event, callback);
+				};
+			}
+
+			// Adds a function to remove all listeners added by us
+			if (prop === 'removeAllTrackedListeners') {
+				return function () {
+					for (const [event, callbacks] of listeners.entries()) {
+						for (const callback of callbacks) {
+							target.off(event, callback);
+						}
+						callbacks.clear();
+					}
+					listeners.clear();
+				};
+			}
+
+			// Return original method/property for everything else
+			return Reflect.get(target, prop, receiver);
+		},
+	};
+
+	return new Proxy(watcher, handler) as WrappedWatcher;
+}

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -108,21 +108,22 @@ export async function createContainer({
 			ssrManifest: devSSRManifest,
 		},
 	);
+	const viteServer = await vite.createServer(viteConfig);
 
 	await syncInternal({
 		settings,
 		mode,
 		logger,
 		skip: {
-			content: true,
+			content: !isRestart,
 			cleanup: true,
 		},
 		force: inlineConfig?.force,
 		manifest,
 		command: 'dev',
+		watcher: viteServer.watcher,
 	});
 
-	const viteServer = await vite.createServer(viteConfig);
 
 	const container: Container = {
 		inlineConfig: inlineConfig ?? {},

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -13,6 +13,7 @@ import { createSafeError } from '../errors/index.js';
 import { formatErrorMessage } from '../messages.js';
 import type { Container } from './container.js';
 import { createContainer, startContainer } from './container.js';
+import { attachContentServerListeners } from '../../content/server-listeners.js';
 
 async function createRestartedContainer(
 	container: Container,
@@ -147,6 +148,8 @@ export async function createContainerWithAutomaticRestart({
 			// Restart success. Add new watches because this is a new container with a new Vite server
 			restart.container = result;
 			setupContainer();
+			await attachContentServerListeners(restart.container);
+
 			if (server) {
 				// Vite expects the resolved URLs to be available
 				server.resolvedUrls = result.viteServer.resolvedUrls;

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { promises as fs, existsSync } from 'node:fs';
+import { setTimeout } from "node:timers/promises"
 import { sep } from 'node:path';
 import { sep as posixSep } from 'node:path/posix';
 import { Writable } from 'node:stream';
@@ -323,7 +324,7 @@ describe('Content Layer', () => {
 			devServer = await fixture.startDevServer({
 				force: true,
 				logger: new Logger({
-					level: 'warn',
+					level: 'info',
 					dest: new Writable({
 						objectMode: true,
 						write(event, _, callback) {
@@ -467,6 +468,8 @@ describe('Content Layer', () => {
 			await fixture.resetAllFiles();
 		});
 
+		
+
 		it('removes old entry when slug is changed', async () => {
 			const rawJsonResponse = await fixture.fetch('/collections.json');
 			const initialJson = devalue.parse(await rawJsonResponse.text());
@@ -524,5 +527,34 @@ describe('Content Layer', () => {
 				await fs.rename(newPath, oldPath);
 			}
 		});
+
+		it('still updates collection when data file is changed after server has restarted via config change', async () => {
+			await fixture.editFile('astro.config.mjs', (prev) => prev.replace("'Astro content layer'", "'Astro content layer edited'"))
+			logs.length = 0;
+
+			// Give time for the server to restart
+			await setTimeout(5000);
+
+			const rawJsonResponse = await fixture.fetch('/collections.json');
+			const initialJson = devalue.parse(await rawJsonResponse.text());
+			assert.equal(initialJson.jsonLoader[0].data.temperament.includes('Bouncy'), false);
+
+			await fixture.editFile('/src/data/dogs.json', (prev) => {
+				const data = JSON.parse(prev);
+				data[0].temperament.push('Bouncy');
+				return JSON.stringify(data, null, 2);
+			});
+			
+			await fixture.onNextDataStoreChange();
+			const updatedJsonResponse = await fixture.fetch('/collections.json');
+			const updated = devalue.parse(await updatedJsonResponse.text());
+			assert.ok(updated.jsonLoader[0].data.temperament.includes('Bouncy'));
+			logs.length = 0
+
+			await fixture.resetAllFiles();
+			// Give time for the server to restart again
+			await setTimeout(5000);
+		});
+
 	});
 });

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { promises as fs, existsSync } from 'node:fs';
-import { setTimeout } from "node:timers/promises"
+import { setTimeout } from 'node:timers/promises';
 import { sep } from 'node:path';
 import { sep as posixSep } from 'node:path/posix';
 import { Writable } from 'node:stream';
@@ -468,8 +468,6 @@ describe('Content Layer', () => {
 			await fixture.resetAllFiles();
 		});
 
-		
-
 		it('removes old entry when slug is changed', async () => {
 			const rawJsonResponse = await fixture.fetch('/collections.json');
 			const initialJson = devalue.parse(await rawJsonResponse.text());
@@ -529,7 +527,9 @@ describe('Content Layer', () => {
 		});
 
 		it('still updates collection when data file is changed after server has restarted via config change', async () => {
-			await fixture.editFile('astro.config.mjs', (prev) => prev.replace("'Astro content layer'", "'Astro content layer edited'"))
+			await fixture.editFile('astro.config.mjs', (prev) =>
+				prev.replace("'Astro content layer'", "'Astro content layer edited'"),
+			);
 			logs.length = 0;
 
 			// Give time for the server to restart
@@ -544,17 +544,16 @@ describe('Content Layer', () => {
 				data[0].temperament.push('Bouncy');
 				return JSON.stringify(data, null, 2);
 			});
-			
+
 			await fixture.onNextDataStoreChange();
 			const updatedJsonResponse = await fixture.fetch('/collections.json');
 			const updated = devalue.parse(await updatedJsonResponse.text());
 			assert.ok(updated.jsonLoader[0].data.temperament.includes('Bouncy'));
-			logs.length = 0
+			logs.length = 0;
 
 			await fixture.resetAllFiles();
 			// Give time for the server to restart again
 			await setTimeout(5000);
 		});
-
 	});
 });

--- a/packages/markdown/remark/src/import-plugin-default.ts
+++ b/packages/markdown/remark/src/import-plugin-default.ts
@@ -10,13 +10,13 @@ let cwdUrlStr: string | undefined;
 export async function importPlugin(p: string): Promise<unified.Plugin> {
 	// Try import from this package first
 	try {
-		const importResult = await import(p);
+		const importResult = await import(/* @vite-ignore */ p);
 		return importResult.default;
 	} catch {}
 
 	// Try import from user project
 	cwdUrlStr ??= pathToFileURL(path.join(process.cwd(), 'package.json')).toString();
 	const resolved = importMetaResolve(p, cwdUrlStr);
-	const importResult = await import(resolved);
+	const importResult = await import(/* @vite-ignore */ resolved);
 	return importResult.default;
 }


### PR DESCRIPTION
## Changes

This PR makes a number of changes to the way that file watchers work in dev with the content layer. There have been a few bugs related to the way that dev server restarts are handled, which were due to the way we were handling file watchers.

When the Astro config is edited, it restarts the dev container to ensure the site is using the latest config. This was causing several bugs: 
- when the server was restarted, it wasn't re-running the Astro sync. This meant that updates in the config were not reflected in the rendered config, for example changes to Markdown config wouldn't update the rendered content.
- the existing watcher was destroyed, but because the loaders weren't being re-run, the glob and file event listeners weren't being attached to the new watcher.

This PR correctly passes in the watcher, but has to handle various implications of this: 

- it needs to ensure that the content layer is recreated when the server is restarted, otherwise it will use the old config even when it syncs the content. This fixes #12700 
- it needs to detach the event listeners that the previous loader run added. We can't clear them all, because this is a shared watcher instance. To handle this, we now wrap the watcher with a Proxy that keeps track of which listeners were attached by the content layer, so they can be removed if the content layer is refreshed or disposed of. Fixes #12976
- it needs to ensure that the files themselves are still being watched, so it now manually adds them to the watcher rather than relying on them still being watched

## Testing

Added new test cases

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
