### PR TITLE
fix: cache raw cookie value and decode when getting

### DIFF
--- a/.changeset/honest-loops-cheat.md
+++ b/.changeset/honest-loops-cheat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused cookies to ignore custom decode function if has() had been called before

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -118,7 +118,7 @@ class AstroCookies implements AstroCookiesInterface {
 				return undefined;
 			}
 		}
-
+		// decodeURIComponent is the default decode function for cookies
 		const decode = options?.decode ?? decodeURIComponent
 
 		const values = this.#ensureParsed();

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -35,6 +35,8 @@ const DELETED_EXPIRATION = new Date(0);
 const DELETED_VALUE = 'deleted';
 const responseSentSymbol = Symbol.for('astro.responseSent');
 
+const identity = (value: string) => value;
+
 class AstroCookie implements AstroCookieInterface {
 	constructor(public value: string) {}
 	json() {
@@ -117,11 +119,13 @@ class AstroCookies implements AstroCookiesInterface {
 			}
 		}
 
-		const values = this.#ensureParsed(options);
+		const decode = options?.decode ?? decodeURIComponent
+
+		const values = this.#ensureParsed();
 		if (key in values) {
 			const value = values[key];
 			if (value) {
-				return new AstroCookie(value);
+				return new AstroCookie(decode(value));
 			}
 		}
 	}
@@ -130,15 +134,16 @@ class AstroCookies implements AstroCookiesInterface {
 	 * Astro.cookies.has(key) returns a boolean indicating whether this cookie is either
 	 * part of the initial request or set via Astro.cookies.set(key)
 	 * @param key The cookie to check for.
+	 * @param _options This parameter is no longer used.
 	 * @returns
 	 */
-	has(key: string, options: AstroCookieGetOptions | undefined = undefined): boolean {
+	has(key: string, _options?: AstroCookieGetOptions): boolean {
 		if (this.#outgoing?.has(key)) {
 			let [, , isSetValue] = this.#outgoing.get(key)!;
 			return isSetValue;
 		}
-		const values = this.#ensureParsed(options);
-		return !!values[key];
+		const values = this.#ensureParsed();
+		return values[key] !== undefined;
 	}
 
 	/**
@@ -227,11 +232,9 @@ class AstroCookies implements AstroCookiesInterface {
 		return cookies.headers();
 	}
 
-	#ensureParsed(
-		options: AstroCookieGetOptions | undefined = undefined,
-	): Record<string, string | undefined> {
+	#ensureParsed(): Record<string, string | undefined> {
 		if (!this.#requestValues) {
-			this.#parse(options);
+			this.#parse();
 		}
 		if (!this.#requestValues) {
 			this.#requestValues = {};
@@ -246,13 +249,14 @@ class AstroCookies implements AstroCookiesInterface {
 		return this.#outgoing;
 	}
 
-	#parse(options: AstroCookieGetOptions | undefined = undefined) {
+	#parse() {
 		const raw = this.#request.headers.get('cookie');
 		if (!raw) {
 			return;
 		}
-
-		this.#requestValues = parse(raw, options);
+		// Pass identity function for decoding so it doesn't use the default.
+		// We'll do the actual decoding when we read the value.
+		this.#requestValues = parse(raw, { decode: identity });
 	}
 }
 

--- a/packages/astro/test/units/cookies/get.test.js
+++ b/packages/astro/test/units/cookies/get.test.js
@@ -5,6 +5,15 @@ import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 
 applyPolyfill();
 
+export const encode = (data) => {
+	const dataSerialized = typeof data === 'string' ? data : JSON.stringify(data);
+	return Buffer.from(dataSerialized).toString('base64');
+};
+
+export const decode = (str) => {
+	return Buffer.from(str, 'base64').toString();
+};
+
 describe('astro/src/core/cookies', () => {
 	describe('Astro.cookies.get', () => {
 		it('gets the cookie value', () => {
@@ -18,7 +27,7 @@ describe('astro/src/core/cookies', () => {
 		});
 
 		it('gets the cookie value with default decode', () => {
-			const url = 'http://localhost';
+			const url = 'http://localhost/?hello=world&foo=bar#hash';
 			const req = new Request('http://example.com/', {
 				headers: {
 					cookie: `url=${encodeURIComponent(url)}`,
@@ -30,15 +39,17 @@ describe('astro/src/core/cookies', () => {
 		});
 
 		it('gets the cookie value with custom decode', () => {
-			const url = 'http://localhost';
+			const url = 'http://localhost/?hello=world&foo=bar#hash';
 			const req = new Request('http://example.com/', {
 				headers: {
-					cookie: `url=${encodeURIComponent(url)}`,
+					cookie: `url=${encode(url)}`,
 				},
 			});
 			const cookies = new AstroCookies(req);
-			// set decode to the identity function to prevent decodeURIComponent on the value
-			assert.equal(cookies.get('url', { decode: (o) => o }).value, encodeURIComponent(url));
+
+			assert.ok(cookies.has('url'));
+			assert.equal(cookies.get('url', { decode } ).value, url);
+			assert.equal(cookies.get('url').value, encode(url));
 		});
 
 		it("Returns undefined is the value doesn't exist", () => {


### PR DESCRIPTION
## Changes

Currently, when a cookie is first parsed from the header the value is cached. This means that if subsequent requests pass a different decode function it will be ignored. This PR changes the behaviour to cache the raw cookie values, and then decode them when getting them. This means the passed decode function will always be used.

Fixes #13078

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
