### PR TITLE
feat: Add Route Groups [WIP]

### DIFF
--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -46,8 +46,13 @@ interface Item {
 // eslint-disable-next-line regexp/no-super-linear-backtracking
 const ROUTE_DYNAMIC_SPLIT = /\[(.+?\(.+?\)|.+?)\]/;
 const ROUTE_SPREAD = /^\.{3}.+$/;
+const ROUTE_GROUP = /^\(.+\)$/;
 
 export function getParts(part: string, file: string) {
+	// Skip route group segments
+	if (ROUTE_GROUP.test(part)) {
+		return [];
+	}
 	const result: RoutePart[] = [];
 	part.split(ROUTE_DYNAMIC_SPLIT).map((str, i) => {
 		if (!str) return;
@@ -160,6 +165,13 @@ function createFileBasedRoutes(
 			}
 			const segment = isDir ? basename : name;
 			validateSegment(segment, file);
+
+			// Check if this is a route group, if yes skip group folder name but process its content
+			const isRouteGroup = ROUTE_GROUP.test(segment);
+			if (isRouteGroup && isDir) {
+				walk(fsMod ?? fs, path.join(dir, basename), parentSegments, parentParams);
+				continue;
+			}
 
 			const parts = getParts(segment, file);
 			const isIndex = isDir ? false : basename.substring(0, basename.lastIndexOf('.')) === 'index';


### PR DESCRIPTION
## Changes

This aims to add Route Groups, as known from Next.js and requested here: https://github.com/withastro/roadmap/discussions/480

Folder names in (parenthesis) should be excluded from the route structure, but their content should not be.

This can especially be helpful with boilerplates to encapsulate some of the logic.

## Testing

Some tests should be added for sure. I had a quick look at [packages/astro/test/route-manifest.test.js](https://github.com/withastro/astro/blob/main/packages/astro/test/route-manifest.test.js) but they are all commented out.

I did some quick manual testing to check that it works as expected, however can't rule out that there have been major oversights since I didn't dig trough the whole codebase. 

## Docs

Docs should be added for this, probably a small passage in https://docs.astro.build/en/guides/routing/
As this this should not clash with any existing route logic, this could hopefully be kept rather short

<!-- /cc @withastro/maintainers-docs for feedback! -->
