### PR TITLE
chore: first implementation for serialized config

### DIFF
--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -189,6 +189,18 @@ declare module 'astro:middleware' {
 	export * from 'astro/virtual-modules/middleware.js';
 }
 
+declare module 'astro:manifest/server' {
+	type ServerConfigSerialized = import('./dist/types/public/manifest.js').ServerConfigSerialized;
+	const manifest: ServerConfigSerialized;
+	export default manifest;
+}
+
+declare module 'astro:manifest/client' {
+	type ClientConfigSerialized = import('./dist/types/public/manifest.js').ClientConfigSerialized;
+	const manifest: ClientConfigSerialized;
+	export default manifest;
+}
+
 declare module 'astro:components' {
 	export * from 'astro/components';
 }

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -97,6 +97,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 		contentIntellisense: false,
 		responsiveImages: false,
 		svg: false,
+		serializeManifest: false,
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -589,6 +590,10 @@ export const AstroConfigSchema = z.object({
 					}
 					return svgConfig;
 				}),
+			serializeManifest: z
+				.boolean()
+				.optional()
+				.default(ASTRO_CONFIG_DEFAULTS.experimental.serializeManifest),
 		})
 		.strict(
 			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/experimental-flags/ for a list of all current experiments.`,

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -16,6 +16,7 @@ import { createEnvLoader } from '../env/env-loader.js';
 import { astroEnv } from '../env/vite-plugin-env.js';
 import { importMetaEnv } from '../env/vite-plugin-import-meta-env.js';
 import astroInternationalization from '../i18n/vite-plugin-i18n.js';
+import astroVirtualManifestPlugin from '../manifest/virtual-module.js';
 import astroPrefetch from '../prefetch/vite-plugin-prefetch.js';
 import astroDevToolbar from '../toolbar/vite-plugin-dev-toolbar.js';
 import astroTransitions from '../transitions/vite-plugin-transitions.js';
@@ -141,6 +142,7 @@ export async function createVite(
 			exclude: ['astro', 'node-fetch'],
 		},
 		plugins: [
+			astroVirtualManifestPlugin({ settings, logger }),
 			configAliasVitePlugin({ settings }),
 			astroLoadFallbackPlugin({ fs, root: settings.config.root }),
 			astroVitePlugin({ settings, logger }),

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1794,18 +1794,6 @@ export const CantUseManifestModule = {
 		`Cannot import the module "${moduleName}" because the experimental feature is disabled. Enable \`experimental.serializeManifest\` in your \`astro.config.mjs\` `,
 } satisfies ErrorData;
 
-/**
- * @docs
- * @description
- * Cannot the module without enabling the experimental feature
- */
-export const ForbiddenManifestModule = {
-	name: 'ForbiddenManifestModule',
-	title: 'Forbidden use of module on the client side.',
-	message:
-		'The module `astro:manifest/server` cannot be used for client side scripts. Use `astro:manifest/client` instead.',
-} satisfies ErrorData;
-
 // Generic catch-all - Only use this in extreme cases, like if there was a cosmic ray bit flip.
 export const UnknownError = { name: 'UnknownError', title: 'Unknown Error.' } satisfies ErrorData;
 

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1782,6 +1782,30 @@ export const ActionCalledFromServerError = {
 	hint: 'See the `Astro.callAction()` reference for usage examples: https://docs.astro.build/en/reference/api-reference/#callaction',
 } satisfies ErrorData;
 
+/**
+ * @docs
+ * @description
+ * Cannot the module without enabling the experimental feature
+ */
+export const CantUseManifestModule = {
+	name: 'CantUseManifestModule',
+	title: 'Cannot the module without enabling the experimental feature.',
+	message: (moduleName) =>
+		`Cannot import the module "${moduleName}" because the experimental feature is disabled. Enable \`experimental.serializeManifest\` in your \`astro.config.mjs\` `,
+} satisfies ErrorData;
+
+/**
+ * @docs
+ * @description
+ * Cannot the module without enabling the experimental feature
+ */
+export const ForbiddenManifestModule = {
+	name: 'ForbiddenManifestModule',
+	title: 'Forbidden use of module on the client side.',
+	message:
+		'The module `astro:manifest/server` cannot be used for client side scripts. Use `astro:manifest/client` instead.',
+} satisfies ErrorData;
+
 // Generic catch-all - Only use this in extreme cases, like if there was a cosmic ray bit flip.
 export const UnknownError = { name: 'UnknownError', title: 'Unknown Error.' } satisfies ErrorData;
 

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -9,16 +9,10 @@ import type {
 	ServerConfigSerialized,
 } from '../types/public/index.js';
 
-const VIRTUAL_MODULES_IDS = {
-	client: 'astro:manifest/client',
-	server: 'astro:manifest/server',
-};
-
-const VIRTUAL_MODULES_IDS_SET = new Set(Object.values(VIRTUAL_MODULES_IDS));
-
-function resolveVirtualModuleId<T extends string>(id: T): `\0${T}` {
-	return `\0${id}`;
-}
+const VIRTUAL_SERVER_ID = 'astro:manifest/server'
+const RESOLVED_VIRTUAL_SERVER_ID = '\0' + VIRTUAL_SERVER_ID
+const VIRTUAL_CLIENT_ID = 'astro:manifest/client'
+const RESOLVED_VIRTUAL_CLIENT_ID = '\0' + VIRTUAL_CLIENT_ID
 
 export default function virtualModulePlugin({
 	settings,

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -84,23 +84,15 @@ function serializeClientConfig(config: AstroConfig): string {
 
 function serializeServerConfig(config: AstroConfig): string {
 	const serverConfig: ServerConfigSerialized = {
-		base: config.base,
-		i18n: config.i18n,
 		build: {
 			client: config.build.client,
 			server: config.build.server,
-			format: config.build.format,
-			redirects: config.build.redirects,
 		},
-		trailingSlash: config.trailingSlash,
-		compressHTML: config.compressHTML,
-		site: config.site,
 		cacheDir: config.cacheDir,
 		outDir: config.outDir,
 		publicDir: config.publicDir,
 		srcDir: config.srcDir,
 		root: config.root,
-		legacy: config.legacy,
 	};
 	const output = [];
 	for (const [key, value] of Object.entries(serverConfig)) {

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -1,0 +1,111 @@
+import type { Plugin } from 'vite';
+import { CantUseManifestModule, ForbiddenManifestModule } from '../core/errors/errors-data.js';
+import { AstroError } from '../core/errors/index.js';
+import type { Logger } from '../core/logger/core.js';
+import type { AstroSettings } from '../types/astro.js';
+import type {
+	AstroConfig,
+	ClientConfigSerialized,
+	ServerConfigSerialized,
+} from '../types/public/index.js';
+
+const VIRTUAL_MODULES_IDS = {
+	client: 'astro:manifest/client',
+	server: 'astro:manifest/server',
+};
+
+const VIRTUAL_MODULES_IDS_SET = new Set(Object.values(VIRTUAL_MODULES_IDS));
+
+function resolveVirtualModuleId<T extends string>(id: T): `\0${T}` {
+	return `\0${id}`;
+}
+
+export default function virtualModulePlugin({
+	settings,
+	logger,
+}: { settings: AstroSettings; logger: Logger }): Plugin {
+	return {
+		enforce: 'pre',
+		name: 'astro-manifest-plugin',
+		resolveId(id) {
+			// Resolve the virtual module
+			if (VIRTUAL_MODULES_IDS_SET.has(id)) {
+				return resolveVirtualModuleId(id);
+			}
+		},
+		load(id, opts) {
+			// client
+			if (id === resolveVirtualModuleId(VIRTUAL_MODULES_IDS.client)) {
+				if (!settings.config.experimental.serializeManifest) {
+					throw new AstroError({
+						...CantUseManifestModule,
+						message: CantUseManifestModule.message(VIRTUAL_MODULES_IDS.client),
+					});
+				}
+				// There's nothing wrong about using `/client` on the server
+				return `${serializeClientConfig(settings.config)};`;
+			}
+			// server
+			else if (id == resolveVirtualModuleId(VIRTUAL_MODULES_IDS.server)) {
+				if (!settings.config.experimental.serializeManifest) {
+					throw new AstroError({
+						...CantUseManifestModule,
+						message: CantUseManifestModule.message(VIRTUAL_MODULES_IDS.server),
+					});
+				}
+				if (!opts?.ssr) {
+					throw new AstroError(ForbiddenManifestModule);
+				}
+				return `${serializeServerConfig(settings.config)};`;
+			}
+		},
+	};
+}
+
+function serializeClientConfig(config: AstroConfig): string {
+	const serClientConfig: ClientConfigSerialized = {
+		base: config.base,
+		i18n: config.i18n,
+		build: {
+			format: config.build.format,
+			redirects: config.build.redirects,
+		},
+		trailingSlash: config.trailingSlash,
+		compressHTML: config.compressHTML,
+		site: config.site,
+		legacy: config.legacy,
+	};
+
+	const output = [];
+	for (const [key, value] of Object.entries(serClientConfig)) {
+		output.push(`export const ${key} = ${JSON.stringify(value)};`);
+	}
+	return output.join('\n') + '\n';
+}
+
+function serializeServerConfig(config: AstroConfig): string {
+	const serverConfig: ServerConfigSerialized = {
+		base: config.base,
+		i18n: config.i18n,
+		build: {
+			client: config.build.client,
+			server: config.build.server,
+			format: config.build.format,
+			redirects: config.build.redirects,
+		},
+		trailingSlash: config.trailingSlash,
+		compressHTML: config.compressHTML,
+		site: config.site,
+		cacheDir: config.cacheDir,
+		outDir: config.outDir,
+		publicDir: config.publicDir,
+		srcDir: config.srcDir,
+		root: config.root,
+		legacy: config.legacy,
+	};
+	const output = [];
+	for (const [key, value] of Object.entries(serverConfig)) {
+		output.push(`export const ${key} = ${JSON.stringify(value)};`);
+	}
+	return output.join('\n') + '\n';
+}

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite';
-import { CantUseManifestModule, ForbiddenManifestModule } from '../core/errors/errors-data.js';
-import { AstroError } from '../core/errors/index.js';
+import { CantUseManifestModule } from '../core/errors/errors-data.js';
+import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
 import type { AstroSettings } from '../types/astro.js';
 import type {
@@ -9,46 +9,51 @@ import type {
 	ServerConfigSerialized,
 } from '../types/public/index.js';
 
-const VIRTUAL_SERVER_ID = 'astro:manifest/server'
-const RESOLVED_VIRTUAL_SERVER_ID = '\0' + VIRTUAL_SERVER_ID
-const VIRTUAL_CLIENT_ID = 'astro:manifest/client'
-const RESOLVED_VIRTUAL_CLIENT_ID = '\0' + VIRTUAL_CLIENT_ID
+const VIRTUAL_SERVER_ID = 'astro:manifest/server';
+const RESOLVED_VIRTUAL_SERVER_ID = '\0' + VIRTUAL_SERVER_ID;
+const VIRTUAL_CLIENT_ID = 'astro:manifest/client';
+const RESOLVED_VIRTUAL_CLIENT_ID = '\0' + VIRTUAL_CLIENT_ID;
 
 export default function virtualModulePlugin({
 	settings,
-	logger,
+	logger: _logger,
 }: { settings: AstroSettings; logger: Logger }): Plugin {
 	return {
 		enforce: 'pre',
 		name: 'astro-manifest-plugin',
 		resolveId(id) {
 			// Resolve the virtual module
-			if (VIRTUAL_MODULES_IDS_SET.has(id)) {
-				return resolveVirtualModuleId(id);
+			if (VIRTUAL_SERVER_ID === id) {
+				return RESOLVED_VIRTUAL_SERVER_ID;
+			} else if (VIRTUAL_CLIENT_ID === id) {
+				return RESOLVED_VIRTUAL_CLIENT_ID;
 			}
 		},
 		load(id, opts) {
 			// client
-			if (id === resolveVirtualModuleId(VIRTUAL_MODULES_IDS.client)) {
+			if (id === RESOLVED_VIRTUAL_CLIENT_ID) {
 				if (!settings.config.experimental.serializeManifest) {
 					throw new AstroError({
 						...CantUseManifestModule,
-						message: CantUseManifestModule.message(VIRTUAL_MODULES_IDS.client),
+						message: CantUseManifestModule.message(VIRTUAL_CLIENT_ID),
 					});
 				}
 				// There's nothing wrong about using `/client` on the server
 				return `${serializeClientConfig(settings.config)};`;
 			}
 			// server
-			else if (id == resolveVirtualModuleId(VIRTUAL_MODULES_IDS.server)) {
+			else if (id == RESOLVED_VIRTUAL_SERVER_ID) {
 				if (!settings.config.experimental.serializeManifest) {
 					throw new AstroError({
 						...CantUseManifestModule,
-						message: CantUseManifestModule.message(VIRTUAL_MODULES_IDS.server),
+						message: CantUseManifestModule.message(VIRTUAL_SERVER_ID),
 					});
 				}
 				if (!opts?.ssr) {
-					throw new AstroError(ForbiddenManifestModule);
+					throw new AstroError({
+						...AstroErrorData.ServerOnlyModule,
+						message: AstroErrorData.ServerOnlyModule.message(VIRTUAL_SERVER_ID),
+					});
 				}
 				return `${serializeServerConfig(settings.config)};`;
 			}

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2059,6 +2059,19 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					 */
 					mode: SvgRenderMode;
 			  };
+
+		/**
+		 * @name experimental.serializeManifest
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 5.x
+		 * @description
+		 *
+		 * Allows to use the virtual modules `astro:manifest/server` and `astro:manifest/client`.
+		 *
+		 * These two virtual modules contain a serializable subset of the Astro configuration.
+		 */
+		serializeManifest?: boolean;
 	};
 }
 

--- a/packages/astro/src/types/public/index.ts
+++ b/packages/astro/src/types/public/index.ts
@@ -9,6 +9,7 @@ export type * from './context.js';
 export type * from './preview.js';
 export type * from './content.js';
 export type * from './common.js';
+export type * from './manifest.js';
 
 export type { AstroIntegrationLogger } from '../../core/logger/core.js';
 export type { ToolbarServerHelpers } from '../../runtime/client/dev-toolbar/helpers.js';

--- a/packages/astro/src/types/public/manifest.ts
+++ b/packages/astro/src/types/public/manifest.ts
@@ -2,10 +2,7 @@ import type { AstroConfig } from './config.js';
 
 export type SerializedClientBuild = Pick<AstroConfig['build'], 'format' | 'redirects'>;
 
-export type SerializedServerBuild = Pick<
-	AstroConfig['build'],
-	'format' | 'client' | 'server' | 'redirects'
->;
+export type SerializedServerBuild = Pick<AstroConfig['build'], 'client' | 'server'>;
 
 export type ClientConfigSerialized = Pick<
 	AstroConfig,
@@ -14,7 +11,9 @@ export type ClientConfigSerialized = Pick<
 	build: SerializedClientBuild;
 };
 
-export type ServerConfigSerialized = ClientConfigSerialized &
-	Pick<AstroConfig, 'cacheDir' | 'outDir' | 'publicDir' | 'srcDir' | 'root'> & {
-		build: SerializedServerBuild;
-	};
+export type ServerConfigSerialized = Pick<
+	AstroConfig,
+	'cacheDir' | 'outDir' | 'publicDir' | 'srcDir' | 'root'
+> & {
+	build: SerializedServerBuild;
+};

--- a/packages/astro/src/types/public/manifest.ts
+++ b/packages/astro/src/types/public/manifest.ts
@@ -1,0 +1,20 @@
+import type { AstroConfig } from './config.js';
+
+export type SerializedClientBuild = Pick<AstroConfig['build'], 'format' | 'redirects'>;
+
+export type SerializedServerBuild = Pick<
+	AstroConfig['build'],
+	'format' | 'client' | 'server' | 'redirects'
+>;
+
+export type ClientConfigSerialized = Pick<
+	AstroConfig,
+	'base' | 'i18n' | 'trailingSlash' | 'compressHTML' | 'site' | 'legacy'
+> & {
+	build: SerializedClientBuild;
+};
+
+export type ServerConfigSerialized = ClientConfigSerialized &
+	Pick<AstroConfig, 'cacheDir' | 'outDir' | 'publicDir' | 'srcDir' | 'root'> & {
+		build: SerializedServerBuild;
+	};

--- a/packages/astro/src/types/public/manifest.ts
+++ b/packages/astro/src/types/public/manifest.ts
@@ -1,3 +1,10 @@
+/**
+ * **IMPORTANT**: use the `Pick` interface to select only the properties that we want to expose
+ * to the users. Using blanket types could expose properties that we don't want. So if we decide to expose
+ * properties, we need to be good at justifying them. For example: why you need this config? can't you use an integration?
+ * why do you need access to the shiki config? (very low-level confiig)
+ */
+
 import type { AstroConfig } from './config.js';
 
 export type SerializedClientBuild = Pick<AstroConfig['build'], 'format' | 'redirects'>;

--- a/packages/astro/test/fixtures/astro-manifest/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-manifest/astro.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from "astro/config";
+
+// https://astro.build/config
+export default defineConfig({
+	site: "https://astro.build/",
+	experimental: {
+		serializeManifest: true,
+	},
+	i18n: {
+		locales: ["en", "fr"],
+		defaultLocale: "en",
+	}
+});

--- a/packages/astro/test/fixtures/astro-manifest/package.json
+++ b/packages/astro/test/fixtures/astro-manifest/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-manifest",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-manifest/src/pages/client.astro
+++ b/packages/astro/test/fixtures/astro-manifest/src/pages/client.astro
@@ -1,0 +1,20 @@
+---
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+	<title>Document</title>
+</head>
+<body>
+<h1>Hello, World!</h1>
+<p>Welcome to this Astro page.</p>
+<script>
+	import { outDir } from "astro:manifest/server"
+	
+	console.log(outDir)
+</script>
+</body>
+</html>

--- a/packages/astro/test/fixtures/astro-manifest/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-manifest/src/pages/index.astro
@@ -1,0 +1,19 @@
+
+---
+import { base, i18n, trailingSlash, compressHTML, site, legacy, build } from "astro:manifest/client";
+
+const config = JSON.stringify({ base, i18n, build, trailingSlash, compressHTML, site, legacy });
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+	<title>Document</title>
+</head>
+<body>
+	<h1>Hello, World!</h1>
+	<p>Welcome to this Astro page.</p>
+	<p id="config">{config}</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/astro-manifest/src/pages/server.astro
+++ b/packages/astro/test/fixtures/astro-manifest/src/pages/server.astro
@@ -1,0 +1,21 @@
+---
+import { root, outDir, srcDir, build, cacheDir } from "astro:manifest/server";
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+	<title>Document</title>
+</head>
+<body>
+<h1>Hello, World!</h1>
+<p>Welcome to this Astro page.</p>
+<p id="out-dir">{outDir}</p>
+<p id="src-dir">{srcDir}</p>
+<p id="root">{root}</p>
+<p id="cache-dir">{cacheDir}</p>
+<p id="build-client">{build.client}</p>
+<p id="build-server">{build.server}</p>
+</body>
+</html>

--- a/packages/astro/test/serializeManifest.test.js
+++ b/packages/astro/test/serializeManifest.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { ForbiddenManifestModule } from '../dist/core/errors/errors-data.js';
+import { ServerOnlyModule } from '../dist/core/errors/errors-data.js';
 import { AstroError } from '../dist/core/errors/index.js';
 import { loadFixture } from './test-utils.js';
 
@@ -94,7 +94,7 @@ describe('astro:manifest/server', () => {
 		it('should return an error when using inside a client script', async () => {
 			const error = await fixture.build().catch((err) => err);
 			assert.equal(error instanceof AstroError, true);
-			assert.equal(error.name, ForbiddenManifestModule.name);
+			assert.equal(error.name, ServerOnlyModule.name);
 		});
 	});
 

--- a/packages/astro/test/serializeManifest.test.js
+++ b/packages/astro/test/serializeManifest.test.js
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { ForbiddenManifestModule } from '../dist/core/errors/errors-data.js';
+import { AstroError } from '../dist/core/errors/index.js';
+import { loadFixture } from './test-utils.js';
+
+describe('astro:manifest/client', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let devServer;
+
+	describe('when the experimental flag is not enabled', async () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-manifest/',
+				experimental: {
+					serializeManifest: false,
+				},
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('should throw an error when importing the module', async () => {
+			const response = await fixture.fetch('/');
+			const html = await response.text();
+			assert.match(html, /CantUseManifestModule/);
+		});
+	});
+
+	describe('when the experimental flag is enabled', async () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-manifest/',
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('should return the expected properties', async () => {
+			const response = await fixture.fetch('/');
+			const html = await response.text();
+
+			const $ = cheerio.load(html);
+
+			assert.deepEqual(
+				$('#config').text(),
+				JSON.stringify({
+					base: '/',
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'fr'],
+						routing: {
+							prefixDefaultLocale: false,
+							redirectToDefaultLocale: true,
+							fallbackType: 'redirect',
+						},
+					},
+					build: {
+						format: 'directory',
+						redirects: true,
+					},
+					trailingSlash: 'ignore',
+					compressHTML: true,
+					site: 'https://astro.build/',
+					legacy: {
+						collections: false,
+					},
+				}),
+			);
+		});
+	});
+});
+
+describe('astro:manifest/server', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let devServer;
+
+	describe('when build', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-manifest/',
+			});
+		});
+
+		it('should return an error when using inside a client script', async () => {
+			const error = await fixture.build().catch((err) => err);
+			assert.equal(error instanceof AstroError, true);
+			assert.equal(error.name, ForbiddenManifestModule.name);
+		});
+	});
+
+	describe('when the experimental flag is not enabled', async () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-manifest/',
+				experimental: {
+					serializeManifest: false,
+				},
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('should throw an error when importing the module', async () => {
+			const response = await fixture.fetch('/server');
+			const html = await response.text();
+			assert.match(html, /CantUseManifestModule/);
+		});
+	});
+
+	describe('when the experimental flag is enabled', async () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-manifest/',
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('should return the expected properties', async () => {
+			const response = await fixture.fetch('/server');
+			const html = await response.text();
+
+			const $ = cheerio.load(html);
+
+			assert.ok($('#out-dir').text().endsWith('/dist/'));
+			assert.ok($('#src-dir').text().endsWith('/src/'));
+			assert.ok($('#cache-dir').text().endsWith('/.astro/'));
+			assert.ok($('#root').text().endsWith('/'));
+			assert.ok($('#build-client').text().endsWith('/dist/client/'));
+			assert.ok($('#build-server').text().endsWith('/dist/server/'));
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,7 +341,7 @@ importers:
   examples/minimal:
     dependencies:
       astro:
-        specifier: ^5.1.7
+        specifier: workspace:*
         version: link:../../packages/astro
 
   examples/portfolio:
@@ -2154,6 +2154,12 @@ importers:
         version: link:../../..
 
   packages/astro/test/fixtures/astro-jsx:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/astro/test/fixtures/astro-manifest:
     dependencies:
       astro:
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,7 +341,7 @@ importers:
   examples/minimal:
     dependencies:
       astro:
-        specifier: workspace:*
+        specifier: ^5.1.7
         version: link:../../packages/astro
 
   examples/portfolio:


### PR DESCRIPTION
## Changes

This PR a first round of implementation of the Stage 2 RFC https://github.com/withastro/roadmap/issues/1099

The PR **isn't** against `main` and it's meant to test the waters.

> [!IMPORTANT]
> Let's **not focus on the naming** of the virtual module, we will use the RFC Stage 3 for that. Focus on the technical implementation and the "expected usage" of the module, and see the information that we want to export from each module make sense

This PR will set the ground work for the Stage 3 RFC

## Testing

Added new tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Not at this stage

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
