### PR TITLE
fix: better error handling on Stackblitz

### DIFF
--- a/.changeset/twelve-gifts-attend.md
+++ b/.changeset/twelve-gifts-attend.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Display useful errors when config loading fails because of Node addons being disabled on Stackblitz

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -3,7 +3,6 @@ import { pathToFileURL } from 'node:url';
 import { type ViteDevServer, createServer } from 'vite';
 import loadFallbackPlugin from '../../vite-plugin-load-fallback/index.js';
 import { debug } from '../logger/core.js';
-import { AstroError, AstroErrorData, AstroUserError } from '../errors/index.js';
 
 async function createViteServer(root: string, fs: typeof fsType): Promise<ViteDevServer> {
 	const viteServer = await createServer({


### PR DESCRIPTION
## Changes

Currently there is a strange error on Stackblitz where if the config cannot be loaded because of native addons it fails silently, because it throws an uncatchable error. This PR improves error handling so that those errors can be properly logged. This is not Stackblitz-specific, but does special-case the `ERR_DLOPEN_DISABLED` error that is thrown. This should be fine, because it's not the sort of error that would ever be recoverable by Vite, as it's due to a setting in Node. 

Fixes #13249

## Testing
Manually tested on Stackblitz:

https://stackblitz.com/github/ascorbic/withastro-astro-banrd5uv/tree/ascorbic/patch-13439

![image](https://github.com/user-attachments/assets/3baf4ec6-26b5-4f26-9a33-24c4cf72d2cf)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
