### PR TITLE
fix(preact,svelte): empty target container before rendering `client:only` island

### DIFF
--- a/.changeset/deep-mammals-watch.md
+++ b/.changeset/deep-mammals-watch.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/preact': patch
+'@astrojs/svelte': patch
+---
+
+Hides fallback content when rendering `client:only` island

--- a/packages/astro/e2e/client-only.test.js
+++ b/packages/astro/e2e/client-only.test.js
@@ -20,6 +20,9 @@ test.describe('Client only', () => {
 		const counter = await page.locator('#react-counter');
 		await expect(counter, 'component is visible').toBeVisible();
 
+		const fallback = await page.locator('[data-fallback=react]');
+		await expect(fallback, 'fallback content is hidden').not.toBeVisible();
+
 		const count = await counter.locator('pre');
 		await expect(count, 'initial count is 0').toHaveText('0');
 
@@ -37,6 +40,10 @@ test.describe('Client only', () => {
 
 		const counter = await page.locator('#preact-counter');
 		await expect(counter, 'component is visible').toBeVisible();
+
+		
+		const fallback = await page.locator('[data-fallback=preact]');
+		await expect(fallback, 'fallback content is hidden').not.toBeVisible();
 
 		const count = await counter.locator('pre');
 		await expect(count, 'initial count is 0').toHaveText('0');
@@ -56,6 +63,9 @@ test.describe('Client only', () => {
 		const counter = await page.locator('#solid-counter');
 		await expect(counter, 'component is visible').toBeVisible();
 
+		const fallback = await page.locator('[data-fallback=solid]');
+		await expect(fallback, 'fallback content is hidden').not.toBeVisible();
+
 		const count = await counter.locator('pre');
 		await expect(count, 'initial count is 0').toHaveText('0');
 
@@ -74,6 +84,9 @@ test.describe('Client only', () => {
 		const counter = await page.locator('#vue-counter');
 		await expect(counter, 'component is visible').toBeVisible();
 
+		const fallback = await page.locator('[data-fallback=vue]');
+		await expect(fallback, 'fallback content is hidden').not.toBeVisible();
+
 		const count = await counter.locator('pre');
 		await expect(count, 'initial count is 0').toHaveText('0');
 
@@ -91,6 +104,9 @@ test.describe('Client only', () => {
 
 		const counter = await page.locator('#svelte-counter');
 		await expect(counter, 'component is visible').toBeVisible();
+
+		const fallback = await page.locator('[data-fallback=svelte]');
+		await expect(fallback, 'fallback content is hidden').not.toBeVisible();
 
 		const count = await counter.locator('pre');
 		await expect(count, 'initial count is 0').toHaveText('0');

--- a/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
@@ -19,22 +19,27 @@ import VueCounter from '../components/vue/VueCounter.vue';
 		<main>
 			<react.Counter id="react-counter" client:only="react">
 				<h1>react</h1>
+				<p slot="fallback" data-fallback="react">Loading React...</p>
 			</react.Counter>
 
 			<PreactCounter id="preact-counter" client:only="preact">
 				<h1>preact</h1>
+				<p slot="fallback" data-fallback="preact">Loading Preact...</p>
 			</PreactCounter>
 
 			<SolidCounter id="solid-counter" client:only="solid-js">
 				<h1>solid</h1>
+				<p slot="fallback" data-fallback="solid">Loading Solid...</p>
 			</SolidCounter>
 
 			<VueCounter id="vue-counter" client:only="vue">
 				<h1>vue</h1>
+				<p slot="fallback" data-fallback="vue">Loading Vue...</p>
 			</VueCounter>
 
 			<SvelteCounter id="svelte-counter" client:only="svelte">
 				<h1>svelte</h1>
+				<p slot="fallback" data-fallback="svelte">Loading Svelte...</p>
 			</SvelteCounter>
 		</main>
 	</body>

--- a/packages/integrations/preact/src/client-dev.ts
+++ b/packages/integrations/preact/src/client-dev.ts
@@ -1,4 +1,4 @@
 import 'preact/debug';
 import clientFn from './client.js';
-
+// 
 export default clientFn;

--- a/packages/integrations/preact/src/client.ts
+++ b/packages/integrations/preact/src/client.ts
@@ -49,12 +49,18 @@ export default (element: HTMLElement) =>
 			}
 		}
 
-		const bootstrap = client !== 'only' ? hydrate : render;
-
-		bootstrap(
-			h(Component, props, children != null ? h(StaticHtml, { value: children }) : children),
-			element,
+		const child = h(
+			Component,
+			props,
+			children != null ? h(StaticHtml, { value: children }) : children,
 		);
+
+		if (client === 'only') {
+			element.innerHTML = '';
+			render(child, element);
+		} else {
+			hydrate(child, element);
+		}
 
 		// Preact has no "unmount" option, but you can use `render(null, element)`
 		element.addEventListener('astro:unmount', () => render(null, element), { once: true });

--- a/packages/integrations/svelte/client.svelte.js
+++ b/packages/integrations/svelte/client.svelte.js
@@ -5,6 +5,7 @@ const existingApplications = new WeakMap();
 
 export default (element) => {
 	return async (Component, props, slotted, { client }) => {
+		console.log('Svelte client integration', { Component, props, slotted, client });
 		if (!element.hasAttribute('ssr')) return;
 
 		let children = undefined;
@@ -61,6 +62,9 @@ export default (element) => {
 function createComponent(Component, target, props, shouldHydrate) {
 	let propsState = $state(props);
 	const bootstrap = shouldHydrate ? hydrate : mount;
+	if(!shouldHydrate) {
+		target.innerHTML = '';
+	}
 	const component = bootstrap(Component, { target, props: propsState });
 	return {
 		setProps(newProps) {


### PR DESCRIPTION
## Changes

Unlike other frameworks, by default, preact and svelte don't replace the target element content when rendering (via `render` or `mount`) respectively. This caused fallback content to remain when using `client:only`. This PR empties the target element before rendering.

Fixes #12513

## Testing

Added e2e tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
