### PR TITLE
fix(astro): stop toolbar settings from overflowing

### DIFF
--- a/.changeset/real-tigers-like.md
+++ b/.changeset/real-tigers-like.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Stop toolbar settings from overflowing

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
@@ -83,6 +83,8 @@ export default {
 				`<style>
 					:host astro-dev-toolbar-window {
 						height: 480px;
+						overflow-y: auto;
+						color-scheme: dark;
 
 						--color-purple: rgba(224, 204, 250, 1);
 					}
@@ -141,6 +143,9 @@ export default {
 					label > section {
 						max-width: 67%;
 					}
+					label > section.full-width {
+						max-width: 100%;
+					}
 					p {
 						line-height: 1.5em;
 					}
@@ -158,7 +163,7 @@ export default {
 				<hr id="general"/>
 
 				<label class="setting-row">
-					<section>
+					<section class="full-width">
 						<h3>Hide toolbar</h3>
 						Run <code>astro preferences disable devToolbar</code> in your terminal to disable the toolbar. <a href="https://docs.astro.build/en/reference/cli-reference/#astro-preferences" target="_blank">Learn more</a>.
 					</section>


### PR DESCRIPTION
## Changes

The problem was the the content of the toolbar settings overflowed the toolbar. That made it very hard to read the text it looked broken.

I did a few things:
1. The text of the last row takes up the whole width of the section
2. If the content is still too large, the developer can scroll the content of the toolbar

### Before

![Bildschirmfoto 2025-03-09 um 12 37 03](https://github.com/user-attachments/assets/e6dffd5a-fcdd-4d05-a09d-4330d1816e25)


### After

https://github.com/user-attachments/assets/d188cb2a-c061-40f2-8432-d55d88ec5a53

## Testing

I did some manual testing, by resizing the window and testing the changes on a real iPhone. I did not any automated tests, because there's now way to test this without a visual test. Please correct me if I'm wrong.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This change does not need documentation, it doesn't change how users
need to interact with Astro.
