### PR TITLE
fix(app): call renderer when routes don't match

### DIFF
--- a/.changeset/wet-bottles-invite.md
+++ b/.changeset/wet-bottles-invite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where an Astro adapter couldn't call the middleware when there isn't a route that matches the incoming request.

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -6,7 +6,8 @@ import {
 	REROUTABLE_STATUS_CODES,
 	REROUTE_DIRECTIVE_HEADER,
 	clientAddressSymbol,
-	responseSentSymbol, 
+	responseSentSymbol,
+	DEFAULT_404_COMPONENT,
 } from '../constants.js';
 import { getSetCookiesFromResponse } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
@@ -334,7 +335,9 @@ export class App {
 		// a "fake" 404 route, so we can call the RenderContext.render
 		// and hit the middleware, which might be able to return a correct Response.
 		if (!routeData) {
-			routeData = this.#manifestData.routes.find(route => route.route === "/404");
+			routeData = this.#manifestData.routes.find(
+				(route) => route.component === '404.astro' || route.component === DEFAULT_404_COMPONENT,
+			);
 		}
 		if (!routeData) {
 			this.#logger.debug('router', "Astro hasn't found routes that match " + request.url);
@@ -349,7 +352,7 @@ export class App {
 		try {
 			// Load route module. We also catch its error here if it fails on initialization
 			const mod = await this.#pipeline.getModuleForRoute(routeData);
-			
+
 			const renderContext = await RenderContext.create({
 				pipeline: this.#pipeline,
 				locals,

--- a/packages/astro/test/fixtures/middleware space/integration-middleware-post.js
+++ b/packages/astro/test/fixtures/middleware space/integration-middleware-post.js
@@ -8,6 +8,10 @@ export const onRequest = defineMiddleware((context, next) => {
 			},
 		});
 	}
+	
+	if (context.url.pathname === '/does-not-exist') {
+		return context.rewrite('/rewrite');
+	}
 
 	return next();
 });

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -318,6 +318,18 @@ describe('Middleware API in PROD mode, SSR', () => {
 		assert.equal(response.headers.get('content-type'), 'text/html');
 	});
 
+	it('can render a page that does not exist', async () => {
+		const request = new Request('http://example.com/does-not-exist');
+		const routeData = app.match(request);
+
+		const response = await app.render(request, { routeData });
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		assert.equal($('p').html(), null);
+		assert.equal($('span').html(), 'New content!!');
+	});
+
 	it('can set locals for prerendered pages to use', async () => {
 		const text = await fixture.readFile('/client/prerendered/index.html');
 		assert.equal(text.includes('<p>yes they can!</p>'), true);


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/13409

The fixes use the same logic as the dev server. If we can't find a `RouteData` that matches the incoming request, we seek the `/404` route, which we usually have, and pass it to the `RenderContext`. The `RenderContext` eventually calls the middleware. 

## Testing

I added a new test. Hopefully I didn't introduce any regressions

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
