### PR TITLE
Remove trailing spaces from blog example links.

### DIFF
--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -34,15 +34,14 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 				<li>Customize the blog post page layout in <code>src/layouts/BlogPost.astro</code></li>
 			</ul>
 			<p>
-				Have fun! If you get stuck, remember to <a href="https://docs.astro.build/"
-					>read the docs
-				</a> or <a href="https://astro.build/chat">join us on Discord</a> to ask questions.
+				Have fun! If you get stuck, remember to
+				<a href="https://docs.astro.build/">read the docs</a>
+				or <a href="https://astro.build/chat">join us on Discord</a> to ask questions.
 			</p>
 			<p>
-				Looking for a blog template with a bit more personality? Check out <a
-					href="https://github.com/Charca/astro-blog-template"
-					>astro-blog-template
-				</a> by <a href="https://twitter.com/Charca">Maxi Ferreira</a>.
+				Looking for a blog template with a bit more personality? Check out
+				<a href="https://github.com/Charca/astro-blog-template">astro-blog-template</a>
+				by <a href="https://twitter.com/Charca">Maxi Ferreira</a>.
 			</p>
 		</main>
 		<Footer />


### PR DESCRIPTION
## Changes

- Remove trailing spaces from blog example's links.
- A formatter introduced newlines inside the anchor tags on the blog example's home `index.astro` page, causing the link to include a trailing space.
- Not the worst thing, just looks a little unpolished compared to everything else I've experienced getting to know Astro :)
- I've put the anchor tags on their own lines to avoid this issue, _and_ prevent future formatters from re-introducing the issue (tested with Astro extension's formatter, at least).
- No changeset because this is in `examples/*`.

### Before
![before](https://github.com/user-attachments/assets/678dd923-ec92-4ef0-b6c3-75666dd49d92)

### After
![after](https://github.com/user-attachments/assets/0baa1075-2608-4019-a825-d731af1b7c4b)

## Testing

 - Ran the example locally (`cd examples/blog && npm run dev`) and it fixes the issue.
 - Ran Astro VS Code extension's formatter, confirmed issue is not re-introduced. (Also tried Prettier's.)

## Docs

No docs added - small visual tweak to blog example page links.
