### PR TITLE
fix: exclude tailwind package when installing integration

### DIFF
--- a/.changeset/green-sloths-switch.md
+++ b/.changeset/green-sloths-switch.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a bug that caused peer dependency errors when running "astro add tailwind"
+Fixes a bug that caused peer dependency errors when running `astro add tailwind`

--- a/.changeset/green-sloths-switch.md
+++ b/.changeset/green-sloths-switch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused peer dependency errors when running "astro add tailwind"

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -40,6 +40,7 @@ interface AddOptions {
 interface IntegrationInfo {
 	id: string;
 	packageName: string;
+	integrationName: string;
 	dependencies: [name: string, version: string][];
 	type: 'integration' | 'adapter';
 }
@@ -283,7 +284,7 @@ export async function add(names: string[], { flags }: AddOptions) {
 						'SKIP_FORMAT',
 						`\n  ${magenta(
 							`Check our deployment docs for ${bold(
-								integration.packageName,
+								integration.integrationName,
 							)} to update your "adapter" config.`,
 						)}`,
 					);
@@ -349,7 +350,9 @@ export async function add(names: string[], { flags }: AddOptions) {
 		case UpdateResult.failure:
 		case UpdateResult.updated:
 		case undefined: {
-			const list = integrations.map((integration) => `  - ${integration.packageName}`).join('\n');
+			const list = integrations
+				.map((integration) => `  - ${integration.integrationName}`)
+				.join('\n');
 			logger.info(
 				'SKIP_FORMAT',
 				msg.success(
@@ -618,8 +621,7 @@ async function convertIntegrationsToInstallSpecifiers(
 	integrations: IntegrationInfo[],
 ): Promise<string[]> {
 	const ranges: Record<string, string> = {};
-	for (let { packageName, dependencies } of integrations) {
-		ranges[packageName] = '*';
+	for (let { dependencies } of integrations) {
 		for (const [name, range] of dependencies) {
 			ranges[name] = range;
 		}
@@ -790,7 +792,7 @@ async function validateIntegrations(integrations: string[]): Promise<Integration
 
 				const resolvedScope = pkgType === 'first-party' ? '@astrojs' : scope;
 				const packageName = `${resolvedScope ? `${resolvedScope}/` : ''}${name}`;
-
+				let integrationName = packageName;
 				let dependencies: IntegrationInfo['dependencies'] = [
 					[pkgJson['name'], `^${pkgJson['version']}`],
 				];
@@ -823,13 +825,19 @@ async function validateIntegrations(integrations: string[]): Promise<Integration
 				}
 
 				if (integration === 'tailwind') {
+					integrationName = 'tailwind';
 					dependencies = [
 						['@tailwindcss/vite', '^4.0.0'],
 						['tailwindcss', '^4.0.0'],
 					];
 				}
-
-				return { id: integration, packageName, dependencies, type: integrationType };
+				return {
+					id: integration,
+					packageName,
+					dependencies,
+					type: integrationType,
+					integrationName,
+				};
 			}),
 		);
 		spinner.success();


### PR DESCRIPTION
## Changes

Special-cases tailwind to ensure it doesn't install the integration package, which is deprecated. Previously it was always installing the integration package, even though it was also always added to the dependencies list. This changes it to only install the listed deps. It also adds an `integrationName` field, because in logs it was confusing having it log `@astrojs/tailwind` when that package wasn't actually installed.

Fixes #13097 

## Testing
There are currently no tests for `atro add`. It's a tough one to test without some kind of mocking for the package manager, so I'll leave it for now, beacuse this bug is affecting lots of users.


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
