### PR TITLE
feat(cloudflare): Includes onerror passthrough

### DIFF
--- a/.changeset/gentle-rings-confess.md
+++ b/.changeset/gentle-rings-confess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Includes onerror passthrough param for Cloudflare Image Service

--- a/packages/integrations/cloudflare/src/entrypoints/image-service.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/image-service.ts
@@ -7,7 +7,7 @@ import { isESMImportedImage, isRemoteAllowed } from '../utils/assets.js';
 const service: ExternalImageService = {
 	...baseService,
 	getURL: (options, imageConfig) => {
-		const resizingParams = [];
+		const resizingParams = ['onerror=redirect'];
 		if (options.width) resizingParams.push(`width=${options.width}`);
 		if (options.height) resizingParams.push(`height=${options.height}`);
 		if (options.quality) resizingParams.push(`quality=${options.quality}`);


### PR DESCRIPTION
## Changes

- Adds `onerror=redirect` to Cloudflare image transform params. This will allow images to continue to work after hitting Cloudflare's free limit. ([docs]( https://developers.cloudflare.com/images/transform-images/transform-via-url/#onerror))

I am not positive how this impacts sites that don't have the image service set up at all, since it might then load the original image as opposed to just erroring and loading nothing as it does now. If it still applies when the image service is disabled entirely, and shows the underlying image, it could cause some confusion with users not realizing the service isn't turned on.

## Testing

None. It's a hardcoded value, and I more want to introduce the idea to see if this should be a configurable value, or just always applied.

## Docs

This might be worth mentioning in the docs. I can make a PR to those once this is decided on.

Should this be a configurable? Currently there aren't configurations to the options, though maybe it could work with the `Image` to offer it if that is the preferred out.
