### PR TITLE
fix: remove special handling for injected endpoint slashes

### DIFF
--- a/.changeset/itchy-roses-walk.md
+++ b/.changeset/itchy-roses-walk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused injected endpoint routes to return not found when trailingSlash was set to always

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -276,8 +276,7 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Rou
 			});
 
 		const type = resolved.endsWith('.astro') ? 'page' : 'endpoint';
-		const isPage = type === 'page';
-		const trailingSlash = isPage ? config.trailingSlash : 'never';
+		const { trailingSlash } = config;
 
 		const pattern = getPattern(segments, settings.config.base, trailingSlash);
 		const generate = getRouteGenerator(segments, trailingSlash);

--- a/packages/astro/test/units/routing/trailing-slash.test.js
+++ b/packages/astro/test/units/routing/trailing-slash.test.js
@@ -11,6 +11,7 @@ import {
 
 const fileSystem = {
 	'/src/pages/api.ts': `export const GET = () => Response.json({ success: true })`,
+	'/src/pages/dot.json.ts': `export const GET = () => Response.json({ success: true })`,
 };
 
 describe('trailingSlash', () => {
@@ -24,6 +25,23 @@ describe('trailingSlash', () => {
 			trailingSlash: 'always',
 			output: 'server',
 			adapter: testAdapter(),
+			integrations: [
+				{
+					name: 'test',
+					hooks: {
+						'astro:config:setup': ({ injectRoute }) => {
+							injectRoute({
+								pattern: '/injected',
+								entrypoint: './src/pages/api.ts',
+							});
+							injectRoute({
+								pattern: '/injected.json',
+								entrypoint: './src/pages/api.ts',
+							});
+						},
+					},
+				},
+			],
 		});
 		container = await createContainer({
 			settings,
@@ -55,4 +73,47 @@ describe('trailingSlash', () => {
 		assert.equal(html.includes(`<span class="statusMessage">Not found</span>`), true);
 		assert.equal(res.statusCode, 404);
 	});
+
+	it('should match an injected route when request has a trailing slash', async () => {
+		const { req, res, text } = createRequestAndResponse({
+			method: 'GET',
+			url: '/injected/',
+		});
+		container.handle(req, res);
+		const json = await text();
+		assert.equal(json, '{"success":true}');
+	});
+
+	it('should NOT match an injected route when request lacks a trailing slash', async () => {
+		const { req, res, text } = createRequestAndResponse({
+			method: 'GET',
+			url: '/injected',
+		});
+		container.handle(req, res);
+		const html = await text();
+		assert.equal(html.includes(`<span class="statusMessage">Not found</span>`), true);
+		assert.equal(res.statusCode, 404);
+	});
+
+	it('should match the API route when request has a trailing slash, with a file extension', async () => {
+		const { req, res, text } = createRequestAndResponse({
+			method: 'GET',
+			url: '/dot.json/',
+		});
+		container.handle(req, res);
+		const json = await text();
+		assert.equal(json, '{"success":true}');
+	});
+
+	it('should NOT match the API route when request lacks a trailing slash, with a file extension', async () => {
+		const { req, res, text } = createRequestAndResponse({
+			method: 'GET',
+			url: '/dot.json',
+		});
+		container.handle(req, res);
+		const html = await text();
+		assert.equal(html.includes(`<span class="statusMessage">Not found</span>`), true);
+		assert.equal(res.statusCode, 404);
+	});
+
 });


### PR DESCRIPTION
## Changes
Back in the day, endpoints were special-cased to ignore trailing slash rules and always have it set to ignore. This turned out to break things, so it was removed for file-based endpoint routes in #9597. However injected endpoints were left out of that fix, meaning there was still the bug for them.

Fixes #13105

## Testing
Added tests
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
