### PR TITLE
fix(config): handle boolean server.allowedHosts

### DIFF
--- a/.changeset/bitter-rockets-pull.md
+++ b/.changeset/bitter-rockets-pull.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Handle server.allowedHosts when the value is true without attempting to push it into an array.

--- a/packages/astro/src/core/config/merge.ts
+++ b/packages/astro/src/core/config/merge.ts
@@ -40,6 +40,11 @@ function mergeConfigRecursively(
 			}
 		}
 
+		// for server.allowedHosts, if the value is a boolean
+		if (key === 'allowedHosts' && rootPath === 'server' && typeof existing === 'boolean') {
+			continue;
+		}
+
 		if (key === 'data' && rootPath === 'db') {
 			// db.data can be a function or an array of functions. When
 			// merging, make sure they become an array


### PR DESCRIPTION
## Changes
- Fixes: #13342 
- Fix handling of server.allowedHosts when the value is true.
- Ensures that a boolean `true` value is accepted without attempting to convert it into an array.

## Testing

- Manually tested by setting allowedHosts: true in astro.config.mjs.
- Verified that astro info and astro dev no longer throw configuration errors.

## Docs

No documentation updates needed as this aligns with existing Vite behavior.
