### PR TITLE
ci: hardcode packages to publish of release

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -38,25 +38,13 @@ jobs:
       - name: Disable git crlf
         run: git config --global core.autocrlf false
 
-
-      - name: resolve pr refs
-        id: refs
-        uses: eficode/resolve-pr-refs@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.refs.outputs.head_ref }}
-          fetch-depth: 0
-
-      - name: Extract base branch from .changeset/config.json
-        id: getBaseBranch
-        run: |
-          baseBranch=$(jq -r '.baseBranch' .changeset/config.json)
-          echo "baseBranch=${baseBranch}" >> $GITHUB_OUTPUT
-
-      - run: git fetch origin ${{ steps.getBaseBranch.outputs.baseBranch }}:${{ steps.getBaseBranch.outputs.baseBranch }}
+#      - name: Extract base branch from .changeset/config.json
+#        id: getBaseBranch
+#        run: |
+#          baseBranch=$(jq -r '.baseBranch' .changeset/config.json)
+#          echo "baseBranch=${baseBranch}" >> $GITHUB_OUTPUT
+#
+#      - run: git fetch origin ${{ steps.getBaseBranch.outputs.baseBranch }}:${{ steps.getBaseBranch.outputs.baseBranch }}
   
       - name: Setup PNPM
         uses: pnpm/action-setup@v3
@@ -73,36 +61,32 @@ jobs:
       - name: Build Packages
         run: pnpm run build
         
-      - name: Changesets status
-        run: pnpm changeset status --output=changesets.json
-        
-      - name: Retrieve packages to publish
-        uses: actions/github-script@v7
-        id: packages
-        with:
-          script: |
-            const fs = require('fs');
-            let packages = JSON.parse(fs.readFileSync('changesets.json', 'utf8'));
-            const releases = packages.releases
-              .filter(p => {
-                return p.changesets.length > 0;
-              })
-              .map(p => p.name);
-            if (releases.length > 0) {
-              return releases.join(' ');
-            }
-            return ""
-          result-encoding: string
+#      - name: Changesets status
+#        run: pnpm changeset status --output=changesets.json
+#        
+#      - name: Retrieve packages to publish
+#        uses: actions/github-script@v7
+#        id: packages
+#        with:
+#          script: |
+#            const fs = require('fs');
+#            let packages = JSON.parse(fs.readFileSync('changesets.json', 'utf8'));
+#            const releases = packages.releases
+#              .filter(p => {
+#                return p.changesets.length > 0;
+#              })
+#              .map(p => p.name);
+#            if (releases.length > 0) {
+#              return releases.join(' ');
+#            }
+#            return ""
+#          result-encoding: string
   
       - name: Publish packages
-        if: ${{ steps.packages.outputs.result != '' }}
-        run: pnpx pkg-pr-new publish --pnpm --compact ${{ steps.packages.outputs.result }} 
-        
-      - name: Add comment
-        if: ${{ steps.packages.outputs.result == '' }}
-        uses: peter-evans/create-or-update-comment@v4
-        continue-on-error: true
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          body: "No preview release was published. Make sure the PR contains a changeset."
-          edit-mode: replace
+        run: |
+          pnpx pkg-pr-new publish --pnpm --compact \
+          'packages/astro' \
+          'packages/integrations/node' \
+          'packages/integrations/cloudflare' \
+          'packages/integrations/netlify' \
+          'packages/integrations/vercel' 


### PR DESCRIPTION
## Changes

As for now, I want to hardcode the packages. We can iterate about filter once we have pkg.pr.new working.

## Testing

Merge and trigger it

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
