### PR TITLE
fix: exclude Vite requests from trailing slash handling

### DIFF
--- a/.changeset/large-waves-cheat.md
+++ b/.changeset/large-waves-cheat.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a bug that caused some dev server asset requests to return 404 in dev
+Fixes a bug that caused some dev server asset requests to return 404 when trailingSlash was set to "always"

--- a/.changeset/large-waves-cheat.md
+++ b/.changeset/large-waves-cheat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused some dev server asset requests to return 404 in dev

--- a/packages/astro/src/vite-plugin-astro-server/trailing-slash.ts
+++ b/packages/astro/src/vite-plugin-astro-server/trailing-slash.ts
@@ -22,6 +22,9 @@ export function trailingSlashMiddleware(settings: AstroSettings): vite.Connect.N
 			/* malformed uri */
 			return next(e);
 		}
+		if(pathname.startsWith('/_') || pathname.startsWith('/@')) {
+			return next();
+		}
 		if (
 			(trailingSlash === 'never' && pathname.endsWith('/') && pathname !== '/') ||
 			(trailingSlash === 'always' && !pathname.endsWith('/') && !hasFileExtension(pathname))

--- a/packages/astro/test/fixtures/astro-dev-headers/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-dev-headers/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	trailingSlash: 'always',
+});

--- a/packages/astro/test/fixtures/astro-dev-headers/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-dev-headers/astro.config.mjs
@@ -1,5 +1,0 @@
-import { defineConfig } from 'astro/config';
-
-export default defineConfig({
-	trailingSlash: 'always',
-});

--- a/packages/astro/test/ssr-error-pages.test.js
+++ b/packages/astro/test/ssr-error-pages.test.js
@@ -169,6 +169,12 @@ describe('trailing slashes for error pages', () => {
 			const $ = cheerio.load(html);
 			assert.equal($('h1').text(), `Something went horribly wrong!`);
 		});
+
+		it('serves Vite assets correctly when trailingSlash is always', async () => {
+			const response = await fixture.fetch('/@vite/client');
+			assert.equal(response.status, 200);
+		});
+
 	});
 
 	describe('Production', () => {


### PR DESCRIPTION
## Changes

Skips internal Vite requests when checking trailing slashes

Fixes #13094

## Testing
Adding tests now

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
