### PR TITLE
fix: respect `--yes` flag for third-party integrations

### DIFF
--- a/.changeset/ten-tips-share.md
+++ b/.changeset/ten-tips-share.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused the `astro add` command to ignore the `--yes` flag for third-party integrations

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -32,6 +32,7 @@ import { eventCliSession, telemetry } from '../../events/index.js';
 import { exec } from '../exec.js';
 import { type Flags, createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { fetchPackageJson, fetchPackageVersions } from '../install-package.js';
+import type yargsParser from 'yargs-parser';
 
 interface AddOptions {
 	flags: Flags;
@@ -138,7 +139,7 @@ export async function add(names: string[], { flags }: AddOptions) {
 	const cwd = inlineConfig.root;
 	const logger = createLoggerFromFlags(flags);
 	const integrationNames = names.map((name) => (ALIASES.has(name) ? ALIASES.get(name)! : name));
-	const integrations = await validateIntegrations(integrationNames);
+	const integrations = await validateIntegrations(integrationNames, flags);
 	let installResult = await tryToInstallIntegrations({ integrations, cwd, flags, logger });
 	const rootPath = resolveRoot(cwd);
 	const root = pathToFileURL(rootPath);
@@ -713,7 +714,10 @@ async function tryToInstallIntegrations({
 	}
 }
 
-async function validateIntegrations(integrations: string[]): Promise<IntegrationInfo[]> {
+async function validateIntegrations(
+	integrations: string[],
+	flags: yargsParser.Arguments,
+): Promise<IntegrationInfo[]> {
 	const spinner = yoctoSpinner({ text: 'Resolving packages...' }).start();
 	try {
 		const integrationEntries = await Promise.all(
@@ -735,13 +739,7 @@ async function validateIntegrations(integrations: string[]): Promise<Integration
 							spinner.warning(yellow(firstPartyPkgCheck.message));
 						}
 						spinner.warning(yellow(`${bold(integration)} is not an official Astro package.`));
-						const response = await prompts({
-							type: 'confirm',
-							name: 'askToContinue',
-							message: 'Continue?',
-							initial: true,
-						});
-						if (!response.askToContinue) {
+						if (!(await askToContinue({ flags }))) {
 							throw new Error(
 								`No problem! Find our official integrations at ${cyan(
 									'https://astro.build/integrations',


### PR DESCRIPTION
## Changes

Ensures that the "x is not an official Astro package" prompt respects the `--yes` flag

Fixes #13399

## Testing

Manually tested.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
