### PR TITLE
[docs] move location of an Actions error

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -903,18 +903,6 @@ export const MiddlewareCantBeLoaded = {
 
 /**
  * @docs
- * @description
- * Thrown in development mode when the actions file can't be loaded.
- *
- */
-export const ActionsCantBeLoaded = {
-	name: 'ActionsCantBeLoaded',
-	title: "Can't load the Astro actions.",
-	message: 'An unknown error was thrown while loading the Astro actions file.',
-} satisfies ErrorData;
-
-/**
- * @docs
  * @see
  * - [Images](https://docs.astro.build/en/guides/images/)
  * @description
@@ -1817,6 +1805,18 @@ export const ActionCalledFromServerError = {
 
 // Generic catch-all - Only use this in extreme cases, like if there was a cosmic ray bit flip.
 export const UnknownError = { name: 'UnknownError', title: 'Unknown Error.' } satisfies ErrorData;
+
+/**
+ * @docs
+ * @description
+ * Thrown in development mode when the actions file can't be loaded.
+ *
+ */
+export const ActionsCantBeLoaded = {
+	name: 'ActionsCantBeLoaded',
+	title: "Can't load the Astro actions.",
+	message: 'An unknown error was thrown while loading the Astro actions file.',
+} satisfies ErrorData;
 
 /**
  * @docs


### PR DESCRIPTION
## Changes

A new Actions error was added in the "Astro Errors" section instead of the "Actions Errors" section. This just moves the error to the appropriate section so that in the main error reference listing page, it shows up with the other actions errors.

## Testing

no tests; docs

## Docs

only affects docs!
