### PR TITLE
fix: make preserveScriptOrder an optional flag

### DIFF
--- a/.changeset/real-results-float.md
+++ b/.changeset/real-results-float.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Makes experimental flag optional

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2210,7 +2210,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * ```
 		 *
 		 */
-		preserveScriptOrder: boolean;
+		preserveScriptOrder?: boolean;
 	};
 }
 


### PR DESCRIPTION
## Changes

Small fix to types

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
