### PR TITLE
feat(fonts): family name validation

### DIFF
--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -36,6 +36,9 @@ export const resolveFontOptionsSchema = z.object({
 	variationSettings: z.string().optional(),
 });
 
+// a-z A-Z 0-9 space underscore colon
+export const VALID_CHAR_RE = /[\w ]/;
+
 export const fontFamilyAttributesSchema = z.object({
 	name: z.string(),
 	provider: z.string(),

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -113,7 +113,6 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 				return metrics;
 			},
 			log: (message) => logger.info('assets', message),
-			// TODO: throw error earlier if name or as isn't valid
 			generateCSSVariableName: (name) => kebab(name),
 		});
 	}

--- a/packages/astro/test/units/assets/fonts/schemas.test.js
+++ b/packages/astro/test/units/assets/fonts/schemas.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
 	fontProviderSchema,
 	resolveFontOptionsSchema,
+	VALID_CHAR_RE,
 } from '../../../../dist/assets/fonts/config.js';
 
 describe('fonts schemas', () => {
@@ -54,5 +55,10 @@ describe('fonts schemas', () => {
 		assert.equal(res.success, false);
 		assert.equal(res.error.issues[0].code, 'custom');
 		assert.equal(res.error.issues[0].message, '"local" is a reserved provider name');
+	});
+
+	it('VALID_CHAR_RE', () => {
+		assert.equal(VALID_CHAR_RE.test('abA _:8'), true);
+		assert.equal(VALID_CHAR_RE.test('('), false);
 	});
 });

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -419,6 +419,38 @@ describe('Config Validation', () => {
 			assert.equal(configError.errors[0].message.includes('Invalid provider "custom"'), true);
 		});
 
+		it('Should error on invalid families name', async () => {
+			let configError = await validateConfig({
+				experimental: {
+					fonts: {
+						families: [{ name: '(' }],
+					},
+				},
+			}).catch((err) => err);
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message.includes(
+					'Family name "(" contains invalid characters for CSS variable generation.',
+				),
+				true,
+			);
+
+			configError = await validateConfig({
+				experimental: {
+					fonts: {
+						families: [{ name: '(', as: ')' }],
+					},
+				},
+			}).catch((err) => err);
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message.includes(
+					'**as** property ")" contains invalid characters for CSS variable generation.',
+				),
+				true,
+			);
+		});
+
 		it('Should error on families name conflicts', async () => {
 			let configError = await validateConfig({
 				experimental: {
@@ -429,7 +461,9 @@ describe('Config Validation', () => {
 			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
-				configError.errors[0].message.includes('Multiple families have the same **name** property: "Foo"'),
+				configError.errors[0].message.includes(
+					'Multiple families have the same **name** property: "Foo"',
+				),
 				true,
 			);
 
@@ -445,17 +479,16 @@ describe('Config Validation', () => {
 			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
-				configError.errors[0].message.includes('Multiple families have the same **as** property: "Bar"'),
+				configError.errors[0].message.includes(
+					'Multiple families have the same **as** property: "Bar"',
+				),
 				true,
 			);
 
 			configError = await validateConfig({
 				experimental: {
 					fonts: {
-						families: [
-							{ name: 'Foo', as: 'Bar' },
-							{ name: 'Bar' },
-						],
+						families: [{ name: 'Foo', as: 'Bar' }, { name: 'Bar' }],
 					},
 				},
 			}).catch((err) => err);


### PR DESCRIPTION
## Changes

- Validates the name of the font family, to make sure we can generate a proper css variable name

## Testing

Added

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
