### PR TITLE
fix: ignore trailing slash for endpoints with file extensions

### DIFF
--- a/.changeset/purple-suits-matter.md
+++ b/.changeset/purple-suits-matter.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ignores trailing slashes for endpoints with file extensions in the route

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -19,7 +19,7 @@ import {
 	UnsupportedExternalRedirect,
 } from '../../errors/errors-data.js';
 import { AstroError } from '../../errors/index.js';
-import { removeLeadingForwardSlash, slash } from '../../path.js';
+import { hasFileExtension, removeLeadingForwardSlash, slash } from '../../path.js';
 import { injectServerIslandRoute } from '../../server-islands/endpoint.js';
 import { resolvePages } from '../../util.js';
 import { ensure404Route } from '../astro-designed-error-pages.js';
@@ -218,12 +218,12 @@ function createFileBasedRoutes(
 			} else {
 				components.push(item.file);
 				const component = item.file;
-				const { trailingSlash } = settings.config;
-				const pattern = getPattern(segments, settings.config.base, trailingSlash);
-				const generate = getRouteGenerator(segments, trailingSlash);
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
 					: null;
+				const trailingSlash = trailingSlashForPath(pathname, settings.config);
+				const pattern = getPattern(segments, settings.config.base, trailingSlash);
+				const generate = getRouteGenerator(segments, trailingSlash);
 				const route = joinSegments(segments);
 				routes.push({
 					route,
@@ -257,6 +257,14 @@ function createFileBasedRoutes(
 	return routes;
 }
 
+// Get trailing slash rule for a path, based on the config and whether the path has an extension.
+// TODO: in Astro 6, change endpoints with extentions to use 'never'
+const trailingSlashForPath = (
+	pathname: string | null,
+	config: AstroConfig,
+): AstroConfig['trailingSlash'] =>
+	pathname && hasFileExtension(pathname) ? 'ignore' : config.trailingSlash;
+
 function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): RouteData[] {
 	const { config } = settings;
 	const prerender = getPrerenderDefault(config);
@@ -276,13 +284,13 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Rou
 			});
 
 		const type = resolved.endsWith('.astro') ? 'page' : 'endpoint';
-		const { trailingSlash } = config;
-
-		const pattern = getPattern(segments, settings.config.base, trailingSlash);
-		const generate = getRouteGenerator(segments, trailingSlash);
 		const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 			? `/${segments.map((segment) => segment[0].content).join('/')}`
 			: null;
+
+		const trailingSlash = trailingSlashForPath(pathname, config);
+		const pattern = getPattern(segments, settings.config.base, trailingSlash);
+		const generate = getRouteGenerator(segments, trailingSlash);
 		const params = segments
 			.flat()
 			.filter((p) => p.dynamic)

--- a/packages/astro/test/units/routing/trailing-slash.test.js
+++ b/packages/astro/test/units/routing/trailing-slash.test.js
@@ -95,24 +95,34 @@ describe('trailingSlash', () => {
 		assert.equal(res.statusCode, 404);
 	});
 
-	it('should match the API route when request has a trailing slash, with a file extension', async () => {
+	it('should match an injected route when request has a file extension and no slash', async () => {
 		const { req, res, text } = createRequestAndResponse({
 			method: 'GET',
-			url: '/dot.json/',
+			url: '/injected.json',
 		});
 		container.handle(req, res);
 		const json = await text();
 		assert.equal(json, '{"success":true}');
 	});
 
-	it('should NOT match the API route when request lacks a trailing slash, with a file extension', async () => {
+	it('should match the API route when request has a trailing slash, with a file extension', async () => {
 		const { req, res, text } = createRequestAndResponse({
 			method: 'GET',
-			url: '/dot.json',
+			url: '/dot.json/',
 		});
 		container.handle(req, res);
 		const html = await text();
 		assert.equal(html.includes(`<span class="statusMessage">Not found</span>`), true);
 		assert.equal(res.statusCode, 404);
+	});
+
+	it('should also match the API route when request lacks a trailing slash, with a file extension', async () => {
+		const { req, res, text } = createRequestAndResponse({
+			method: 'GET',
+			url: '/dot.json',
+		});
+		container.handle(req, res);
+		const json = await text();
+		assert.equal(json, '{"success":true}');
 	});
 });

--- a/packages/astro/test/units/routing/trailing-slash.test.js
+++ b/packages/astro/test/units/routing/trailing-slash.test.js
@@ -111,9 +111,8 @@ describe('trailingSlash', () => {
 			url: '/dot.json/',
 		});
 		container.handle(req, res);
-		const html = await text();
-		assert.equal(html.includes(`<span class="statusMessage">Not found</span>`), true);
-		assert.equal(res.statusCode, 404);
+		const json = await text();
+		assert.equal(json, '{"success":true}');
 	});
 
 	it('should also match the API route when request lacks a trailing slash, with a file extension', async () => {


### PR DESCRIPTION
## Changes

#13111 removed special handling for endpoint trailing slashes, because they broke trailignSlash=always. However this caused a regression for endpoints that include a file extension. This PR changes the handling for endpoints that include a file extension, to always use `trailingSlash: "ignore"`. This means it will match with and without the extension. I've done it liek this rather than setting to `never`, because that would be a breakign change. Currently _file-based_ endpoints do obey trailing slash rules, even with file extensions. This is probably a mistake (who wants `/sitemap.xml/`), but some may rely on it so we'll move any change to Astro 6.

Fixes #13128


## Testing
Adds tests
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
