### PR TITLE
fix(svg): prevent empty attributes

### DIFF
--- a/.changeset/itchy-bulldogs-scream.md
+++ b/.changeset/itchy-bulldogs-scream.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Prevent empty attributes from appearing in the SVG output

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -163,7 +163,7 @@
     "tinyexec": "^0.3.2",
     "tinyglobby": "^0.2.12",
     "tsconfck": "^3.1.5",
-    "ultrahtml": "^1.5.3",
+    "ultrahtml": "^1.6.0",
     "unist-util-visit": "^5.0.0",
     "unstorage": "^1.15.0",
     "vfile": "^6.0.3",

--- a/packages/astro/src/assets/utils/svg.ts
+++ b/packages/astro/src/assets/utils/svg.ts
@@ -19,7 +19,10 @@ function parseSvg(contents: string) {
 
 export function makeSvgComponent(meta: ImageMetadata, contents: Buffer | string) {
 	const file = typeof contents === 'string' ? contents : contents.toString('utf-8');
-	const { attributes, body: children } = parseSvg(file);
+	const { attributes, body: children } = parseSvg(
+		// NOTE: This is a workaround for the `ultrahtml` bug that adds empty attributes
+		file.replaceAll(/\s+/g, ' '),
+	);
 	const props: SvgComponentProps = {
 		meta,
 		attributes: dropAttributes(attributes),

--- a/packages/astro/src/assets/utils/svg.ts
+++ b/packages/astro/src/assets/utils/svg.ts
@@ -19,10 +19,7 @@ function parseSvg(contents: string) {
 
 export function makeSvgComponent(meta: ImageMetadata, contents: Buffer | string) {
 	const file = typeof contents === 'string' ? contents : contents.toString('utf-8');
-	const { attributes, body: children } = parseSvg(
-		// NOTE: This is a workaround for the `ultrahtml` bug that adds empty attributes
-		file.replaceAll(/\s+/g, ' '),
-	);
+	const { attributes, body: children } = parseSvg(file);
 	const props: SvgComponentProps = {
 		meta,
 		attributes: dropAttributes(attributes),

--- a/packages/astro/test/core-image-svg.test.js
+++ b/packages/astro/test/core-image-svg.test.js
@@ -54,9 +54,11 @@ describe('astro:assets - SVG Components', () => {
 		describe('props', () => {
 			describe('strip', () => {
 				let $;
+				let html;
+
 				before(async () => {
 					let res = await fixture.fetch('/strip');
-					let html = await res.text();
+					html = await res.text();
 					$ = cheerio.load(html, { xml: true });
 				});
 
@@ -77,6 +79,9 @@ describe('astro:assets - SVG Components', () => {
 					assert.equal(!!$svg.attr('xmlns'), false);
 					assert.equal(!!$svg.attr('xmlns:xlink'), false);
 					assert.equal(!!$svg.attr('version'), false);
+				});
+				it('should have no empty attributes', () => {
+					assert.equal(/\s=""/.test(html), false);
 				});
 			});
 			describe('additional props', () => {

--- a/packages/astro/test/fixtures/core-image-svg/src/pages/strip.astro
+++ b/packages/astro/test/fixtures/core-image-svg/src/pages/strip.astro
@@ -1,6 +1,7 @@
 ---
 import Alpine from '~/assets/alpine-multi-color.svg'
 import Dragon from '~/assets/dragon.svg'
+import Github from '~/assets/github.svg'
 ---
 <html>
 <head>
@@ -12,6 +13,9 @@ import Dragon from '~/assets/dragon.svg'
 	</div>
 	<div id="additionalNodes">
 		<Dragon />
+	</div>
+	<div id="emptyAttrs">
+		<Github />
 	</div>
 </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,8 +596,8 @@ importers:
         specifier: ^3.1.5
         version: 3.1.5(typescript@5.8.2)
       ultrahtml:
-        specifier: ^1.5.3
-        version: 1.5.3
+        specifier: ^1.6.0
+        version: 1.6.0
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -10016,7 +10016,6 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:
@@ -11803,6 +11802,9 @@ packages:
 
   ultrahtml@1.5.3:
     resolution: {integrity: sha512-GykOvZwgDWZlTQMtp5jrD4BVL+gNn2NVlVafjcFUJ7taY20tqYdwdoWBFy6GBJsNTZe1GkGPkSl5knQAjtgceg==}
+
+  ultrahtml@1.6.0:
+    resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -14917,7 +14919,7 @@ snapshots:
       marked: 12.0.2
       marked-footnote: 1.2.4(marked@12.0.2)
       marked-smartypants: 1.1.8(marked@12.0.2)
-      ultrahtml: 1.5.3
+      ultrahtml: 1.6.0
 
   async-listen@3.1.0: {}
 
@@ -18654,6 +18656,8 @@ snapshots:
   uhyphen@0.2.0: {}
 
   ultrahtml@1.5.3: {}
+
+  ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
 


### PR DESCRIPTION
## Changes

Updating to the latest 1.6.0 which fixes the issue and brings in some optimizations to the regexes it uses.
Fixes #13496

## Testing

Added a test to assert that there were no empty attributes `=""` in the resultant html with an SVG known to produce it.

## Docs

Not necessary as this is just a bug fix.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
