### PR TITLE
Remove react integration ssr.external config

### DIFF
--- a/.changeset/many-pianos-develop.md
+++ b/.changeset/many-pianos-develop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Removes hardcoded `ssr.external: ['react-dom/server', 'react-dom/client']` config that causes issues with adapters that bundle all dependencies (e.g. Cloudflare). These externals should already be inferred by default by Vite when deploying to a server environment.

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -59,7 +59,6 @@ function getViteConfiguration(
 		},
 		plugins: [react({ include, exclude, babel }), optionsPlugin(!!experimentalReactChildren)],
 		ssr: {
-			external: reactConfig.externals,
 			noExternal: [
 				// These are all needed to get mui to work.
 				'@mui/material',

--- a/packages/integrations/react/src/version.ts
+++ b/packages/integrations/react/src/version.ts
@@ -19,16 +19,13 @@ export const versionsConfig = {
 	17: {
 		server: '@astrojs/react/server-v17.js',
 		client: '@astrojs/react/client-v17.js',
-		externals: ['react-dom/server.js', 'react-dom/client.js'],
 	},
 	18: {
 		server: '@astrojs/react/server.js',
 		client: '@astrojs/react/client.js',
-		externals: ['react-dom/server', 'react-dom/client'],
 	},
 	19: {
 		server: '@astrojs/react/server.js',
 		client: '@astrojs/react/client.js',
-		externals: ['react-dom/server', 'react-dom/client'],
 	},
 };


### PR DESCRIPTION
## Changes

Helps with #12824 (not complete fix yet, needs to check cloudflare adapter support)

Removes the `ssr.external` config as it's forcing them to be externalized even in builds for cloudflare where all dependencies should be bundled by default. (This is a similar change to https://github.com/withastro/astro/pull/10601)

## Testing

Existing tests should pass.

## Docs

n/a. bug fix.