### PR TITLE
docs: update the JSDoc of `integrations` to replace Tailwind integration

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -361,10 +361,10 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 *
 	 * ```js
 	 * import react from '@astrojs/react';
-	 * import tailwind from '@astrojs/tailwind';
+	 * import mdx from '@astrojs/mdx';
 	 * {
-	 *   // Example: Add React + Tailwind support to Astro
-	 *   integrations: [react(), tailwind()]
+	 *   // Example: Add React + MDX support to Astro
+	 *   integrations: [react(), mdx()]
 	 * }
 	 * ```
 	 */


### PR DESCRIPTION
## Changes

**For `5.2`** :

Since `@astrojs/tailwind` is deprecated and we recommend to remove the integration in favor of the Vite plugin, I think we should update the example in the [Configuration reference](https://docs.astro.build/en/reference/configuration-reference/#integrations) to replace `@astrojs/tailwind` with another integration (I chose MDX but I can change).

I didn't add a changeset because I don't think it's necessary (if merged in time 😄). This is somehow part of #13049.

## Testing

N/A

## Docs

This is docs, just a small change but in case we prefer another example:
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
