### PR TITLE
Enable XSL for sitemap-index.xml

### DIFF
--- a/.changeset/free-icons-own.md
+++ b/.changeset/free-icons-own.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': minor
+---
+
+Add support for XSL in sitemap-index.xml

--- a/packages/integrations/sitemap/src/write-sitemap.ts
+++ b/packages/integrations/sitemap/src/write-sitemap.ts
@@ -37,6 +37,7 @@ export async function writeSitemap(
 
 	const sitemapAndIndexStream = new SitemapAndIndexStream({
 		limit,
+		xslUrl,
 		getSitemapStream: (i) => {
 			const sitemapStream = new SitemapStream({
 				hostname,

--- a/packages/integrations/sitemap/test/config.test.js
+++ b/packages/integrations/sitemap/test/config.test.js
@@ -28,6 +28,12 @@ describe('Config', () => {
 		});
 
 		it('xslURL: Includes xml-stylesheet', async () => {
+			const indexXml = await fixture.readFile('/sitemap-index.xml');
+			assert.ok(
+				indexXml.includes('<?xml-stylesheet type="text/xsl" href="http://example.com/sitemap.xsl"?>'),
+				indexXml,
+			);
+
 			const xml = await fixture.readFile('/sitemap-0.xml');
 			assert.ok(
 				xml.includes('<?xml-stylesheet type="text/xsl" href="http://example.com/sitemap.xsl"?>'),
@@ -57,6 +63,12 @@ describe('Config', () => {
 		});
 
 		it('xslURL: Includes xml-stylesheet', async () => {
+			const indexXml = await fixture.readFile('/client/sitemap-index.xml');
+			assert.ok(
+				indexXml.includes('<?xml-stylesheet type="text/xsl" href="http://example.com/sitemap.xsl"?>'),
+				indexXml,
+			);
+
 			const xml = await fixture.readFile('/client/sitemap-0.xml');
 			assert.ok(
 				xml.includes('<?xml-stylesheet type="text/xsl" href="http://example.com/sitemap.xsl"?>'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,6 +634,10 @@ importers:
       zod-to-ts:
         specifier: ^1.2.0
         version: 1.2.0(typescript@5.8.2)(zod@3.24.2)
+    optionalDependencies:
+      sharp:
+        specifier: ^0.33.3
+        version: 0.33.5
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
@@ -740,10 +744,6 @@ importers:
       vitest:
         specifier: ^3.0.8
         version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.29.1)(sass@1.85.1)(yaml@2.5.1)
-    optionalDependencies:
-      sharp:
-        specifier: ^0.33.3
-        version: 0.33.5
 
   packages/astro-prism:
     dependencies:


### PR DESCRIPTION
## Changes

- Enables styling of sitemap via XSL (eXtensible Styling Language)
- Passes existing config.xslURL to `SiteMapIndexStream` [Docs Link](https://github.com/ekalinin/sitemap.js/blob/0af656e6a4a7b1403c9b3af23603261bd9cf94d3/lib/sitemap-index-stream.ts#L40)
  - I assume that a separate config value for `sitemap-index.xml` is unneeded, as historic examples of XSL for sitemaps handle both the index and map XML files.

## Testing

- I extended the tests that ensured `sitemap-0.xml` included the XSL to also test that `sitemap-index.xml` includes it.

## Docs

I don't believe the docs need to be updated, as the description of the sitemap plugin's config is the only place I've seen XSL (or `xslURL`) referenced, and that value's usage doesn't differ in a way that merits documentation. I expected the `xslURL` value to behave this way already, from the docs.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
