### PR TITLE
feat(fonts): better local provider

### DIFF
--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -14,43 +14,39 @@ type InitializedProvider = NonNullable<Awaited<ReturnType<unifont.Provider>>>;
 
 type ResolveFontResult = NonNullable<Awaited<ReturnType<InitializedProvider['resolveFont']>>>;
 
-interface Options {
-	root: URL;
-}
-
 interface ResolveOptions {
+	root: URL;
 	proxyURL: URLProxy;
 }
 
 // TODO: dev watcher and ways to update during dev
-export function createLocalProvider({ root }: Options) {
-	return {
-		resolveFont: async (
-			family: LocalFontFamily,
-			{ proxyURL }: ResolveOptions,
-		): Promise<ResolveFontResult> => {
-			const fonts: ResolveFontResult['fonts'] = [];
+// change: update hashToUrlMap
+// unlink: throw error
+export function resolveLocalFont(
+	family: LocalFontFamily,
+	{ proxyURL, root }: ResolveOptions,
+): ResolveFontResult {
+	const fonts: ResolveFontResult['fonts'] = [];
 
-			for (const src of family.src) {
-				for (const weight of src.weights ?? DEFAULTS.weights) {
-					for (const style of src.styles ?? DEFAULTS.styles) {
-						// TODO: handle fallbacks?
-						// TODO: handle subset
-						fonts.push({
-							weight,
-							style,
-							src: src.paths.map((path) => ({
-								url: proxyURL(fileURLToPath(new URL(path, root))),
-								format: extractFontType(path),
-							})),
-						});
-					}
-				}
+	for (const src of family.src) {
+		for (const weight of src.weights ?? DEFAULTS.weights) {
+			for (const style of src.styles ?? DEFAULTS.styles) {
+				// TODO: handle fallbacks?
+				// TODO: handle subset
+				fonts.push({
+					weight,
+					style,
+					src: src.paths.map((path) => ({
+						// TODO: check files exist or throw
+						url: proxyURL(fileURLToPath(new URL(path, root))),
+						format: extractFontType(path),
+					})),
+				});
 			}
+		}
+	}
 
-			return {
-				fonts,
-			};
-		},
+	return {
+		fonts,
 	};
 }

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -50,3 +50,26 @@ export function resolveLocalFont(
 		fonts,
 	};
 }
+
+export class LocalFontsWatcher {
+	getPaths: (() => Array<string>) | null = null;
+	update: (() => void) | null = null;
+
+	#matches(path: string): boolean {
+		return this.getPaths?.().includes(path) ?? false;
+	}
+
+	onUpdate(path: string) {
+		if (!this.#matches(path)) {
+			return;
+		}
+		this.update?.();
+	}
+	onUnlink(path: string) {
+		if (!this.#matches(path)) {
+			return;
+		}
+		// TODO: improve
+		throw new Error('File used for font deleted. Restore it or update your config');
+	}
+}

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -19,9 +19,6 @@ interface ResolveOptions {
 	proxyURL: (value: string) => string;
 }
 
-// TODO: dev watcher and ways to update during dev
-// change: update hashToUrlMap
-// unlink: throw error
 export function resolveLocalFont(
 	family: LocalFontFamily,
 	{ proxyURL, root }: ResolveOptions,
@@ -37,7 +34,6 @@ export function resolveLocalFont(
 					weight,
 					style,
 					src: src.paths.map((path) => ({
-						// TODO: check files exist or throw
 						url: proxyURL(fileURLToPath(new URL(path, root))),
 						format: extractFontType(path),
 					})),

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -2,7 +2,7 @@ import type * as unifont from 'unifont';
 import type { LocalFontFamily } from '../types.js';
 import { DEFAULTS } from '../constants.js';
 import { fileURLToPath } from 'node:url';
-import { extractFontType, type URLProxy } from '../utils.js';
+import { extractFontType } from '../utils.js';
 
 // https://fonts.nuxt.com/get-started/providers#local
 // https://github.com/nuxt/fonts/blob/main/src/providers/local.ts
@@ -16,7 +16,7 @@ type ResolveFontResult = NonNullable<Awaited<ReturnType<InitializedProvider['res
 
 interface ResolveOptions {
 	root: URL;
-	proxyURL: URLProxy;
+	proxyURL: (value: string) => string;
 }
 
 // TODO: dev watcher and ways to update during dev

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -47,21 +47,42 @@ export function resolveLocalFont(
 	};
 }
 
+/**
+ * Orchestrates local font updates and deletions during development
+ */
 export class LocalFontsWatcher {
-	getPaths: (() => Array<string>) | null = null;
-	update: (() => void) | null = null;
+	/**
+	 * Watched fonts files
+	 */
+	#paths: Array<string>;
+	/**
+	 * Action performed when a font file is updated
+	 */
+	#update: () => void;
 
-	#matches(path: string): boolean {
-		return this.getPaths?.().includes(path) ?? false;
+	constructor({ paths, update }: { paths: Array<string>; update: () => void }) {
+		this.#paths = paths;
+		this.#update = update;
 	}
 
-	onUpdate(path: string) {
+	#matches(path: string): boolean {
+		return this.#paths.includes(path);
+	}
+
+	/**
+	 * Callback to call whenever a file is updated
+	 */
+	onUpdate(path: string): void {
 		if (!this.#matches(path)) {
 			return;
 		}
-		this.update?.();
+		this.#update();
 	}
-	onUnlink(path: string) {
+
+	/**
+	 * Callback to call whenever a file is unlinked
+	 */
+	onUnlink(path: string): void {
 		if (!this.#matches(path)) {
 			return;
 		}

--- a/packages/astro/src/assets/fonts/utils.ts
+++ b/packages/astro/src/assets/fonts/utils.ts
@@ -74,6 +74,15 @@ export function createCache(storage: Storage) {
 
 export type CacheHandler = ReturnType<typeof createCache>;
 
+export interface ProxyURLOptions {
+	hashString: (value: string) => string;
+	collect: (data: {
+		hash: string;
+		type: FontType;
+		value: string;
+	}) => string;
+}
+
 /**
  * The fonts data we receive contains urls or file paths we do no control.
  * However, we will emit font files ourselves so we store the original value
@@ -83,24 +92,10 @@ export type CacheHandler = ReturnType<typeof createCache>;
  * - `collect` will save the association of the original url and the new hash for later use
  * - the returned url will be `/_astro/fonts/<hash>.woff2`
  */
-export function createURLProxy({
-	hashString,
-	collect,
-}: {
-	hashString: (value: string) => string;
-	collect: (data: {
-		hash: string;
-		type: FontType;
-		value: string;
-	}) => string;
-}) {
-	return function proxyURL(value: string): string {
-		const type = extractFontType(value);
-		const hash = `${hashString(value)}.${type}`;
-		const url = collect({ hash, type, value });
-		// Now that we collected the original url, we return our proxy so the consumer can override it
-		return url;
-	};
+export function proxyURL(value: string, { hashString, collect }: ProxyURLOptions): string {
+	const type = extractFontType(value);
+	const hash = `${hashString(value)}.${type}`;
+	const url = collect({ hash, type, value });
+	// Now that we collected the original url, we return our proxy so the consumer can override it
+	return url;
 }
-
-export type URLProxy = ReturnType<typeof createURLProxy>;

--- a/packages/astro/src/assets/fonts/utils.ts
+++ b/packages/astro/src/assets/fonts/utils.ts
@@ -75,7 +75,19 @@ export function createCache(storage: Storage) {
 export type CacheHandler = ReturnType<typeof createCache>;
 
 export interface ProxyURLOptions {
+	/**
+	 * The original URL
+	 */
+	value: string;
+	/**
+	 * Specifies how the hash is computed. Can be based on the value,
+	 * a specific string for testing etc 
+	 */
 	hashString: (value: string) => string;
+	/**
+	 * Use the hook to save the associated value and hash, and possibly
+	 * transform it (eg. apply a base)
+	 */
 	collect: (data: {
 		hash: string;
 		type: FontType;
@@ -92,7 +104,7 @@ export interface ProxyURLOptions {
  * - `collect` will save the association of the original url and the new hash for later use
  * - the returned url will be `/_astro/fonts/<hash>.woff2`
  */
-export function proxyURL(value: string, { hashString, collect }: ProxyURLOptions): string {
+export function proxyURL({ value, hashString, collect }: ProxyURLOptions): string {
 	const type = extractFontType(value);
 	const hash = `${hashString(value)}.${type}`;
 	const url = collect({ hash, type, value });

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -19,7 +19,7 @@ import { removeTrailingForwardSlash } from '@astrojs/internal-helpers/path';
 import type { Logger } from '../../core/logger/core.js';
 import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import { createViteLoader } from '../../core/module-loader/vite.js';
-import { createLocalProvider, LOCAL_PROVIDER_NAME } from './providers/local.js';
+import { resolveLocalFont, LOCAL_PROVIDER_NAME } from './providers/local.js';
 import { readFile } from 'node:fs/promises';
 import { createStorage } from 'unstorage';
 import fsLiteDriver from 'unstorage/drivers/fs-lite';
@@ -172,7 +172,6 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 			resolved.map((e) => e.provider(e.config)),
 			{ storage },
 		);
-		const { resolveFont: resolveLocalFont } = createLocalProvider({ root: settings.config.root });
 
 		// We initialize shared variables here and reset them in buildEnd
 		// to avoid locking memory
@@ -200,7 +199,10 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 			css = '';
 
 			if (family.provider === LOCAL_PROVIDER_NAME) {
-				const { fonts, fallbacks } = await resolveLocalFont(family, { proxyURL });
+				const { fonts, fallbacks } = resolveLocalFont(family, {
+					proxyURL,
+					root: settings.config.root,
+				});
 				for (const data of fonts) {
 					css += generateFontFace(family.name, data);
 				}

--- a/packages/astro/test/units/assets/fonts/providers.test.js
+++ b/packages/astro/test/units/assets/fonts/providers.test.js
@@ -26,7 +26,8 @@ function resolveLocalFontSpy(family, root) {
 
 	const { fonts } = resolveLocalFont(family, {
 		proxyURL: (v) =>
-			proxyURL(v, {
+			proxyURL({
+				value: v,
 				hashString: (value) => basename(value, extname(value)),
 				collect: ({ hash, value }) => {
 					values.push(value);
@@ -154,26 +155,27 @@ describe('fonts providers', () => {
 	});
 
 	it('LocalFontsWatcher', () => {
-		const watcher = new LocalFontsWatcher();
 		let updated = 0;
-		watcher.update = () => {
-			updated++;
-		};
-		watcher.getPaths = () => ['foo', 'bar']
+		const watcher = new LocalFontsWatcher({
+			paths: ['foo', 'bar'],
+			update: () => {
+				updated++;
+			},
+		});
 
-		watcher.onUpdate('baz')
-		assert.equal(updated, 0)
-		
-		watcher.onUpdate('foo')
-		watcher.onUpdate('bar')
-		assert.equal(updated, 2)
+		watcher.onUpdate('baz');
+		assert.equal(updated, 0);
 
-		assert.doesNotThrow(() => watcher.onUnlink('baz'))
+		watcher.onUpdate('foo');
+		watcher.onUpdate('bar');
+		assert.equal(updated, 2);
+
+		assert.doesNotThrow(() => watcher.onUnlink('baz'));
 		try {
-			watcher.onUnlink('foo')
-			assert.fail()
+			watcher.onUnlink('foo');
+			assert.fail();
 		} catch (err) {
-			assert.equal(err instanceof Error, true)
+			assert.equal(err instanceof Error, true);
 			assert.equal(err.message, 'File used for font deleted. Restore it or update your config');
 		}
 	});

--- a/packages/astro/test/units/assets/fonts/providers.test.js
+++ b/packages/astro/test/units/assets/fonts/providers.test.js
@@ -9,7 +9,7 @@ import * as bunnyEntrypoint from '../../../../dist/assets/fonts/providers/entryp
 import * as fontshareEntrypoint from '../../../../dist/assets/fonts/providers/entrypoints/fontshare.js';
 import * as fontsourceEntrypoint from '../../../../dist/assets/fonts/providers/entrypoints/fontsource.js';
 import { validateMod, resolveProviders } from '../../../../dist/assets/fonts/providers/utils.js';
-import { createURLProxy } from '../../../../dist/assets/fonts/utils.js';
+import { proxyURL } from '../../../../dist/assets/fonts/utils.js';
 import { basename, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -21,15 +21,17 @@ function resolveLocalFontSpy(family, root) {
 	/** @type {Array<string>} */
 	const values = [];
 
-	const proxyURL = createURLProxy({
-		hashString: (value) => basename(value, extname(value)),
-		collect: ({ hash, value }) => {
-			values.push(value);
-			return `/_astro/fonts/${hash}`;
-		},
+	const { fonts } = resolveLocalFont(family, {
+		proxyURL: (v) =>
+			proxyURL(v, {
+				hashString: (value) => basename(value, extname(value)),
+				collect: ({ hash, value }) => {
+					values.push(value);
+					return `/_astro/fonts/${hash}`;
+				},
+			}),
+		root,
 	});
-
-	const { fonts } = resolveLocalFont(family, { proxyURL, root });
 
 	return {
 		fonts,

--- a/packages/astro/test/units/assets/fonts/utils.test.js
+++ b/packages/astro/test/units/assets/fonts/utils.test.js
@@ -45,7 +45,8 @@ function createSpyCache() {
 function proxyURLSpy(id, value) {
 	/** @type {Parameters<import('../../../../dist/assets/fonts/utils.js').ProxyURLOptions['collect']>[0]} */
 	let collected = /** @type {any} */ (undefined);
-	const url = proxyURL(value, {
+	const url = proxyURL({
+		value,
 		hashString: () => id,
 		collect: (data) => {
 			collected = data;

--- a/packages/astro/test/units/assets/fonts/utils.test.js
+++ b/packages/astro/test/units/assets/fonts/utils.test.js
@@ -5,7 +5,7 @@ import {
 	isFontType,
 	extractFontType,
 	createCache,
-	createURLProxy,
+	proxyURL,
 } from '../../../../dist/assets/fonts/utils.js';
 
 function createSpyCache() {
@@ -43,16 +43,15 @@ function createSpyCache() {
  * @param {string} value
  */
 function proxyURLSpy(id, value) {
-	/** @type {Parameters<Parameters<typeof createURLProxy>[0]['collect']>[0]} */
+	/** @type {Parameters<import('../../../../dist/assets/fonts/utils.js').ProxyURLOptions['collect']>[0]} */
 	let collected = /** @type {any} */ (undefined);
-	const proxyURL = createURLProxy({
+	const url = proxyURL(value, {
 		hashString: () => id,
 		collect: (data) => {
 			collected = data;
 			return 'base/' + data.hash;
 		},
 	});
-	const url = proxyURL(value);
 
 	return {
 		url,
@@ -122,7 +121,7 @@ describe('fonts utils', () => {
 		assert.deepStrictEqual(getKeys(), ['foo']);
 	});
 
-	it('createURLProxy()', () => {
+	it('proxyURL()', () => {
 		let { url, collected } = proxyURLSpy(
 			'foo',
 			'https://fonts.gstatic.com/s/roboto/v47/KFO5CnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmkC3kaSTbQWt4N.woff2',


### PR DESCRIPTION
## Changes

- Simplifies code for url proxying and local font provider
- Introduces a way to refresh local fonts in development
- Local fonts hash is now computed based on the name and the file contents (RFC to be updated after this PR is merged)

## Testing

Adds tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
