### PR TITLE
fix(astro:db): resolve Astro DB seed failure with paths containing spaces

### DIFF
--- a/.changeset/hip-horses-count.md
+++ b/.changeset/hip-horses-count.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fix Astro DB seed failing when project path contains spaces. This resolves by properly decoding URL pathnames that contain encoded spaces (%20) before passing them to Vite's ssrLoadModule.

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -197,7 +197,10 @@ async function executeSeedFile({
 	fileUrl: URL;
 	viteServer: ViteDevServer;
 }) {
-	const mod = await viteServer.ssrLoadModule(fileUrl.pathname);
+	// Use decodeURIComponent to handle paths with spaces correctly
+	// This ensures that %20 in the pathname is properly handled
+	const pathname = decodeURIComponent(fileUrl.pathname);
+	const mod = await viteServer.ssrLoadModule(pathname);
 	if (typeof mod.default !== 'function') {
 		throw new AstroDbError(EXEC_DEFAULT_EXPORT_ERROR(fileURLToPath(fileUrl)));
 	}


### PR DESCRIPTION
## Changes
adds `decodeURIComponent` to properly handle the pathname

closes: #13332

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

there's no need to update docs.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
