### PR TITLE
fix: error message text

### DIFF
--- a/.changeset/mean-icons-applaud.md
+++ b/.changeset/mean-icons-applaud.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the wording of the an error message

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -27,7 +27,7 @@ export const CantUseAstroConfigModuleError = {
 	name: 'CantUseAstroConfigModuleError',
 	title: 'Cannot use the `astro:config` module without enabling the experimental feature.',
 	message: (moduleName) =>
-		`Cannot import the module "${moduleName}" because the experimental feature is disabled. Enable \`experimental.serializeManifest\` in your \`astro.config.mjs\` `,
+		`Cannot import the module "${moduleName}" because the experimental feature is disabled. Enable \`experimental.serializeConfig\` in your \`astro.config.mjs\` `,
 } satisfies ErrorData;
 
 /**


### PR DESCRIPTION
## Changes

Fixes a typo inside the error message

## Testing

CI should stay green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
