### PR TITLE
Prevent rerunning scripts already ran in router

### DIFF
--- a/.changeset/forty-houses-taste.md
+++ b/.changeset/forty-houses-taste.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent re-executing scripts in client router

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/eight.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/eight.astro
@@ -1,0 +1,16 @@
+---
+import Layout from '../components/Layout.astro';
+import { ClientRouter } from 'astro:transitions';
+
+Astro.response.headers.set('Content-Type', 'text/html ; charset=utf-8');
+---
+<html>
+	<head>
+		<ClientRouter handleForms />
+	</head>
+	<body>
+		<p id="eight">Page 8</p>
+
+		<a id="click-one" href="/one">go to 1</a>
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -7,6 +7,7 @@ import Layout from '../components/Layout.astro';
 	<a id="click-two" href="/two">go to 2</a>
 	<a id="click-three" href="/three">go to 3</a>
 	<a id="click-seven" href="/seven">go to 7</a>
+	<a id="click-eight" href="/eight">go to 8</a>
 	<a id="click-longpage" href="/long-page">go to long page</a>
 	<a id="click-self" href="">go to top</a>
 	<a id="click-redirect-two" href="/redirect-two">go to redirect 2</a>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/page1-with-scripts.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/page1-with-scripts.astro
@@ -1,0 +1,15 @@
+---
+import {ClientRouter} from "astro:transitions";
+---
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<ClientRouter />
+		<title>Page 1</title>
+		<script is:inline data-astro-rerun>console.log('[test] 3');</script>
+		<script is:inline>console.log('[test] 1');</script>
+	</head>
+	<body>
+		<a id="link" href="/page2-with-scripts">to page 2</a>
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/page2-with-scripts.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/page2-with-scripts.astro
@@ -1,0 +1,15 @@
+---
+import {ClientRouter} from "astro:transitions";
+---
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<ClientRouter />
+		<title>Page 2</title>
+		<script is:inline data-astro-rerun>console.log('[test] 2');</script>
+		<script is:inline>console.log('[test] 1');</script>
+	</head>
+	<body>
+		<a id="link" href="/page3-with-scripts">to page 3</a>
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/page3-with-scripts.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/page3-with-scripts.astro
@@ -1,0 +1,16 @@
+---
+import {ClientRouter} from "astro:transitions";
+---
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<ClientRouter />
+		<title>Page 3</title>
+		<script is:inline>console.log('[test] 1');</script>
+		<script is:inline data-astro-rerun>console.log('[test] 2');</script>
+		<script is:inline data-astro-rerun>console.log('[test] 3');</script>
+	</head>
+	<body>
+		<a id="link" href="/page1-with-scripts">to page 1</a>
+	</body>
+</html>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1604,7 +1604,7 @@ test.describe('View Transitions', () => {
 		expect(lines.join('\n')).toBe(expected);
 	});
 
-	test.skip('astro-data-rerun reruns known scripts', async ({ page, astro }) => {
+	test('astro-data-rerun reruns known scripts', async ({ page, astro }) => {
 		let lines = [];
 		page.on('console', (msg) => {
 			msg.text().startsWith('[test]') && lines.push(msg.text().slice('[test]'.length + 1));

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -660,18 +660,12 @@ test.describe('View Transitions', () => {
 		p = page.locator('#one');
 		await expect(p, 'should have content').toHaveText('Page 1');
 
-		// Go to page 3
-		await page.click('#click-three');
-		const article3 = page.locator('#three');
-		await expect(article3, 'should have content').toHaveText('Page 3');
-
-		// Go to page 5
-		await page.click('#click-five');
-		const article5 = page.locator('#five');
-		await expect(article5, 'should have content').toHaveText('Page 5');
+		// Go to page 8
+		await page.click('#click-eight');
+		const article8 = page.locator('#eight');
+		await expect(article8, 'should have content').toHaveText('Page 8');
 
 		// Go back to page 1
-		await page.goBack();
 		await page.goBack();
 		p = page.locator('#one');
 		await expect(p, 'should have content').toHaveText('Page 1');

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -647,13 +647,34 @@ test.describe('View Transitions', () => {
 	test('Scripts are only executed once', async ({ page, astro }) => {
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));
-		const p = page.locator('#one');
+		let p = page.locator('#one');
 		await expect(p, 'should have content').toHaveText('Page 1');
 
 		// go to page 2
 		await page.click('#click-two');
 		const article = page.locator('#twoarticle');
 		await expect(article, 'should have script content').toHaveText('works');
+
+		// Go back to page 1
+		await page.goBack();
+		p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// Go to page 3
+		await page.click('#click-three');
+		const article3 = page.locator('#three');
+		await expect(article3, 'should have content').toHaveText('Page 3');
+
+		// Go to page 5
+		await page.click('#click-five');
+		const article5 = page.locator('#five');
+		await expect(article5, 'should have content').toHaveText('Page 5');
+
+		// Go back to page 1
+		await page.goBack();
+		await page.goBack();
+		p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
 
 		const meta = page.locator('[name="script-executions"]');
 		await expect(meta).toHaveAttribute('content', '0');

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1603,4 +1603,20 @@ test.describe('View Transitions', () => {
 		await page.click('#click-two');
 		expect(lines.join('\n')).toBe(expected);
 	});
+
+	test.skip('astro-data-rerun reruns known scripts', async ({ page, astro }) => {
+		let lines = [];
+		page.on('console', (msg) => {
+			msg.text().startsWith('[test]') && lines.push(msg.text().slice('[test]'.length + 1));
+		});
+		await page.goto(astro.resolveUrl('/page1-with-scripts'));
+		await expect(page).toHaveTitle('Page 1');
+		await page.click('#link');
+		await expect(page).toHaveTitle('Page 2');
+		await page.click('#link');
+		await expect(page).toHaveTitle('Page 3');
+		await page.click('#link');
+		await expect(page).toHaveTitle('Page 1');
+		expect(lines.join("")).toBe('312233');
+	});
 });

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -139,6 +139,7 @@ function runScripts() {
 		if (script.dataset.astroExec === '') continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
+		if (detectScriptExecuted(script)) continue;
 		const newScript = document.createElement('script');
 		newScript.innerHTML = script.innerHTML;
 		for (const attr of script.attributes) {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -132,9 +132,13 @@ export function getFallback(): Fallback {
 	return 'animate';
 }
 
+const scriptsAlreadyRan = new Set<string>();
 function runScripts() {
 	let wait = Promise.resolve();
 	for (const script of document.getElementsByTagName('script')) {
+		const key = script.src || script.textContent!;
+		if (scriptsAlreadyRan.has(key)) continue;
+		scriptsAlreadyRan.add(key);
 		if (script.dataset.astroExec === '') continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
@@ -149,7 +153,6 @@ function runScripts() {
 			}
 			newScript.setAttribute(attr.name, attr.value);
 		}
-		newScript.dataset.astroExec = '';
 		script.replaceWith(newScript);
 	}
 	return wait;

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -1,6 +1,7 @@
 import type { TransitionBeforePreparationEvent } from './events.js';
 import { TRANSITION_AFTER_SWAP, doPreparation, doSwap } from './events.js';
 import type { Direction, Fallback, Options } from './types.js';
+import { detectScriptExecuted } from './swap-functions.js';
 
 type State = {
 	index: number;

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -142,9 +142,9 @@ const detectScriptExecuted = (script: HTMLScriptElement) => {
 function runScripts() {
 	let wait = Promise.resolve();
 	for (const script of document.getElementsByTagName('script')) {
-		if (detectScriptExecuted(script)) continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
+		if (detectScriptExecuted(script)) continue;
 		const newScript = document.createElement('script');
 		newScript.innerHTML = script.innerHTML;
 		for (const attr of script.attributes) {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -136,7 +136,7 @@ const scriptsAlreadyRan = new Set<string>();
 function runScripts() {
 	let wait = Promise.resolve();
 	for (const script of document.getElementsByTagName('script')) {
-		const key = script.src || script.textContent!;
+		const key = script.src ? new URL(script.src, location.href).href : script.textContent!;
 		if (scriptsAlreadyRan.has(key)) continue;
 		scriptsAlreadyRan.add(key);
 		if (script.dataset.astroExec === '') continue;

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -132,19 +132,12 @@ export function getFallback(): Fallback {
 	return 'animate';
 }
 
-const scriptsAlreadyRan = new Set<string>();
-const detectScriptExecuted = (script: HTMLScriptElement) => {
-	const key = script.src ? new URL(script.src, location.href).href : script.textContent!;
-	if (scriptsAlreadyRan.has(key)) return true;
-	scriptsAlreadyRan.add(key);
-	return false;
-};
 function runScripts() {
 	let wait = Promise.resolve();
 	for (const script of document.getElementsByTagName('script')) {
+		if (script.dataset.astroExec === '') continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
-		if (detectScriptExecuted(script)) continue;
 		const newScript = document.createElement('script');
 		newScript.innerHTML = script.innerHTML;
 		for (const attr of script.attributes) {
@@ -156,6 +149,7 @@ function runScripts() {
 			}
 			newScript.setAttribute(attr.name, attr.value);
 		}
+		newScript.dataset.astroExec = '';
 		script.replaceWith(newScript);
 	}
 	return wait;

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -139,7 +139,6 @@ function runScripts() {
 		if (script.dataset.astroExec === '') continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
-		if (detectScriptExecuted(script)) continue;
 		const newScript = document.createElement('script');
 		newScript.innerHTML = script.innerHTML;
 		for (const attr of script.attributes) {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -133,13 +133,16 @@ export function getFallback(): Fallback {
 }
 
 const scriptsAlreadyRan = new Set<string>();
+const detectScriptExecuted = (script: HTMLScriptElement) => {
+	const key = script.src ? new URL(script.src, location.href).href : script.textContent!;
+	if (scriptsAlreadyRan.has(key)) return true;
+	scriptsAlreadyRan.add(key);
+	return false;
+};
 function runScripts() {
 	let wait = Promise.resolve();
 	for (const script of document.getElementsByTagName('script')) {
-		const key = script.src ? new URL(script.src, location.href).href : script.textContent!;
-		if (scriptsAlreadyRan.has(key)) continue;
-		scriptsAlreadyRan.add(key);
-		if (script.dataset.astroExec === '') continue;
+		if (detectScriptExecuted(script)) continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
 		const newScript = document.createElement('script');
@@ -647,7 +650,7 @@ if (inBrowser) {
 		}
 	}
 	for (const script of document.getElementsByTagName('script')) {
-		script.dataset.astroExec = '';
+		detectScriptExecuted(script);
 	}
 }
 

--- a/packages/astro/src/transitions/swap-functions.ts
+++ b/packages/astro/src/transitions/swap-functions.ts
@@ -28,7 +28,6 @@ export function deselectScripts(doc: Document) {
 			// the old script is in the new document and doesn't have the rerun attribute
 			// we mark it as executed to prevent re-execution
 			s2.dataset.astroExec = '';
-			break;
 		}
 	}
 }

--- a/packages/astro/src/transitions/swap-functions.ts
+++ b/packages/astro/src/transitions/swap-functions.ts
@@ -7,12 +7,12 @@ export type SavedFocus = {
 const PERSIST_ATTR = 'data-astro-transition-persist';
 
 const scriptsAlreadyRan = new Set<string>();
-const detectScriptExecuted = (script: HTMLScriptElement) => {
+export function detectScriptExecuted(script: HTMLScriptElement) {
 	const key = script.src ? new URL(script.src, location.href).href : script.textContent!;
 	if (scriptsAlreadyRan.has(key)) return true;
 	scriptsAlreadyRan.add(key);
 	return false;
-};
+}
 
 /*
  * 	Mark new scripts that should not execute

--- a/packages/astro/src/transitions/swap-functions.ts
+++ b/packages/astro/src/transitions/swap-functions.ts
@@ -6,6 +6,14 @@ export type SavedFocus = {
 
 const PERSIST_ATTR = 'data-astro-transition-persist';
 
+const scriptsAlreadyRan = new Set<string>();
+const detectScriptExecuted = (script: HTMLScriptElement) => {
+	const key = script.src ? new URL(script.src, location.href).href : script.textContent!;
+	if (scriptsAlreadyRan.has(key)) return true;
+	scriptsAlreadyRan.add(key);
+	return false;
+};
+
 /*
  * 	Mark new scripts that should not execute
  */
@@ -15,6 +23,8 @@ export function deselectScripts(doc: Document) {
 			if (
 				// Check if the script should be rerun regardless of it being the same
 				!s2.hasAttribute('data-astro-rerun') &&
+				// Check if the script has already been executed
+				detectScriptExecuted(s2) &&
 				// Inline
 				((!s1.src && s1.textContent === s2.textContent) ||
 					// External

--- a/packages/astro/src/transitions/swap-functions.ts
+++ b/packages/astro/src/transitions/swap-functions.ts
@@ -18,23 +18,17 @@ export function detectScriptExecuted(script: HTMLScriptElement) {
  * 	Mark new scripts that should not execute
  */
 export function deselectScripts(doc: Document) {
-	for (const s1 of document.scripts) {
-		for (const s2 of doc.scripts) {
-			if (
-				// Check if the script should be rerun regardless of it being the same
-				!s2.hasAttribute('data-astro-rerun') &&
-				// Check if the script has already been executed
-				detectScriptExecuted(s2) &&
-				// Inline
-				((!s1.src && s1.textContent === s2.textContent) ||
-					// External
-					(s1.src && s1.type === s2.type && s1.src === s2.src))
-			) {
-				// the old script is in the new document and doesn't have the rerun attribute
-				// we mark it as executed to prevent re-execution
-				s2.dataset.astroExec = '';
-				break;
-			}
+	for (const s2 of doc.scripts) {
+		if (
+			// Check if the script should be rerun regardless of it being the same
+			!s2.hasAttribute('data-astro-rerun') &&
+			// Check if the script has already been executed
+			detectScriptExecuted(s2)
+		) {
+			// the old script is in the new document and doesn't have the rerun attribute
+			// we mark it as executed to prevent re-execution
+			s2.dataset.astroExec = '';
+			break;
 		}
 	}
 }


### PR DESCRIPTION
## Changes

- In a long session you might navigate between several pages, some contain the script and some not, but nevertheless the script should run a total of 1 time.
- This also helps with smaller bundled scripts in production, where some are inlined.
- Keeps track of scripts that have run, either by the src or by the inner text (for inline scripts) and uses that as a key, rather than the data attribute we previously adde.

## Testing

- Updated the existing tests to navigate between more pages.

## Docs

N/A, bug fix.