### PR TITLE
ci: add new command for vite ecosystem CI

### DIFF
--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "pnpm run test-fn && pnpm run test-static",
     "test-fn": "astro-scripts test \"test/functions/*.test.js\"",
     "test-static": "astro-scripts test \"test/static/*.test.js\"",

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -42,6 +42,7 @@
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "astro-scripts test --timeout 50000 \"test/**/!(hosted).test.js\"",
     "test:hosted": "astro-scripts test --timeout 30000 \"test/hosted/*.test.js\""
   },


### PR DESCRIPTION
## Changes

This PR adds the command `build:ci` to the adapters we recently moved.

That command is used by the ecosystem CI of `vite`

## Testing

Merge it and check with the vite team

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
