### PR TITLE
Fix:changes the paginate function to allow readonly array types

### DIFF
--- a/.changeset/thick-crabs-juggle.md
+++ b/.changeset/thick-crabs-juggle.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Changes the data parameter in paginate to readonly
+Allows readonly arrays to be passed to the `paginate()` function

--- a/.changeset/thick-crabs-juggle.md
+++ b/.changeset/thick-crabs-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Changes the data parameter in paginate to readonly

--- a/packages/astro/src/core/render/paginate.ts
+++ b/packages/astro/src/core/render/paginate.ts
@@ -15,7 +15,7 @@ export function generatePaginateFunction(
 	base: AstroConfig['base'],
 ): (...args: Parameters<PaginateFunction>) => ReturnType<PaginateFunction> {
 	return function paginateUtility(
-		data: any[],
+		data: readonly any[],
 		args: PaginateOptions<Props, Params> = {},
 	): ReturnType<PaginateFunction> {
 		let { pageSize: _pageSize, params: _params, props: _props } = args;

--- a/packages/astro/src/types/public/common.ts
+++ b/packages/astro/src/types/public/common.ts
@@ -82,7 +82,7 @@ export type PaginateFunction = <
 	AdditionalPaginateProps extends Props,
 	AdditionalPaginateParams extends Params,
 >(
-	data: PaginateData[],
+	data: readonly PaginateData[],
 	args?: PaginateOptions<AdditionalPaginateProps, AdditionalPaginateParams>,
 ) => {
 	params: Simplify<


### PR DESCRIPTION
## Changes

Resolves this issue #13196 

The paginate function allows for readonly arrays.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Just types were changed.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Just types were added