### PR TITLE
fix: actions codegen types

### DIFF
--- a/.changeset/real-hairs-scream.md
+++ b/.changeset/real-hairs-scream.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a case where `astro:actions` would not work when using `src/actions.ts`
+Fixes a case where `astro:actions` types would not work when using `src/actions.ts`

--- a/.changeset/real-hairs-scream.md
+++ b/.changeset/real-hairs-scream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where `astro:actions` would not work when using `src/actions.ts`

--- a/packages/astro/src/actions/integration.ts
+++ b/packages/astro/src/actions/integration.ts
@@ -38,7 +38,7 @@ export default function astroIntegrationActionsRouteHandler({
 				}
 
 				const stringifiedActionsImport = JSON.stringify(
-					viteID(new URL('./actions/index.ts', params.config.srcDir)),
+					viteID(new URL('./actions', params.config.srcDir)),
 				);
 				settings.injectedTypes.push({
 					filename: ACTIONS_TYPES_FILE,


### PR DESCRIPTION
## Changes

- Currently, we resolve the actions config to `${srcDir}/actions`. That means `src/actions.ts` is valid, just like `src/actions/index.ts`. However, typegen was harcoding `${srcDir}/actions/index.ts`. This PR updates the types to let TS figure out what file to resolve

## Testing

Should still pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
