### PR TITLE
fix(assets): remove export of internal function

### DIFF
--- a/.changeset/twenty-news-tease.md
+++ b/.changeset/twenty-news-tease.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the internal function `makeSvgComponent` was incorrectly exposed as a public API.

--- a/packages/astro/src/assets/utils/index.ts
+++ b/packages/astro/src/assets/utils/index.ts
@@ -1,10 +1,16 @@
+/**
+ * NOTE: this is a public module exposed to the user, so all functions exposed 
+ * here must be documented via JsDoc and in the docs website.
+ * 
+ * If some functions don't need to be exposed, just import the file that contains the functions.
+ */
+
 export { emitESMImage } from './node/emitAsset.js';
 export { isESMImportedImage, isRemoteImage } from './imageKind.js';
 export { imageMetadata } from './metadata.js';
 export { getOrigQueryParams } from './queryParams.js';
 export { hashTransform, propsToFilename } from './transformToPath.js';
 export { inferRemoteSize } from './remoteProbe.js';
-export { makeSvgComponent } from './svg.js';
 export {
 	isRemoteAllowed,
 	matchHostname,


### PR DESCRIPTION
## Changes

This PR removes `makeSvgComponent` from the exported functions. That function is meant to be used internally and shouldn't be exported.

I added a note at top of the file. 

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
