### PR TITLE
fixes property shadowing for form.attributes

### DIFF
--- a/.changeset/purple-jokes-pay.md
+++ b/.changeset/purple-jokes-pay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where a form field named "attributes" shadows the form.attributes property.

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/form-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/form-one.astro
@@ -12,5 +12,6 @@ export const prerender = false;
 		<input type="hidden" name="name" value="Testing" />
 		{postShowThrow ? <input type="hidden" name="throw" value="true" /> : ''}
 		<input type="submit" value="Submit" id="submit" />
+		<input type="text" name="attributes" />
 	</form>
 </Layout>

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -397,8 +397,7 @@ async function transition(
 			//
 			// Note: getNamedItem can return null in real life, even if TypeScript doesn't think so, hence
 			// the ?.
-			init.body =
-				form?.attributes.getNamedItem('enctype')?.value === 'application/x-www-form-urlencoded'
+			init.body = (from !== undefined && Reflect.get(HTMLFormElement.prototype, "attributes", form).getNamedItem('enctype')?.value === 'application/x-www-form-urlencoded')
 					? new URLSearchParams(preparationEvent.formData as any)
 					: preparationEvent.formData;
 		}


### PR DESCRIPTION
## Changes
When a form contains an input field named attributes, this shadows the access to the form.attributes property.
Changed property access to get the real thing.

Closes #13307 

## Testing
extended exiting form-one.astro

## Docs
n.a., bugfix