### PR TITLE
ClientRouter: prevent double execution of scripts when custom swap() only swaps parts of the DOM

### DIFF
--- a/.changeset/lazy-kings-rush.md
+++ b/.changeset/lazy-kings-rush.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an edge case where the client router executed scripts twice when used with a custom swap function that only swaps parts of the DOM.

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/partial-swap.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/partial-swap.astro
@@ -1,0 +1,20 @@
+---
+import { ClientRouter } from "astro:transitions";
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <ClientRouter />
+    <script is:inline>
+			console.log("[test] head script");
+			document.addEventListener("astro:before-swap", e => e.swap = () => {});
+		</script>
+  </head>
+  <body>
+    <h1>Astro</h1>
+		<script is:inline>console.log("[test] body script")</script>
+    <a id="link2" href="/partial-swap?v=2">revisit</a><br/>
+    <a id="link3" href="/partial-swap?v=3">revisit</a>
+  </body>
+</html>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1619,4 +1619,19 @@ test.describe('View Transitions', () => {
 		await expect(page).toHaveTitle('Page 1');
 		expect(lines.join('')).toBe('312233');
 	});
+
+	test('initial scripts are not re-executed after partial swap', async ({ page, astro }) => {
+		let consoleErrors = [];
+		page.on('console', (msg) => {
+			const txt = msg.text();
+			txt.startsWith("[test] ") && consoleErrors.push(txt.substring(7));
+		});
+		await page.goto(astro.resolveUrl('/partial-swap'));
+		await page.waitForURL('**/partial-swap');
+		await page.click('#link2');
+		await page.waitForURL('**/partial-swap?v=2');
+		await page.click('#link3');
+		await page.waitForURL('**/partial-swap?v=3');
+		expect(consoleErrors.join(", "), 'There should only be two executions').toEqual("head script, body script");
+	});
 });

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -649,6 +649,7 @@ if (inBrowser) {
 	}
 	for (const script of document.getElementsByTagName('script')) {
 		detectScriptExecuted(script);
+		script.dataset.astroExec = '';
 	}
 }
 


### PR DESCRIPTION
## Changes

Fixes #13375 

Marks scripts executed on initial page load as executed to prevent their re-execution if they are not replaced with the next call to swap. 
This might happen if a custom swap() function only swaps part of the DOM and leaves some original scripts in place. 

## Testing

added e2e test

## Docs

n.a. / bug fix