### PR TITLE
Revert "feat(server-islands): only encode ETAGO delimiter (#11513)"

### DIFF
--- a/.changeset/fifty-socks-end.md
+++ b/.changeset/fifty-socks-end.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Updates the server islands encoding logic to only escape the script end tag open delimiter and opening HTML comment syntax

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -15,19 +15,13 @@ export function containsServerDirective(props: Record<string | number, any>) {
 	return 'server:component-directive' in props;
 }
 
-const SCRIPT_RE = /<\/script/giu;
-const COMMENT_RE = /<!--/gu;
-const SCRIPT_REPLACER = '<\\/script';
-const COMMENT_REPLACER = '\\u003C!--';
-
-/**
- * Encodes the script end-tag open (ETAGO) delimiter and opening HTML comment syntax for JSON inside a `<script>` tag.
- * @see https://mathiasbynens.be/notes/etago
- */
 function safeJsonStringify(obj: any) {
 	return JSON.stringify(obj)
-		.replace(SCRIPT_RE, SCRIPT_REPLACER)
-		.replace(COMMENT_RE, COMMENT_REPLACER);
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029')
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/\//g, '\\u002f');
 }
 
 function createSearchParams(componentExport: string, encryptedProps: string, slots: string) {

--- a/packages/astro/test/fixtures/server-islands/ssr/src/pages/index.astro
+++ b/packages/astro/test/fixtures/server-islands/ssr/src/pages/index.astro
@@ -1,7 +1,5 @@
 ---
 import Island from '../components/Island.astro';
-
-const xssMe ="</script><script>alert('xss')</script><!--"
 ---
 <html>
 <head>
@@ -9,6 +7,6 @@ const xssMe ="</script><script>alert('xss')</script><!--"
 </head>
 <body>
   <h1>Testing</h1>
-  <Island server:defer message={xssMe} />
+  <Island server:defer />
 </body>
 </html>

--- a/packages/astro/test/server-islands.test.js
+++ b/packages/astro/test/server-islands.test.js
@@ -37,13 +37,6 @@ describe('Server islands', () => {
 				assert.equal(serverIslandEl.length, 0);
 			});
 
-			it('HTML escapes scripts', async () => {
-				const res = await fixture.fetch('/');
-				assert.equal(res.status, 200);
-				const html = await res.text();
-				assert.equal(html.includes("</script><script>alert('xss')</script><!--"), false);
-			});
-
 			it('island is not indexed', async () => {
 				const res = await fixture.fetch('/_server-islands/Island', {
 					method: 'POST',


### PR DESCRIPTION
This reverts commit f64b73cb8aaae02c52fa438ac8361044cf67f6dc.

## Changes

#11513 caused test failures on main

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
