### PR TITLE
Add rel links to sitemap and rss feed in blog starter kit

### DIFF
--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -2,6 +2,7 @@
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
 import '../styles/global.css';
+import { SITE_TITLE } from '../consts';
 
 interface Props {
 	title: string;
@@ -18,6 +19,8 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="sitemap" href="/sitemap-index.xml" />
+<link rel="alternate" type="application/rss+xml" title={SITE_TITLE} href={new URL("rss.xml", Astro.site)} />
 <meta name="generator" content={Astro.generator} />
 
 <!-- Font preloads -->


### PR DESCRIPTION
## Changes

This PR fixes #13041 

- It edits only one file, `BaseHead.astro`, in [the Astro blog starter kit](https://github.com/withastro/astro/tree/main/examples/blog). It adds three new lines to that file.
- It adds a rel link to the (already-existing) `/sitemap-index.xml` file created by @astrojs/sitemap
- It adds a rel link to the (already-existing) `/rss.xml` file created by @astrojs/rss
- The link to the RSS feed file needs the global `SITE_TITLE`, so I added a line to the frontmatter to import that.

## Testing

I created a personal blog using the Astro blog starter kit and noticed that these rel links were missing, so I added them. It worked.

## Docs

No additional documentation is required because of this PR. In fact, I got most of the code for this PR from existing Astro documentation:

- [the documentation for `@astrojs/sitemap`](https://docs.astro.build/en/guides/integrations-guide/sitemap/#sitemap-discovery)
- [the documentation for `@astrojs/rss`](https://docs.astro.build/en/recipes/rss/#enabling-rss-feed-auto-discovery)
