### PR TITLE
docs: fix formatting of `excludeLangs` default value

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1332,7 +1332,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					 * @name markdown.syntaxHighlight.excludeLangs
 					 * @kind h4
 					 * @type {string[]}
-					 * @default ['math']
+					 * @default `['math']`
 					 * @version 5.5.0
 					 * @description
 					 *


### PR DESCRIPTION
## Changes

The default value for `markdown.syntaxHighlight.excludeLangs` didn't have backticks so the formatting in the [docs preview](https://deploy-preview-11212--astro-docs-2.netlify.app/en/reference/configuration-reference/#markdownsyntaxhighlightexcludelangs) was wrong.

## Testing

Existing tests should still pass.

## Docs

This is a docs fix.
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
