### PR TITLE
feat(fonts): typegen for <Font /> family prop

### DIFF
--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -2,6 +2,7 @@
 /// <reference path="./types/content.d.ts" />
 /// <reference path="./types/actions.d.ts" />
 /// <reference path="./types/env.d.ts" />
+/// <reference path="./types/fonts.d.ts" />
 
 interface ImportMetaEnv {
 	/**
@@ -74,6 +75,7 @@ declare module 'astro:assets' {
 		imageConfig,
 		Image,
 		Picture,
+		Font,
 		inferRemoteSize,
 	}: AstroAssets;
 }

--- a/packages/astro/components/Font.astro
+++ b/packages/astro/components/Font.astro
@@ -7,7 +7,7 @@ const { fontsData } = await import('virtual:astro:assets/fonts/internal').catch(
 });
 
 interface Props {
-	family: string;
+	family: import('astro:assets').FontFamily;
 	preload?: boolean;
 }
 

--- a/packages/astro/src/assets/fonts/constants.ts
+++ b/packages/astro/src/assets/fonts/constants.ts
@@ -37,3 +37,5 @@ export const DEFAULT_FALLBACKS: Record<string, Array<string>> = {
 	math: [],
 	fangsong: [],
 };
+
+export const FONTS_TYPES_FILE = 'fonts.d.ts';

--- a/packages/astro/src/assets/fonts/load.ts
+++ b/packages/astro/src/assets/fonts/load.ts
@@ -180,7 +180,7 @@ export async function loadFonts({
 
 		css += `:root { --astro-font-${generateCSSVariableName(getFamilyName(family))}: ${cssVarValues.join(', ')}; }`;
 
-		resolvedMap.set(family.name, { preloadData, css });
+		resolvedMap.set(getFamilyName(family), { preloadData, css });
 	}
 	log('Fonts initialized');
 }

--- a/packages/astro/src/assets/fonts/sync.ts
+++ b/packages/astro/src/assets/fonts/sync.ts
@@ -1,0 +1,17 @@
+import type { AstroSettings } from '../../types/astro.js';
+import { FONTS_TYPES_FILE } from './constants.js';
+import { getFamilyName } from './utils.js';
+
+export function syncFonts(settings: AstroSettings): void {
+	if (!settings.config.experimental.fonts) {
+		return;
+	}
+
+	settings.injectedTypes.push({
+		filename: FONTS_TYPES_FILE,
+		content: `declare module 'astro:assets' {
+	export type FontFamily = (${JSON.stringify(settings.config.experimental.fonts.families.map((family) => getFamilyName(family)))})[number];
+}
+`,
+	});
+}

--- a/packages/astro/src/assets/fonts/sync.ts
+++ b/packages/astro/src/assets/fonts/sync.ts
@@ -10,6 +10,7 @@ export function syncFonts(settings: AstroSettings): void {
 	settings.injectedTypes.push({
 		filename: FONTS_TYPES_FILE,
 		content: `declare module 'astro:assets' {
+	/** @internal */
 	export type FontFamily = (${JSON.stringify(settings.config.experimental.fonts.families.map((family) => getFamilyName(family)))})[number];
 }
 `,

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -34,6 +34,7 @@ import type { Logger } from '../logger/core.js';
 import { createRoutesList } from '../routing/index.js';
 import { ensureProcessNodeEnv } from '../util.js';
 import { normalizePath } from '../viteUtils.js';
+import { syncFonts } from '../../assets/fonts/sync.js';
 
 export type SyncOptions = {
 	mode: string;
@@ -181,6 +182,7 @@ export async function syncInternal({
 		}
 	}
 	syncAstroEnv(settings);
+	syncFonts(settings);
 
 	writeInjectedTypes(settings, fs);
 	logger.info('types', `Generated ${dim(getTimeStat(timerStart, performance.now()))}`);

--- a/packages/astro/test/units/assets/fonts/load.test.js
+++ b/packages/astro/test/units/assets/fonts/load.test.js
@@ -90,9 +90,9 @@ it('loadFonts()', async () => {
 		true,
 	);
 	assert.equal(Array.from(hashToUrlMap.keys()).length > 0, true);
-	assert.deepStrictEqual(Array.from(resolvedMap.keys()), ['Roboto']);
+	assert.deepStrictEqual(Array.from(resolvedMap.keys()), ['Custom']);
 	assert.deepStrictEqual(logs, ['Fonts initialized']);
-	const css = resolvedMap.get('Roboto').css;
+	const css = resolvedMap.get('Custom').css;
 	assert.equal(
 		css.includes(':root { --astro-font-Custom: Custom, "Custom fallback: Arial", sans-serif; }'),
 		true,

--- a/packages/astro/types/fonts.d.ts
+++ b/packages/astro/types/fonts.d.ts
@@ -1,0 +1,4 @@
+declare module 'astro:assets' {
+	/** Run `astro dev` or `astro sync` to generate high fidelity types */
+	export type FontFamily = string;
+}

--- a/packages/astro/types/fonts.d.ts
+++ b/packages/astro/types/fonts.d.ts
@@ -1,4 +1,4 @@
 declare module 'astro:assets' {
-	/** Run `astro dev` or `astro sync` to generate high fidelity types */
+	/** @internal Run `astro dev` or `astro sync` to generate high fidelity types */
 	export type FontFamily = string;
 }


### PR DESCRIPTION
## Changes

- Now generates types for the `Font` component family prop
- Fixes a bug where the map passed to the virtual module was not using `family.as` if provided

## Testing

Updated + manual

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
