### PR TITLE
fix: return all codes in toCodes() for custom locale paths

### DIFF
--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -230,11 +230,11 @@ export function normalizeTheLocale(locale: string): string {
  * @param locales
  */
 export function toCodes(locales: Locales): string[] {
-	return locales.map((loopLocale) => {
+	return locales.flatMap((loopLocale) => {
 		if (typeof loopLocale === 'string') {
 			return loopLocale;
 		} else {
-			return loopLocale.codes[0];
+			return loopLocale.codes;
 		}
 	});
 }


### PR DESCRIPTION
## Changes

- Modified the `toCodes` function implementation from `map` to `flatMap` to support expanding all language codes
- Now returns all language codes (`codes`) instead of just the first one (`codes[0]`)

## Testing
N/A
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
