### PR TITLE
Tailwind v4 onboarding enhancements

### DIFF
--- a/.changeset/spotty-maps-sneeze.md
+++ b/.changeset/spotty-maps-sneeze.md
@@ -2,4 +2,6 @@
 'astro': patch
 ---
 
-Improves `astro add tailwind` steps
+Adds extra guidance in the terminal when using the `astro add tailwind` CLI command
+
+Now, users are given a friendly reminder to import the stylesheet containing their Tailwind classes into any pages  where they want to use Tailwind. Commonly, this is a shared layout component so that Tailwind styling can be used on multiple pages.

--- a/.changeset/spotty-maps-sneeze.md
+++ b/.changeset/spotty-maps-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Make onboarding to tailwind v4 a bit more clear

--- a/.changeset/spotty-maps-sneeze.md
+++ b/.changeset/spotty-maps-sneeze.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Make onboarding to tailwind v4 a bit more clear
+Improves `astro add tailwind` steps

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -361,7 +361,12 @@ export async function add(names: string[], { flags }: AddOptions) {
 					} to your project:\n${list}`,
 				),
 			);
-			logger.info('SKIP_FORMAT', msg.success("Import './src/styles/global.css' in a layout"));
+			logger.warn(
+				'SKIP_FORMAT',
+				msg.action(
+					"You must make a manual change by adding the following in a layout\nimport './src/styles/global.css'",
+				),
+			);
 		}
 	}
 

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -371,7 +371,7 @@ export async function add(names: string[], { flags }: AddOptions) {
 						title: 'src/layouts/Layout.astro',
 					},
 				);
-				logger.warn('SKIP_FORMAT', msg.actionRequired('You must add the following in a layout:\n'));
+				logger.warn('SKIP_FORMAT', msg.actionRequired('You must import your Tailwind stylesheet, e.g. in a shared layout:\n'));
 				logger.info('SKIP_FORMAT', code + '\n');
 			}
 		}

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -364,7 +364,7 @@ export async function add(names: string[], { flags }: AddOptions) {
 			logger.warn(
 				'SKIP_FORMAT',
 				msg.action(
-					"You must make a manual change by adding the following in a layout\nimport './src/styles/global.css'",
+					"You must make a manual change by adding the following in a layout\n  import './src/styles/global.css'\n",
 				),
 			);
 		}

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -361,12 +361,19 @@ export async function add(names: string[], { flags }: AddOptions) {
 					} to your project:\n${list}`,
 				),
 			);
-			logger.warn(
-				'SKIP_FORMAT',
-				msg.actionRequired(
-					"You must add the following in a layout:\n  import './src/styles/global.css'\n",
-				),
-			);
+			if (integrations.find((integration) => integration.integrationName === 'tailwind')) {
+				const code = boxen(
+					getDiffContent('---\n---', "---\nimport './src/styles/global.css'\n---")!,
+					{
+						margin: 0.5,
+						padding: 0.5,
+						borderStyle: 'round',
+						title: 'src/layouts/Layout.astro',
+					},
+				);
+				logger.warn('SKIP_FORMAT', msg.actionRequired('You must add the following in a layout:\n'));
+				logger.info('SKIP_FORMAT', code + '\n');
+			}
 		}
 	}
 

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -363,8 +363,8 @@ export async function add(names: string[], { flags }: AddOptions) {
 			);
 			logger.warn(
 				'SKIP_FORMAT',
-				msg.action(
-					"You must make a manual change by adding the following in a layout\n  import './src/styles/global.css'\n",
+				msg.actionRequired(
+					"You must add the following in a layout:\n  import './src/styles/global.css'\n",
 				),
 			);
 		}

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -209,6 +209,15 @@ export function failure(message: string, tip?: string) {
 		.join('\n');
 }
 
+export function action(message: string) {
+	const badge = bgYellow(black(` action`));
+	const headline = yellow(message);
+	return ['', `${badge} ${headline}`]
+		.filter((v) => v !== undefined)
+		.map((msg) => `  ${msg}`)
+		.join('\n');
+}
+
 export function cancelled(message: string, tip?: string) {
 	const badge = bgYellow(black(` cancelled `));
 	const headline = yellow(message);

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -210,7 +210,7 @@ export function failure(message: string, tip?: string) {
 }
 
 export function action(message: string) {
-	const badge = bgYellow(black(` action`));
+	const badge = bgYellow(black(` action `));
 	const headline = yellow(message);
 	return ['', `${badge} ${headline}`]
 		.filter((v) => v !== undefined)

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -209,8 +209,8 @@ export function failure(message: string, tip?: string) {
 		.join('\n');
 }
 
-export function action(message: string) {
-	const badge = bgYellow(black(` action `));
+export function actionRequired(message: string) {
+	const badge = bgYellow(black(` action required `));
 	const headline = yellow(message);
 	return ['', `${badge} ${headline}`]
 		.filter((v) => v !== undefined)


### PR DESCRIPTION
## Changes

Making it more clear that a user action is required after onboarding to tailwind v4.

twitter thread: https://x.com/Hacksore/status/1885490439437857143

## Testing

built locally and ran `node astro.js add tailwind` in the `packages/astro` dir.
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/b9e86d74-f28a-4680-9560-1291454c1bb4" />

## Docs
N/A
