### PR TITLE
fix: set correct statusText for custom error pages

### DIFF
--- a/.changeset/bumpy-sites-ring.md
+++ b/.changeset/bumpy-sites-ring.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+---
+
+Sets correct response status text for custom error pages
+

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -81,14 +81,18 @@ export async function renderPage(
 		headers.set('Content-Length', body.byteLength.toString());
 	}
 	let status = init.status;
+	let statusText = init.statusText;
 	// Custom 404.astro and 500.astro are particular routes that must return a fixed status code
 	if (route?.route === '/404') {
 		status = 404;
+		statusText = 'Not Found';
 	} else if (route?.route === '/500') {
 		status = 500;
-	}
+		statusText = 'Internal Server Error';		
+	} 
+
 	if (status) {
-		return new Response(body, { ...init, headers, status });
+		return new Response(body, { ...init, headers, status, statusText });
 	} else {
 		return new Response(body, { ...init, headers });
 	}

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -85,11 +85,15 @@ export async function renderPage(
 	// Custom 404.astro and 500.astro are particular routes that must return a fixed status code
 	if (route?.route === '/404') {
 		status = 404;
-		statusText = 'Not Found';
+		if (statusText === 'OK') {
+			statusText = 'Not Found';
+		}
 	} else if (route?.route === '/500') {
-		status = 500;
-		statusText = 'Internal Server Error';		
-	} 
+		status = 500; 
+		if (statusText === 'OK') {
+			statusText = 'Internal Server Error';
+		}
+	}
 
 	if (status) {
 		return new Response(body, { ...init, headers, status, statusText });

--- a/packages/astro/test/custom-404-static.test.js
+++ b/packages/astro/test/custom-404-static.test.js
@@ -35,6 +35,7 @@ describe('Custom 404 with Static', () => {
 		it('renders 404 for /a', async () => {
 			const res = await fixture.fetch('/a');
 			assert.equal(res.status, 404);
+			assert.equal(res.statusText, 'Not Found');
 
 			const html = await res.text();
 			$ = cheerio.load(html);

--- a/packages/astro/test/custom-500.test.js
+++ b/packages/astro/test/custom-500.test.js
@@ -94,6 +94,8 @@ describe('Custom 500', () => {
 			const request = new Request('http://example.com/');
 			const response = await app.render(request);
 			assert.equal(response.status, 500);
+			assert.equal(response.statusText, 'Internal Server Error');
+			
 
 			const html = await response.text();
 			const $ = cheerio.load(html);


### PR DESCRIPTION
## Changes

Currently if a user has a custom `404.astro` or `500.astro` we set the correct status code in the response, but not the correct status text, instead leaving the default `OK`. This PR ensures the correct text is set too.

Fixes #13259

## Testing

Added tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
