### PR TITLE
fix: display unhandled AstroErrors in dev server correctly

### DIFF
--- a/.changeset/hot-games-doubt.md
+++ b/.changeset/hot-games-doubt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug in error handling that saving a content file with a schema error would display an "unhandled rejection" error instead of the correct schema error

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -92,10 +92,12 @@ export default function createVitePluginAstroServer({
 			viteServer.watcher.on('change', rebuildManifest);
 
 			function handleUnhandledRejection(rejection: any) {
-				const error = new AstroError({
-					...AstroErrorData.UnhandledRejection,
-					message: AstroErrorData.UnhandledRejection.message(rejection?.stack || rejection),
-				});
+				const error = AstroError.is(rejection)
+					? rejection
+					: new AstroError({
+							...AstroErrorData.UnhandledRejection,
+							message: AstroErrorData.UnhandledRejection.message(rejection?.stack || rejection),
+						});
 				const store = localStorage.getStore();
 				if (store instanceof IncomingMessage) {
 					const request = store;


### PR DESCRIPTION
## Changes

Currently if a file is edited in dev, any schema errors will be displayed by the Vite dev server as an `UnhandledRejectionError`. This is because the schema validation happens in the file watcher, and isn't caught and displayed during the rendering. This ensures that AstroErrors (including `InvalidContentEntryDataError`) that are caught by the dev server are recognised and displayed directly, rather than as unhandled rejections.

## Testing

Tested manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
