### PR TITLE
chore(renovate): group updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,24 +4,70 @@
     "config:recommended",
     "schedule:weekly",
     "group:allNonMajor",
-    ":disablePeerDependencies", 
+    ":disablePeerDependencies",
     "regexManagers:biomeVersions",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  "labels": ["dependencies"],
+  "labels": [
+    "dependencies"
+  ],
   "rangeStrategy": "bump",
-  "postUpdateOptions": ["pnpmDedupe"],
-  "ignorePaths": ["**/node_modules/**"],
+  "postUpdateOptions": [
+    "pnpmDedupe"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**"
+  ],
   "packageRules": [
     // TODO: remove once the tailwind integration is removed
     {
-      "matchPackageNames": ["tailwindcss"],
-      "ignorePaths": ["packages/integrations/tailwind"]
+      "matchPackageNames": [
+        "tailwindcss"
+      ],
+      "ignorePaths": [
+        "packages/integrations/tailwind"
+      ]
     },
     {
       "groupName": "github-actions",
       "matchManagers": [
         "github-actions"
+      ]
+    },
+    {
+      "groupName": "astro dependencies",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "packages/astro/**",
+        "packages/integrations/mdx/**",
+        "packages/integrations/remark/**",
+      ]
+    },
+    {
+      "groupName": "astro adapters",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "packages/integrations/node/**",
+        "packages/integrations/netlify/**",
+        "packages/integrations/cloudflare/**",
+        "packages/integrations/vercel/**",
+      ]
+    },
+    {
+      "groupName": "astro client runtimes",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "packages/integrations/react/**",
+        "packages/integrations/solid/**",
+        "packages/integrations/preact/**",
+        "packages/integrations/svelte/**",
+        "packages/integrations/vue/**",
       ]
     }
   ],
@@ -29,18 +75,19 @@
     // manually bumping deps
     "@biomejs/biome",
     "@types/node",
-    "astro-embed", // TODO: investigate upgrade (zod import issues with atproto)
-    "drizzle-orm", // TODO: investigate upgrade (has type issues)
+    
+    // TODO: investigate upgrade (zod import issues with atproto)
+    "astro-embed",
+    
+    // TODO: investigate upgrade (has type issues)
+    "drizzle-orm",
     "sharp",
-
     // manually bumping workflow actions
     "actions/labeler",
-
     // ignore "engines" update
     "node",
     "npm",
     "pnpm",
-
     // follow vite deps version
     "postcss-load-config",
     "esbuild",


### PR DESCRIPTION
## Changes

This PR breaks down the groups handled by renovate.

At the moment when renovate sends a PR, it's fall all packages that we have in the monorepo. This can be overwhelming sometimes, and few times there are breaking changes that require fixes across packages.

This PR creates the following groups:
- the astro deps (`astro`, `@astrojs/mdx` and `@astrojs/markdown-remark`)
- adapters
- runtime integrations (react, solid, etc.)
- the rest

## Testing

I'll check the board once this is merged

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
