### PR TITLE
feat: add `session.load(id)` method

### DIFF
--- a/.changeset/famous-areas-peel.md
+++ b/.changeset/famous-areas-peel.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Adds support for loading a session by ID
+
+Adds a new `session.load()` method to the experimental session API that allows you to load a session by ID. In normal use a session is loaded automatically from the session cookie. This method allows a session to be loaded manually instead. This is useful for cases where the session ID has been persisted somewhere other than the browser cookie. For example, a session ID might be stored in a user database. This would allow that user's session to be loaded when logging-in on another device or in a different browser. It would also allow a session to be loaded in an API when cookies can't be set, such as when loading across domains.

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -293,6 +293,20 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 	}
 
 	/**
+	 * Loads a session from storage with the given ID, and replaces the current session.
+	 * Any changes made to the current session will be lost.
+	 * This is not normally needed, as the session is automatically loaded using the cookie.
+	 * However it can be used to restore a session where the ID has been recorded somewhere
+	 * else (e.g. in a database).
+	 */
+	async load(sessionID: string) {
+		this.#sessionID = sessionID;
+		this.#data = undefined;
+		await this.#setCookie();
+		await this.#ensureData();
+	}
+
+	/**
 	 * Sets the session cookie.
 	 */
 	async #setCookie() {

--- a/packages/astro/test/fixtures/sessions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/sessions/src/actions/index.ts
@@ -17,6 +17,14 @@ export const server = {
 			return await context.session.get('cart');
 		},
 	}),
+	loadCart: defineAction({
+		input: z.object({ id: z.string() }),
+		handler: async (input, context) => {
+			context.session.load(input.id);
+			const cart = await context.session.get('cart');
+			return { cart };
+		}
+	}),
 	clearCart: defineAction({
 		accept: 'json',
 		handler: async (input, context) => {

--- a/packages/astro/test/sessions.test.js
+++ b/packages/astro/test/sessions.test.js
@@ -99,6 +99,34 @@ describe('Astro.session', () => {
 				'Favorite URL set to https://example.com/ from https://domain.invalid/',
 			);
 		});
+
+		it('can load a session by ID', async () => {
+			const firstResponse = await fetchResponse('/_actions/addToCart', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'Origin': 'http://example.com',
+				},
+				body: new URLSearchParams({ productId: 'item1' }),
+			});
+			const firstResponseData = devalue.parse(await firstResponse.text());
+			assert.equal(firstResponseData.cart.includes('item1'), true);
+
+			const firstHeaders = Array.from(app.setCookieHeaders(firstResponse));
+			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
+
+			//  Load without a cookie, but with the session ID for the action to load
+			const secondResponse = await fetchResponse('/_actions/loadCart', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ id: firstSessionId }),
+			});
+			const cartData = devalue.parse(await secondResponse.text());
+			assert.deepEqual(cartData.cart, firstResponseData.cart);
+		});
+
 	});
 
 	describe('Development', () => {


### PR DESCRIPTION
## Changes

Adds support for loading a session by ID

Adds a new `session.load()` method to the experimental session API that allows you to load a session by ID. In normal use a session is loaded automatically from the session cookie. This method allows a session to be loaded manually instead. This has been requested in the RFC, and is useful for cases where the session ID has been persisted somewhere other than the browser cookie. For example, a session ID might be stored in a user database. This would allow that user's session to be loaded when logging-in on another device or in a different browser. It would also allow a session to be loaded in an API when cookies can't be set, such as when loading across domains.


## Testing

Added tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I will do a separate docs PR

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
