### PR TITLE
Add deprecation notice to Tailwind integration README

### DIFF
--- a/.changeset/witty-socks-relax.md
+++ b/.changeset/witty-socks-relax.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/tailwind': patch
+---
+
+Updates the README to indicate that the Tailwind integration is deprecated

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -4,7 +4,7 @@
 >
 > Tailwind CSS now offers a Vite plugin which is the preferred way to use Tailwind 4 in Astro.
 >
-> [Learn how to add Tailwind 4 in the Astro Docs.](https://docs.astro.build/en/guides/styling/#tailwind)
+> [Learn how to add Tailwind 4 in the Astro Docs.][docs]
 
 ## Support
 
@@ -29,6 +29,7 @@ MIT
 Copyright (c) 2023–present [Astro][astro]
 
 [astro]: https://astro.build/
+[docs]: https://docs.astro.build/en/guides/styling/#tailwind
 [contributing]: https://github.com/withastro/astro/blob/main/CONTRIBUTING.md
 [coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
 [community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -2,9 +2,9 @@
 
 > ⚠️ **This integration is deprecated**
 >
-> Tailwind CSS now offers a Vite plugin which is the preferred way to use Tailwind 4 in Astro.
+> [Tailwind CSS now offers a Vite plugin](https://tailwindcss.com/docs/installation/framework-guides/astro) which is the preferred way to use Tailwind 4 in Astro.
 >
-> [Learn how to add Tailwind 4 in the Astro Docs.][docs]
+> [Learn how to use Tailwind in your Astro project in the Styling guide.][docs]
 
 ## Support
 

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -1,10 +1,10 @@
 # @astrojs/tailwind 💨
 
-This **[Astro integration][astro-integration]** brings [Tailwind's](https://tailwindcss.com/) utility CSS classes to every `.astro` file and [framework component](https://docs.astro.build/en/core-concepts/framework-components/) in your project, along with support for the Tailwind configuration file.
-
-## Documentation
-
-Read the [`@astrojs/tailwind` docs][docs]
+> ⚠️ **This integration is deprecated**
+>
+> Tailwind CSS now offers a Vite plugin which is the preferred way to use Tailwind 4 in Astro.
+>
+> [Learn how to add Tailwind 4 in the Astro Docs.](https://docs.astro.build/en/guides/styling/#tailwind)
 
 ## Support
 
@@ -29,7 +29,6 @@ MIT
 Copyright (c) 2023–present [Astro][astro]
 
 [astro]: https://astro.build/
-[docs]: https://docs.astro.build/en/guides/integrations-guide/tailwind/
 [contributing]: https://github.com/withastro/astro/blob/main/CONTRIBUTING.md
 [coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
 [community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md


### PR DESCRIPTION
## Changes

- Updates the Tailwind integration README to show it is deprecated and remove links to docs which are no longer useful

## Testing

n/a — docs only

## Docs

cc @withastro/maintainers-docs for feedback!

