### PR TITLE
fix: allow imports of Markdown files as raw text

### DIFF
--- a/.changeset/large-dodos-bake.md
+++ b/.changeset/large-dodos-bake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression that prevented the import of Markdown files as raw text

--- a/.changeset/large-dodos-bake.md
+++ b/.changeset/large-dodos-bake.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a regression that prevented the import of Markdown files as raw text
+Fixes a regression that prevented the import of Markdown files as raw text or URLs.

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -18,6 +18,9 @@ export function isURL(value: unknown): value is URL {
 }
 /** Check if a file is a markdown file based on its extension */
 export function isMarkdownFile(fileId: string, option?: { suffix?: string }): boolean {
+	if (fileId.endsWith('?raw')) {
+		return false;
+	}
 	const id = removeQueryString(fileId);
 	const _suffix = option?.suffix ?? '';
 	for (let markdownFileExtension of SUPPORTED_MARKDOWN_FILE_EXTENSIONS) {

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -6,6 +6,7 @@ import type { AstroConfig } from '../types/public/config.js';
 import type { RouteData } from '../types/public/internal.js';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './constants.js';
 import { removeQueryString, removeTrailingForwardSlash, slash } from './path.js';
+import { hasSpecialQueries } from '../vite-plugin-utils/index.js';
 
 /** Returns true if argument is an object of any prototype/class (but not null). */
 export function isObject(value: unknown): value is Record<string, any> {
@@ -18,7 +19,7 @@ export function isURL(value: unknown): value is URL {
 }
 /** Check if a file is a markdown file based on its extension */
 export function isMarkdownFile(fileId: string, option?: { suffix?: string }): boolean {
-	if (fileId.endsWith('?raw')) {
+	if (hasSpecialQueries(fileId)) {
 		return false;
 	}
 	const id = removeQueryString(fileId);

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -24,6 +24,14 @@ describe('Astro Markdown', () => {
 		);
 	});
 
+	it('Allows ?raw imports', async () => {
+		const raw = await fixture.readFile('/raw-content.txt');
+		assert.equal(
+			fixLineEndings(raw).trim(),
+			`# Basic page\n\nLets make sure raw and compiled content look right!`,
+		);
+	});
+
 	it('Exposes compiled HTML content', async () => {
 		const { compiled } = JSON.parse(await fixture.readFile('/raw-content.json'));
 

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -24,12 +24,13 @@ describe('Astro Markdown', () => {
 		);
 	});
 
-	it('Allows ?raw imports', async () => {
-		const raw = await fixture.readFile('/raw-content.txt');
+	it('Allows ?raw and ?url imports', async () => {
+		const { rawImport, url } = JSON.parse(await fixture.readFile('/raw-content.json'));
 		assert.equal(
-			fixLineEndings(raw).trim(),
+			fixLineEndings(rawImport).trim(),
 			`# Basic page\n\nLets make sure raw and compiled content look right!`,
 		);
+		assert.ok(url.startsWith("data:text/markdown;base64,"));
 	});
 
 	it('Exposes compiled HTML content', async () => {

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
@@ -1,8 +1,11 @@
 import { compiledContent, rawContent } from './basic.md';
-
+import md from './basic.md?raw';
+import url from './basic.md?url';
 export async function GET() {
 	return Response.json({
 		raw: rawContent(),
 		compiled: await compiledContent(),
+		rawImport: md,
+		url,
 	});
 }

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.txt.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.txt.js
@@ -1,0 +1,5 @@
+import md from './basic.md?raw';
+
+export async function GET() {
+	return new Response(md);
+}

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.txt.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.txt.js
@@ -1,5 +1,0 @@
-import md from './basic.md?raw';
-
-export async function GET() {
-	return new Response(md);
-}


### PR DESCRIPTION
## Changes

The fix in #12711 caused a regression for imports for markdown files as static assets using the `?raw` param. That only worked accidentally before, but this is the proper fix.

I am just checking the id for `?raw`. I realise this could in theory miss cases where there are multiple params, but I'm not aware of any cases where that would be legitimate so didn't think it was worth the cost of adding a full query param parse on every import. I'm open to other opinions on this though.

Fixes #13025

## Testing

Added a test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
