### PR TITLE
fix: don't attempt to move files after build with base

### DIFF
--- a/.changeset/eight-eyes-swim.md
+++ b/.changeset/eight-eyes-swim.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a bug that caused builds to fail when a base dir is set

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -260,18 +260,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 			},
 			'astro:build:done': async ({ pages, dir, logger, assets }) => {
 				await cloudflareModulePlugin.afterBuildCompleted(_config);
-				const PLATFORM_FILES = ['_headers', '_redirects', '_routes.json'];
-				if (_config.base !== '/') {
-					for (const file of PLATFORM_FILES) {
-						try {
-							await rename(new URL(file, _config.build.client), new URL(file, _config.outDir));
-						} catch (_e) {
-							logger.error(
-								`There was an error moving ${file} to the root of the output directory.`,
-							);
-						}
-					}
-				}
 
 				let redirectsExists = false;
 				try {

--- a/packages/integrations/cloudflare/src/utils/generate-routes-json.ts
+++ b/packages/integrations/cloudflare/src/utils/generate-routes-json.ts
@@ -49,6 +49,7 @@ async function writeRoutesFileToOutDir(
 	include: string[],
 	exclude: string[],
 ) {
+	console.log('Writing _routes.json to', _config.outDir.href);
 	try {
 		await writeFile(
 			new URL('./_routes.json', _config.outDir),

--- a/packages/integrations/cloudflare/test/fixtures/with-base/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/with-base/astro.config.mjs
@@ -1,0 +1,12 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+	base: '/blog/',
+	output: 'server',
+	adapter: cloudflare(),
+	redirects: {
+		'/a/redirect': '/',
+	},
+});

--- a/packages/integrations/cloudflare/test/fixtures/with-base/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/with-base/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-cloudflare-with-base",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/cloudflare": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/cloudflare/test/fixtures/with-base/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/with-base/src/pages/index.astro
@@ -1,0 +1,4 @@
+---
+export const prerender = false;
+---
+<h1>Hello</h1>

--- a/packages/integrations/cloudflare/test/fixtures/with-base/src/pages/static.astro
+++ b/packages/integrations/cloudflare/test/fixtures/with-base/src/pages/static.astro
@@ -1,0 +1,4 @@
+---
+export const prerender = true;
+---
+<h1>Hello</h1>

--- a/packages/integrations/cloudflare/test/with-base-path.js
+++ b/packages/integrations/cloudflare/test/with-base-path.js
@@ -1,0 +1,22 @@
+// @ts-check
+import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { astroCli } from './_test-utils.js';
+import { existsSync, promises as fs } from 'node:fs';
+
+const root = new URL('./fixtures/with-base/', import.meta.url);
+
+describe('With base', () => {
+	before(async () => {
+		await fs.rm(new URL('dist/', root), { recursive: true, force: true });
+		await astroCli(fileURLToPath(root), 'build');
+	});
+
+	it('generates platform files in the correct directory', async () => {
+		for (const file of ['_redirects',  '_routes.json', 'blog/static/index.html']) {
+			assert.ok(existsSync(new URL(`dist/${file}`, root)));
+		}
+	});
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4670,6 +4670,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/cloudflare/test/fixtures/with-base:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/cloudflare/test/fixtures/with-solid-js:
     dependencies:
       '@astrojs/cloudflare':


### PR DESCRIPTION
## Changes

Currently the Cloudflare adapter attempts to move the `_redirects` and `_routes.json` files out of the base dir into the root when a base value is set in the config. This fails, because the files are already created in the root. This PR removes that code path.

Fixes #13162

## Testing

Adds tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
