### PR TITLE
test: update test assertion after error rename

### DIFF
--- a/packages/astro/test/sessions.test.js
+++ b/packages/astro/test/sessions.test.js
@@ -241,7 +241,7 @@ describe('Astro.session', () => {
 			});
 			// Disable actions so we can do a static build
 			await fixture.editFile('src/actions/index.ts', () => '');
-			await assert.rejects(fixture.build({}), /Error: A server is required to use session/);
+			await assert.rejects(fixture.build({}), /Sessions require an adapter that supports server output/);
 			await fixture.resetAllFiles();
 		});
 	});


### PR DESCRIPTION
## Changes

A test is failing because it asserted a message that we recently changed

## Testing

Test should pass (checked locally, it passed)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
