### PR TITLE
ci: pin actions via digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     "group:allNonMajor",
     ":disablePeerDependencies", 
     "regexManagers:biomeVersions",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
@@ -16,6 +17,12 @@
     {
       "matchPackageNames": ["tailwindcss"],
       "ignorePaths": ["packages/integrations/tailwind"]
+    },
+    {
+      "groupName": "github-actions",
+      "matchManagers": [
+        "github-actions"
+      ]
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## Changes

Due to the recent events that happened with [`changed-files`](https://github.com/tj-actions/changed-files/issues/2464), this PR enforces the use of the commit digests for our GH actions, instead of a tag.

I also added a group to renovate, so renovate will make a PR to update them all at once.

## Testing

Once merged, renovate should update its dependency board. I will trigger a PR

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
