### PR TITLE
Handle bad values in x-forwarded-host

### DIFF
--- a/.changeset/true-moose-report.md
+++ b/.changeset/true-moose-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent bad value in x-forwarded-host from crashing request

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -90,7 +90,7 @@ export class NodeApp extends App {
 		try {
 			const hostnamePort = getHostnamePort(hostname, port);
 			url = new URL(`${protocol}://${hostnamePort}${req.url}`);
-		} catch (error) {
+		} catch {
 			// Fallback to the provided hostname and port
 			const hostnamePort = getHostnamePort(providedHostname, port);
 			url = new URL(`${providedProtocol}://${hostnamePort}`);

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -75,19 +75,27 @@ export class NodeApp extends App {
 		// We need to handle it here and parse the header correctly.
 		// @example "https, http,http" => "http"
 		const forwardedProtocol = getFirstForwardedValue(req.headers['x-forwarded-proto']);
-		const protocol = forwardedProtocol ?? (isEncrypted ? 'https' : 'http');
+		const providedProtocol = (isEncrypted ? 'https' : 'http');
+		const protocol = forwardedProtocol ?? providedProtocol;
 
 		// @example "example.com,www2.example.com" => "example.com"
 		const forwardedHostname = getFirstForwardedValue(req.headers['x-forwarded-host']);
-		const hostname = forwardedHostname ?? req.headers.host ?? req.headers[':authority'];
+		const providedHostname = req.headers.host ?? req.headers[':authority'];
+		const hostname = forwardedHostname ?? providedHostname;
 
 		// @example "443,8080,80" => "443"
 		const port = getFirstForwardedValue(req.headers['x-forwarded-port']);
 
-		const portInHostname = typeof hostname === 'string' && /:\d+$/.test(hostname);
-		const hostnamePort = portInHostname ? hostname : `${hostname}${port ? `:${port}` : ''}`;
+		let url: URL;
+		try {
+			const hostnamePort = getHostnamePort(hostname, port);
+			url = new URL(`${protocol}://${hostnamePort}${req.url}`);
+		} catch (error) {
+			// Fallback to the provided hostname and port
+			const hostnamePort = getHostnamePort(providedHostname, port);
+			url = new URL(`${providedProtocol}://${hostnamePort}`);
+		}
 
-		const url = `${protocol}://${hostnamePort}${req.url}`;
 		const options: RequestInit = {
 			method: req.method || 'GET',
 			headers: makeRequestHeaders(req),
@@ -159,6 +167,12 @@ export class NodeApp extends App {
 			});
 		}
 	}
+}
+
+function getHostnamePort(hostname: string | string[] | undefined, port?: string): string {
+	const portInHostname = typeof hostname === 'string' && /:\d+$/.test(hostname);
+	const hostnamePort = portInHostname ? hostname : `${hostname}${port ? `:${port}` : ''}`;
+	return hostnamePort;
 }
 
 function makeRequestHeaders(req: NodeRequest): Headers {

--- a/packages/astro/test/units/app/node.test.js
+++ b/packages/astro/test/units/app/node.test.js
@@ -86,6 +86,17 @@ describe('NodeApp', () => {
 				});
 				assert.equal(result.url, 'https://example.com/');
 			});
+
+			it('bad values are ignored and fallback to host header', () => {
+				const result = NodeApp.createRequest({
+					...mockNodeRequest,
+					headers: {
+						host: 'example.com',
+						'x-forwarded-host': ':123'
+					},
+				});
+				assert.equal(result.url, 'https://example.com/');
+			});
 		});
 
 		describe('x-forwarded-proto', () => {


### PR DESCRIPTION
## Changes

- If a bad value is provide by this header, we simply ignore it and fallback to the host provided by the host header (if there is one).
- Fixes https://github.com/withastro/astro/issues/13392

## Testing

- Test added

## Docs

N/A, bug fix