### PR TITLE
Expose ilike function from drizzle-orm

### DIFF
--- a/.changeset/late-mails-beam.md
+++ b/.changeset/late-mails-beam.md
@@ -2,4 +2,4 @@
 '@astrojs/db': patch
 ---
 
-Expose ilike function from drizzle-orm
+Expose `ilike` function from `drizzle-orm`

--- a/.changeset/late-mails-beam.md
+++ b/.changeset/late-mails-beam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Expose ilike function from drizzle-orm

--- a/packages/db/src/runtime/virtual.ts
+++ b/packages/db/src/runtime/virtual.ts
@@ -68,6 +68,7 @@ export {
 	between,
 	notBetween,
 	like,
+	ilike,
 	notIlike,
 	not,
 	asc,

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -28,6 +28,7 @@ declare module 'astro:db' {
 	export const between: RuntimeConfig['between'];
 	export const notBetween: RuntimeConfig['notBetween'];
 	export const like: RuntimeConfig['like'];
+	export const ilike: RuntimeConfig['ilike'];
 	export const notIlike: RuntimeConfig['notIlike'];
 	export const not: RuntimeConfig['not'];
 	export const asc: RuntimeConfig['asc'];


### PR DESCRIPTION
## Changes

Expose `ilike` function from drizzle-orm in astro:db runtime.

![2025-02-25-220016_hyprshot](https://github.com/user-attachments/assets/1aa460cc-ae1e-4634-b9d0-d919abf930a7)

Fixes #13308 

## Testing

Tested by modifying astro built-in example (not pushed of course), no tests added.

## Docs

N/A, self documented via Typescript.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
