### PR TITLE
feat(fonts): set default fallbacks

### DIFF
--- a/packages/astro/src/assets/fonts/constants.ts
+++ b/packages/astro/src/assets/fonts/constants.ts
@@ -9,6 +9,8 @@ export const DEFAULTS: ResolveFontOptions = {
 	weights: ['400'],
 	styles: ['normal', 'italic'],
 	subsets: ['cyrillic-ext', 'cyrillic', 'greek-ext', 'greek', 'vietnamese', 'latin-ext', 'latin'],
+	// Technically serif is the browser default but most websites these days use sans-serif
+	fallbacks: ['sans-serif'],
 	automaticFallback: true,
 };
 

--- a/packages/astro/src/assets/fonts/load.ts
+++ b/packages/astro/src/assets/fonts/load.ts
@@ -117,8 +117,7 @@ export async function loadFonts({
 					weights: family.weights ?? DEFAULTS.weights,
 					styles: family.styles ?? DEFAULTS.styles,
 					subsets: family.subsets ?? DEFAULTS.subsets,
-					// No default fallback to be used here
-					fallbacks: family.fallbacks,
+					fallbacks: family.fallbacks ?? DEFAULTS.fallbacks,
 				},
 				// By default, unifont goes through all providers. We use a different approach
 				// where we specify a provider per font (default to google)


### PR DESCRIPTION
## Changes

- After discussing with @delucis, we came to the conclusion that having `sans-serif` as a default fallback makes sense so users can benefit from automatic fallback generation by default

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Will be documented properly alongside all defaults

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
