### PR TITLE
fix: reuse storage objects in sessions

### DIFF
--- a/.changeset/dull-papers-fry.md
+++ b/.changeset/dull-papers-fry.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+---
+
+Reuses experimental session storage object between requests. This prevents memory leaks and improves performance for drivers that open persistent connections to a database. 
+


### PR DESCRIPTION
## Changes

Moves the storage object to a static property on `AstroSession`, meaning it can be reused between requests. This avoids memory leaks and excessive connections when using drivers that open persistent DB connections.

Fixes #13376

## Testing

Tested manually. Passes all session tests.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
