### PR TITLE
fix(alpinejs): start on DOMContentLoaded

### DIFF
--- a/.changeset/tall-bears-return.md
+++ b/.changeset/tall-bears-return.md
@@ -2,4 +2,4 @@
 "@astrojs/alpinejs": patch
 ---
 
-Temp
+Fixes an issue with user scripts running after `Alpine.start()`

--- a/.changeset/tall-bears-return.md
+++ b/.changeset/tall-bears-return.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/alpinejs": patch
+---
+
+Temp

--- a/packages/integrations/alpinejs/src/index.ts
+++ b/packages/integrations/alpinejs/src/index.ts
@@ -98,7 +98,7 @@ export default function createPlugin(options?: Options): AstroIntegration {
 import { setup } from 'virtual:@astrojs/alpinejs/entrypoint';
 setup(Alpine);
 window.Alpine = Alpine;
-Alpine.start();`,
+document.addEventListener('DOMContentLoaded', () => Alpine.start());`
 				);
 				updateConfig({
 					vite: {


### PR DESCRIPTION
Related to issue https://github.com/withastro/astro/issues/12710#issuecomment-2596129872.

Externally loaded AlpineJS component scripts were loaded after `Alpine.start()` was triggered. Issue started with Astro V5.

## Changes

- Runs `Alpine.start()` on the `DOMContentLoaded` event. According to MDN documentation (https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event), `DOMContentLoaded` fires immediately after HTML and deferred scripts are loaded. In short, this change guarantees that `Alpine.start()` is only called after all scripts are loaded.

## Testing

- This is a bugfix and integrations do not appear to have tests.

## Docs
- No documentation updates necessary; resolving a bug.
