### PR TITLE
feat(fonts): resolve config todos

### DIFF
--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -6,8 +6,11 @@ function dedupe<T>(arr: Array<T>): Array<T> {
 
 export const resolveFontOptionsSchema = z.object({
 	weights: z
-		// TODO: support numbers
-		.array(z.string())
+		.array(
+			z
+				.union([z.string(), z.number()])
+				.transform((val) => (typeof val === 'number' ? val.toString() : val)),
+		)
 		.nonempty()
 		.transform((arr) => dedupe(arr)),
 	styles: z
@@ -23,6 +26,11 @@ export const resolveFontOptionsSchema = z.object({
 		.nonempty()
 		.transform((arr) => dedupe(arr))
 		.optional(),
+	display: z.enum(['auto', 'block', 'swap', 'fallback', 'optional']).optional(),
+	unicodeRange: z.array(z.string()).nonempty().optional(),
+	stretch: z.string().optional(),
+	featureSettings: z.string().optional(),
+	variationSettings: z.string().optional(),
 });
 
 export const fontFamilyAttributesSchema = z.object({

--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -5,6 +5,8 @@ function dedupe<T>(arr: Array<T>): Array<T> {
 	return [...new Set(arr)];
 }
 
+// TODO: jsdoc for everything, most of those end up in the public AstroConfig type
+
 export const resolveFontOptionsSchema = z.object({
 	weights: z
 		.array(

--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -60,24 +60,22 @@ export const fontProviderSchema = z
 export const localFontFamilySchema = z
 	.object({
 		provider: z.literal(LOCAL_PROVIDER_NAME),
-		src: z
-			.array(
-				z
-					.object({
-						paths: z.array(z.string()).nonempty(),
-					})
-					.merge(
-						resolveFontOptionsSchema
-							.omit({
-								fallbacks: true,
-								// TODO: find a way to support subsets
-								subsets: true,
-							})
-							.partial(),
-					)
-					.strict(),
-			)
-			.nonempty(),
+		src: z.array(
+			z
+				.object({
+					paths: z.array(z.string()).nonempty(),
+				})
+				.merge(
+					resolveFontOptionsSchema
+						.omit({
+							fallbacks: true,
+							// TODO: find a way to support subsets
+							subsets: true,
+						})
+						.partial(),
+				)
+				.strict(),
+		),
 	})
 	.merge(fontFamilyAttributesSchema.omit({ provider: true }))
 	.merge(

--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BUILTIN_PROVIDERS, GOOGLE_PROVIDER_NAME, LOCAL_PROVIDER_NAME } from './constants.js';
 
 function dedupe<T>(arr: Array<T>): Array<T> {
 	return [...new Set(arr)];
@@ -38,3 +39,60 @@ export const fontFamilyAttributesSchema = z.object({
 	provider: z.string(),
 	as: z.string().optional(),
 });
+
+export const fontProviderSchema = z
+	.object({
+		name: z.string().superRefine((name, ctx) => {
+			if (BUILTIN_PROVIDERS.includes(name as any)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: `"${name}" is a reserved provider name`,
+				});
+			}
+		}),
+		entrypoint: z.union([z.string(), z.instanceof(URL)]),
+		config: z.record(z.string(), z.any()).optional(),
+	})
+	.strict();
+
+export const localFontFamilySchema = z
+	.object({
+		provider: z.literal(LOCAL_PROVIDER_NAME),
+		src: z
+			.array(
+				z
+					.object({
+						paths: z.array(z.string()).nonempty(),
+					})
+					.merge(
+						resolveFontOptionsSchema
+							.omit({
+								fallbacks: true,
+								// TODO: find a way to support subsets
+								subsets: true,
+							})
+							.partial(),
+					)
+					.strict(),
+			)
+			.nonempty(),
+	})
+	.merge(fontFamilyAttributesSchema.omit({ provider: true }))
+	.merge(
+		resolveFontOptionsSchema
+			.omit({
+				weights: true,
+				styles: true,
+				subsets: true,
+			})
+			.partial(),
+	)
+	.strict();
+
+export const commonFontFamilySchema = z
+	.object({
+		provider: z.string().optional().default(GOOGLE_PROVIDER_NAME),
+	})
+	.merge(fontFamilyAttributesSchema.omit({ provider: true }))
+	.merge(resolveFontOptionsSchema.partial())
+	.strict();

--- a/packages/astro/src/assets/fonts/load.ts
+++ b/packages/astro/src/assets/fonts/load.ts
@@ -131,7 +131,17 @@ export async function loadFonts({
 		}
 
 		for (const data of fonts) {
-			css += generateFontFace(family.name, data);
+			// TODO: should the user setting override or act as a fallback when a provider already returns a property?
+			css += generateFontFace(getFamilyName(family), {
+				src: data.src,
+				display: data.display ?? family.display,
+				unicodeRange: data.unicodeRange ?? family.unicodeRange,
+				weight: data.weight,
+				style: data.style,
+				stretch: data.stretch ?? family.stretch,
+				featureSettings: data.featureSettings ?? family.featureSettings,
+				variationSettings: data.variationSettings ?? family.variationSettings,
+			});
 		}
 		const urls = fonts
 			.flatMap((font) => font.src.map((src) => ('originalURL' in src ? src.originalURL : null)))

--- a/packages/astro/src/assets/fonts/load.ts
+++ b/packages/astro/src/assets/fonts/load.ts
@@ -131,7 +131,7 @@ export async function loadFonts({
 		}
 
 		for (const data of fonts) {
-			// TODO: should the user setting override or act as a fallback when a provider already returns a property?
+			// User settings override the generated font settings
 			css += generateFontFace(getFamilyName(family), {
 				src: data.src,
 				display: data.display ?? family.display,

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -26,7 +26,7 @@ export function resolveLocalFont(
 	for (const src of family.src) {
 		for (const weight of src.weights ?? DEFAULTS.weights) {
 			for (const style of src.styles ?? DEFAULTS.styles) {
-				fonts.push({
+				const data: ResolveFontResult['fonts'][number] = {
 					weight,
 					style,
 					src: src.paths.map((path) => {
@@ -37,12 +37,14 @@ export function resolveLocalFont(
 							format: extractFontType(path),
 						};
 					}),
-					display: src.display,
-					unicodeRange: src.unicodeRange,
-					stretch: src.stretch,
-					featureSettings: src.featureSettings,
-					variationSettings: src.variationSettings,
-				});
+				};
+				if (src.display) data.display = src.display;
+				if (src.unicodeRange) data.unicodeRange = src.unicodeRange;
+				if (src.stretch) data.stretch = src.stretch;
+				if (src.featureSettings) data.featureSettings = src.featureSettings;
+				if (src.variationSettings) data.variationSettings = src.variationSettings;
+
+				fonts.push(data);
 			}
 		}
 	}

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -37,6 +37,11 @@ export function resolveLocalFont(
 							format: extractFontType(path),
 						};
 					}),
+					display: src.display,
+					unicodeRange: src.unicodeRange,
+					stretch: src.stretch,
+					featureSettings: src.featureSettings,
+					variationSettings: src.variationSettings,
 				});
 			}
 		}

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -26,7 +26,6 @@ export function resolveLocalFont(
 	for (const src of family.src) {
 		for (const weight of src.weights ?? DEFAULTS.weights) {
 			for (const style of src.styles ?? DEFAULTS.styles) {
-				// TODO: handle subset
 				fonts.push({
 					weight,
 					style,

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -28,9 +28,11 @@ export interface FontFamilyAttributes
 	extends z.infer<typeof fontFamilyAttributesSchema>,
 		Partial<ResolveFontOptions> {}
 
-export interface LocalFontFamily extends Pick<FontFamilyAttributes, 'name' | 'fallbacks' | 'as'> {
+export interface LocalFontFamily
+	extends Omit<FontFamilyAttributes, 'provider' | 'weights' | 'styles' | 'subsets'> {
 	provider: LocalProviderName;
-	src: Array<Partial<Omit<ResolveFontOptions, 'fallbacks'>> & { paths: Array<string> }>;
+	// TODO: find a way to support subsets
+	src: Array<Partial<Omit<ResolveFontOptions, 'fallbacks' | 'subsets'>> & { paths: Array<string> }>;
 }
 
 interface CommonFontFamily<TProvider extends string>

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -6,14 +6,18 @@ import type {
 	FONT_TYPES,
 } from './constants.js';
 import type * as unifont from 'unifont';
-import type { fontFamilyAttributesSchema, resolveFontOptionsSchema } from './config.js';
+import type {
+	commonFontFamilySchema,
+	fontFamilyAttributesSchema,
+	fontProviderSchema,
+	localFontFamilySchema,
+	resolveFontOptionsSchema,
+} from './config.js';
 
 // TODO: jsdoc for everything, most of those end up in the public AstroConfig type
 
-export interface FontProvider<TName extends string> {
+export interface FontProvider<TName extends string> extends z.infer<typeof fontProviderSchema> {
 	name: TName;
-	entrypoint: string | URL;
-	config?: Record<string, any>;
 }
 
 export interface ResolvedFontProvider {
@@ -28,15 +32,10 @@ export interface FontFamilyAttributes
 	extends z.infer<typeof fontFamilyAttributesSchema>,
 		Partial<ResolveFontOptions> {}
 
-export interface LocalFontFamily
-	extends Omit<FontFamilyAttributes, 'provider' | 'weights' | 'styles' | 'subsets'> {
-	provider: LocalProviderName;
-	// TODO: find a way to support subsets
-	src: Array<Partial<Omit<ResolveFontOptions, 'fallbacks' | 'subsets'>> & { paths: Array<string> }>;
-}
+export type LocalFontFamily = z.infer<typeof localFontFamilySchema>;
 
 interface CommonFontFamily<TProvider extends string>
-	extends Omit<FontFamilyAttributes, 'provider'> {
+	extends z.infer<typeof commonFontFamilySchema> {
 	provider: TProvider;
 }
 

--- a/packages/astro/src/assets/fonts/utils.ts
+++ b/packages/astro/src/assets/fonts/utils.ts
@@ -6,14 +6,13 @@ import type { Storage } from 'unstorage';
 import type * as fontaine from 'fontaine';
 import type { Logger } from '../../core/logger/core.js';
 
-// TODO: expose all relevant options in config
 // Source: https://github.com/nuxt/fonts/blob/main/src/css/render.ts#L7-L21
 export function generateFontFace(family: string, font: unifont.FontFaceData) {
 	return [
 		'@font-face {',
-		`  font-family: '${family}';`,
+		`  font-family: ${JSON.stringify(family)};`,
 		`  src: ${renderFontSrc(font.src)};`,
-		`  font-display: ${font.display || 'swap'};`,
+		`  font-display: ${font.display ?? 'swap'};`,
 		font.unicodeRange && `  unicode-range: ${font.unicodeRange};`,
 		font.weight &&
 			`  font-weight: ${Array.isArray(font.weight) ? font.weight.join(' ') : font.weight};`,
@@ -194,7 +193,6 @@ export async function generateFallbacksCSS({
  * - If there are many downloads started at once, only one log is shown for start and end
  * - If a given file has already been logged, it won't show up anymore (useful in dev)
  */
-// TODO: test
 export function createLogManager(logger: Logger) {
 	const done = new Set<string>();
 	const items = new Set<string>();

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -649,9 +649,9 @@ export const AstroConfigSchema = z.object({
 								code: z.ZodIssueCode.custom,
 								message:
 									key === 'name' && existing === 'name'
-										? `2 families have the same **name** property: "${name}". Names have to be unique, you can override one of these family name by specifying the **as** property. Read more at TODO:`
+										? `Multiple families have the same **name** property: "${name}". Names have to be unique, you can override one of these family name by specifying the **as** property. Read more at TODO:`
 										: key === 'as' && existing === 'as'
-											? `2 families have the same **as** property: "${name}". Names have to be unique, update one of these family **as** property to avoid conflicts. Read more at TODO:`
+											? `Multiple families have the same **as** property: "${name}". Names have to be unique, update one of these family **as** property to avoid conflicts. Read more at TODO:`
 											: `A family **name** property is conflicting with another family **as** property: "${name}". Either update the current **as** property or add a unique **as** property to the family that has a **name** property. Read more at TODO:`,
 								path: ['families', i, key],
 							});

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -14,12 +14,12 @@ import type { SvgRenderMode } from '../../assets/utils/svg.js';
 import { EnvSchema } from '../../env/schema.js';
 import type { AstroUserConfig, ViteUserConfig } from '../../types/public/config.js';
 import { appendForwardSlash, prependForwardSlash, removeTrailingForwardSlash } from '../path.js';
+import { BUILTIN_PROVIDERS, GOOGLE_PROVIDER_NAME } from '../../assets/fonts/constants.js';
 import {
-	BUILTIN_PROVIDERS,
-	GOOGLE_PROVIDER_NAME,
-	LOCAL_PROVIDER_NAME,
-} from '../../assets/fonts/constants.js';
-import { fontFamilyAttributesSchema, resolveFontOptionsSchema } from '../../assets/fonts/config.js';
+	commonFontFamilySchema,
+	fontProviderSchema,
+	localFontFamilySchema,
+} from '../../assets/fonts/config.js';
 import { getFamilyName } from '../../assets/fonts/utils.js';
 
 // The below types are required boilerplate to workaround a Zod issue since v3.21.2. Since that version,
@@ -606,56 +606,14 @@ export const AstroConfigSchema = z.object({
 
 			fonts: z
 				.object({
-					providers: z
-						.array(
-							z
-								.object({
-									name: z.string().superRefine((name, ctx) => {
-										if (BUILTIN_PROVIDERS.includes(name as any)) {
-											ctx.addIssue({
-												code: z.ZodIssueCode.custom,
-												message: `"${name}" is a reserved provider name`,
-											});
-										}
-									}),
-									entrypoint: z.string(),
-									config: z.record(z.string(), z.any()).optional(),
-								})
-								.strict(),
-						)
-						.optional(),
+					providers: z.array(fontProviderSchema).optional(),
 					families: z.array(
-						z
-							.union([
-								z.string(),
-								z
-									.object({
-										provider: z.literal(LOCAL_PROVIDER_NAME),
-										src: z.array(
-											z
-												.object({
-													paths: z.array(z.string()).nonempty(),
-												})
-												.merge(resolveFontOptionsSchema.omit({ fallbacks: true }).partial())
-												.strict(),
-										),
-									})
-									.merge(fontFamilyAttributesSchema.omit({ provider: true }))
-									.merge(resolveFontOptionsSchema.pick({ fallbacks: true }).partial())
-									.strict(),
-								z
-									.object({
-										provider: z.string().optional().default(GOOGLE_PROVIDER_NAME),
-									})
-									.merge(fontFamilyAttributesSchema.omit({ provider: true }))
-									.merge(resolveFontOptionsSchema.partial())
-									.strict(),
-							])
-							.transform((family) =>
-								typeof family === 'string'
-									? { name: family, provider: GOOGLE_PROVIDER_NAME }
-									: family,
-							),
+						z.union([
+							// Shorthand
+							z.string().transform((name) => ({ name, provider: GOOGLE_PROVIDER_NAME })),
+							localFontFamilySchema,
+							commonFontFamilySchema,
+						]),
 					),
 				})
 				.strict()

--- a/packages/astro/test/units/assets/fonts/load.test.js
+++ b/packages/astro/test/units/assets/fonts/load.test.js
@@ -57,7 +57,8 @@ it('loadFonts()', async () => {
 				// we do weird typings internally for "reasons" (provider is typed as "local" | "custom") but this is valid
 				provider: /** @type {any} */ ('google'),
 				fallbacks: ['sans-serif'],
-				as: 'Custom'
+				as: 'Custom',
+				display: 'block',
 			},
 		],
 		storage,
@@ -91,10 +92,10 @@ it('loadFonts()', async () => {
 	assert.equal(Array.from(hashToUrlMap.keys()).length > 0, true);
 	assert.deepStrictEqual(Array.from(resolvedMap.keys()), ['Roboto']);
 	assert.deepStrictEqual(logs, ['Fonts initialized']);
+	const css = resolvedMap.get('Roboto').css;
 	assert.equal(
-		resolvedMap
-			.get('Roboto')
-			.css.includes(':root { --astro-font-Custom: Custom, "Custom fallback: Arial", sans-serif; }'),
+		css.includes(':root { --astro-font-Custom: Custom, "Custom fallback: Arial", sans-serif; }'),
 		true,
 	);
+	assert.equal(css.includes('font-display: block'), true);
 });

--- a/packages/astro/test/units/assets/fonts/providers.test.js
+++ b/packages/astro/test/units/assets/fonts/providers.test.js
@@ -95,6 +95,7 @@ describe('fonts providers', () => {
 				src: [
 					{
 						paths: ['./src/fonts/foo.woff2', './src/fonts/foo.ttf'],
+						display: 'block',
 					},
 				],
 			},
@@ -105,6 +106,7 @@ describe('fonts providers', () => {
 			{
 				weight: '400',
 				style: 'normal',
+				display: 'block',
 				src: [
 					{
 						originalURL: fileURLToPath(new URL('./src/fonts/foo.woff2', import.meta.url)),
@@ -121,6 +123,7 @@ describe('fonts providers', () => {
 			{
 				weight: '400',
 				style: 'italic',
+				display: 'block',
 				src: [
 					{
 						originalURL: fileURLToPath(new URL('./src/fonts/foo.woff2', import.meta.url)),
@@ -149,6 +152,7 @@ describe('fonts providers', () => {
 						weights: ['600', '700'],
 						styles: ['oblique'],
 						paths: ['./src/fonts/bar.eot'],
+						stretch: 'condensed',
 					},
 				],
 			},
@@ -159,6 +163,7 @@ describe('fonts providers', () => {
 			{
 				weight: '600',
 				style: 'oblique',
+				stretch: 'condensed',
 				src: [
 					{
 						originalURL: fileURLToPath(new URL('./src/fonts/bar.eot', import.meta.url)),
@@ -170,6 +175,7 @@ describe('fonts providers', () => {
 			{
 				weight: '700',
 				style: 'oblique',
+				stretch: 'condensed',
 				src: [
 					{
 						originalURL: fileURLToPath(new URL('./src/fonts/bar.eot', import.meta.url)),

--- a/packages/astro/test/units/assets/fonts/schemas.test.js
+++ b/packages/astro/test/units/assets/fonts/schemas.test.js
@@ -1,0 +1,58 @@
+// @ts-check
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	fontProviderSchema,
+	resolveFontOptionsSchema,
+} from '../../../../dist/assets/fonts/config.js';
+
+describe('fonts schemas', () => {
+	it('resolveFontOptionsSchema', () => {
+		assert.deepStrictEqual(
+			resolveFontOptionsSchema.safeParse({
+				weights: ['400', 400, '500', 600, '100..900'],
+				styles: ['normal', 'normal', 'oblique'],
+				subsets: ['latin', 'latin', 'latin-extended'],
+				fallbacks: ['Arial', 'Roboto', 'Arial'],
+			}),
+			{
+				success: true,
+				data: {
+					weights: ['400', '500', '600', '100..900'],
+					styles: ['normal', 'oblique'],
+					subsets: ['latin', 'latin-extended'],
+					fallbacks: ['Arial', 'Roboto'],
+				},
+			},
+		);
+	});
+
+	it('fontProviderSchema', () => {
+		assert.deepStrictEqual(
+			fontProviderSchema.safeParse({
+				name: 'custom',
+				entrypoint: '',
+			}),
+			{
+				success: true,
+				data: { name: 'custom', entrypoint: '' },
+			},
+		);
+
+		let res = fontProviderSchema.safeParse({
+			name: 'google',
+			entrypoint: '',
+		});
+		assert.equal(res.success, false);
+		assert.equal(res.error.issues[0].code, 'custom');
+		assert.equal(res.error.issues[0].message, '"google" is a reserved provider name');
+
+		res = fontProviderSchema.safeParse({
+			name: 'local',
+			entrypoint: '',
+		});
+		assert.equal(res.success, false);
+		assert.equal(res.error.issues[0].code, 'custom');
+		assert.equal(res.error.issues[0].message, '"local" is a reserved provider name');
+	});
+});

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -1,23 +1,32 @@
+// @ts-check
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { stripVTControlCharacters } from 'node:util';
 import { z } from 'zod';
-import { validateConfig } from '../../../dist/core/config/validate.js';
+import { validateConfig as _validateConfig } from '../../../dist/core/config/validate.js';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
 import { envField } from '../../../dist/env/config.js';
 
+/**
+ *
+ * @param {any} userConfig
+ */
+function validateConfig(userConfig) {
+	return _validateConfig(userConfig, process.cwd(), '');
+}
+
 describe('Config Validation', () => {
 	it('empty user config is valid', async () => {
-		assert.doesNotThrow(() => validateConfig({}, process.cwd()).catch((err) => err));
+		assert.doesNotThrow(() => validateConfig({}).catch((err) => err));
 	});
 
 	it('Zod errors are returned when invalid config is used', async () => {
-		const configError = await validateConfig({ site: 42 }, process.cwd()).catch((err) => err);
+		const configError = await validateConfig({ site: 42 }).catch((err) => err);
 		assert.equal(configError instanceof z.ZodError, true);
 	});
 
 	it('A validation error can be formatted correctly', async () => {
-		const configError = await validateConfig({ site: 42 }, process.cwd()).catch((err) => err);
+		const configError = await validateConfig({ site: 42 }).catch((err) => err);
 		assert.equal(configError instanceof z.ZodError, true);
 		const formattedError = stripVTControlCharacters(formatConfigErrorMessage(configError));
 		assert.equal(
@@ -33,7 +42,7 @@ describe('Config Validation', () => {
 			integrations: [42],
 			build: { format: 'invalid' },
 		};
-		const configError = await validateConfig(veryBadConfig, process.cwd()).catch((err) => err);
+		const configError = await validateConfig(veryBadConfig).catch((err) => err);
 		assert.equal(configError instanceof z.ZodError, true);
 		const formattedError = stripVTControlCharacters(formatConfigErrorMessage(configError));
 		assert.equal(
@@ -48,21 +57,17 @@ describe('Config Validation', () => {
 	});
 
 	it('ignores falsey "integration" values', async () => {
-		const result = await validateConfig(
-			{ integrations: [0, false, null, undefined] },
-			process.cwd(),
-		);
+		const result = await validateConfig({ integrations: [0, false, null, undefined] });
 		assert.deepEqual(result.integrations, []);
 	});
 	it('normalizes "integration" values', async () => {
-		const result = await validateConfig({ integrations: [{ name: '@astrojs/a' }] }, process.cwd());
+		const result = await validateConfig({ integrations: [{ name: '@astrojs/a' }] });
 		assert.deepEqual(result.integrations, [{ name: '@astrojs/a', hooks: {} }]);
 	});
 	it('flattens array "integration" values', async () => {
-		const result = await validateConfig(
-			{ integrations: [{ name: '@astrojs/a' }, [{ name: '@astrojs/b' }, { name: '@astrojs/c' }]] },
-			process.cwd(),
-		);
+		const result = await validateConfig({
+			integrations: [{ name: '@astrojs/a' }, [{ name: '@astrojs/b' }, { name: '@astrojs/c' }]],
+		});
 		assert.deepEqual(result.integrations, [
 			{ name: '@astrojs/a', hooks: {} },
 			{ name: '@astrojs/b', hooks: {} },
@@ -70,16 +75,13 @@ describe('Config Validation', () => {
 		]);
 	});
 	it('ignores null or falsy "integration" values', async () => {
-		const configError = await validateConfig(
-			{ integrations: [null, undefined, false, '', ``] },
-			process.cwd(),
-		).catch((err) => err);
+		const configError = await validateConfig({
+			integrations: [null, undefined, false, '', ``],
+		}).catch((err) => err);
 		assert.equal(configError instanceof Error, false);
 	});
 	it('Error when outDir is placed within publicDir', async () => {
-		const configError = await validateConfig({ outDir: './public/dist' }, process.cwd()).catch(
-			(err) => err,
-		);
+		const configError = await validateConfig({ outDir: './public/dist' }).catch((err) => err);
 		assert.equal(configError instanceof z.ZodError, true);
 		assert.equal(
 			configError.errors[0].message,
@@ -89,15 +91,12 @@ describe('Config Validation', () => {
 
 	describe('i18n', async () => {
 		it('defaultLocale is not in locales', async () => {
-			const configError = await validateConfig(
-				{
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es'],
-					},
+			const configError = await validateConfig({
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es'],
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -106,21 +105,18 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if codes are empty', async () => {
-			const configError = await validateConfig(
-				{
-					i18n: {
-						defaultLocale: 'uk',
-						locales: [
-							'es',
-							{
-								path: 'something',
-								codes: [],
-							},
-						],
-					},
+			const configError = await validateConfig({
+				i18n: {
+					defaultLocale: 'uk',
+					locales: [
+						'es',
+						{
+							path: 'something',
+							codes: [],
+						},
+					],
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -129,21 +125,18 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if the default locale is not in path', async () => {
-			const configError = await validateConfig(
-				{
-					i18n: {
-						defaultLocale: 'uk',
-						locales: [
-							'es',
-							{
-								path: 'something',
-								codes: ['en-UK'],
-							},
-						],
-					},
+			const configError = await validateConfig({
+				i18n: {
+					defaultLocale: 'uk',
+					locales: [
+						'es',
+						{
+							path: 'something',
+							codes: ['en-UK'],
+						},
+					],
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -152,18 +145,15 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if a fallback value does not exist', async () => {
-			const configError = await validateConfig(
-				{
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						fallback: {
-							es: 'it',
-						},
+			const configError = await validateConfig({
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					fallback: {
+						es: 'it',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -172,18 +162,15 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if a fallback key does not exist', async () => {
-			const configError = await validateConfig(
-				{
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						fallback: {
-							it: 'en',
-						},
+			const configError = await validateConfig({
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					fallback: {
+						it: 'en',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -192,18 +179,15 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if a fallback key contains the default locale', async () => {
-			const configError = await validateConfig(
-				{
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						fallback: {
-							en: 'es',
-						},
+			const configError = await validateConfig({
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					fallback: {
+						en: 'es',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -212,19 +196,16 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if `i18n.prefixDefaultLocale` is `false` and `i18n.redirectToDefaultLocale` is `true`', async () => {
-			const configError = await validateConfig(
-				{
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						routing: {
-							prefixDefaultLocale: false,
-							redirectToDefaultLocale: false,
-						},
+			const configError = await validateConfig({
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					routing: {
+						prefixDefaultLocale: false,
+						redirectToDefaultLocale: false,
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -233,19 +214,16 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if a domains key does not exist', async () => {
-			const configError = await validateConfig(
-				{
-					output: 'server',
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						domains: {
-							lorem: 'https://example.com',
-						},
+			const configError = await validateConfig({
+				output: 'server',
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					domains: {
+						lorem: 'https://example.com',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -254,19 +232,16 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if a domains value is not an URL', async () => {
-			const configError = await validateConfig(
-				{
-					output: 'server',
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						domains: {
-							en: 'www.example.com',
-						},
+			const configError = await validateConfig({
+				output: 'server',
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					domains: {
+						en: 'www.example.com',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -275,19 +250,16 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if a domains value is not an URL with incorrect protocol', async () => {
-			const configError = await validateConfig(
-				{
-					output: 'server',
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						domains: {
-							en: 'tcp://www.example.com',
-						},
+			const configError = await validateConfig({
+				output: 'server',
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					domains: {
+						en: 'tcp://www.example.com',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -296,19 +268,16 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if a domain is a URL with a pathname that is not the home', async () => {
-			const configError = await validateConfig(
-				{
-					output: 'server',
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						domains: {
-							en: 'https://www.example.com/blog/page/',
-						},
+			const configError = await validateConfig({
+				output: 'server',
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					domains: {
+						en: 'https://www.example.com/blog/page/',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -317,19 +286,16 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if domains is enabled but site is not provided', async () => {
-			const configError = await validateConfig(
-				{
-					output: 'server',
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						domains: {
-							en: 'https://www.example.com/',
-						},
+			const configError = await validateConfig({
+				output: 'server',
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					domains: {
+						en: 'https://www.example.com/',
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -338,20 +304,17 @@ describe('Config Validation', () => {
 		});
 
 		it('errors if domains is enabled but the `output` is not "server"', async () => {
-			const configError = await validateConfig(
-				{
-					output: 'static',
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['es', 'en'],
-						domains: {
-							en: 'https://www.example.com/',
-						},
+			const configError = await validateConfig({
+				output: 'static',
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['es', 'en'],
+					domains: {
+						en: 'https://www.example.com/',
 					},
-					site: 'https://foo.org',
 				},
-				process.cwd(),
-			).catch((err) => err);
+				site: 'https://foo.org',
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -363,43 +326,34 @@ describe('Config Validation', () => {
 	describe('env', () => {
 		it('Should allow not providing a schema', () => {
 			assert.doesNotThrow(() =>
-				validateConfig(
-					{
-						env: {
-							schema: undefined,
-						},
+				validateConfig({
+					env: {
+						schema: undefined,
 					},
-					process.cwd(),
-				),
+				}),
 			);
 		});
 
 		it('Should allow schema variables with numbers', () => {
 			assert.doesNotThrow(() =>
-				validateConfig(
-					{
-						env: {
-							schema: {
-								ABC123: envField.string({ access: 'public', context: 'server' }),
-							},
+				validateConfig({
+					env: {
+						schema: {
+							ABC123: envField.string({ access: 'public', context: 'server' }),
 						},
 					},
-					process.cwd(),
-				),
+				}),
 			);
 		});
 
 		it('Should not allow schema variables starting with a number', async () => {
-			const configError = await validateConfig(
-				{
-					env: {
-						schema: {
-							'123ABC': envField.string({ access: 'public', context: 'server' }),
-						},
+			const configError = await validateConfig({
+				env: {
+					schema: {
+						'123ABC': envField.string({ access: 'public', context: 'server' }),
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
@@ -408,16 +362,14 @@ describe('Config Validation', () => {
 		});
 
 		it('Should provide a useful error for access/context invalid combinations', async () => {
-			const configError = await validateConfig(
-				{
-					env: {
-						schema: {
-							BAR: envField.string({ access: 'secret', context: 'client' }),
-						},
+			const configError = await validateConfig({
+				env: {
+					schema: {
+						// @ts-expect-error we test an invalid combination
+						BAR: envField.string({ access: 'secret', context: 'client' }),
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message.includes(
@@ -431,69 +383,89 @@ describe('Config Validation', () => {
 	describe('fonts', () => {
 		it('Should allow empty providers and families', () => {
 			assert.doesNotThrow(() =>
-				validateConfig(
-					{
-						experimental: {
-							fonts: {
-								providers: [],
-								families: [],
-							},
+				validateConfig({
+					experimental: {
+						fonts: {
+							providers: [],
+							families: [],
 						},
 					},
-					process.cwd(),
-				),
+				}),
 			);
 		});
 
-		it('Should not allow providers with reserved names', async () => {
-			let configError = await validateConfig(
-				{
-					experimental: {
-						fonts: {
-							providers: [{ name: 'google', entrypoint: '' }],
-							families: [],
-						},
+		it('Tranforms family shorthand', async () => {
+			const config = await validateConfig({
+				experimental: {
+					fonts: {
+						families: ['Roboto'],
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
-			assert.equal(configError instanceof z.ZodError, true);
-			assert.equal(
-				configError.errors[0].message.includes('"google" is a reserved provider name'),
-				true,
-			);
-
-			configError = await validateConfig(
-				{
-					experimental: {
-						fonts: {
-							providers: [{ name: 'local', entrypoint: '' }],
-							families: [],
-						},
-					},
-				},
-				process.cwd(),
-			).catch((err) => err);
-			assert.equal(configError instanceof z.ZodError, true);
-			assert.equal(
-				configError.errors[0].message.includes('"local" is a reserved provider name'),
-				true,
-			);
+			});
+			assert.deepEqual(config.experimental.fonts, {
+				families: [{ name: 'Roboto', provider: 'google' }],
+			});
 		});
 
 		it('Should not allow using non registed providers', async () => {
-			const configError = await validateConfig(
-				{
-					experimental: {
-						fonts: {
-							families: [{ provider: 'custom', name: 'foo' }],
-						},
+			const configError = await validateConfig({
+				experimental: {
+					fonts: {
+						families: [{ provider: 'custom', name: 'foo' }],
 					},
 				},
-				process.cwd(),
-			).catch((err) => err);
+			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(configError.errors[0].message.includes('Invalid provider "custom"'), true);
+		});
+
+		it('Should error on families name conflicts', async () => {
+			let configError = await validateConfig({
+				experimental: {
+					fonts: {
+						families: [{ name: 'Foo' }, { name: 'Foo' }],
+					},
+				},
+			}).catch((err) => err);
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message.includes('2 families have the same **name** property: "Foo"'),
+				true,
+			);
+
+			configError = await validateConfig({
+				experimental: {
+					fonts: {
+						families: [
+							{ name: 'Foo', as: 'Bar' },
+							{ name: 'Foo', as: 'Bar' },
+						],
+					},
+				},
+			}).catch((err) => err);
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message.includes('2 families have the same **as** property: "Bar"'),
+				true,
+			);
+
+			configError = await validateConfig({
+				experimental: {
+					fonts: {
+						families: [
+							{ name: 'Foo', as: 'Bar' },
+							{ name: 'Bar' },
+						],
+					},
+				},
+			}).catch((err) => err);
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message.includes(
+					'A family **name** property is conflicting with another family **as** property: "Bar"',
+				),
+				true,
+			);
 		});
 	});
 });

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -429,7 +429,7 @@ describe('Config Validation', () => {
 			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
-				configError.errors[0].message.includes('2 families have the same **name** property: "Foo"'),
+				configError.errors[0].message.includes('Multiple families have the same **name** property: "Foo"'),
 				true,
 			);
 
@@ -445,7 +445,7 @@ describe('Config Validation', () => {
 			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
-				configError.errors[0].message.includes('2 families have the same **as** property: "Bar"'),
+				configError.errors[0].message.includes('Multiple families have the same **as** property: "Bar"'),
 				true,
 			);
 


### PR DESCRIPTION
## Changes

This PR makes a bunch of changes related to the fonts configuration:

- Extracts schemas to be reused in the Astro config and in types
- Improves schemas to allow more font options (eg. `featureSettings`)
- Adds errors to avoid name conflicts. Consider the errors messages placeholders, we'll refine them once team docs make a proper review
- ~~I'd like your opinion on a TODO (I added a PR comment as well)~~

## Testing

- Adds unit tests
- Disable whitespace sensitivty as I took the opportunity to improve some things in the config validation test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
