### PR TITLE
chore: fix linting issues, integration tests

### DIFF
--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
-    "directory": "packages/cloudflare"
+    "directory": "packages/integrations/cloudflare"
   },
   "keywords": [
     "withastro",

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
-    "directory": "packages/netlify"
+    "directory": "packages/integrations/netlify"
   },
   "keywords": [
     "withastro",
@@ -50,7 +50,7 @@
     "@netlify/edge-functions": "^2.11.1",
     "@netlify/edge-handler-types": "^0.34.1",
     "@types/node": "^22.10.6",
-    "astro": "^5.1.6",
+    "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.0.0",
     "execa": "^8.0.1",

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -91,7 +91,7 @@ export function remotePatternToRegex(
 	}
 	try {
 		new RegExp(regexStr);
-	} catch (_e) {
+	} catch {
 		logger.warn(
 			`Could not generate a valid regex from the remotePattern "${JSON.stringify(
 				pattern,

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -91,7 +91,7 @@ export function remotePatternToRegex(
 	}
 	try {
 		new RegExp(regexStr);
-	} catch (e) {
+	} catch (_e) {
 		logger.warn(
 			`Could not generate a valid regex from the remotePattern "${JSON.stringify(
 				pattern,

--- a/packages/integrations/netlify/test/functions/redirects.test.js
+++ b/packages/integrations/netlify/test/functions/redirects.test.js
@@ -46,7 +46,7 @@ describe(
 
 		it('does not pass through 404 request', async () => {
 			let testServerCalls = 0;
-			const testServer = createServer((req, res) => {
+			const testServer = createServer((_req, res) => {
 				testServerCalls++;
 				res.writeHead(200);
 				res.end();

--- a/packages/integrations/netlify/test/hosted/hosted-astro-project/package.json
+++ b/packages/integrations/netlify/test/hosted/hosted-astro-project/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "@astrojs/netlify": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
-    "directory": "packages/node"
+    "directory": "packages/integrations/node"
   },
   "keywords": [
     "withastro",
@@ -41,7 +41,7 @@
     "@types/node": "^22.10.6",
     "@types/send": "^0.17.4",
     "@types/server-destroy": "^1.0.4",
-    "astro": "^5.1.6",
+    "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.0.0",
     "express": "^4.21.2",

--- a/packages/integrations/node/src/middleware.ts
+++ b/packages/integrations/node/src/middleware.ts
@@ -23,7 +23,6 @@ export default function createMiddleware(app: NodeApp): RequestHandler {
 			const error = req;
 			if (next) {
 				return next(error);
-				// biome-ignore lint/style/noUselessElse: <explanation>
 			} else {
 				throw error;
 			}
@@ -34,7 +33,6 @@ export default function createMiddleware(app: NodeApp): RequestHandler {
 			logger.error(`Could not render ${req.url}`);
 			console.error(err);
 			if (!res.headersSent) {
-				// biome-ignore lint/style/noUnusedTemplateLiteral: <explanation>
 				res.writeHead(500, `Server error`);
 				res.end();
 			}

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -10,13 +10,11 @@ type MaybeServerModule = Partial<ServerModule>;
 
 const createPreviewServer: CreatePreviewServer = async (preview) => {
 	let ssrHandler: ServerModule['handler'];
-	let _options: ServerModule['options'];
 	try {
 		process.env.ASTRO_NODE_AUTOSTART = 'disabled';
 		const ssrModule: MaybeServerModule = await import(preview.serverEntrypoint.toString());
 		if (typeof ssrModule.handler === 'function') {
 			ssrHandler = ssrModule.handler;
-			_options = ssrModule.options!;
 		} else {
 			throw new AstroError(
 				`The server entrypoint doesn't have a handler. Are you sure this is the right file?`,

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -10,14 +10,13 @@ type MaybeServerModule = Partial<ServerModule>;
 
 const createPreviewServer: CreatePreviewServer = async (preview) => {
 	let ssrHandler: ServerModule['handler'];
-	let options: ServerModule['options'];
+	let _options: ServerModule['options'];
 	try {
 		process.env.ASTRO_NODE_AUTOSTART = 'disabled';
 		const ssrModule: MaybeServerModule = await import(preview.serverEntrypoint.toString());
 		if (typeof ssrModule.handler === 'function') {
 			ssrHandler = ssrModule.handler;
-			// biome-ignore lint/style/noNonNullAssertion: <explanation>
-			options = ssrModule.options!;
+			_options = ssrModule.options!;
 		} else {
 			throw new AstroError(
 				`The server entrypoint doesn't have a handler. Are you sure this is the right file?`,
@@ -30,7 +29,6 @@ const createPreviewServer: CreatePreviewServer = async (preview) => {
 					preview.serverEntrypoint,
 				)} does not exist. Have you ran a build yet?`,
 			);
-			// biome-ignore lint/style/noUselessElse: <explanation>
 		} else {
 			throw err;
 		}

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -38,7 +38,6 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 			switch (trailingSlash) {
 				case 'never': {
 					if (isDirectory && urlPath !== '/' && hasSlash) {
-						// biome-ignore lint/style/useTemplate: more readable like this
 						pathname = urlPath.slice(0, -1) + (urlQuery ? '?' + urlQuery : '');
 						res.statusCode = 301;
 						res.setHeader('Location', pathname);
@@ -58,7 +57,6 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 				case 'always': {
 					// trailing slash is not added to "subresources"
 					if (!hasSlash && !isSubresourceRegex.test(urlPath)) {
-						// biome-ignore lint/style/useTemplate: more readable like this
 						pathname = urlPath + '/' + (urlQuery ? '?' + urlQuery : '');
 						res.statusCode = 301;
 						res.setHeader('Location', pathname);
@@ -117,7 +115,6 @@ function resolveClientDir(options: Options) {
 	while (!serverEntryFolderURL.endsWith(serverFolder)) {
 		serverEntryFolderURL = path.dirname(serverEntryFolderURL);
 	}
-	// biome-ignore lint/style/useTemplate: <explanation>
 	const serverEntryURL = serverEntryFolderURL + '/entry.mjs';
 	const clientURL = new URL(appendForwardSlash(rel), serverEntryURL);
 	const client = url.fileURLToPath(clientURL);
@@ -125,11 +122,9 @@ function resolveClientDir(options: Options) {
 }
 
 function prependForwardSlash(pth: string) {
-	// biome-ignore lint/style/useTemplate: <explanation>
 	return pth.startsWith('/') ? pth : '/' + pth;
 }
 
 function appendForwardSlash(pth: string) {
-	// biome-ignore lint/style/useTemplate: <explanation>
 	return pth.endsWith('/') ? pth : pth + '/';
 }

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -39,7 +39,6 @@ export function createStandaloneHandler(app: NodeApp, options: Options) {
 	return (req: http.IncomingMessage, res: http.ServerResponse) => {
 		try {
 			// validate request path
-			// biome-ignore lint/style/noNonNullAssertion: <explanation>
 			decodeURI(req.url!);
 		} catch {
 			res.writeHead(400);

--- a/packages/integrations/node/test/errors.test.js
+++ b/packages/integrations/node/test/errors.test.js
@@ -20,7 +20,6 @@ describe('Errors', () => {
 	});
 	let devPreview;
 
-	// biome-ignore lint/suspicious/noDuplicateTestHooks: <explanation>
 	before(async () => {
 		// The two tests that need the server to run are skipped
 		// devPreview = await fixture.preview();
@@ -76,9 +75,6 @@ describe('Errors', () => {
 			const chunk2 = await reader.read();
 			const chunk3 = await reader.read();
 			assert.equal(chunk1.done, false);
-			console.log(chunk1);
-			console.log(chunk2);
-			console.log(chunk3);
 			if (chunk2.done) {
 				assert.equal(decoder.decode(chunk1.value), result.join(''));
 			} else if (chunk3.done) {

--- a/packages/integrations/node/test/fixtures/api-route/package.json
+++ b/packages/integrations/node/test/fixtures/api-route/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/bad-urls/package.json
+++ b/packages/integrations/node/test/fixtures/bad-urls/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/encoded/package.json
+++ b/packages/integrations/node/test/fixtures/encoded/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/errors/package.json
+++ b/packages/integrations/node/test/fixtures/errors/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/headers/package.json
+++ b/packages/integrations/node/test/fixtures/headers/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/image/package.json
+++ b/packages/integrations/node/test/fixtures/image/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   },
   "peerDependencies": {
     "sharp": "^0.33.5"

--- a/packages/integrations/node/test/fixtures/locals/package.json
+++ b/packages/integrations/node/test/fixtures/locals/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/node-middleware/package.json
+++ b/packages/integrations/node/test/fixtures/node-middleware/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/prerender-404-500/package.json
+++ b/packages/integrations/node/test/fixtures/prerender-404-500/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/prerender/package.json
+++ b/packages/integrations/node/test/fixtures/prerender/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/preview-headers/package.json
+++ b/packages/integrations/node/test/fixtures/preview-headers/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/trailing-slash/package.json
+++ b/packages/integrations/node/test/fixtures/trailing-slash/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/url/package.json
+++ b/packages/integrations/node/test/fixtures/url/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/fixtures/well-known-locations/package.json
+++ b/packages/integrations/node/test/fixtures/well-known-locations/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@astrojs/node": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -225,7 +225,6 @@ describe('Prerendering', () => {
 		});
 
 		it('Can render SSR route', async () => {
-			// biome-ignore lint/style/noUnusedTemplateLiteral: <explanation>
 			const res = await fixture.fetch(`/one`);
 			const html = await res.text();
 			const $ = cheerio.load(html);
@@ -235,7 +234,6 @@ describe('Prerendering', () => {
 		});
 
 		it('Can render prerendered route', async () => {
-			// biome-ignore lint/style/noUnusedTemplateLiteral: <explanation>
 			const res = await fixture.fetch(`/two`);
 			const html = await res.text();
 			const $ = cheerio.load(html);

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
-    "directory": "packages/vercel"
+    "directory": "packages/integrations/vercel"
   },
   "keywords": [
     "withastro",

--- a/packages/integrations/vercel/test/edge-middleware.test.js
+++ b/packages/integrations/vercel/test/edge-middleware.test.js
@@ -48,7 +48,7 @@ describe('Vercel edge middleware', () => {
 			root: './fixtures/middleware-with-edge-file/',
 		});
 		await fixture.build();
-		const contents = await fixture.readFile(
+		const _contents = await fixture.readFile(
 			// this is abysmal...
 			'../.vercel/output/functions/render.func/www/withastro/astro/packages/vercel/test/fixtures/middleware-with-edge-file/dist/middleware.mjs',
 		);
@@ -63,7 +63,7 @@ describe('Vercel edge middleware', () => {
 			root: './fixtures/middleware-without-edge-file/',
 		});
 		await fixture.build();
-		const contents = await fixture.readFile(
+		const _contents = await fixture.readFile(
 			// this is abysmal...
 			'../.vercel/output/functions/render.func/www/withastro/astro/packages/vercel/test/fixtures/middleware-without-edge-file/dist/middleware.mjs',
 		);

--- a/packages/integrations/vercel/test/hosted/hosted-astro-project/package.json
+++ b/packages/integrations/vercel/test/hosted/hosted-astro-project/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "@astrojs/vercel": "workspace:*",
-    "astro": "^5.1.6"
+    "astro": "workspace:*"
   }
 }

--- a/packages/integrations/vercel/test/hosted/hosted.test.js
+++ b/packages/integrations/vercel/test/hosted/hosted.test.js
@@ -6,7 +6,6 @@ const VERCEL_TEST_URL = 'https://astro-vercel-image-test.vercel.app';
 describe('Hosted Vercel Tests', () => {
 	it('Image endpoint works', async () => {
 		const image = await fetch(
-			// biome-ignore lint/style/useTemplate: <explanation>
 			VERCEL_TEST_URL + '/_image?href=%2F_astro%2Fpenguin.e9c64733.png&w=300&f=webp',
 		);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5204,7 +5204,7 @@ importers:
         specifier: ^22.10.6
         version: 22.13.1
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../astro
       astro-scripts:
         specifier: workspace:*
@@ -5252,7 +5252,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/netlify/test/static/fixtures/redirects:
@@ -5280,7 +5280,7 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../astro
       astro-scripts:
         specifier: workspace:*
@@ -5301,7 +5301,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/bad-urls:
@@ -5310,7 +5310,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/encoded:
@@ -5319,7 +5319,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/errors:
@@ -5328,7 +5328,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/headers:
@@ -5337,7 +5337,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/image:
@@ -5346,7 +5346,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/locals:
@@ -5355,7 +5355,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/node-middleware:
@@ -5364,7 +5364,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/prerender:
@@ -5373,7 +5373,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/prerender-404-500:
@@ -5382,7 +5382,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/preview-headers:
@@ -5391,7 +5391,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/trailing-slash:
@@ -5400,7 +5400,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/url:
@@ -5409,7 +5409,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/node/test/fixtures/well-known-locations:
@@ -5418,7 +5418,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/partytown:
@@ -5867,7 +5867,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^5.1.6
+        specifier: workspace:*
         version: link:../../../../../astro
 
   packages/integrations/vue:


### PR DESCRIPTION
## Changes

This PR does the following:
- addresses many linting warnings, the majority were coming from unnecessary ignore comments
- updates the `package.json#repository.directory` of the newly moved adapters 
- updates all the integrations tests of the newly moved adapters to use the workspace version of Astro

## Testing

CI should be green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
