### PR TITLE
fix: support for Deno to install npm packages

### DIFF
--- a/.changeset/wet-onions-kick.md
+++ b/.changeset/wet-onions-kick.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Support for Deno to install npm pacakges.
+
+Deno requires npm prefix to install packages on npm. For example, to install react, we need to run `deno add npm:react`. But currently the command executed is `deno add react`, which doesn't work. So, we change the package names to have an npm prefix if you are using Deno.

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -675,7 +675,12 @@ async function tryToInstallIntegrations({
 	const installCommand = resolveCommand(packageManager?.agent ?? 'npm', 'add', inheritedFlags);
 	if (!installCommand) return UpdateResult.none;
 
-	const installSpecifiers = await convertIntegrationsToInstallSpecifiers(integrations);
+	const installSpecifiers = await convertIntegrationsToInstallSpecifiers(integrations).then(
+		(specifiers) =>
+			installCommand.command === 'deno'
+				? specifiers.map((specifier) => `npm:${specifier}`) // Deno requires npm prefix to install packages
+				: specifiers,
+	);
 
 	const coloredOutput = `${bold(installCommand.command)} ${installCommand.args.join(' ')} ${cyan(installSpecifiers.join(' '))}`;
 	const message = `\n${boxen(coloredOutput, {

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -70,6 +70,10 @@ async function installPackage(
 	const installCommand = resolveCommand(packageManager?.agent ?? 'npm', 'add', []);
 	if (!installCommand) return false;
 
+	if (installCommand.command === 'deno') {
+		// Deno requires npm prefix to install packages
+		packageNames = packageNames.map((name) => `npm:${name}`);
+	}
 	const coloredOutput = `${bold(installCommand.command)} ${installCommand.args.join(' ')} ${cyan(packageNames.join(' '))}`;
 	const message = `\n${boxen(coloredOutput, {
 		margin: 0.5,


### PR DESCRIPTION
## Changes

- Deno requires a prefix when installing packages
- So, if you use Deno as your package manager, prepend `npm:` to the library name

### Before `deno task astro add react`

![image](https://github.com/user-attachments/assets/97f4247e-7e1a-45ac-8ad6-5a91036b588a)

### After `deno task astro add react`

![image](https://github.com/user-attachments/assets/1159a3c3-c819-4d29-b154-b84d9c526286)

## Testing

It was manually tested on local. We can install and try out this PR's `astro`.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I think Astro don't officially supports Deno as a package manager, so I'll write about it if necessary.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
