### PR TITLE
Extend the simulated viewTransition object with the  `types` property

### DIFF
--- a/.changeset/every-birds-stick.md
+++ b/.changeset/every-birds-stick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds the `types` property to the viewTransition object when the ClientRouter simulates parts of the View Transition API on browsers w/o native support.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -508,7 +508,6 @@ async function transition(
 		//
 		// "finished" resolves after all animations are done.
 
-		// @ts-expect-error the internal type `types` isn't provided and not even documented on MDN
 		currentTransition.viewTransition = {
 			updateCallbackDone: updateDone, // this is about correct
 			ready: updateDone, // good enough
@@ -520,6 +519,7 @@ async function transition(
 				// This cancels all animations of the simulation
 				document.documentElement.removeAttribute(OLD_NEW_ATTR);
 			},
+			types: new Set<string>(), // empty by default
 		};
 	}
 	// In earlier versions was then'ed on viewTransition.ready which would not execute


### PR DESCRIPTION
## Changes

In `typescript/lib/lib.dom.d.ts` the ViewTransition interface now includes the `types` property.
Added the property to our simulated viewTransition object for browsers without native support.  

https://discord.com/channels/830184174198718474/1055240348970000454/1346390166356361289  

## Testing

Compiles without errors after removing the @ts-expect-error comment

## Docs

n.a. / upstream change