### PR TITLE
fix(fonts): throw error on unsuccessful responses

### DIFF
--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -36,9 +36,13 @@ async function fetchFont(url: string): Promise<Buffer> {
 		if (isAbsolute(url)) {
 			return await readFile(url);
 		}
-		const r = await fetch(url);
-		const arr = await r.arrayBuffer();
-		return Buffer.from(arr);
+		// TODO: find a way to pass headers
+		// https://github.com/unjs/unifont/issues/143
+		const response = await fetch(url);
+		if (!response.ok) {
+			throw new Error(`Response was not successful, received status code ${response.status}`);
+		}
+		return Buffer.from(await response.arrayBuffer());
 	} catch (cause) {
 		throw new AstroError(
 			{


### PR DESCRIPTION
## Changes

- We now throw an error if the response from a font file download is not successful

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
