### PR TITLE
Add a propType for receiving a raw value directly

### DIFF
--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -30,6 +30,7 @@ declare const Astro: {
 		9: (value) => new Uint16Array(value),
 		10: (value) => new Uint32Array(value),
 		11: (value) => Infinity * value,
+		12: (value) => value,
 	};
 
 	// Not using JSON.parse reviver because it's bottom-up but we want top-down


### PR DESCRIPTION
## Changes

- Adds a propType for using a parsed-from-JSON value directly, without reviving sub-objects via tuples. This allows web pages generated by external systems (not Astro) to use Astro islands without needing to encode props containing nested but basic (representable with JSON) data into tuples.

## Testing

- No tests added yet. Wanting to get confirmation on whether Astro maintainers are open to this PR before I spend time on adding tests.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- No docs added yet. Wanting to get confirmation on whether Astro maintainers are open to this PR before I spend time on adding docs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
