### PR TITLE
feat: multi bundle workspaces

### DIFF
--- a/.devcontainer/workspace/devcontainer.json
+++ b/.devcontainer/workspace/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "Workspace",
+  "build": {
+    "dockerfile": "../examples.Dockerfile"
+  },
+
+  "workspaceFolder": "/workspaces/astro/examples/Workspace",
+
+  "portsAttributes": {
+    "4321": {
+      "label": "Application",
+      "onAutoForward": "openPreview"
+    }
+  },
+
+  "forwardPorts": [4321],
+
+  "postCreateCommand": "pnpm install && cd /workspaces/astro && pnpm run build",
+
+  "waitFor": "postCreateCommand",
+
+  "postAttachCommand": {
+    "Server": "pnpm start --host"
+  },
+
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["src/pages/index.astro"]
+    },
+    "vscode": {
+      "extensions": ["astro-build.astro-vscode", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/examples/workspace/.codesandbox/Dockerfile
+++ b/examples/workspace/.codesandbox/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:18-bullseye

--- a/examples/workspace/.gitignore
+++ b/examples/workspace/.gitignore
@@ -1,0 +1,24 @@
+# build output
+dist/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# jetbrains setting folder
+.idea/

--- a/examples/workspace/.vscode/extensions.json
+++ b/examples/workspace/.vscode/extensions.json
@@ -1,0 +1,4 @@
+{
+  "recommendations": ["astro-build.astro-vscode", "unifiedjs.vscode-mdx"],
+  "unwantedRecommendations": []
+}

--- a/examples/workspace/.vscode/launch.json
+++ b/examples/workspace/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "./node_modules/.bin/astro dev",
+      "name": "Development server",
+      "request": "launch",
+      "type": "node-terminal"
+    }
+  ]
+}

--- a/examples/workspace/README.md
+++ b/examples/workspace/README.md
@@ -1,0 +1,53 @@
+# Astro Starter Kit: Workspace
+
+```sh
+npm create astro@latest -- --template workspace
+```
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/workspace)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/workspace)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/workspace/devcontainer.json)
+
+> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+
+## 🚀 Project Structure
+
+Inside of your Astro project, you'll see the following folders and files:
+
+```text
+├── public/
+├── src/
+├── astro.config.mjs
+├── README.md
+├── package.json
+└── tsconfig.json
+```
+
+Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+
+There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+
+The `src/content/` directory contains "collections" of related Markdown and MDX documents. Use `getCollection()` to retrieve posts from `src/content/blog/`, and type-check your frontmatter using an optional schema. See [Astro's Content Collections docs](https://docs.astro.build/en/guides/content-collections/) to learn more.
+
+Any static assets, like images, can be placed in the `public/` directory.
+
+## 🧞 Commands
+
+All commands are run from the root of the project, from a terminal:
+
+| Command                   | Action                                           |
+| :------------------------ | :----------------------------------------------- |
+| `npm install`             | Installs dependencies                            |
+| `npm run dev`             | Starts local dev server at `localhost:4321`      |
+| `npm run build`           | Build your production site to `./dist/`          |
+| `npm run preview`         | Preview your build locally, before deploying     |
+| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
+| `npm run astro -- --help` | Get help using the Astro CLI                     |
+
+## 👀 Want to learn more?
+
+Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+
+## Credit
+
+This theme is based off of the lovely [Bear Blog](https://github.com/HermanMartinus/bearblog/).

--- a/examples/workspace/app-bundle/astro.config.mjs
+++ b/examples/workspace/app-bundle/astro.config.mjs
@@ -1,0 +1,25 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+import node from '@astrojs/node';
+import react from '@astrojs/react';
+
+// https://astro.build/config
+export default defineConfig({
+	output: 'server',	
+	
+	server: {
+		port: 3002,
+	},
+	
+	adapter: node({
+		mode: 'standalone',
+	}),
+	
+	integrations: [react()],	
+	
+	experimental: {
+		multiBundle: {
+			mode: 'bundle',
+		},
+	},
+});

--- a/examples/workspace/app-bundle/astro.config.mjs
+++ b/examples/workspace/app-bundle/astro.config.mjs
@@ -20,6 +20,9 @@ export default defineConfig({
 	experimental: {
 		multiBundle: {
 			mode: 'bundle',
+			imports: [
+				'../common-module',
+			],
 		},
 	},
 });

--- a/examples/workspace/app-bundle/src/components/AlertButton.tsx
+++ b/examples/workspace/app-bundle/src/components/AlertButton.tsx
@@ -1,0 +1,3 @@
+export const AlertButton: React.FC = () => {
+	return <button onClick={() => alert("App bundle")}>Alert!</button>;
+}

--- a/examples/workspace/app-bundle/src/pages/index.astro
+++ b/examples/workspace/app-bundle/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import { AlertButton } from "../components/AlertButton";
+---
+
+<div>
+	app
+	
+	<AlertButton client:load />
+</div>

--- a/examples/workspace/astro.config.mjs
+++ b/examples/workspace/astro.config.mjs
@@ -1,0 +1,11 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	experimental: {
+		multiBundle: {
+			mode: 'workspace',
+		},
+	},
+});

--- a/examples/workspace/common-module/astro.config.mjs
+++ b/examples/workspace/common-module/astro.config.mjs
@@ -1,0 +1,11 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	experimental: {
+		multiBundle: {
+			mode: 'module',
+		},
+	},
+});

--- a/examples/workspace/common-module/src/pages/common.astro
+++ b/examples/workspace/common-module/src/pages/common.astro
@@ -1,0 +1,3 @@
+<div>
+	common-module
+</div>

--- a/examples/workspace/landing-bundle/astro.config.mjs
+++ b/examples/workspace/landing-bundle/astro.config.mjs
@@ -1,0 +1,25 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+import node from '@astrojs/node';
+import react from '@astrojs/react';
+
+// https://astro.build/config
+export default defineConfig({
+	output: 'server',	
+	
+	server: {
+		port: 3001,
+	},
+	
+	adapter: node({
+		mode: 'standalone',
+	}),
+
+	integrations: [react()],
+	
+	experimental: {
+		multiBundle: {
+			mode: 'bundle',
+		},
+	},
+});

--- a/examples/workspace/landing-bundle/astro.config.mjs
+++ b/examples/workspace/landing-bundle/astro.config.mjs
@@ -20,6 +20,9 @@ export default defineConfig({
 	experimental: {
 		multiBundle: {
 			mode: 'bundle',
+			imports: [
+				'../common-module',
+			],
 		},
 	},
 });

--- a/examples/workspace/landing-bundle/src/components/AlertButton.tsx
+++ b/examples/workspace/landing-bundle/src/components/AlertButton.tsx
@@ -1,0 +1,3 @@
+export const AlertButton: React.FC = () => {
+	return <button onClick={() => alert("Landing bundle")}>Alert!</button>;
+}

--- a/examples/workspace/landing-bundle/src/pages/index.astro
+++ b/examples/workspace/landing-bundle/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import { AlertButton } from "../components/AlertButton";
+---
+
+<div>
+	landing
+	
+	<AlertButton client:load />
+</div>

--- a/examples/workspace/package.json
+++ b/examples/workspace/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@example/workspace",
+  "type": "module",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/node": "^9.1.3",
+    "astro": "^5.5.5",
+    "@astrojs/react": "^4.2.2",
+    "@types/react": "^18.3.20",
+    "@types/react-dom": "^18.3.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/examples/workspace/tsconfig.json
+++ b/examples/workspace/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -27,7 +27,7 @@ import { apply as applyPolyfill } from '../polyfill.js';
 import { createRoutesList } from '../routing/index.js';
 import { getServerIslandRouteData } from '../server-islands/endpoint.js';
 import { clearContentLayerCache } from '../sync/index.js';
-import { ensureProcessNodeEnv } from '../util.js';
+import { ensureProcessNodeEnv, getExtraSrcDirsForBundle } from '../util.js';
 import { collectPagesData } from './page-data.js';
 import { staticBuild, viteBuild } from './static-build.js';
 import type { StaticBuildOptions } from './types.js';
@@ -93,6 +93,7 @@ export default async function build(
 			logger,
 			mode: inlineConfig.mode ?? 'production',
 			runtimeMode: options.devOutput ? 'development' : 'production',
+			isModule: mode === 'module',
 		});
 		await builder.run();
 	}
@@ -116,6 +117,7 @@ interface AstroBuilderOptions extends BuildOptions {
 	logger: Logger;
 	mode: string;
 	runtimeMode: RuntimeMode;
+	isModule?: boolean;
 }
 
 class AstroBuilder {
@@ -155,8 +157,11 @@ class AstroBuilder {
 			command: 'build',
 			logger: logger,
 		});
-
-		this.routesList = await createRoutesList({ settings: this.settings }, this.logger);
+		
+		this.routesList = await createRoutesList({
+			settings: this.settings,
+			extraSrcDirs: getExtraSrcDirsForBundle(this.settings),
+		}, this.logger);
 
 		await runHookConfigDone({ settings: this.settings, logger: logger, command: 'build' });
 

--- a/packages/astro/src/core/config/index.ts
+++ b/packages/astro/src/core/config/index.ts
@@ -9,3 +9,4 @@ export { mergeConfig } from './merge.js';
 export type { AstroConfigType } from './schema.js';
 export { createSettings } from './settings.js';
 export { loadTSConfig, updateTSConfigForFramework } from './tsconfig.js';
+export { scanForConfigs } from './scan.js';

--- a/packages/astro/src/core/config/scan.ts
+++ b/packages/astro/src/core/config/scan.ts
@@ -1,0 +1,38 @@
+import {promisify} from "node:util";
+import fs from "node:fs";
+import path from "node:path";
+import {configPaths} from "./config.js";
+
+export async function scanForConfigs(rootDir: string): Promise<string[]> {
+	rootDir = await (promisify(fs.realpath))(rootDir);
+
+	const foundFiles: string[] = [];
+	const stack: string[] = [rootDir];
+	
+	while (stack.length > 0) {
+		const dir = stack.pop();
+		if (!dir || !fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+			continue;
+		}
+	
+		for (const entry of fs.readdirSync(dir)) {
+			const fullPath = path.join(dir, entry);
+	
+			try {
+				const stats = await (promisify(fs.lstat))(fullPath);
+	
+				if (stats.isDirectory()) {
+					stack.push(fullPath);
+				} else if (configPaths.includes(entry)) {
+					if (path.resolve(path.dirname(fullPath)) != rootDir) {
+						foundFiles.push(fullPath);
+					}
+				}
+			} catch (error: any) {
+				console.warn(`Skipping ${fullPath}: ${error?.message ?? error}`);
+			}
+		}
+	}
+	
+	return foundFiles;
+}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -626,6 +626,15 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.preserveScriptOrder),
+			multiBundle: z
+				.object({
+					mode: z.enum(['disabled', 'workspace', 'bundle', 'module'])
+						.default('disabled')
+						.optional(),
+					name: z.string()
+						.optional()
+				})
+				.optional()
 		})
 		.strict(
 			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/experimental-flags/ for a list of all current experiments.`,

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -631,7 +631,7 @@ export const AstroConfigSchema = z.object({
 					mode: z.enum(['disabled', 'workspace', 'bundle', 'module'])
 						.default('disabled')
 						.optional(),
-					name: z.string()
+					imports: z.array(z.string())
 						.optional()
 				})
 				.optional()

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -18,6 +18,7 @@ import { apply as applyPolyfill } from '../polyfill.js';
 import { createRoutesList } from '../routing/index.js';
 import { syncInternal } from '../sync/index.js';
 import { warnMissingAdapter } from './adapter-validation.js';
+import {getExtraSrcDirsForBundle} from "../util.js";
 
 export interface Container {
 	fs: typeof nodeFs;
@@ -82,7 +83,11 @@ export async function createContainer({
 		.filter(Boolean) as string[];
 
 	// Create the route manifest already outside of Vite so that `runHookConfigDone` can use it to inform integrations of the build output
-	const routesList = await createRoutesList({ settings, fsMod: fs }, logger, { dev: true });
+	const routesList = await createRoutesList({
+		settings,
+		fsMod: fs,
+		extraSrcDirs: getExtraSrcDirsForBundle(settings),
+	}, logger, { dev: true });
 	const manifest = createDevelopmentManifest(settings);
 
 	await runHookConfigDone({ settings, logger, command: 'dev' });

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -34,6 +34,7 @@ export type LoggerLabel =
 	| 'update'
 	| 'adapter'
 	| 'islands'
+	| 'workspace'
 	// SKIP_FORMAT: A special label that tells the logger not to apply any formatting.
 	// Useful for messages that are already formatted, like the server start message.
 	| 'SKIP_FORMAT';

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -62,14 +62,17 @@ export function serverStart({
 	resolvedUrls,
 	host,
 	base,
+	name,
 }: {
 	startupTime: number;
 	resolvedUrls: ResolvedServerUrls;
 	host: string | boolean;
 	base: string;
+	name?: string;
 }): string {
 	// PACKAGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
+	const namePrefix = `${dim('┃')} Name     `;
 	const localPrefix = `${dim('┃')} Local    `;
 	const networkPrefix = `${dim('┃')} Network  `;
 	const emptyPrefix = ' '.repeat(11);
@@ -96,6 +99,7 @@ export function serverStart({
 			startupTime,
 		)} ${dim('ms')}`,
 		'',
+		...(name ? [`${namePrefix}${cyan(name)}`] : []),
 		...localUrlMessages,
 		...networkUrlMessages,
 		'',

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -109,10 +109,12 @@ export interface CreateRouteManifestParams {
 	cwd?: string;
 	/** fs module, for testing */
 	fsMod?: typeof nodeFs;
+	/** Extra source directories */
+	extraSrcDirs?: string[];
 }
 
 function createFileBasedRoutes(
-	{ settings, cwd, fsMod }: CreateRouteManifestParams,
+	{ settings, cwd, fsMod, extraSrcDirs }: CreateRouteManifestParams,
 	logger: Logger,
 ): RouteData[] {
 	const components: string[] = [];
@@ -245,6 +247,7 @@ function createFileBasedRoutes(
 	}
 
 	const { config } = settings;
+	
 	const pages = resolvePages(config);
 
 	if (localFs.existsSync(pages)) {
@@ -253,6 +256,14 @@ function createFileBasedRoutes(
 		const pagesDirRootRelative = pages.href.slice(settings.config.root.href.length);
 		logger.warn(null, `Missing pages directory: ${pagesDirRootRelative}`);
 	}
+	
+	extraSrcDirs?.forEach((srcDir) => {
+		const extraPages = path.resolve(srcDir, 'pages')
+		
+		if (localFs.existsSync(extraPages)) {
+			walk(localFs, extraPages, [], []);
+		}
+	})
 
 	return routes;
 }

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -188,3 +188,15 @@ export function ensureProcessNodeEnv(defaultNodeEnv: string) {
 		process.env.NODE_ENV = defaultNodeEnv;
 	}
 }
+
+export function getExtraSrcDirsForBundle(settings: AstroSettings): string[] {
+	const imports = settings.config.experimental?.multiBundle?.imports;
+
+	return (imports ?? []).map((i) => {
+		if (i.startsWith('@')) {
+			return path.resolve('./node_modules', i.slice(1), 'src');
+		} else {
+			return path.resolve(fileURLToPath(settings.config.root), i, 'src');
+		}
+	});
+}

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2211,6 +2211,40 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 *
 		 */
 		preserveScriptOrder?: boolean;
+
+		multiBundle?: {
+			/**
+			 * @name experimental.multiBundle.mode
+			 * @type {false | 'workspace' | 'bundle' | 'plugin'}
+			 * @default `false`
+			 * @description
+			 *
+			 * When set to `false` or `disabled`, Astro tooling will act as usual.
+			 * 
+			 * When set to `workspace`, will make Astro tooling *not* build the app as it is by default.
+			 * Instead, tooling will search for nested `astro.config...` files,
+			 * and treat them as separate bundles.
+			 * Nested configs are allowed only in this mode, and can only be of 'bundle' and 'plugin' modes.
+			 * 
+			 * When this is a nested config and `mode` is set to `bundle`,
+			 * it will generate a deployable bundle based on this config and the workspace one.
+			 * 
+			 * When this is a nested config and `mode` is set to `module`,
+			 * it will generate a reusable module subdirectory, alongside with a virtual module
+			 * for other module and bundles.
+			 */
+			mode?: 'disabled' | 'workspace' | 'bundle' | 'module';
+
+			/**
+			 * @name experimental.multiBundle.name
+			 * @type {string}
+			 * @default Whatever the current config's directory name is
+			 * @description
+			 * 
+			 * Used to determine a name for a bundle or a plugin.
+			 */
+			name?: string;
+		};
 	};
 }
 

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2219,7 +2219,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 			 * @default `false`
 			 * @description
 			 *
-			 * When set to `false` or `disabled`, Astro tooling will act as usual.
+			 * When set to `disabled` (the default value), Astro tooling will act as usual.
 			 * 
 			 * When set to `workspace`, will make Astro tooling *not* build the app as it is by default.
 			 * Instead, tooling will search for nested `astro.config...` files,
@@ -2236,14 +2236,19 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 			mode?: 'disabled' | 'workspace' | 'bundle' | 'module';
 
 			/**
-			 * @name experimental.multiBundle.name
-			 * @type {string}
-			 * @default Whatever the current config's directory name is
+			 * @name experimental.multiBundle.imports
+			 * @type {string[]}
+			 * @default []
 			 * @description
 			 * 
-			 * Used to determine a name for a bundle or a plugin.
+			 * Specifies what modules should be wired into the current bundle.
+			 * 
+			 * Local modules can be imported by providing a relative path to the module directory.
+			 * Modules from npm packages will be picked up if you prefix the path with `@`.
+			 * 
+			 * You do not need to use this if you just want to import code from a module.
 			 */
-			name?: string;
+			imports?: string[];
 		};
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,30 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.0)(yaml@2.5.1)
 
+  examples/workspace:
+    dependencies:
+      '@astrojs/node':
+        specifier: ^9.1.3
+        version: link:../../packages/integrations/node
+      '@astrojs/react':
+        specifier: ^4.2.2
+        version: link:../../packages/integrations/react
+      '@types/react':
+        specifier: ^18.3.20
+        version: 18.3.20
+      '@types/react-dom':
+        specifier: ^18.3.5
+        version: 18.3.5(@types/react@18.3.20)
+      astro:
+        specifier: ^5.5.5
+        version: link:../../packages/astro
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+
   packages/astro:
     dependencies:
       '@astrojs/compiler':
@@ -9947,7 +9971,6 @@ packages:
 
   libsql@0.5.3:
     resolution: {integrity: sha512-S3WR8WNCJV1VXraBFUKjDA6+8LcNDJMLm+83qohm1O3YM1iVqV2+/XN3SXOxpxVjuL4g/rLrjO5kzygkPefCFQ==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
# THIS IS A DRAFT, WILL UPDATE ACCORDING TO THE CONTRIBUTING GUIDE STYLE AFTER FINALIZING THE FUNCTIONALITY

## Changes

- [x] Allows creating bundle-less workspaces, similar to what you can find in https://encore.dev/ backend framework
- [x] In a workspace, if you define a bundle config in a nested folder, it will be built as a regular Astro app
- [x] If you define a module config, it will allow defining reusable pages that can be imported into another bundle
- [ ] In a module config, allows defining reusable fragments of discoverable configuration, to help code pieces link to each other based on what modules are loaded.

## Disclaimer

Everything in this PR is disabled by default, and should not affect any existing projects.

## Testing

Added `examples/workspace`.

Unit tests to be added, if applicable.

## Docs

TODO

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
