### PR TITLE
feat(fonts): allow disabling automatic fallback generation

### DIFF
--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -29,6 +29,7 @@ export const resolveFontOptionsSchema = z.object({
 		.nonempty()
 		.transform((arr) => dedupe(arr))
 		.optional(),
+	automaticFallback: z.boolean().optional().default(true),
 	display: z.enum(['auto', 'block', 'swap', 'fallback', 'optional']).optional(),
 	unicodeRange: z.array(z.string()).nonempty().optional(),
 	stretch: z.string().optional(),
@@ -72,6 +73,7 @@ export const localFontFamilySchema = z
 					resolveFontOptionsSchema
 						.omit({
 							fallbacks: true,
+							automaticFallback: true,
 							// TODO: find a way to support subsets
 							subsets: true,
 						})

--- a/packages/astro/src/assets/fonts/constants.ts
+++ b/packages/astro/src/assets/fonts/constants.ts
@@ -9,6 +9,7 @@ export const DEFAULTS: ResolveFontOptions = {
 	weights: ['400'],
 	styles: ['normal', 'italic'],
 	subsets: ['cyrillic-ext', 'cyrillic', 'greek-ext', 'greek', 'vietnamese', 'latin-ext', 'latin'],
+	automaticFallback: true,
 };
 
 export const VIRTUAL_MODULE_ID = 'virtual:astro:assets/fonts/internal';

--- a/packages/astro/src/assets/fonts/load.ts
+++ b/packages/astro/src/assets/fonts/load.ts
@@ -162,8 +162,13 @@ export async function loadFonts({
 			family,
 			font: fallbackFontData,
 			fallbacks: family.fallbacks ?? [],
-			getMetricsForFamily,
-			generateFontFace: generateFallbackFontFace,
+			metrics:
+				(family.automaticFallback ?? DEFAULTS.automaticFallback)
+					? {
+							getMetricsForFamily,
+							generateFontFace: generateFallbackFontFace,
+						}
+					: null,
 		});
 
 		const cssVarValues = [getFamilyName(family)];

--- a/packages/astro/test/units/assets/fonts/schemas.test.js
+++ b/packages/astro/test/units/assets/fonts/schemas.test.js
@@ -23,6 +23,7 @@ describe('fonts schemas', () => {
 					styles: ['normal', 'oblique'],
 					subsets: ['latin', 'latin-extended'],
 					fallbacks: ['Arial', 'Roboto'],
+					automaticFallback: true,
 				},
 			},
 		);

--- a/packages/astro/test/units/assets/fonts/utils.test.js
+++ b/packages/astro/test/units/assets/fonts/utils.test.js
@@ -182,10 +182,27 @@ describe('fonts utils', () => {
 					family: { name: 'Roboto' },
 					fallbacks: [],
 					font: null,
-					getMetricsForFamily: async () => null,
-					generateFontFace: () => '',
+					metrics: {
+						getMetricsForFamily: async () => null,
+						generateFontFace: () => '',
+					},
 				}),
 				null,
+			);
+		});
+
+		it('should return fallbacks even without automatic fallbacks generation', async () => {
+			assert.deepStrictEqual(
+				await generateFallbacksCSS({
+					family: { name: 'Roboto' },
+					fallbacks: ['foo'],
+					font: null,
+					metrics: null,
+				}),
+				{
+					css: '',
+					fallbacks: ['foo'],
+				},
 			);
 		});
 
@@ -195,8 +212,10 @@ describe('fonts utils', () => {
 					family: { name: 'Roboto' },
 					fallbacks: ['foo'],
 					font: null,
-					getMetricsForFamily: async () => null,
-					generateFontFace: () => '',
+					metrics: {
+						getMetricsForFamily: async () => null,
+						generateFontFace: () => '',
+					},
 				}),
 				{
 					css: '',
@@ -211,14 +230,16 @@ describe('fonts utils', () => {
 					family: { name: 'Roboto' },
 					fallbacks: ['foo'],
 					font: null,
-					getMetricsForFamily: async () => ({
-						ascent: 0,
-						descent: 0,
-						lineGap: 0,
-						unitsPerEm: 0,
-						xWidthAvg: 0,
-					}),
-					generateFontFace: () => '',
+					metrics: {
+						getMetricsForFamily: async () => ({
+							ascent: 0,
+							descent: 0,
+							lineGap: 0,
+							unitsPerEm: 0,
+							xWidthAvg: 0,
+						}),
+						generateFontFace: () => '',
+					},
 				}),
 				{
 					css: '',
@@ -233,14 +254,16 @@ describe('fonts utils', () => {
 					family: { name: 'Roboto' },
 					fallbacks: ['emoji'],
 					font: null,
-					getMetricsForFamily: async () => ({
-						ascent: 0,
-						descent: 0,
-						lineGap: 0,
-						unitsPerEm: 0,
-						xWidthAvg: 0,
-					}),
-					generateFontFace: () => '',
+					metrics: {
+						getMetricsForFamily: async () => ({
+							ascent: 0,
+							descent: 0,
+							lineGap: 0,
+							unitsPerEm: 0,
+							xWidthAvg: 0,
+						}),
+						generateFontFace: () => '',
+					},
 				}),
 				{
 					css: '',
@@ -255,14 +278,16 @@ describe('fonts utils', () => {
 					family: { name: 'Roboto' },
 					fallbacks: ['foo', 'bar'],
 					font: null,
-					getMetricsForFamily: async () => ({
-						ascent: 0,
-						descent: 0,
-						lineGap: 0,
-						unitsPerEm: 0,
-						xWidthAvg: 0,
-					}),
-					generateFontFace: (_metrics, fallback) => `[${fallback.font},${fallback.name}]`,
+					metrics: {
+						getMetricsForFamily: async () => ({
+							ascent: 0,
+							descent: 0,
+							lineGap: 0,
+							unitsPerEm: 0,
+							xWidthAvg: 0,
+						}),
+						generateFontFace: (_metrics, fallback) => `[${fallback.font},${fallback.name}]`,
+					},
 				}),
 				{
 					css: '',
@@ -274,14 +299,16 @@ describe('fonts utils', () => {
 					family: { name: 'Roboto' },
 					fallbacks: ['sans-serif', 'foo'],
 					font: null,
-					getMetricsForFamily: async () => ({
-						ascent: 0,
-						descent: 0,
-						lineGap: 0,
-						unitsPerEm: 0,
-						xWidthAvg: 0,
-					}),
-					generateFontFace: (_metrics, fallback) => `[${fallback.font},${fallback.name}]`,
+					metrics: {
+						getMetricsForFamily: async () => ({
+							ascent: 0,
+							descent: 0,
+							lineGap: 0,
+							unitsPerEm: 0,
+							xWidthAvg: 0,
+						}),
+						generateFontFace: (_metrics, fallback) => `[${fallback.font},${fallback.name}]`,
+					},
 				}),
 				{
 					css: '',
@@ -293,14 +320,16 @@ describe('fonts utils', () => {
 					family: { name: 'Roboto', as: 'Custom' },
 					fallbacks: ['foo', 'sans-serif'],
 					font: null,
-					getMetricsForFamily: async () => ({
-						ascent: 0,
-						descent: 0,
-						lineGap: 0,
-						unitsPerEm: 0,
-						xWidthAvg: 0,
-					}),
-					generateFontFace: (_metrics, fallback) => `[${fallback.font},${fallback.name}]`,
+					metrics: {
+						getMetricsForFamily: async () => ({
+							ascent: 0,
+							descent: 0,
+							lineGap: 0,
+							unitsPerEm: 0,
+							xWidthAvg: 0,
+						}),
+						generateFontFace: (_metrics, fallback) => `[${fallback.font},${fallback.name}]`,
+					},
 				}),
 				{
 					css: `[Arial,"Custom fallback: Arial"]`,


### PR DESCRIPTION
## Changes

This follows a RFC review from @matthewp 

- By default, we try to generate automatic fallbacks
- With this PR, set `automaticFallback: false` on a family to disable this behaviors

## Testing

Adds a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

RFC has been updated

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
