### PR TITLE
fix(routing): don't add site to static redirects

### DIFF
--- a/.changeset/dark-rooms-enter.md
+++ b/.changeset/dark-rooms-enter.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where `site` was added to the generated redirects.

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -290,7 +290,7 @@ export class App {
 
 		if (redirect !== url.pathname) {
 			const status = request.method === 'GET' ? 301 : 308;
-			return new Response(redirectTemplate({ status, location: redirect, from: request.url }), {
+			return new Response(redirectTemplate({ status, relativeLocation: url.pathname, absoluteLocation: redirect, from: request.url }), {
 				status,
 				headers: {
 					location: redirect + url.search,

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -548,7 +548,7 @@ async function generatePath(
 		const siteURL = config.site;
 		const location = siteURL ? new URL(locationSite, siteURL) : locationSite;
 		const fromPath = new URL(request.url).pathname;
-		body = redirectTemplate({ status: response.status, location, from: fromPath });
+		body = redirectTemplate({ status: response.status, location: locationSite, from: fromPath });
 		if (config.compressHTML === true) {
 			body = body.replaceAll('\n', '');
 		}

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -548,7 +548,12 @@ async function generatePath(
 		const siteURL = config.site;
 		const location = siteURL ? new URL(locationSite, siteURL) : locationSite;
 		const fromPath = new URL(request.url).pathname;
-		body = redirectTemplate({ status: response.status, location: locationSite, from: fromPath });
+		body = redirectTemplate({
+			status: response.status,
+			absoluteLocation: location,
+			relativeLocation: locationSite,
+			from: fromPath,
+		});
 		if (config.compressHTML === true) {
 			body = body.replaceAll('\n', '');
 		}

--- a/packages/astro/src/core/routing/3xx.ts
+++ b/packages/astro/src/core/routing/3xx.ts
@@ -1,19 +1,25 @@
 export type RedirectTemplate = {
 	from?: string;
-	location: string | URL;
+	absoluteLocation: string | URL;
 	status: number;
+	relativeLocation: string;
 };
 
-export function redirectTemplate({ status, location, from }: RedirectTemplate) {
+export function redirectTemplate({
+	status,
+	absoluteLocation,
+	relativeLocation,
+	from,
+}: RedirectTemplate) {
 	// A short delay causes Google to interpret the redirect as temporary.
 	// https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh
 	const delay = status === 302 ? 2 : 0;
 	return `<!doctype html>
-<title>Redirecting to: ${location}</title>
-<meta http-equiv="refresh" content="${delay};url=${location}">
+<title>Redirecting to: ${relativeLocation}</title>
+<meta http-equiv="refresh" content="${delay};url=${relativeLocation}">
 <meta name="robots" content="noindex">
-<link rel="canonical" href="${location}">
+<link rel="canonical" href="${absoluteLocation}">
 <body>
-	<a href="${location}">Redirecting ${from ? `from <code>${from}</code> ` : ''}to <code>${location}</code></a>
+	<a href="${relativeLocation}">Redirecting ${from ? `from <code>${from}</code> ` : ''}to <code>${relativeLocation}</code></a>
 </body>`;
 }

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -59,7 +59,7 @@ export function writeRedirectResponse(
 	statusCode: number,
 	location: string,
 ) {
-	const html = redirectTemplate({ status: statusCode, location });
+	const html = redirectTemplate({ status: statusCode, absoluteLocation: location, relativeLocation: location });
 	res.writeHead(statusCode, {
 		Location: location,
 		'Content-Type': 'text/html',

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -302,10 +302,12 @@ export async function handleRoute({
 		) {
 			// If we're here, it means that the calling static redirect that was configured by the user
 			// We try to replicate the same behaviour that we provide during a static build
+			const location = response.headers.get('location')!;
 			response = new Response(
 				redirectTemplate({
 					status: response.status,
-					location: response.headers.get('location')!,
+					absoluteLocation: location,
+					relativeLocation: location,
 					from: pathname,
 				}),
 				{

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -327,15 +327,15 @@ describe('Astro.redirect', () => {
 				redirects: {
 					'/one': '/',
 				},
-				site: "https://example.com"
+				site: 'https://example.com',
 			});
 			await fixture.build();
 		});
 
 		it('Does not add it to the generated HTML file', async () => {
 			const secretHtml = await fixture.readFile('/secret/index.html');
-			assert.equal(secretHtml.includes('https://example.com'), false);
+			assert.equal(secretHtml.includes('url=https://example.com/login'), false);
+			assert.equal(secretHtml.includes('url=/login'), true);
 		});
-
 	});
 });

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -317,4 +317,25 @@ describe('Astro.redirect', () => {
 			assert.equal(secretHtml.includes('to <code>/login</code>'), true);
 		});
 	});
+
+	describe('when site is specified', () => {
+		before(async () => {
+			process.env.STATIC_MODE = true;
+			fixture = await loadFixture({
+				root: './fixtures/redirects/',
+				output: 'static',
+				redirects: {
+					'/one': '/',
+				},
+				site: "https://example.com"
+			});
+			await fixture.build();
+		});
+
+		it('Does not add it to the generated HTML file', async () => {
+			const secretHtml = await fixture.readFile('/secret/index.html');
+			assert.equal(secretHtml.includes('https://example.com'), false);
+		});
+
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2514,12 +2514,6 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
-  packages/astro/test/fixtures/container:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/container-custom-renderers:
     dependencies:
       '@astrojs/react':


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/13371

To avoid possible breaking changes with the canonical tag, now the function that creates the HTML redirect accepts a relative location and an absolution location. 


## Testing

Added a new test. I also tested it manually to make sure that it keeps working as expected. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
