### PR TITLE
Fix get relative locale

### DIFF
--- a/.changeset/seven-avocados-confess.md
+++ b/.changeset/seven-avocados-confess.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-fix i18n url utilities behavior when trailingSlash:never
+Fixes a bug where the some utility functions of the `astro:i18n` virtual module would return an incorrect result when `trailingSlash` is set to `never`

--- a/.changeset/seven-avocados-confess.md
+++ b/.changeset/seven-avocados-confess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix i18n url utilities behavior when trailingSlash:never

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -106,11 +106,17 @@ export function getLocaleRelativeUrl({
 	}
 	pathsToJoin.push(path);
 
+	let relativePath: string;
 	if (shouldAppendForwardSlash(trailingSlash, format)) {
-		return appendForwardSlash(joinPaths(...pathsToJoin));
+		relativePath = appendForwardSlash(joinPaths(...pathsToJoin));
 	} else {
-		return joinPaths(...pathsToJoin);
+		relativePath = joinPaths(...pathsToJoin);
 	}
+
+	if (relativePath === '') {
+		return '/';
+	}
+	return relativePath;
 }
 
 /**

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -130,7 +130,9 @@ export function getLocaleAbsoluteUrl({ site, isBuild, ...rest }: GetLocaleAbsolu
 		const base = domains[locale];
 		url = joinPaths(base, localeUrl.replace(`/${rest.locale}`, ''));
 	} else {
-		if (site) {
+		if (localeUrl === '/') {
+			url = site || '/';
+		} else if (site) {
 			url = joinPaths(site, localeUrl);
 		} else {
 			url = localeUrl;

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -1260,6 +1260,8 @@ describe('getLocaleAbsoluteUrl', () => {
 				'https://example.com/blog/es/',
 			);
 		});
+	});
+	describe('with [prefix-other-locales]', () => {
 		it('should correctly return the URL without base', () => {
 			/**
 			 *
@@ -1314,6 +1316,39 @@ describe('getLocaleAbsoluteUrl', () => {
 					site: 'https://example.com',
 				}),
 				'https://example.com/italiano/',
+			);
+			assert.equal(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/',
+					...config.experimental.i18n,
+					trailingSlash: 'never',
+					format: 'directory',
+					site: 'https://example.com',
+				}),
+				'https://example.com',
+			);
+			assert.equal(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/',
+					...config.experimental.i18n,
+					trailingSlash: 'never',
+					format: 'directory',
+					site: 'https://example.com',
+				}),
+				'https://example.com/es',
+			);
+			assert.equal(
+				getLocaleAbsoluteUrl({
+					locale: 'it-VA',
+					base: '/',
+					...config.experimental.i18n,
+					trailingSlash: 'never',
+					format: 'directory',
+					site: 'https://example.com',
+				}),
+				'https://example.com/italiano',
 			);
 		});
 

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -9,8 +9,7 @@ import {
 	getLocaleRelativeUrl,
 	getLocaleRelativeUrlList,
 } from '../../../dist/i18n/index.js';
-import { toRoutingStrategy } from '../../../dist/i18n/utils.js';
-import { parseLocale } from '../../../dist/i18n/utils.js';
+import { parseLocale, toRoutingStrategy } from '../../../dist/i18n/utils.js';
 
 describe('getLocaleRelativeUrl', () => {
 	it('should correctly return the URL with the base', () => {
@@ -125,6 +124,39 @@ describe('getLocaleRelativeUrl', () => {
 				format: 'directory',
 			}),
 			'/es/',
+		);
+
+		assert.equal(
+			getLocaleRelativeUrl({
+				locale: 'en',
+				base: '/',
+				...config.experimental.i18n,
+				trailingSlash: 'never',
+				format: 'file',
+			}),
+			'/',
+		);
+
+		assert.equal(
+			getLocaleRelativeUrl({
+				locale: 'es',
+				base: '/',
+				...config.experimental.i18n,
+				trailingSlash: 'never',
+				format: 'file',
+			}),
+			'/es',
+		);
+
+		assert.equal(
+			getLocaleRelativeUrl({
+				locale: 'en',
+				base: '/',
+				...config.experimental.i18n,
+				trailingSlash: 'never',
+				format: 'directory',
+			}),
+			'/',
 		);
 	});
 


### PR DESCRIPTION
## Changes

fixes #13035 
`getLocaleRelativeUrl` will now return a '/' instead of an empty string in the case of `base: '/'` and `trailingSlash: 'never'`.
Changing this behavior of `getLocalRelativeUrl` caused a similar error in `getLocaleAbsoluteUrl` for `trailingSlash: 'never'` because it internaly uses `getLocaleRelativeUrl`. This is resolved similarly. 

## Testing

Added tests for both cases - the logic for testing `base: '/'` had only been testing when `trailingSlash:'always'`. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
