### PR TITLE
fix: audit list window covered by tooltip and highlight

### DIFF
--- a/.changeset/silent-planes-show.md
+++ b/.changeset/silent-planes-show.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where highlights and tooltips render over the audit list window.

--- a/packages/astro/e2e/dev-toolbar.test.js
+++ b/packages/astro/e2e/dev-toolbar.test.js
@@ -241,7 +241,8 @@ test.describe('Dev Toolbar', () => {
 
 		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
 		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
-		for (const highlight of await auditHighlights.all()) {
+		const highlights = (await auditHighlights.all()).filter((_, index) => index !== 1);
+		for (const highlight of highlights) {
 			await expect(highlight).toBeVisible();
 			await highlight.hover();
 			const tooltip = highlight.locator('astro-dev-toolbar-tooltip');
@@ -254,6 +255,22 @@ test.describe('Dev Toolbar', () => {
 			expect(tooltipBox.x + tooltipBox.width).toBeLessThan(clientWidth);
 			expect(tooltipBox.y + tooltipBox.height).toBeLessThan(clientHeight);
 		}
+	});
+
+	test('tooltip is rendered behind audit list window', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/tooltip-position'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
+		await appButton.click();
+
+		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
+		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
+		const highlight = auditHighlights.nth(1)
+
+		await expect(async() => {
+			await highlight.hover({timeout: 100});
+		}).rejects.toThrowError()
 	});
 
 	test('can open Settings app', async ({ page, astro }) => {

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/tooltip-position.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/tooltip-position.astro
@@ -4,7 +4,7 @@
 
 <div>
   <button role="top-left">Top left</button>
-  <button role="top-right">Top right</button>
+  <button role="button">Top right</button>
   <button role="bottom-left">Bottom left</button>
   <button role="bottom-right">Bottom right</button>
 </div>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/tooltip-position.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/tooltip-position.astro
@@ -4,7 +4,7 @@
 
 <div>
   <button role="top-left">Top left</button>
-  <button role="button">Top right</button>
+  <button role="top-right">Top right</button>
   <button role="bottom-left">Bottom left</button>
   <button role="bottom-right">Bottom right</button>
 </div>

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/ui/audit-list-window.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/ui/audit-list-window.ts
@@ -83,7 +83,7 @@ export class DevToolbarAuditListWindow extends HTMLElement {
 					"Noto Color Emoji";
 				color: rgba(191, 193, 201, 1);
 				position: fixed;
-				z-index: 999999999;
+				z-index: 2000000009;
 				bottom: 72px;
 				left: 50%;
 				transform: translateX(-50%);


### PR DESCRIPTION
## Changes

This fixes pop-ups and highlights rendering over the audit list window. 

Fixes #11114 

## Testing
Added e2e test.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
