### PR TITLE
docs: fix config types (images, i18n)

### DIFF
--- a/.changeset/rude-maps-visit.md
+++ b/.changeset/rude-maps-visit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the documentation of the i18n configuration where `manual` was presented as a key of `routing` instead of an available value.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1611,9 +1611,10 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 			| 'manual';
 
 		/**
+		 * @docs
 		 * @name i18n.domains
 		 * @type {Record<string, string> }
-		 * @default '{}'
+		 * @default `{}`
 		 * @version 4.3.0
 		 * @description
 		 *
@@ -1644,7 +1645,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * })
 		 * ```
 		 *
-		 * Both page routes built and URLs returned by the `astro:i18n` helper functions [`getAbsoluteLocaleUrl()`](https://docs.astro.build/en/reference/api-reference/#getabsolutelocaleurl) and [`getAbsoluteLocaleUrlList()`](https://docs.astro.build/en/reference/api-reference/#getabsolutelocaleurllist) will use the options set in `i18n.domains`.
+		 * Both page routes built and URLs returned by the `astro:i18n` helper functions [`getAbsoluteLocaleUrl()`](https://docs.astro.build/en/reference/modules/astro-i18n/#getabsolutelocaleurl) and [`getAbsoluteLocaleUrlList()`](https://docs.astro.build/en/reference/modules/astro-i18n/#getabsolutelocaleurllist) will use the options set in `i18n.domains`.
 		 *
 		 * See the [Internationalization Guide](https://docs.astro.build/en/guides/internationalization/#domains) for more details, including the limitations of this feature.
 		 */

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1122,7 +1122,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * @docs
 		 * @name image.domains
 		 * @type {string[]}
-		 * @default `{domains: []}`
+		 * @default `[]`
 		 * @version 2.10.10
 		 * @description
 		 * Defines a list of permitted image source domains for remote image optimization. No other remote images will be optimized by Astro.
@@ -1145,7 +1145,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * @docs
 		 * @name image.remotePatterns
 		 * @type {RemotePattern[]}
-		 * @default `{remotePatterns: []}`
+		 * @default `[]`
 		 * @version 2.10.10
 		 * @description
 		 * Defines a list of permitted image source URL patterns for remote image optimization.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1475,11 +1475,38 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		/**
 		 * @docs
 		 * @name i18n.routing
-		 * @type {Routing}
+		 * @type {object | "manual"}
+		 * @default `object`
 		 * @version 3.7.0
 		 * @description
 		 *
 		 * Controls the routing strategy to determine your site URLs. Set this based on your folder/URL path configuration for your default language.
+		 *
+		 * ```js
+		 * export default defineConfig({
+		 * 	i18n: {
+		 * 		defaultLocale: "en",
+		 * 		locales: ["en", "fr"],
+		 * 		routing: {
+		 * 			prefixDefaultLocale: false,
+		 * 			redirectToDefaultLocale: true,
+		 * 			fallbackType: "redirect",
+		 * 		}
+		 * 	}
+		 * })
+		 * ```
+		 *
+		 * Since 4.6.0, this option can also be set to `manual`. When this routing strategy is enabled, Astro will **disable** its i18n middleware and no other `routing` options (e.g. `prefixDefaultLocale`) may be configured. You will be responsible for writing your own routing logic, or executing Astro's i18n middleware manually alongside your own.
+		 *
+		 * ```js
+		 * export default defineConfig({
+		 * 	i18n: {
+		 * 		defaultLocale: "en",
+		 * 		locales: ["en", "fr"],
+		 * 		routing: "manual"
+		 * 	}
+		 * })
+		 * ```
 		 *
 		 */
 		routing?:
@@ -1581,30 +1608,6 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					 */
 					fallbackType?: 'redirect' | 'rewrite';
 			  }
-			/**
-			 *
-			 * @docs
-			 * @name i18n.routing.manual
-			 * @kind h4
-			 * @type {string}
-			 * @version 4.6.0
-			 * @description
-			 * When this option is enabled, Astro will **disable** its i18n middleware so that you can implement your own custom logic. No other `routing` options (e.g. `prefixDefaultLocale`) may be configured with `routing: "manual"`.
-			 *
-			 * You will be responsible for writing your own routing logic, or executing Astro's i18n middleware manually alongside your own.
-			 *
-			 * ```js
-			 * export default defineConfig({
-			 * 	i18n: {
-			 * 		defaultLocale: "en",
-			 * 		locales: ["en", "fr", "pt-br", "es"],
-			 * 		routing: {
-			 * 			prefixDefaultLocale: true,
-			 * 		}
-			 * 	}
-			 * })
-			 * ```
-			 */
 			| 'manual';
 
 		/**

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1400,7 +1400,6 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 * @name i18n
 	 * @type {object}
 	 * @version 3.5.0
-	 * @type {object}
 	 * @description
 	 *
 	 * Configures i18n routing and allows you to specify some customization options.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1580,17 +1580,6 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					 * ```
 					 */
 					fallbackType?: 'redirect' | 'rewrite';
-
-					/**
-					 * @name i18n.routing.strategy
-					 * @type {"pathname"}
-					 * @default `"pathname"`
-					 * @version 3.7.0
-					 * @description
-					 *
-					 * - `"pathname": The strategy is applied to the pathname of the URLs
-					 */
-					strategy?: 'pathname';
 			  }
 			/**
 			 *


### PR DESCRIPTION
## Changes

* Fixes `image.domains` and `image.remotePatterns` default values (these options expect an array, not an object).

* De-duplicates the type for `i18n` (the JSDoc `@type` tag was set twice)

* Merge `i18n.routing.manual` description into `i18n.routing` and updates the example.

`manual` is not a key of `i18n.routing` but an available value. So it currently seems odd that this is listed with the available keys [in the docs](https://docs.astro.build/en/reference/configuration-reference/#i18nroutingmanual). And the example is not helpful, this is the one used for `prefixDefaultLocale`.

* Fixes the type of `i18n.routing`

Unless I'm mistaken, the `Routing` type doesn't exist so maybe it's better to use `object`? And, the value can also be `"manual"`.

* Adds missing `@docs` tag to `i18n.domains`

The [`i18n.domains`](https://docs.astro.build/en/reference/configuration-reference/#i18n) configuration is currently missing. I believe it's because the `@docs` tag was missing and I don't see any reason why it shouldn't appear in the docs since it is [documented in the guides](https://docs.astro.build/en/guides/internationalization/#domains).

* Removes `i18n.routing.strategy`

If I'm not mistaken, this is a leftover from #10193 where `i18n.routing.strategy: "pathname"` became `i18n.routing: "manual"`. The `strategy` key [does not exist in the schema](https://github.com/withastro/astro/blob/d83f92a20403ffc8d088cfd13d2806e0f4f1a11e/packages/astro/src/core/config/schema.ts#L416-L420) and doesn't seem to be used anywhere.
This key doesn't appear in the docs, so it's not a big deal, but Intellisense suggests it as an available option:

![`i18n.routing.strategy` suggested by VS Code Intellisense](https://github.com/user-attachments/assets/52d67860-45b0-47bc-8c07-539230440a18)

## Testing

Existing tests should still pass, unless I'm wrong for `i18n.routing.strategy`.

## Docs

This is docs so, 
/cc @withastro/maintainers-docs for feedback
(mainly for the new description of `i18n.routing`)

I added a changeset just for merging the description of `i18n.routing` and `i18n.routing.strategy` as I think this is the "biggest" change. Should I include the other changes in this changeset/add more changesets?

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
