### PR TITLE
fix: rethrow astroerrors in image processing

### DIFF
--- a/.changeset/small-masks-wink.md
+++ b/.changeset/small-masks-wink.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Displays correct error message when sharp isn't installed

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -279,6 +279,9 @@ export async function generateImagesForPath(
 				)
 			).data;
 		} catch (e) {
+			if (AstroError.is(e)) {
+				throw e;
+			}
 			const error = new AstroError(
 				{
 					...AstroErrorData.CouldNotTransformImage,


### PR DESCRIPTION
## Changes

If Astro detects that sharp is not installed when trying to transform an image it will throw a `MissingSharp` error. However when this happens during a build, we currently catch it and instead throw a `CouldNotTransformImage` error, with a message suggesting the image is corrupt. The correct error is buried in the  `cause`. This PR checks if the thrown error is an AstroError, and if so rethrows it rather than throwing a `CouldNotTransformImage` error. This means that the `MissingSharp` error is logged correctly.

## Testing
Tested manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
