### PR TITLE
chore: ignore jsonc files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,7 @@ pnpm-lock.yaml
 
 # Formatted by Biome
 **/*.json
+**/*.jsonc
 **/*.js
 **/*.ts
 **/*.tsx

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
     "ignore": ["**/smoke/**", "**/fixtures/**", "**/_temp-fixtures/**", "**/vendor/**"],
     "include": ["test/**", "e2e/**", "packages/**", "scripts/**", "benchmark", "biome.jsonc"]

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,133 +1,133 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
-	"files": {
-		"ignore": ["**/smoke/**", "**/fixtures/**", "**/_temp-fixtures/**", "**/vendor/**"],
-		"include": ["test/**", "e2e/**", "packages/**", "scripts/**", "benchmark"],
-	},
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true,
-	},
-	"formatter": {
-		"indentStyle": "tab",
-		"indentWidth": 2,
-		"lineWidth": 100,
-		"ignore": [".changeset", "pnpm-lock.yaml", "*.astro"],
-	},
-	"organizeImports": {
-		"enabled": true,
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": false,
-			"style": {
-				"useNodejsImportProtocol": "error",
-				// Enforce separate type imports for type-only imports to avoid bundling unneeded code
-				"useImportType": "error",
-			},
-			"suspicious": {
-				// This one is specific to catch `console.log`. The rest of logs are permitted
-				"noConsoleLog": "warn",
-			},
-			"correctness": {
-				"noUnusedVariables": "info",
-				"noUnusedFunctionParameters": "info",
-				"noUnusedImports": "warn",
-			},
-		},
-	},
-	"javascript": {
-		"formatter": {
-			"trailingCommas": "all",
-			"quoteStyle": "single",
-			"semicolons": "always",
-		},
-	},
-	"json": {
-		"parser": {
-			"allowComments": true,
-			"allowTrailingCommas": true,
-		},
-		"formatter": {
-			"indentStyle": "space",
-			"trailingCommas": "none",
-		},
-	},
-	"overrides": [
-		{
-			// Workaround to format files like npm does
-			"include": ["package.json"],
-			"json": {
-				"formatter": {
-					"lineWidth": 1,
-				},
-			},
-		},
-		{
-			// We don"t want to have node modules in code that should be runtime agnostic
-			"include": ["packages/astro/src/runtime/**/*.ts"],
-			"linter": {
-				"rules": {
-					"correctness": {
-						"noNodejsModules": "error",
-					},
-				},
-			},
-		},
-		{
-			"include": ["*.test.js"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noFocusedTests": "error",
-						"noConsole": "off",
-					},
-				},
-			},
-		},
-		{
-			"include": ["*.astro", "client.d.ts", "jsx-runtime.d.ts"],
-			"linter": {
-				"rules": {
-					"correctness": {
-						"noUnusedVariables": "off",
-						"noUnusedImports": "off",
-					},
-				},
-			},
-		},
-		{
-			"include": ["packages/integrations/**/*.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": {
-							"level": "error",
-							"options": {
-								"allow": ["warn", "error", "info", "debug"],
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			"include": [
-				"packages/db/**/cli/**/*.ts",
-				"benchmark/**/*.js",
-				"packages/astro/src/cli/**/*.ts",
-				"packages/astro/astro.js",
-			],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": "off",
-						"noConsoleLog": "off",
-					},
-				},
-			},
-		},
-	],
+  "$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
+  "files": {
+    "ignore": ["**/smoke/**", "**/fixtures/**", "**/_temp-fixtures/**", "**/vendor/**"],
+    "include": ["test/**", "e2e/**", "packages/**", "scripts/**", "benchmark", "biome.jsonc"]
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "indentStyle": "tab",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "ignore": [".changeset", "pnpm-lock.yaml", "*.astro"]
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "style": {
+        "useNodejsImportProtocol": "error",
+        // Enforce separate type imports for type-only imports to avoid bundling unneeded code
+        "useImportType": "error"
+      },
+      "suspicious": {
+        // This one is specific to catch `console.log`. The rest of logs are permitted
+        "noConsoleLog": "warn"
+      },
+      "correctness": {
+        "noUnusedVariables": "info",
+        "noUnusedFunctionParameters": "info",
+        "noUnusedImports": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "trailingCommas": "all",
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  },
+  "json": {
+    "parser": {
+      "allowComments": true,
+      "allowTrailingCommas": true
+    },
+    "formatter": {
+      "indentStyle": "space",
+      "trailingCommas": "none"
+    }
+  },
+  "overrides": [
+    {
+      // Workaround to format files like npm does
+      "include": ["package.json"],
+      "json": {
+        "formatter": {
+          "lineWidth": 1
+        }
+      }
+    },
+    {
+      // We don"t want to have node modules in code that should be runtime agnostic
+      "include": ["packages/astro/src/runtime/**/*.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noNodejsModules": "error"
+          }
+        }
+      }
+    },
+    {
+      "include": ["*.test.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noFocusedTests": "error",
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["*.astro", "client.d.ts", "jsx-runtime.d.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["packages/integrations/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": {
+              "level": "error",
+              "options": {
+                "allow": ["warn", "error", "info", "debug"]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "include": [
+        "packages/db/**/cli/**/*.ts",
+        "benchmark/**/*.js",
+        "packages/astro/src/cli/**/*.ts",
+        "packages/astro/astro.js"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off",
+            "noConsoleLog": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
-    "@biomejs/biome": "1.9.3",
+    "@biomejs/biome": "1.9.4",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.11",
     "@types/node": "^18.17.8",

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -21,13 +21,11 @@ declare namespace astroHTML.JSX {
 		children?: Children;
 	}
 
-	type AstroComponentDirectives = import(
-		'./dist/types/public/elements.js',
-	).AstroComponentDirectives;
+	// biome-ignore format: bug
+	type AstroComponentDirectives = import('./dist/types/public/elements.js').AstroComponentDirectives;
 	type AstroBuiltinAttributes = import('./dist/types/public/elements.js').AstroBuiltinAttributes;
-	type AstroDefineVarsAttribute = import(
-		'./dist/types/public/elements.js',
-	).AstroDefineVarsAttribute;
+	// biome-ignore format: bug
+	type AstroDefineVarsAttribute = import('./dist/types/public/elements.js').AstroDefineVarsAttribute;
 	type AstroScriptAttributes = import('./dist/types/public/elements.js').AstroScriptAttributes &
 		AstroDefineVarsAttribute;
 	type AstroStyleAttributes = import('./dist/types/public/elements.js').AstroStyleAttributes &

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -21,11 +21,13 @@ declare namespace astroHTML.JSX {
 		children?: Children;
 	}
 
-	type AstroComponentDirectives =
-		import('./dist/types/public/elements.js').AstroComponentDirectives;
+	type AstroComponentDirectives = import(
+		'./dist/types/public/elements.js',
+	).AstroComponentDirectives;
 	type AstroBuiltinAttributes = import('./dist/types/public/elements.js').AstroBuiltinAttributes;
-	type AstroDefineVarsAttribute =
-		import('./dist/types/public/elements.js').AstroDefineVarsAttribute;
+	type AstroDefineVarsAttribute = import(
+		'./dist/types/public/elements.js',
+	).AstroDefineVarsAttribute;
 	type AstroScriptAttributes = import('./dist/types/public/elements.js').AstroScriptAttributes &
 		AstroDefineVarsAttribute;
 	type AstroStyleAttributes = import('./dist/types/public/elements.js').AstroStyleAttributes &

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -152,8 +152,9 @@ declare module 'astro:transitions/client' {
 
 	export type Fallback = import('./dist/virtual-modules/transitions-types.js').Fallback;
 	export type Direction = import('./dist/virtual-modules/transitions-types.ts').Direction;
-	export type NavigationTypeString =
-		import('./dist/virtual-modules/transitions-types.js').NavigationTypeString;
+	export type NavigationTypeString = import(
+		'./dist/virtual-modules/transitions-types.js',
+	).NavigationTypeString;
 	export type Options = import('./dist/virtual-modules/transitions-types.js').Options;
 
 	type EventModule = typeof import('./dist/virtual-modules/transitions-events.js');
@@ -162,14 +163,17 @@ declare module 'astro:transitions/client' {
 	export const TRANSITION_BEFORE_SWAP: EventModule['TRANSITION_BEFORE_SWAP'];
 	export const TRANSITION_AFTER_SWAP: EventModule['TRANSITION_AFTER_SWAP'];
 	export const TRANSITION_PAGE_LOAD: EventModule['TRANSITION_PAGE_LOAD'];
-	export type TransitionBeforePreparationEvent =
-		import('./dist/virtual-modules/transitions-events.js').TransitionBeforePreparationEvent;
-	export type TransitionBeforeSwapEvent =
-		import('./dist/virtual-modules/transitions-events.js').TransitionBeforeSwapEvent;
+	export type TransitionBeforePreparationEvent = import(
+		'./dist/virtual-modules/transitions-events.js',
+	).TransitionBeforePreparationEvent;
+	export type TransitionBeforeSwapEvent = import(
+		'./dist/virtual-modules/transitions-events.js',
+	).TransitionBeforeSwapEvent;
 	export const isTransitionBeforePreparationEvent: EventModule['isTransitionBeforePreparationEvent'];
 	export const isTransitionBeforeSwapEvent: EventModule['isTransitionBeforeSwapEvent'];
-	type TransitionSwapFunctionModule =
-		typeof import('./dist/virtual-modules/transitions-swap-functions.js');
+	type TransitionSwapFunctionModule = typeof import(
+		'./dist/virtual-modules/transitions-swap-functions.js',
+	);
 	export const swapFunctions: TransitionSwapFunctionModule['swapFunctions'];
 }
 

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -152,9 +152,8 @@ declare module 'astro:transitions/client' {
 
 	export type Fallback = import('./dist/virtual-modules/transitions-types.js').Fallback;
 	export type Direction = import('./dist/virtual-modules/transitions-types.ts').Direction;
-	export type NavigationTypeString = import(
-		'./dist/virtual-modules/transitions-types.js',
-	).NavigationTypeString;
+	// biome-ignore format: bug
+	export type NavigationTypeString = import('./dist/virtual-modules/transitions-types.js').NavigationTypeString;
 	export type Options = import('./dist/virtual-modules/transitions-types.js').Options;
 
 	type EventModule = typeof import('./dist/virtual-modules/transitions-events.js');
@@ -163,12 +162,10 @@ declare module 'astro:transitions/client' {
 	export const TRANSITION_BEFORE_SWAP: EventModule['TRANSITION_BEFORE_SWAP'];
 	export const TRANSITION_AFTER_SWAP: EventModule['TRANSITION_AFTER_SWAP'];
 	export const TRANSITION_PAGE_LOAD: EventModule['TRANSITION_PAGE_LOAD'];
-	export type TransitionBeforePreparationEvent = import(
-		'./dist/virtual-modules/transitions-events.js',
-	).TransitionBeforePreparationEvent;
-	export type TransitionBeforeSwapEvent = import(
-		'./dist/virtual-modules/transitions-events.js',
-	).TransitionBeforeSwapEvent;
+	// biome-ignore format: bug
+	export type TransitionBeforePreparationEvent = import('./dist/virtual-modules/transitions-events.js').TransitionBeforePreparationEvent;
+	// biome-ignore format: bug
+	export type TransitionBeforeSwapEvent = import('./dist/virtual-modules/transitions-events.js').TransitionBeforeSwapEvent;
 	export const isTransitionBeforePreparationEvent: EventModule['isTransitionBeforePreparationEvent'];
 	export const isTransitionBeforeSwapEvent: EventModule['isTransitionBeforeSwapEvent'];
 	type TransitionSwapFunctionModule = typeof import(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^0.9.4
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.3)
       '@biomejs/biome':
-        specifier: 1.9.3
-        version: 1.9.3
+        specifier: 1.9.4
+        version: 1.9.4
       '@changesets/changelog-github':
         specifier: ^0.5.0
         version: 0.5.0
@@ -5844,55 +5844,55 @@ packages:
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@1.9.3':
-    resolution: {integrity: sha512-POjAPz0APAmX33WOQFGQrwLvlu7WLV4CFJMlB12b6ZSg+2q6fYu9kZwLCOA+x83zXfcPd1RpuWOKJW0GbBwLIQ==}
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.3':
-    resolution: {integrity: sha512-QZzD2XrjJDUyIZK+aR2i5DDxCJfdwiYbUKu9GzkCUJpL78uSelAHAPy7m0GuPMVtF/Uo+OKv97W3P9nuWZangQ==}
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.3':
-    resolution: {integrity: sha512-vSCoIBJE0BN3SWDFuAY/tRavpUtNoqiceJ5PrU3xDfsLcm/U6N93JSM0M9OAiC/X7mPPfejtr6Yc9vSgWlEgVw==}
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.3':
-    resolution: {integrity: sha512-VBzyhaqqqwP3bAkkBrhVq50i3Uj9+RWuj+pYmXrMDgjS5+SKYGE56BwNw4l8hR3SmYbLSbEo15GcV043CDSk+Q==}
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.3':
-    resolution: {integrity: sha512-vJkAimD2+sVviNTbaWOGqEBy31cW0ZB52KtpVIbkuma7PlfII3tsLhFa+cwbRAcRBkobBBhqZ06hXoZAN8NODQ==}
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.3':
-    resolution: {integrity: sha512-TJmnOG2+NOGM72mlczEsNki9UT+XAsMFAOo8J0me/N47EJ/vkLXxf481evfHLlxMejTY6IN8SdRSiPVLv6AHlA==}
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.3':
-    resolution: {integrity: sha512-x220V4c+romd26Mu1ptU+EudMXVS4xmzKxPVb9mgnfYlN4Yx9vD5NZraSx/onJnd3Gh/y8iPUdU5CDZJKg9COA==}
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.3':
-    resolution: {integrity: sha512-lg/yZis2HdQGsycUvHWSzo9kOvnGgvtrYRgoCEwPBwwAL8/6crOp3+f47tPwI/LI1dZrhSji7PNsGKGHbwyAhw==}
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.3':
-    resolution: {integrity: sha512-cQMy2zanBkVLpmmxXdK6YePzmZx0s5Z7KEnwmrW54rcXK3myCNbQa09SwGZ8i/8sLw0H9F3X7K4rxVNGU8/D4Q==}
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -11495,39 +11495,39 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@biomejs/biome@1.9.3':
+  '@biomejs/biome@1.9.4':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.3
-      '@biomejs/cli-darwin-x64': 1.9.3
-      '@biomejs/cli-linux-arm64': 1.9.3
-      '@biomejs/cli-linux-arm64-musl': 1.9.3
-      '@biomejs/cli-linux-x64': 1.9.3
-      '@biomejs/cli-linux-x64-musl': 1.9.3
-      '@biomejs/cli-win32-arm64': 1.9.3
-      '@biomejs/cli-win32-x64': 1.9.3
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
 
-  '@biomejs/cli-darwin-arm64@1.9.3':
+  '@biomejs/cli-darwin-arm64@1.9.4':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.3':
+  '@biomejs/cli-darwin-x64@1.9.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.3':
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.3':
+  '@biomejs/cli-linux-arm64@1.9.4':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.3':
+  '@biomejs/cli-linux-x64-musl@1.9.4':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.3':
+  '@biomejs/cli-linux-x64@1.9.4':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.3':
+  '@biomejs/cli-win32-arm64@1.9.4':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.3':
+  '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
   '@bluwy/giget-core@0.1.2':


### PR DESCRIPTION
## Changes

Prettier was still formatting `biome.jsonc` file. `.jsonc` files are now ignored and correctly formatted by Biome.

I updated `biome` to the latest and run `format:code`

## Testing

CI should stay green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
