### PR TITLE
fix: correct broken import formatting

### DIFF
--- a/.changeset/clean-suns-shout.md
+++ b/.changeset/clean-suns-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes broken type declaration

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -168,9 +168,8 @@ declare module 'astro:transitions/client' {
 	export type TransitionBeforeSwapEvent = import('./dist/virtual-modules/transitions-events.js').TransitionBeforeSwapEvent;
 	export const isTransitionBeforePreparationEvent: EventModule['isTransitionBeforePreparationEvent'];
 	export const isTransitionBeforeSwapEvent: EventModule['isTransitionBeforeSwapEvent'];
-	type TransitionSwapFunctionModule = typeof import(
-		'./dist/virtual-modules/transitions-swap-functions.js',
-	);
+	// biome-ignore format: bug
+	type TransitionSwapFunctionModule = typeof import('./dist/virtual-modules/transitions-swap-functions.js');
 	export const swapFunctions: TransitionSwapFunctionModule['swapFunctions'];
 }
 


### PR DESCRIPTION
## Changes

#13029 seems to have introduced a syntax error in an import. This fixes it and adds a biome ignore

Fixes #13057 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
