### PR TITLE
ci: preview release via pkg.pr.new for current packages

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -79,9 +79,9 @@ jobs:
   
       - name: Publish packages
         if: ${{ steps.packages.outputs.result != '' }}
-        run: pnpx pkg-pr-new publish --pnpm ${{ steps.packages.outputs.result }}
+        run: pnpx pkg-pr-new publish --pnpm ${{ steps.packages.outputs.result }} --compact
         
-      - name: Publish packages
+      - name: Add comment
         permissions:
           pull-requests: write
         if: ${{ steps.packages.outputs.result == '' }}

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -79,7 +79,7 @@ jobs:
   
       - name: Publish packages
         if: ${{ steps.packages.outputs.result != '' }}
-        run: pnpx pkg-pr-new publish --pnpm ${{ steps.packages.outputs.result }} --compact
+        run: pnpx pkg-pr-new publish --pnpm --compact ${{ steps.packages.outputs.result }} 
         
       - name: Add comment
         permissions:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -3,7 +3,7 @@ name: Preview release
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, labeled, ready_for_review]
+    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
@@ -55,6 +55,39 @@ jobs:
   
       - name: Build Packages
         run: pnpm run build
+        
+      - name: Changesets status
+        run: pnpm changeset status --output=changesets.json
+        
+      - name: Retrieve packages to publish
+        uses: actions/github-script@v7
+        id: packages
+        with:
+          script: |
+            const fs = require('fs');
+            let packages = JSON.parse(fs.readFileSync('changesets.json', 'utf8'));
+            const releases = packages.releases
+              .filter(p => {
+                return p.changesets.length > 0;
+              })
+              .map(p => p.name);
+            if (releases.length > 0) {
+              return releases.join(' ');
+            }
+            return ""
+          result-encoding: string
   
       - name: Publish packages
-        run: pnpx pkg-pr-new publish --pnpm './packages/*' './packages/integrations/*'
+        if: ${{ steps.packages.outputs.result != '' }}
+        run: pnpx pkg-pr-new publish --pnpm ${{ steps.packages.outputs.result }}
+        
+      - name: Publish packages
+        permissions:
+          pull-requests: write
+        if: ${{ steps.packages.outputs.result == '' }}
+        uses: peter-evans/create-or-update-comment@v4
+        continue-on-error: true
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: "No preview release was published. Make sure the PR contains a changeset."
+          edit-mode: replace


### PR DESCRIPTION
## Changes

This PR revamps the pkg.pr.new that we had disabled.

Changes:
- triggers the job only on `labeled` event
- uses `changeset status` to retrieve the upcoming releases
- uses a script to parse the JSON emitted by the previous step, and return a list of packages that have changesets. It returns a string
- if the previous string is empty, we write a message in the PR saying that no preview release was published
- if the previous string isn't empty, it's passed to the pkg pr new CLI

## Testing

I tested the script locally.
This PR needs to be merged, I will enable the job again, and then open a PR to test it.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
