### PR TITLE
fix: escape img attributes in Markdown

### DIFF
--- a/.changeset/fuzzy-planes-collect.md
+++ b/.changeset/fuzzy-planes-collect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Correctly escapes attributes in Markdown images

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -6,6 +6,8 @@ import type { GetImageResult, ImageMetadata } from '../assets/types.js';
 import { imageSrcToImportId } from '../assets/utils/resolveImports.js';
 import { AstroError, AstroErrorData, AstroUserError } from '../core/errors/index.js';
 import { prependForwardSlash } from '../core/path.js';
+import { escape } from 'html-escaper';
+
 import {
 	type AstroComponentFactory,
 	createComponent,
@@ -451,7 +453,7 @@ async function updateImageReferencesInBody(html: string, fileName: string) {
 			src: image.src,
 			srcset: image.srcSet.attribute,
 		})
-			.map(([key, value]) => (value ? `${key}=${JSON.stringify(String(value))}` : ''))
+			.map(([key, value]) => (value ? `${key}="${escape(value)}"` : ''))
 			.join(' ');
 	});
 }

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -252,6 +252,10 @@ describe('Content Layer', () => {
 			assert.ok($('img[alt="shuttle"]').attr('src').startsWith('/_astro'));
 		});
 
+		it('escapes alt text in markdown', async () => {
+			assert.equal($('img[alt^="xss"]').attr('alt'), 'xss "><script>alert(1)</script>'); 
+		});
+		
 		it('returns a referenced entry', async () => {
 			assert.ok(json.hasOwnProperty('referencedEntry'));
 			assert.deepEqual(json.referencedEntry, {

--- a/packages/astro/test/fixtures/content-layer/src/content/space/lunar-module.md
+++ b/packages/astro/test/fixtures/content-layer/src/content/space/lunar-module.md
@@ -13,3 +13,5 @@ The Lunar Module (LM, pronounced "Lem"), originally designated the Lunar Excursi
 ![buzz](/buzz.jpg)
 
 ![shuttle](shuttle.jpg)
+
+![xss "><script>alert(1)</script>](./shuttle.jpg)


### PR DESCRIPTION
## Changes
In Markdown, the generated attributes in img elements were not being correctly esacaped. This meant that including `>` or `"` in the img alt would break the tag. This isn't a security issue because Markdown is trusted, and you can add an actual script tag if you want.

Fixes #13345

## Testing

Added test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
