### PR TITLE
chore: adds wontfix label action

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -28,3 +28,16 @@ jobs:
           body: |
             Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new/repro). Issues marked with `needs repro` will be closed if they have no activity within 3 days.
           labels: "needs triage"
+      - name: wontfix
+        if: github.event.label.name == 'wontfix'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment, close-issue"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello! 
+
+            We're closing this issue because this isn't something that's likely to be fixed in the near future. With limited resources, we have to prioritize work that will benefit the most users.
+
+            We very much welcome [contributions](https://docs.astro.build/en/contribute/) so if you think you have a fix for this issue, please feel free to submit a PR. You can also discuss it in the [Astro Discord](https://astro.build/chat).

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -40,7 +40,7 @@ jobs:
 
             This is an automated message to let you know that we've triaged this issue and unfortunately, we will be closing it as "not planned".
 
-            We sometimes have to close good ideas (even great ones!) because our limited resources simply do not allow us to pursue all possible features and improvements, and when fixing bugs we have to balance the impact of the bug against the effort required for the fix. Before closing this we considered several factors such as the amount of work involved, the severity of the problem, the number of people affected, whether a workaround is available and the ongoing cost of maintenance.
+            We sometimes have to close good ideas (even great ones!) because our limited resources simply do not allow us to pursue all possible features and improvements, and when fixing bugs we have to balance the impact of the bug against the effort required for the fix. Before closing this we considered several factors such as the amount of work involved, the severity of the problem, the number of people affected, whether a workaround is available, and the ongoing cost of maintenance.
 
             If you're seeing this message and believe you can contribute to this issue, please consider submitting a PR yourself. Astro encourages [community contributions]((https://docs.astro.build/en/contribute/)!
 

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -38,6 +38,10 @@ jobs:
           body: |
             Hello! 
 
-            We're closing this issue because this isn't something that's likely to be fixed in the near future. With limited resources, we have to prioritize work that will benefit the most users.
+            This is an automated message to let you know that we've triaged this issue and unfortunately, we will be closing it as "not planned".
 
-            We very much welcome [contributions](https://docs.astro.build/en/contribute/) so if you think you have a fix for this issue, please feel free to submit a PR. You can also discuss it in the [Astro Discord](https://astro.build/chat).
+            We sometimes have to close good ideas (even great ones!) because our limited resources simply do not allow us to pursue all possible features and improvements, and when fixing bugs we have to balance the impact of the bug against the effort required for the fix. Before closing this we considered several factors such as the amount of work involved, the severity of the problem, the number of people affected, whether a workaround is available and the ongoing cost of maintenance.
+
+            If you're seeing this message and believe you can contribute to this issue, please consider submitting a PR yourself. Astro encourages [community contributions]((https://docs.astro.build/en/contribute/)!
+
+            If you have more questions, come and say hi in the [Astro Discord](https://astro.build/chat).


### PR DESCRIPTION
Adds a new action when the `wontfix` label is applied which leaves a comment and closes the issue as "not planned"