### PR TITLE
fix: let sharp process svg images

### DIFF
--- a/.changeset/swift-mayflies-film.md
+++ b/.changeset/swift-mayflies-film.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where SVGs could not be transformed via Sharp

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -58,10 +58,6 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 		if (!sharp) sharp = await loadSharp();
 		const transform: BaseServiceTransform = transformOptions as BaseServiceTransform;
 
-		// Return SVGs as-is
-		// TODO: Sharp has some support for SVGs, we could probably support this once Sharp is the default and only service.
-		if (transform.format === 'svg') return { data: inputBuffer, format: 'svg' };
-
 		const result = sharp(inputBuffer, {
 			failOnError: false,
 			pages: -1,


### PR DESCRIPTION
Hello!

We have a repo where I wanted to use our logo as favicon. SVGs may finally be used directly! 🤗
But we do have to provide PNGs as fallback. And even `.ico`, to be really safe.

The idea was to then commit just the SVG as asset and single source of truth, and convert that through `getImage`.

Generating the `.ico` is kind of special[^1], but this approach worked, so I figured it'd be pretty much the same for `getImage`.

[^1]: https://github.com/sealambda/ostaro/blob/main/src/pages/favicon.ico.ts

Interestingly, however, when we tried to do the same in the component using `getImage` we would just get the same SVG out, untouched.

I was then able to find #7643 where this was deliberately implemented. From what I understand, other transformation services may not support SVG, but I'm not sure why it would be prevented in Sharp, too?

I couldn't really figure out the rationale, but maybe I'm missing something. Hope this makes sense!

## Changes

- Let Sharp process SVG files

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I tested this against my repo, where I had identified the bug, with the following component:

```astro
---
import faviconSrc from "@assets/logo.svg";

const favicon = (size: number) =>
  getImage({
    src: faviconSrc,
    format: "png",
    width: size,
    height: size,
  });

const appleTouchIcon = await favicon(180);
const favicon32 = await favicon(32);
const favicon16 = await favicon(16);
---

<link rel="apple-touch-icon" href={appleTouchIcon.src} />
<link rel="icon" type="image/png" sizes="32x32" href={favicon32.src} />
<link rel="icon" type="image/png" sizes="16x16" href={favicon16.src} />

```

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
I'm not sure whether something should be added to the docs, to be honest, I didn't find anything mentioning that SVG would not be supported as an input to `getImage` in the docs, but that's the case right now. With this fix, nothing should be mentioned as things should just work out of the box.
