### PR TITLE
ci: remove colon from label

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -24,8 +24,7 @@ env:
 
 jobs:
   preview:
-    if: |
-      ${{ github.repository_owner == 'withastro' && github.event.label.name == 'pr: preview' }}
+    if: ${{ github.repository_owner == 'withastro' && github.event.label.name == 'pr preview' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Changes

It seems that the issue was the fact that `if: ` was using a `|`. I removed the `|` but having a `:` inside the `pr: preview` label name was causing some parsing issue in the YAML file.

Solution? Remove the `:` from the label name

## Testing

Merge and trigger it 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
