### PR TITLE
ci: trick changesets to use the correct ref

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -37,9 +37,26 @@ jobs:
     steps:
       - name: Disable git crlf
         run: git config --global core.autocrlf false
-  
-      - name: Checkout
-        uses: actions/checkout@v4
+
+
+      - name: resolve pr refs
+        id: refs
+        uses: eficode/resolve-pr-refs@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
+          fetch-depth: 0
+
+      - name: Extract base branch from .changeset/config.json
+        id: getBaseBranch
+        run: |
+          baseBranch=$(jq -r '.baseBranch' .changeset/config.json)
+          echo "baseBranch=${baseBranch}" >> $GITHUB_OUTPUT
+
+      - run: git fetch origin ${{ steps.getBaseBranch.outputs.baseBranch }}:${{ steps.getBaseBranch.outputs.baseBranch }}
   
       - name: Setup PNPM
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
## Changes

This PR updates the pkg.pr.new to use the same workflow steps used by the previous workflow to "trick" changesets to use the correct ref.

## Testing

I copied the same code. IT should work. We should merge the PR and trigger another the workflow again.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

 N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
