### PR TITLE
chore: use workspace Node.js adapter

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "workspace:*",
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "@benchmark/timer": "workspace:*",
     "@benchmark/adapter": "workspace:*",
     "astro": "workspace:*",

--- a/packages/astro/e2e/fixtures/actions-blog/package.json
+++ b/packages/astro/e2e/fixtures/actions-blog/package.json
@@ -12,7 +12,7 @@
 	"dependencies": {
 		"@astrojs/check": "^0.9.4",
 		"@astrojs/db": "workspace:*",
-		"@astrojs/node": "^9.0.2",
+		"@astrojs/node": "workspace:*",
 		"@astrojs/react": "workspace:*",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",

--- a/packages/astro/e2e/fixtures/actions-react-19/package.json
+++ b/packages/astro/e2e/fixtures/actions-react-19/package.json
@@ -12,7 +12,7 @@
 	"dependencies": {
 		"@astrojs/check": "^0.9.4",
 		"@astrojs/db": "workspace:*",
-		"@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
 		"@astrojs/react": "workspace:*",
 		"@types/react": "npm:types-react",
 		"@types/react-dom": "npm:types-react-dom",

--- a/packages/astro/e2e/fixtures/i18n/package.json
+++ b/packages/astro/e2e/fixtures/i18n/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "astro": "workspace:*",
-    "@astrojs/node": "^9.0.2"
+    "@astrojs/node": "workspace:*"
   }
 }

--- a/packages/astro/e2e/fixtures/server-islands-key/package.json
+++ b/packages/astro/e2e/fixtures/server-islands-key/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "astro": "workspace:*",
-    "@astrojs/node": "^9.0.2"
+    "@astrojs/node": "workspace:*"
   }
 }

--- a/packages/astro/e2e/fixtures/server-islands/package.json
+++ b/packages/astro/e2e/fixtures/server-islands/package.json
@@ -9,7 +9,7 @@
     "@astrojs/react": "workspace:*",
     "astro": "workspace:*",
     "@astrojs/mdx": "workspace:*",
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/astro/e2e/fixtures/view-transitions/package.json
+++ b/packages/astro/e2e/fixtures/view-transitions/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "@astrojs/react": "workspace:*",
     "@astrojs/solid-js": "workspace:*",
     "@astrojs/svelte": "workspace:*",

--- a/packages/astro/test/fixtures/client-address-node/package.json
+++ b/packages/astro/test/fixtures/client-address-node/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "astro": "workspace:*"
   }
 }

--- a/packages/astro/test/fixtures/custom-assets-name/package.json
+++ b/packages/astro/test/fixtures/custom-assets-name/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "astro": "workspace:*",
-    "@astrojs/node": "^9.0.2"
+    "@astrojs/node": "workspace:*"
   }
 }

--- a/packages/astro/test/fixtures/ssr-api-route/package.json
+++ b/packages/astro/test/fixtures/ssr-api-route/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "astro": "workspace:*"
   }
 }

--- a/packages/astro/test/fixtures/static-build-ssr/package.json
+++ b/packages/astro/test/fixtures/static-build-ssr/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "@test/static-build-pkg": "workspace:*",
     "astro": "workspace:*"
   }

--- a/packages/db/test/fixtures/ticketing-example/package.json
+++ b/packages/db/test/fixtures/ticketing-example/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/db": "workspace:*",
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "@astrojs/react": "workspace:*",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -38,7 +38,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@astrojs/node": "^9.1.0",
+    "@astrojs/node": "workspace:*",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "xml2js": "0.6.2"

--- a/packages/integrations/web-vitals/test/fixtures/basics/package.json
+++ b/packages/integrations/web-vitals/test/fixtures/basics/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@astrojs/db": "workspace:*",
-    "@astrojs/node": "^9.0.2",
+    "@astrojs/node": "workspace:*",
     "@astrojs/web-vitals": "workspace:*",
     "astro": "workspace:*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/integrations/mdx
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../packages/integrations/node
       '@benchmark/adapter':
         specifier: workspace:*
@@ -798,7 +798,7 @@ importers:
         specifier: workspace:*
         version: link:../../../../db
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       '@astrojs/react':
         specifier: workspace:*
@@ -831,7 +831,7 @@ importers:
         specifier: workspace:*
         version: link:../../../../db
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       '@astrojs/react':
         specifier: workspace:*
@@ -1067,7 +1067,7 @@ importers:
   packages/astro/e2e/fixtures/i18n:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       astro:
         specifier: workspace:*
@@ -1469,7 +1469,7 @@ importers:
         specifier: workspace:*
         version: link:../../../../integrations/mdx
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       '@astrojs/react':
         specifier: workspace:*
@@ -1487,7 +1487,7 @@ importers:
   packages/astro/e2e/fixtures/server-islands-key:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       astro:
         specifier: workspace:*
@@ -1582,7 +1582,7 @@ importers:
   packages/astro/e2e/fixtures/view-transitions:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       '@astrojs/react':
         specifier: workspace:*
@@ -2438,7 +2438,7 @@ importers:
   packages/astro/test/fixtures/client-address-node:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       astro:
         specifier: workspace:*
@@ -2969,7 +2969,7 @@ importers:
   packages/astro/test/fixtures/custom-assets-name:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       astro:
         specifier: workspace:*
@@ -3861,7 +3861,7 @@ importers:
   packages/astro/test/fixtures/ssr-api-route:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       astro:
         specifier: workspace:*
@@ -4073,7 +4073,7 @@ importers:
   packages/astro/test/fixtures/static-build-ssr:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       '@test/static-build-pkg':
         specifier: workspace:*
@@ -4448,7 +4448,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../integrations/node
       '@astrojs/react':
         specifier: workspace:*
@@ -5576,7 +5576,7 @@ importers:
         version: 3.24.1
     devDependencies:
       '@astrojs/node':
-        specifier: ^9.1.0
+        specifier: workspace:*
         version: link:../node
       astro:
         specifier: workspace:*
@@ -6047,7 +6047,7 @@ importers:
         specifier: workspace:*
         version: link:../../../../../db
       '@astrojs/node':
-        specifier: ^9.0.2
+        specifier: workspace:*
         version: link:../../../../node
       '@astrojs/web-vitals':
         specifier: workspace:*


### PR DESCRIPTION
## Changes

This PR changes our monorepo to use the workspace version of the Node.js adapter.

I changed all packages, exception for the examples.

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
