### PR TITLE
fix(routing): skip middleware for external redirects

### DIFF
--- a/.changeset/lazy-readers-change.md
+++ b/.changeset/lazy-readers-change.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where Astro was failing to build an external redirect when the middleware was triggered

--- a/packages/astro/src/core/routing/match.ts
+++ b/packages/astro/src/core/routing/match.ts
@@ -1,5 +1,6 @@
 import type { RoutesList } from '../../types/astro.js';
 import type { RouteData } from '../../types/public/internal.js';
+import { redirectIsExternal } from '../redirects/render.js';
 import { SERVER_ISLAND_BASE_PREFIX, SERVER_ISLAND_COMPONENT } from '../server-islands/endpoint.js';
 
 /** Find matching route from pathname */
@@ -75,4 +76,19 @@ export function requestIs404Or500(request: Request, base = '') {
 	const pathname = url.pathname.slice(base.length);
 
 	return isRoute404(pathname) || isRoute500(pathname);
+}
+
+/**
+ * Determines whether a given route is an external redirect.
+ *
+ * @param {RouteData} route - The route object to check.
+ * @return {boolean} Returns true if the route is an external redirect, otherwise false.
+ */
+export function isRouteExternalRedirect(route: RouteData): boolean {
+	if (route.type === 'redirect') {
+		if (route.redirect && redirectIsExternal(route.redirect)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/astro/src/core/routing/match.ts
+++ b/packages/astro/src/core/routing/match.ts
@@ -85,10 +85,5 @@ export function requestIs404Or500(request: Request, base = '') {
  * @return {boolean} Returns true if the route is an external redirect, otherwise false.
  */
 export function isRouteExternalRedirect(route: RouteData): boolean {
-	if (route.type === 'redirect') {
-		if (route.redirect && redirectIsExternal(route.redirect)) {
-			return true;
-		}
-	}
-	return false;
+	return !!(route.type === 'redirect' && route.redirect && redirectIsExternal(route.redirect));
 }

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -64,6 +64,7 @@ export function createI18nMiddleware(
 	};
 
 	return async (context, next) => {
+		console.log('calling headers type');
 		const response = await next();
 		const type = response.headers.get(ROUTE_TYPE_HEADER);
 

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -64,7 +64,6 @@ export function createI18nMiddleware(
 	};
 
 	return async (context, next) => {
-		console.log('calling headers type');
 		const response = await next();
 		const type = response.headers.get(ROUTE_TYPE_HEADER);
 

--- a/packages/astro/test/fixtures/redirects-i18n/astro.config.mjs
+++ b/packages/astro/test/fixtures/redirects-i18n/astro.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+	i18n: {
+		defaultLocale: 'de',
+		locales: ['de', 'en'],
+		routing: {
+			prefixDefaultLocale: true,
+		},
+		fallback: {
+			en: 'de',
+		},
+	},
+	redirects: {
+		'/mytest': 'https://example.com/about',
+	},
+})

--- a/packages/astro/test/fixtures/redirects-i18n/package.json
+++ b/packages/astro/test/fixtures/redirects-i18n/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/redirects-i18n",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -269,6 +269,22 @@ describe('Astro.redirect', () => {
 				assert.equal(response.headers.get('Location'), '/more/new/welcome/world');
 			});
 		});
+
+		describe('with i18n, build step', () => {
+			before(async () => {
+				process.env.STATIC_MODE = true;
+				fixture = await loadFixture({
+					root: './fixtures/redirects-i18n/',
+				});
+				await fixture.build();
+			});
+
+			it('should render the external redirect', async () => {
+				const html = await fixture.readFile('/mytest/index.html');
+				assert.equal(html.includes('http-equiv="refresh'), true);
+				assert.equal(html.includes('url=https://example.com/about'), true);
+			});
+		});
 	});
 
 	describe('config.build.redirects = false', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3579,6 +3579,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/redirects-i18n:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/reexport-astro-containing-client-component:
     dependencies:
       '@astrojs/preact':


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/13120

The fix is inside `RenderContext`, and now check if the route that we are about to render is an external redirect. If it is, we skip the whole middleware chain, and render the redirect straight away.

I checked with Matt and Florian, and they agree with the proposed solution. 

## Testing

I added a new test and fixture based on the reproduction provided.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
