### PR TITLE
fix(i18n): incorrect validation

### DIFF
--- a/.changeset/heavy-months-sin.md
+++ b/.changeset/heavy-months-sin.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Fixes an incorrect default configuration value. The configuration `i18n.routing.redirectToDefaultLocale` default value is now `false`.

--- a/.changeset/heavy-months-sin.md
+++ b/.changeset/heavy-months-sin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an incorrect default configuration value. The configuration `i18n.routing.redirectToDefaultLocale` default value is now `false`.

--- a/.changeset/old-animals-shop.md
+++ b/.changeset/old-animals-shop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where Astro validate the i18n options incorrectly, causing false positives to downstream libraries. Now Astro emits an error when `i18n.routing.prefixDefaultLocale` is `false` and `i18n.routing.redirectToDefaultLocale` is set to `true`.

--- a/.changeset/old-animals-shop.md
+++ b/.changeset/old-animals-shop.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue where Astro validate the i18n options incorrectly, causing false positives to downstream libraries. Now Astro emits an error when `i18n.routing.prefixDefaultLocale` is `false` and `i18n.routing.redirectToDefaultLocale` is set to `true`.
+Fixes an issue where Astro validated the i18n configuration incorrectly, causing false positives in downstream libraries. Astro now only emits this error when both `i18n.routing.prefixDefaultLocale` is `false` and `i18n.routing.redirectToDefaultLocale` is `true`.

--- a/.changeset/old-animals-shop.md
+++ b/.changeset/old-animals-shop.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue where Astro validated the i18n configuration incorrectly, causing false positives in downstream libraries. Astro now only emits this error when both `i18n.routing.prefixDefaultLocale` is `false` and `i18n.routing.redirectToDefaultLocale` is `true`.
+Fixes an issue where Astro validated the i18n configuration incorrectly, causing false positives in downstream libraries.

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -402,7 +402,8 @@ export const AstroConfigSchema = z.object({
 					.or(
 						z.object({
 							prefixDefaultLocale: z.boolean().optional().default(false),
-							redirectToDefaultLocale: z.boolean().optional().default(false),
+							// TODO: Astro 6.0 change to false
+							redirectToDefaultLocale: z.boolean().optional().default(true),
 							fallbackType: z.enum(['redirect', 'rewrite']).optional().default('redirect'),
 						}),
 					)

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -402,7 +402,7 @@ export const AstroConfigSchema = z.object({
 					.or(
 						z.object({
 							prefixDefaultLocale: z.boolean().optional().default(false),
-							redirectToDefaultLocale: z.boolean().optional().default(true),
+							redirectToDefaultLocale: z.boolean().optional().default(false),
 							fallbackType: z.enum(['redirect', 'rewrite']).optional().default('redirect'),
 						}),
 					)

--- a/packages/astro/src/core/config/schemas/refined.ts
+++ b/packages/astro/src/core/config/schemas/refined.ts
@@ -45,13 +45,13 @@ export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((con
 	if (
 		config.i18n &&
 		typeof config.i18n.routing !== 'string' &&
-		!config.i18n.routing.redirectToDefaultLocale &&
-		!config.i18n.routing.prefixDefaultLocale
+		config.i18n.routing.prefixDefaultLocale === false &&
+		config.i18n.routing.redirectToDefaultLocale === true
 	) {
 		ctx.addIssue({
 			code: z.ZodIssueCode.custom,
 			message:
-				'The option `i18n.routing.redirectToDefaultLocale` is only useful when the `i18n.routing.prefixDefaultLocale` is set to `true`. Remove the option `i18n.routing.redirectToDefaultLocale`, or change its value to `true`.',
+				'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`; setting `i18n.routing.prefixDefaultLocale` to `false` might cause infinite loops. Remove the option `i18n.routing.prefixDefaultLocale`, or change its value to `true`.',
 			path: ['i18n', 'routing', 'redirectToDefaultLocale'],
 		});
 	}

--- a/packages/astro/src/core/config/schemas/refined.ts
+++ b/packages/astro/src/core/config/schemas/refined.ts
@@ -51,7 +51,7 @@ export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((con
 		ctx.addIssue({
 			code: z.ZodIssueCode.custom,
 			message:
-				'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`; setting `i18n.routing.prefixDefaultLocale` to `false` might cause infinite loops. Remove the option `i18n.routing.prefixDefaultLocale`, or change its value to `true`.',
+				'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`, otherwise redirects might cause infinite loops. Remove the option `i18n.routing.redirectToDefaultLocale`, or change its value to `false`.',
 			path: ['i18n', 'routing', 'redirectToDefaultLocale'],
 		});
 	}

--- a/packages/astro/src/core/config/schemas/refined.ts
+++ b/packages/astro/src/core/config/schemas/refined.ts
@@ -42,19 +42,21 @@ export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((con
 		}
 	}
 
-	if (
-		config.i18n &&
-		typeof config.i18n.routing !== 'string' &&
-		config.i18n.routing.prefixDefaultLocale === false &&
-		config.i18n.routing.redirectToDefaultLocale === true
-	) {
-		ctx.addIssue({
-			code: z.ZodIssueCode.custom,
-			message:
-				'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`, otherwise redirects might cause infinite loops. Remove the option `i18n.routing.redirectToDefaultLocale`, or change its value to `false`.',
-			path: ['i18n', 'routing', 'redirectToDefaultLocale'],
-		});
-	}
+	// TODO: Astro 6.0
+	// Uncomment this validation check, and change the default value of redirectToDefaultLocale to false
+	// if (
+	// 	config.i18n &&
+	// 	typeof config.i18n.routing !== 'string' &&
+	// 	config.i18n.routing.prefixDefaultLocale === false &&
+	// 	config.i18n.routing.redirectToDefaultLocale === true
+	// ) {
+	// 	ctx.addIssue({
+	// 		code: z.ZodIssueCode.custom,
+	// 		message:
+	// 			'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`, otherwise redirects might cause infinite loops. Remove the option `i18n.routing.redirectToDefaultLocale`, or change its value to `false`.',
+	// 		path: ['i18n', 'routing', 'redirectToDefaultLocale'],
+	// 	});
+	// }
 
 	if (config.outDir.toString().startsWith(config.publicDir.toString())) {
 		ctx.addIssue({

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -346,6 +346,12 @@ export async function runHookConfigSetup({
 	if (astroJSXRenderer) {
 		updatedSettings.renderers.push(astroJSXRenderer);
 	}
+	
+	// TODO: Astro 6.0
+	// Remove this hack to avoid breaking changes, and change the default value of redirectToDefaultLocale
+	if (updatedConfig.i18n && typeof updatedConfig.i18n.routing !== "string") {
+		updatedConfig.i18n.routing.redirectToDefaultLocale ??= updatedConfig.i18n.routing.prefixDefaultLocale || false;
+	}
 
 	updatedSettings.config = updatedConfig;
 	return updatedSettings;

--- a/packages/astro/test/fixtures/i18n-routing-prefix-always/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-prefix-always/astro.config.mjs
@@ -11,7 +11,6 @@ export default defineConfig({
 			], 
 			routing: {
 				prefixDefaultLocale: true,
-				redirectToDefaultLocale: true,
 			}
 		},
 		base: "/new-site"

--- a/packages/astro/test/fixtures/i18n-routing-prefix-always/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-prefix-always/astro.config.mjs
@@ -10,7 +10,8 @@ export default defineConfig({
 				}
 			], 
 			routing: {
-				prefixDefaultLocale: true
+				prefixDefaultLocale: true,
+				redirectToDefaultLocale: true,
 			}
 		},
 		base: "/new-site"

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -209,7 +209,7 @@ describe('Config Validation', () => {
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
-				'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`; setting `i18n.routing.prefixDefaultLocale` to `false` might cause infinite loops. Remove the option `i18n.routing.prefixDefaultLocale`, or change its value to `true`.'
+				'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`, otherwise redirects might cause infinite loops. Remove the option `i18n.routing.redirectToDefaultLocale`, or change its value to `false`.'
 			);
 		});
 

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -195,7 +195,7 @@ describe('Config Validation', () => {
 			);
 		});
 
-		it('errors if `i18n.prefixDefaultLocale` is `false` and `i18n.redirectToDefaultLocale` is `true`', async () => {
+		it('errors if `i18n.prefixDefaultLocale` is `false` and `i18n.redirectToDefaultLocale` is `true`', { todo: "Enable in Astro 6.0", skip: "Removed validation"}, async () => {
 			const configError = await validateConfig({
 				i18n: {
 					defaultLocale: 'en',

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -202,14 +202,14 @@ describe('Config Validation', () => {
 					locales: ['es', 'en'],
 					routing: {
 						prefixDefaultLocale: false,
-						redirectToDefaultLocale: false,
+						redirectToDefaultLocale: true,
 					},
 				},
 			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
 			assert.equal(
 				configError.errors[0].message,
-				'The option `i18n.routing.redirectToDefaultLocale` is only useful when the `i18n.routing.prefixDefaultLocale` is set to `true`. Remove the option `i18n.routing.redirectToDefaultLocale`, or change its value to `true`.',
+				'The option `i18n.routing.redirectToDefaultLocale` can be used only when `i18n.routing.prefixDefaultLocale` is set to `true`; setting `i18n.routing.prefixDefaultLocale` to `false` might cause infinite loops. Remove the option `i18n.routing.prefixDefaultLocale`, or change its value to `true`.'
 			);
 		});
 


### PR DESCRIPTION
## Changes

Closes #13551

After 5.6.0, where we changed how we validate the astro configuration, we found out that Astro was validating incorrect values for `i18n.routing.

This PR fixes the values.

## Testing

Updated tests and error message.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->
cc @delucis and @HiDeoo 
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
