### PR TITLE
Handle module not found errors in server entrypoint

### DIFF
--- a/.changeset/sixty-carrots-pick.md
+++ b/.changeset/sixty-carrots-pick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Handle errors where a module is not found when loading the server entrypoint

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -21,7 +21,7 @@ const createPreviewServer: CreatePreviewServer = async (preview) => {
 			);
 		}
 	} catch (err) {
-		if ((err as any).code === 'ERR_MODULE_NOT_FOUND') {
+		if ((err as any).code === 'ERR_MODULE_NOT_FOUND' && (err as any).url?.endsWith?.('/server/entry.mjs')) {
 			throw new AstroError(
 				`The server entrypoint ${fileURLToPath(
 					preview.serverEntrypoint,

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -21,7 +21,7 @@ const createPreviewServer: CreatePreviewServer = async (preview) => {
 			);
 		}
 	} catch (err) {
-		if ((err as any).code === 'ERR_MODULE_NOT_FOUND' && (err as any).url?.endsWith?.('/server/entry.mjs')) {
+		if ((err as any).code === 'ERR_MODULE_NOT_FOUND' && (err as any).url === preview.serverEntrypoint.href) {
 			throw new AstroError(
 				`The server entrypoint ${fileURLToPath(
 					preview.serverEntrypoint,


### PR DESCRIPTION
## Changes

Handles module not found errors thrown when importing the `dist/server/entry.mjs` file. If the file itself is missing, the existing error will still be thrown

## Testing

Manually. This was replicated by modifying a build output to import a missing package.

## Docs

N/A
