### PR TITLE
fix(fonts): config family types for inferred provider

### DIFF
--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BUILTIN_PROVIDERS, GOOGLE_PROVIDER_NAME, LOCAL_PROVIDER_NAME } from './constants.js';
+import { BUILTIN_PROVIDERS, LOCAL_PROVIDER_NAME } from './constants.js';
 
 function dedupe<T>(arr: Array<T>): Array<T> {
 	return [...new Set(arr)];
@@ -96,7 +96,7 @@ export const localFontFamilySchema = z
 
 export const commonFontFamilySchema = z
 	.object({
-		provider: z.string().optional().default(GOOGLE_PROVIDER_NAME),
+		provider: z.string().optional(),
 	})
 	.merge(fontFamilyAttributesSchema.omit({ provider: true }))
 	.merge(resolveFontOptionsSchema.partial())

--- a/packages/astro/src/assets/fonts/load.ts
+++ b/packages/astro/src/assets/fonts/load.ts
@@ -12,7 +12,7 @@ import {
 } from './utils.js';
 import * as unifont from 'unifont';
 import { AstroError, AstroErrorData } from '../../core/errors/index.js';
-import { DEFAULTS, LOCAL_PROVIDER_NAME } from './constants.js';
+import { DEFAULTS, GOOGLE_PROVIDER_NAME, LOCAL_PROVIDER_NAME } from './constants.js';
 import type { FontFamily, FontProvider, PreloadData } from './types.js';
 import type { Storage } from 'unstorage';
 import type { generateFallbackFontFace } from './metrics.js';
@@ -122,7 +122,7 @@ export async function loadFonts({
 				},
 				// By default, unifont goes through all providers. We use a different approach
 				// where we specify a provider per font (default to google)
-				[family.provider],
+				[family.provider ?? GOOGLE_PROVIDER_NAME],
 			);
 
 			fonts = result.fonts.map((font) => ({

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -36,7 +36,7 @@ export type LocalFontFamily = z.infer<typeof localFontFamilySchema>;
 
 interface CommonFontFamily<TProvider extends string>
 	extends z.infer<typeof commonFontFamilySchema> {
-	provider: TProvider;
+	provider?: TProvider;
 }
 
 export type FontFamily<TProvider extends string> = TProvider extends LocalProviderName

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -621,7 +621,10 @@ export const AstroConfigSchema = z.object({
 									}),
 								),
 							localFontFamilySchema,
-							commonFontFamilySchema,
+							commonFontFamilySchema.transform((family) => ({
+								provider: GOOGLE_PROVIDER_NAME,
+								...family,
+							})),
 						]),
 					),
 				})

--- a/packages/astro/test/types/define-config.ts
+++ b/packages/astro/test/types/define-config.ts
@@ -95,6 +95,8 @@ describe('defineConfig()', () => {
 						families: [
 							{ name: 'foo', provider: 'google' },
 							{ name: 'bar', provider: 'local', src: [] },
+							{ name: 'baz' },
+							'test',
 						],
 					},
 				},
@@ -107,11 +109,9 @@ describe('defineConfig()', () => {
 						never,
 						[
 							{ readonly name: 'foo'; readonly provider: 'google' },
-							{
-								readonly name: 'bar';
-								readonly provider: 'local';
-								readonly src: [];
-							},
+							{ readonly name: 'bar'; readonly provider: 'local'; readonly src: [] },
+							{ readonly name: 'baz' },
+							'test',
 						]
 					>
 				>();
@@ -122,6 +122,8 @@ describe('defineConfig()', () => {
 					[
 						{ readonly name: 'foo'; readonly provider: 'google' },
 						{ readonly name: 'bar'; readonly provider: 'local'; readonly src: [] },
+						{ readonly name: 'baz' },
+						'test',
 					]
 				>();
 			},


### PR DESCRIPTION
## Changes

- There was a regression in #13401 that made impossible to provide an object without a `provider` for a family
- This PR moves some things around to have types working properly

## Testing

Updates the types tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
