### PR TITLE
feat: Add `eagerness` support for `prefetch()`

### DIFF
--- a/.changeset/poor-squids-like.md
+++ b/.changeset/poor-squids-like.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add `eagerness` support for `prefetch()`

--- a/.changeset/poor-squids-like.md
+++ b/.changeset/poor-squids-like.md
@@ -1,5 +1,5 @@
 ---
-'astro': patch
+'astro': minor
 ---
 
 Add `eagerness` support for `prefetch()`

--- a/.changeset/poor-squids-like.md
+++ b/.changeset/poor-squids-like.md
@@ -2,12 +2,13 @@
 'astro': minor
 ---
 
-Add `eagerness` support for `prefetch()`
+Adds a new `eagerness` option for `prefetch()` when using `experimental.clientPrerender`
 
-With [`clientPrerender`](https://docs.astro.build/en/reference/experimental-flags/client-prerender/) experiment enabled, you can use `eagerness` option, following the same API described in [Speculation Rules API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/speculationrules#eagerness).
+With the experimental [`clientPrerender`](https://docs.astro.build/en/reference/experimental-flags/client-prerender/) flag enabled, you can use the `eagerness` option on `prefetch()` to suggest to the browser how eagerly it should prefetch/prerender link targets.
 
-For example, you have a set of links that you want to be prerendered/prefetched but there are too many for browsers to handle (Chrome have some [limits in place](https://developer.chrome.com/blog/speculation-rules-improvements#chrome-limits)).
-To prevent that, you can set `eagerness: 'moderate'` to get advantage of FIFO strategies and browser heuristics to let it decide when prerender/prefetch them and in what order.
+This follows the same API described in the [Speculation Rules API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/speculationrules#eagerness) and allows you to balance the benefit of reduced wait times against bandwidth, memory, and CPU costs for your site visitors.
+
+For example, you can now use `prefetch()` programmatically with large sets of links and avoid [browser limits in place to guard against over-speculating](https://developer.chrome.com/blog/speculation-rules-improvements#chrome-limits)  (prerendering/prefetching too many links). Set `eagerness: 'moderate'` to take advantage of [First In, First Out (FIFO)](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) strategies and browser heuristics to let the browser decide when to prerender/prefetch them and in what order:
 
 ```astro
 <a class="link-moderate" href="/nice-link-1">A Nice Link 1</a>

--- a/.changeset/poor-squids-like.md
+++ b/.changeset/poor-squids-like.md
@@ -3,3 +3,23 @@
 ---
 
 Add `eagerness` support for `prefetch()`
+
+With [`clientPrerender`](https://docs.astro.build/en/reference/experimental-flags/client-prerender/) experiment enabled, you can use `eagerness` option, following the same API described in [Speculation Rules API](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/speculationrules#eagerness).
+
+For example, you have a set of links that you want to be prerendered/prefetched but there are too many for browsers to handle (Chrome have some [limits in place](https://developer.chrome.com/blog/speculation-rules-improvements#chrome-limits)).
+To prevent that, you can set `eagerness: 'moderate'` to get advantage of FIFO strategies and browser heuristics to let it decide when prerender/prefetch them and in what order.
+
+```astro
+<a class="link-moderate" href="/nice-link-1">A Nice Link 1</a>
+<a class="link-moderate" href="/nice-link-2">A Nice Link 2</a>
+<a class="link-moderate" href="/nice-link-3">A Nice Link 3</a>
+<a class="link-moderate" href="/nice-link-4">A Nice Link 4</a>
+...
+<a class="link-moderate" href="/nice-link-20">A Nice Link 20</a>
+<script>
+  import { prefetch } from 'astro:prefetch';
+  const linkModerate = document.getElementsByClassName('link-moderate');
+  linkModerate.forEach((link) => prefetch(link.getAttribute('href'), {eagerness: 'moderate'}));
+  
+</script>
+```

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -202,19 +202,8 @@ export interface PrefetchOptions {
 	ignoreSlowConnection?: boolean;
 	/**
 	 * A string providing a hint to the browser as to how eagerly it should prefetch/prerender link targets in order to balance performance advantages against resource overheads. (default `immediate`)
-	 * Only works if `clientPrerender` is enabled and supported.
-	 * Possible values are:
-	 *
-	 * - `"immediate"`
-	 *   : The author thinks the link is very likely to be followed, and/or the document may take significant time to fetch. Prefetch/prerender should start as soon as possible, subject only to considerations such as user preferences and resource limits.
-	 * - `"eager"`
-	 *   : The author wants to prefetch/prerender a large number of navigations, as early as possible. Prefetch/prerender should start on any slight suggestion that a link may be followed. For example, the user could move their mouse cursor towards the link, hover/focus it for a moment, or pause scrolling with the link in a prominent place.
-	 * - `"moderate"`
-	 *   : The author is looking for a balance between `eager` and `conservative`. Prefetch/prerender should start when there is a reasonable suggestion that the user will follow a link in the near future. For example, the user could scroll a link into the viewport and hover/focus it for some time.
-	 * - `"conservative"`
-	 *   : The author wishes to get some benefit from speculative loading with a fairly small tradeoff of resources. Prefetch/prerender should start only when the user is starting to click on the link, for example on `"mousedown"` or `"pointerdown"`.
-	 *
-	 * If `"eagerness"` is not explicitly specified, it rules default to `immediate`. The browser takes this hint into consideration along with its own heuristics, so it may select a link that the author has hinted as less eager than another, if the less eager candidate is considered a better choice.
+	 * Only works if `clientPrerender` is enabled and browser supports Speculation Rules API.
+	 * The browser takes this hint into consideration along with its own heuristics, so it may select a link that the author has hinted as less eager than another, if the less eager candidate is considered a better choice.
 	 *
 	 * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/speculationrules#eagerness
 	 */


### PR DESCRIPTION
## Changes

- What does this change?

New `PrefetchOptions` param `eagerness` that can be explicitly stated for `prefetch()` function.

Usecase: letting a browser manage when a page should be prerendered will simplify web site code compared to default behavior (no `eagerness` passed will automatically default to `immediate`, causing headcaches if you want to use FIFO strategy available for `moderate` and `conservative` args)

Reference doc: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/speculationrules#eagerness

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No tests added, as there weren't for `PrefetchOptions`

## Docs

/cc @withastro/maintainers-docs

`prefetch()` doc should be updated accordingly to notify users a new option to be passed on

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
