### PR TITLE
feat: Add CSS variables in getImage for experimental.responsiveImages

### DIFF
--- a/.changeset/clever-rice-compete.md
+++ b/.changeset/clever-rice-compete.md
@@ -2,6 +2,22 @@
 'astro': patch
 ---
 
-Add CSS variables in `getImage` for `experimental.responsiveImages`
+Adds experimental responsive image support in Markdown
 
-Previously, the responsive images experiment only applied to the `<Image />` and `<Picture />` components. However, images included through Markdown would not have the same styling applied to them, unless using MDX. This change consolidates more styling into `getImage` so it is accessible in more places.
+Previously, the `experimental.responsiveImages` could only provide responsive images when using the `<Image />` and `<Picture />` components.
+
+Now, images written with the `![]()` Markdown syntax in Markdown and MDX files will generate responsive images by default when using this experimental feature.
+
+To try this experimental feature, set `experimental.responsiveImages` to true in your `astro.config.mjs` file:
+
+```js
+{
+   experimental: {
+      responsiveImages: true,
+   },
+}
+```
+
+Learn more about using this feature in the [Experimental responsive images feature reference](https://docs.astro.build/en/reference/experimental-flags/responsive-images/).
+
+For a complete overview, and to give feedback on this experimental API, see the [Responsive Images RFC](https://github.com/withastro/roadmap/blob/responsive-images/proposals/0053-responsive-images.md).

--- a/.changeset/clever-rice-compete.md
+++ b/.changeset/clever-rice-compete.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Add CSS variables in `getImage` for `experimental.responsiveImages`
+
+Previously, the responsive images experiment only applied to the `<Image />` and `<Picture />` components. However, images included through Markdown would not have the same styling applied to them, unless using MDX. This change consolidates more styling into `getImage` so it is accessible in more places.

--- a/.changeset/clever-rice-compete.md
+++ b/.changeset/clever-rice-compete.md
@@ -4,7 +4,7 @@
 
 Adds experimental responsive image support in Markdown
 
-Previously, the `experimental.responsiveImages` could only provide responsive images when using the `<Image />` and `<Picture />` components.
+Previously, the `experimental.responsiveImages` feature could only provide responsive images when using the `<Image />` and `<Picture />` components.
 
 Now, images written with the `![]()` Markdown syntax in Markdown and MDX files will generate responsive images by default when using this experimental feature.
 
@@ -18,6 +18,6 @@ To try this experimental feature, set `experimental.responsiveImages` to true in
 }
 ```
 
-Learn more about using this feature in the [Experimental responsive images feature reference](https://docs.astro.build/en/reference/experimental-flags/responsive-images/).
+Learn more about using this feature in the [experimental responsive images feature reference](https://docs.astro.build/en/reference/experimental-flags/responsive-images/).
 
 For a complete overview, and to give feedback on this experimental API, see the [Responsive Images RFC](https://github.com/withastro/roadmap/blob/responsive-images/proposals/0053-responsive-images.md).

--- a/packages/astro/components/Image.astro
+++ b/packages/astro/components/Image.astro
@@ -1,7 +1,6 @@
 ---
 import { type LocalImageProps, type RemoteImageProps, getImage, imageConfig } from 'astro:assets';
 import type { UnresolvedImageTransform } from '../dist/assets/types';
-import { applyResponsiveAttributes } from '../dist/assets/utils/imageAttributes.js';
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
 import type { HTMLAttributes } from '../types';
 
@@ -46,14 +45,7 @@ if (import.meta.env.DEV) {
 	additionalAttributes['data-image-component'] = 'true';
 }
 
-const { class: className, ...attributes } = useResponsive
-	? applyResponsiveAttributes({
-			layout,
-			image,
-			props,
-			additionalAttributes,
-		})
-	: { ...additionalAttributes, ...image.attributes };
+const { class: className, ...attributes } = { ...additionalAttributes, ...image.attributes };
 ---
 
 {/* Applying class outside of the spread prevents it from applying unnecessary astro-* classes */}

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -1,8 +1,7 @@
 ---
 import { type LocalImageProps, type RemoteImageProps, getImage, imageConfig } from 'astro:assets';
 import * as mime from 'mrmime';
-import { applyResponsiveAttributes } from '../dist/assets/utils/imageAttributes';
-import { isESMImportedImage, resolveSrc } from '../dist/assets/utils/imageKind';
+import { isESMImportedImage, resolveSrc } from '../dist/assets/utils/imageKind.js';
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
 import type {
 	GetImageResult,
@@ -101,18 +100,14 @@ if (fallbackImage.srcSet.values.length > 0) {
 	imgAdditionalAttributes.srcset = fallbackImage.srcSet.attribute;
 }
 
-const { class: className, ...attributes } = useResponsive
-	? applyResponsiveAttributes({
-			layout,
-			image: fallbackImage,
-			props,
-			additionalAttributes: imgAdditionalAttributes,
-		})
-	: { ...imgAdditionalAttributes, ...fallbackImage.attributes };
-
 if (import.meta.env.DEV) {
 	imgAdditionalAttributes['data-image-component'] = 'true';
 }
+
+const { class: className, ...attributes } = {
+	...imgAdditionalAttributes,
+	...fallbackImage.attributes,
+};
 ---
 
 <picture {...pictureAttributes}>

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -18,6 +18,7 @@ import {
 } from './types.js';
 import { isESMImportedImage, isRemoteImage, resolveSrc } from './utils/imageKind.js';
 import { inferRemoteSize } from './utils/remoteProbe.js';
+import { addCSSVarsToStyle, cssFitValues } from './utils/imageAttributes.js';
 
 export async function getConfiguredImageService(): Promise<ImageService> {
 	if (!globalThis?.astroAsset?.imageService) {
@@ -151,6 +152,19 @@ export async function getImage(
 		}
 		delete resolvedOptions.priority;
 		delete resolvedOptions.densities;
+
+		if (layout !== 'none') {
+			resolvedOptions.style = addCSSVarsToStyle(
+				{
+					w: String(resolvedOptions.width),
+					h: String(resolvedOptions.height),
+					fit: cssFitValues.includes(resolvedOptions.fit ?? '') && resolvedOptions.fit,
+					pos: resolvedOptions.position,
+				},
+				resolvedOptions.style,
+			);
+			resolvedOptions['data-astro-image'] = layout;
+		}
 	}
 
 	const validatedOptions = service.validateOptions

--- a/packages/astro/src/assets/utils/imageAttributes.ts
+++ b/packages/astro/src/assets/utils/imageAttributes.ts
@@ -1,5 +1,6 @@
 import { toStyleString } from '../../runtime/server/render/util.js';
-import type { GetImageResult, ImageLayout, LocalImageProps, RemoteImageProps } from '../types.js';
+
+export const cssFitValues = ['fill', 'contain', 'cover', 'scale-down'];
 
 export function addCSSVarsToStyle(
 	vars: Record<string, string | false | undefined>,
@@ -16,33 +17,4 @@ export function addCSSVarsToStyle(
 	const style = typeof styles === 'string' ? styles : toStyleString(styles);
 
 	return `${cssVars} ${style}`;
-}
-
-const cssFitValues = ['fill', 'contain', 'cover', 'scale-down'];
-
-export function applyResponsiveAttributes<
-	T extends LocalImageProps<unknown> | RemoteImageProps<unknown>,
->({
-	layout,
-	image,
-	props,
-	additionalAttributes,
-}: {
-	layout: Exclude<ImageLayout, 'none'>;
-	image: GetImageResult;
-	additionalAttributes: Record<string, any>;
-	props: T;
-}) {
-	const attributes = { ...additionalAttributes, ...image.attributes };
-	attributes.style = addCSSVarsToStyle(
-		{
-			w: image.attributes.width ?? props.width ?? image.options.width,
-			h: image.attributes.height ?? props.height ?? image.options.height,
-			fit: cssFitValues.includes(props.fit ?? '') && props.fit,
-			pos: props.position,
-		},
-		attributes.style,
-	);
-	attributes['data-astro-image'] = layout;
-	return attributes;
 }


### PR DESCRIPTION
## Changes

- Currently, `experimental.responsiveImages` only adds CSS variables to images included via the `<Image />` or `<Picture />` components.
- In my other PR #13254, we can only use `getImage` to transform images.
- I would like to have `getImage` participate more fully in the responsive images experiment.
- Moving the CSS variable logic inside `getImage` removes a lot of redundant/confusing logic anyways.

## Testing

I tested this change by running my personal blog with it on. It provides a better outcome than when `getImage` is used on its own with this experiment turned on:

<table>
<thead>
<tr><th>Before</th><th>After</th></tr>
</thead>
<tbody>
<tr>
<td>

![image](https://github.com/user-attachments/assets/5f89577e-241c-4478-8034-36a2e7744c4d)

</td>
<td>

![image](https://github.com/user-attachments/assets/8b7e8c83-75f6-480e-9f27-cfc13f9e28d9)

</td>
</tr>
</tbody>
</table>

Note: the before pic has `width: 100%` applied to it in page styles. Without that, it looks even worse (no scaling applied based on page size)

## Docs

We may need to update the doc page on this (<https://docs.astro.build/en/reference/experimental-flags/responsive-images/>), as well as the RFC (<https://github.com/withastro/roadmap/blob/eff726cec3bf214b42ab13b819ed7b200753509e/proposals/0053-responsive-images.md>). Currently, neither make mention of `getImage` being affected by this experiment.

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
