### PR TITLE
feat: pass astro version as argument to integration hook astro:config...

### DIFF
--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -32,6 +32,7 @@ import type {
 } from '../types/public/integrations.js';
 import type { RouteData } from '../types/public/internal.js';
 import { validateSupportedFeatures } from './features-validation.js';
+import { ASTRO_VERSION } from '../core/constants.js';
 
 async function withTakingALongTimeMsg<T>({
 	name,
@@ -176,6 +177,7 @@ export async function runHookConfigSetup({
 				config: updatedConfig,
 				command,
 				isRestart,
+				astroVersion: ASTRO_VERSION,
 				addRenderer(renderer: AstroRenderer) {
 					if (!renderer.name) {
 						throw new Error(`Integration ${bold(integration.name)} has an unnamed renderer.`);

--- a/packages/astro/src/types/public/integrations.ts
+++ b/packages/astro/src/types/public/integrations.ts
@@ -160,6 +160,7 @@ export interface BaseIntegrationHooks {
 		config: AstroConfig;
 		command: 'dev' | 'build' | 'preview' | 'sync';
 		isRestart: boolean;
+		astroVersion: string;
 		updateConfig: (newConfig: DeepPartial<AstroConfig>) => AstroConfig;
 		addRenderer: (renderer: AstroRenderer) => void;
 		addWatchFile: (path: URL | string) => void;


### PR DESCRIPTION
## Changes
- Pass constant `ASTRO_VERSION` as argument to integration hook `astro:config:setup`.

## Testing
None added yet.

## Docs
Argument needs to be added to docs page [Integration API](https://docs.astro.build/en/reference/integrations-reference/#astroconfigsetup)

/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
