### PR TITLE
docs: document utility functions

### DIFF
--- a/.changeset/gold-pears-reply.md
+++ b/.changeset/gold-pears-reply.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds documentation to various utility functions used for remote image services

--- a/packages/astro/src/assets/utils/imageKind.ts
+++ b/packages/astro/src/assets/utils/imageKind.ts
@@ -1,13 +1,35 @@
 import type { ImageMetadata, UnresolvedImageTransform } from '../types.js';
 
+/**
+ * Determines if the given source is an ECMAScript Module (ESM) imported image.
+ *
+ * @param {ImageMetadata | string} src - The source to check. It can be an `ImageMetadata` object or a string.
+ * @return {boolean} Returns `true` if the source is an `ImageMetadata` object, otherwise `false`.
+ */
 export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
 	return typeof src === 'object' || (typeof src === 'function' && 'src' in src);
 }
 
+/**
+ * Determines if the provided source is a remote image URL in the form of a string.
+ *
+ * @param {ImageMetadata | string} src - The source to check, which can either be an `ImageMetadata` object or a string.
+ * @return {boolean} Returns `true` if the source is a string, otherwise `false`.
+ */
 export function isRemoteImage(src: ImageMetadata | string): src is string {
 	return typeof src === 'string';
 }
 
-export async function resolveSrc(src: UnresolvedImageTransform['src']) {
-	return typeof src === 'object' && 'then' in src ? ((await src).default ?? (await src)) : src;
+/**
+ * Resolves the source of an image transformation by handling asynchronous or synchronous inputs.
+ * 
+ * @param {UnresolvedImageTransform['src']} src - The source of the image transformation. 
+ * @return {Promise<string | ImageMetadata>} A promise that resolves to the image source. It returns either the default export of the resolved source or the resolved source itself if the default export doesn't exist.
+ */
+export async function resolveSrc(src: UnresolvedImageTransform['src']): Promise<string | ImageMetadata> {
+	if (typeof src === 'object' && 'then' in src) {
+		const resource = await src;
+		return resource.default ?? resource;
+	}
+	return src;
 }

--- a/packages/astro/src/assets/utils/metadata.ts
+++ b/packages/astro/src/assets/utils/metadata.ts
@@ -2,32 +2,41 @@ import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import type { ImageInputFormat, ImageMetadata } from '../types.js';
 import { lookup as probe } from '../utils/vendor/image-size/lookup.js';
 
+/**
+ * Extracts image metadata such as dimensions, format, and orientation from the provided image data.
+ *
+ * @param {Uint8Array} data - The binary data of the image.
+ * @param {string} [src] - The source path or URL of the image, used for error messages. Optional.
+ * @return {Promise<Omit<ImageMetadata, 'src' | 'fsPath'>>} A promise that resolves with the extracted metadata, excluding `src` and `fsPath`.
+ * @throws {AstroError} Throws an error if the image metadata cannot be extracted.
+ */
 export async function imageMetadata(
 	data: Uint8Array,
 	src?: string,
 ): Promise<Omit<ImageMetadata, 'src' | 'fsPath'>> {
+	let result;
 	try {
-		const result = probe(data);
-		if (!result.height || !result.width || !result.type) {
-			throw new AstroError({
-				...AstroErrorData.NoImageMetadata,
-				message: AstroErrorData.NoImageMetadata.message(src),
-			});
-		}
-
-		const { width, height, type, orientation } = result;
-		const isPortrait = (orientation || 0) >= 5;
-
-		return {
-			width: isPortrait ? height : width,
-			height: isPortrait ? width : height,
-			format: type as ImageInputFormat,
-			orientation,
-		};
+		result = probe(data);
 	} catch {
 		throw new AstroError({
 			...AstroErrorData.NoImageMetadata,
 			message: AstroErrorData.NoImageMetadata.message(src),
 		});
 	}
+	if (!result.height || !result.width || !result.type) {
+		throw new AstroError({
+			...AstroErrorData.NoImageMetadata,
+			message: AstroErrorData.NoImageMetadata.message(src),
+		});
+	}
+
+	const { width, height, type, orientation } = result;
+	const isPortrait = (orientation || 0) >= 5;
+
+	return {
+		width: isPortrait ? height : width,
+		height: isPortrait ? width : height,
+		format: type as ImageInputFormat,
+		orientation,
+	};
 }

--- a/packages/astro/src/assets/utils/node/emitAsset.ts
+++ b/packages/astro/src/assets/utils/node/emitAsset.ts
@@ -9,6 +9,15 @@ import { imageMetadata } from '../metadata.js';
 type FileEmitter = vite.Rollup.EmitFile;
 type ImageMetadataWithContents = ImageMetadata & { contents?: Buffer };
 
+/**
+ * Processes an image file and emits its metadata and optionally its contents. This function supports both build and development modes.
+ *
+ * @param {string | undefined} id - The identifier or path of the image file to process. If undefined, the function returns immediately.
+ * @param {boolean} _watchMode - **Deprecated**: Indicates if the method is operating in watch mode. This parameter will be removed or updated in the future.
+ * @param {boolean} experimentalSvgEnabled - A flag to enable experimental handling of SVG files. Embeds SVG file data if set to true.
+ * @param {FileEmitter | undefined} [fileEmitter] - Function for emitting files during the build process. May throw in certain scenarios.
+ * @return {Promise<ImageMetadataWithContents | undefined>} Resolves to metadata with optional image contents or `undefined` if processing fails.
+ */
 export async function emitESMImage(
 	id: string | undefined,
 	/** @deprecated */
@@ -46,7 +55,7 @@ export async function emitESMImage(
 
 	// Attach file data for SVGs
 	// TODO: this is a workaround to prevent a memory leak, and it must be fixed before we remove the experimental flag, see
-	if (fileMetadata.format === 'svg' && experimentalSvgEnabled === true) {
+	if (fileMetadata.format === 'svg' && experimentalSvgEnabled) {
 		emittedImage.contents = fileData;
 	}
 

--- a/packages/astro/src/assets/utils/queryParams.ts
+++ b/packages/astro/src/assets/utils/queryParams.ts
@@ -1,5 +1,14 @@
 import type { ImageInputFormat, ImageMetadata } from '../types.js';
 
+/**
+ * Extracts the original image query parameters (width, height, format) from the given `URLSearchParams` object
+ * and returns them as an object. If any of the required parameters are missing or invalid, the function returns undefined.
+ * 
+ * The `width` and `height` are parsed to integer values.
+ *
+ * @param {URLSearchParams} params - The `URLSearchParams` object containing the query parameters.
+ * @return {Pick<ImageMetadata, 'width' | 'height' | 'format'> | undefined} An object with the original image parameters (width, height, format) or undefined if any parameter is missing.
+ */
 export function getOrigQueryParams(
 	params: URLSearchParams,
 ): Pick<ImageMetadata, 'width' | 'height' | 'format'> | undefined {

--- a/packages/astro/src/assets/utils/remoteProbe.ts
+++ b/packages/astro/src/assets/utils/remoteProbe.ts
@@ -2,6 +2,13 @@ import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import type { ImageMetadata } from '../types.js';
 import { imageMetadata } from './metadata.js';
 
+/**
+ * Infers the dimensions of a remote image by streaming its data and analyzing it progressively until sufficient metadata is available.
+ *
+ * @param {string} url - The URL of the remote image from which to infer size metadata.
+ * @return {Promise<Omit<ImageMetadata, 'src' | 'fsPath'>>} Returns a promise that resolves to an object containing the image dimensions metadata excluding `src` and `fsPath`. Throws an error if the image dimensions cannot be determined or the fetch fails.
+ * @throws {AstroError} Thrown when the fetching fails or metadata cannot be extracted.
+ */
 export async function inferRemoteSize(url: string): Promise<Omit<ImageMetadata, 'src' | 'fsPath'>> {
 	// Start fetching the image
 	const response = await fetch(url);

--- a/packages/astro/src/assets/utils/remoteProbe.ts
+++ b/packages/astro/src/assets/utils/remoteProbe.ts
@@ -6,7 +6,7 @@ import { imageMetadata } from './metadata.js';
  * Infers the dimensions of a remote image by streaming its data and analyzing it progressively until sufficient metadata is available.
  *
  * @param {string} url - The URL of the remote image from which to infer size metadata.
- * @return {Promise<Omit<ImageMetadata, 'src' | 'fsPath'>>} Returns a promise that resolves to an object containing the image dimensions metadata excluding `src` and `fsPath`. Throws an error if the image dimensions cannot be determined or the fetch fails.
+ * @return {Promise<Omit<ImageMetadata, 'src' | 'fsPath'>>} Returns a promise that resolves to an object containing the image dimensions metadata excluding `src` and `fsPath`.
  * @throws {AstroError} Thrown when the fetching fails or metadata cannot be extracted.
  */
 export async function inferRemoteSize(url: string): Promise<Omit<ImageMetadata, 'src' | 'fsPath'>> {

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -5,7 +5,29 @@ import { shorthash } from '../../runtime/server/shorthash.js';
 import type { ImageTransform } from '../types.js';
 import { isESMImportedImage } from './imageKind.js';
 
-export function propsToFilename(filePath: string, transform: ImageTransform, hash: string) {
+/**
+ * Converts a file path and transformation properties of the transformation image service, into a formatted filename.
+ *
+ * The formatted filename follows this structure:
+ *
+ * `<prefixDirname>/<baseFilename>_<hash><outputExtension>`
+ *
+ * - `prefixDirname`: If the image is an ESM imported image, this is the directory name of the original file path; otherwise, it will be an empty string.
+ * - `baseFilename`: The base name of the file or a hashed short name if the file is a `data:` URI.
+ * - `hash`: A unique hash string generated to distinguish the transformed file.
+ * - `outputExtension`: The desired output file extension derived from the `transform.format` or the original file extension.
+ *
+ * ## Example
+ * - Input: `filePath = '/images/photo.jpg'`, `transform = { format: 'png', src: '/images/photo.jpg' }`, `hash = 'abcd1234'`.
+ * - Output: `/images/photo_abcd1234.png`
+ *
+ * @param {string} filePath - The original file path or data URI of the source image.
+ * @param {ImageTransform} transform - An object representing the transformation properties, including format and source.
+ * @param {string} hash - A unique hash used to differentiate the transformed file.
+ * @return {string} The generated filename based on the provided input, transformations, and hash.
+ */
+
+export function propsToFilename(filePath: string, transform: ImageTransform, hash: string): string {
 	let filename = decodeURIComponent(removeQueryString(filePath));
 	const ext = extname(filename);
 	if (filePath.startsWith('data:')) {
@@ -19,11 +41,20 @@ export function propsToFilename(filePath: string, transform: ImageTransform, has
 	return decodeURIComponent(`${prefixDirname}/${filename}_${hash}${outputExt}`);
 }
 
+/**
+ * Transforms the provided `transform` object into a hash string based on selected properties
+ * and the specified `imageService`.
+ *
+ * @param {ImageTransform} transform - The transform object containing various image transformation properties.
+ * @param {string} imageService - The name of the image service related to the transform.
+ * @param {string[]} propertiesToHash - An array of property names from the `transform` object that should be used to generate the hash.
+ * @return {string} A hashed string created from the specified properties of the `transform` object and the image service.
+ */
 export function hashTransform(
 	transform: ImageTransform,
 	imageService: string,
 	propertiesToHash: string[],
-) {
+): string {
 	// Extract the fields we want to hash
 	const hashFields = propertiesToHash.reduce(
 		(acc, prop) => {


### PR DESCRIPTION
## Changes

This PR adds more JsDoc to the utility functions that we expose for image services.

I used a LLM tool to generate the docs, and then reviewed them to make sure they seem correct.

I also noticed `resolveSrc` was awaiting **twice** the same resource in case no `.default` wasn't returned. I changed the code so the awaiting is done once every time.

I also slightly refactored `imageMetadata` because we were throwing an error inside a `try` block.

## Testing

CI should stay green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
