### PR TITLE
feat: Add isRedirect to context

### DIFF
--- a/.changeset/spicy-ducks-fly.md
+++ b/.changeset/spicy-ducks-fly.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add isRedirect field to context

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -86,6 +86,7 @@ function createContext({
 			});
 		},
 		isPrerendered: false,
+		isRedirect: false,
 		get preferredLocale(): string | undefined {
 			return (preferredLocale ??= computePreferredLocale(request, userDefinedLocales));
 		},

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -334,6 +334,7 @@ export class RenderContext {
 			cookies,
 			routePattern: this.routeData.route,
 			isPrerendered: this.routeData.prerender,
+			isRedirect: this.routeData.type === "redirect",
 			get clientAddress() {
 				return renderContext.getClientAddress();
 			},
@@ -515,6 +516,7 @@ export class RenderContext {
 			glob: astroStaticPartial.glob,
 			routePattern: this.routeData.route,
 			isPrerendered: this.routeData.prerender,
+			isRedirect: this.routeData.type === "redirect",
 			cookies,
 			session,
 			get clientAddress() {

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -354,6 +354,11 @@ interface AstroSharedContext<
 	 * Whether the current route is prerendered or not.
 	 */
 	isPrerendered: boolean;
+
+	/**
+	 * Whether the current route is a redirect or not.
+	 */
+	isRedirect: boolean;
 }
 
 /**

--- a/packages/astro/test/fixtures/redirects/src/middleware.ts
+++ b/packages/astro/test/fixtures/redirects/src/middleware.ts
@@ -1,6 +1,6 @@
 import { defineMiddleware } from 'astro:middleware';
 
-export const onRequest = defineMiddleware(({ request }, next) => {
+export const onRequest = defineMiddleware(async ({ request, isRedirect }, next) => {
 	if(new URL(request.url).pathname === '/middleware-redirect/') {
 		return new Response(null, {
 			status: 301,
@@ -9,5 +9,7 @@ export const onRequest = defineMiddleware(({ request }, next) => {
 			}
 		});
 	}
-	return next();
+	const response = await next();
+	response.headers.set('X-Is-Redirect', `${isRedirect}`);
+	return response;
 });

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -268,6 +268,11 @@ describe('Astro.redirect', () => {
 				const response = await fixture.fetch('/more/old/welcome/world', { redirect: 'manual' });
 				assert.equal(response.headers.get('Location'), '/more/new/welcome/world');
 			});
+
+			it('provides isRedirect to the context', async () => {
+				const response = await fixture.fetch('/one', { redirect: 'manual' });
+				assert.equal(response.headers.get("X-Is-Redirect"), "true");
+			});
 		});
 
 		describe('with i18n, build step', () => {


### PR DESCRIPTION
## Changes

I added the `isRedirect` field to the Render context. This can help users avoid running middleware on routes that might just be a redirect.

For example, the Arcjet integration [fails if run on a redirect](https://github.com/arcjet/arcjet-js/issues/3094) because `isPrerendered` is false, but `clientAddress` throws if accessed; however, it would be generally recommended not to run Arcjet on a redirect because it'll run on the final endpoint. With this change, we can recommend users skip Arcjet when `isRedirect` is true.

## Testing

I added a test to the redirects fixture that checks a header that is set by the middleware.

## Docs

Yep! I'll add this to the Astro docs for Render context if this is something y'all want to include. 🎉 
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
