### PR TITLE
Fix typo

### DIFF
--- a/packages/integrations/svelte/client.svelte.js
+++ b/packages/integrations/svelte/client.svelte.js
@@ -1,6 +1,6 @@
 import { createRawSnippet, hydrate, mount, unmount } from 'svelte';
 
-/** @type {WrakMap<any, ReturnType<typeof createComponent>} */
+/** @type {WeakMap<any, ReturnType<typeof createComponent>} */
 const existingApplications = new WeakMap();
 
 export default (element) => {


### PR DESCRIPTION
## Changes

This PR fixes a typo in the JSDoc: `WrakMap` should be `WeakMap`

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
