### PR TITLE
feat(fonts): improve local font files deletion

### DIFF
--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -2,7 +2,6 @@ import type * as unifont from 'unifont';
 import type { ResolvedLocalFontFamily } from '../types.js';
 import { fileURLToPath } from 'node:url';
 import { extractFontType } from '../utils.js';
-import { AstroError, AstroErrorData } from '../../../core/errors/index.js';
 
 // https://fonts.nuxt.com/get-started/providers#local
 // https://github.com/nuxt/fonts/blob/main/src/providers/local.ts
@@ -48,47 +47,4 @@ export function resolveLocalFont(
 	return {
 		fonts,
 	};
-}
-
-/**
- * Orchestrates local font updates and deletions during development
- */
-export class LocalFontsWatcher {
-	/**
-	 * Watched fonts files
-	 */
-	#paths: Array<string>;
-	/**
-	 * Action performed when a font file is updated
-	 */
-	#update: () => void;
-
-	constructor({ paths, update }: { paths: Array<string>; update: () => void }) {
-		this.#paths = paths;
-		this.#update = update;
-	}
-
-	#matches(path: string): boolean {
-		return this.#paths.includes(path);
-	}
-
-	/**
-	 * Callback to call whenever a file is updated
-	 */
-	onUpdate(path: string): void {
-		if (!this.#matches(path)) {
-			return;
-		}
-		this.#update();
-	}
-
-	/**
-	 * Callback to call whenever a file is unlinked
-	 */
-	onUnlink(path: string): void {
-		if (!this.#matches(path)) {
-			return;
-		}
-		throw new AstroError(AstroErrorData.DeletedLocalFont);
-	}
 }

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1333,18 +1333,6 @@ export const CannotFetchFontFile = {
 /**
  * @docs
  * @description
- * A local font file referenced in your Astro config has been deleted. Restore the file or update your Astro config.
- */
-export const DeletedLocalFont = {
-	name: 'DeletedLocalFont',
-	title: 'A local font has been deleted',
-	message: 'A local font file referenced in your config has been deleted.',
-	hint: 'Restore the file or remove this font from your configuration if it is no longer needed.',
-} satisfies ErrorData;
-
-/**
- * @docs
- * @description
  * Cannot load font provider
  * @message
  * Astro is unable to load the given font provider. Open an issue on the corresponding provider's repository.

--- a/packages/astro/test/units/assets/fonts/providers.test.js
+++ b/packages/astro/test/units/assets/fonts/providers.test.js
@@ -3,10 +3,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { fontProviders } from '../../../../dist/config/entrypoint.js';
 import { google } from '../../../../dist/assets/fonts/providers/google.js';
-import {
-	LocalFontsWatcher,
-	resolveLocalFont,
-} from '../../../../dist/assets/fonts/providers/local.js';
+import { resolveLocalFont } from '../../../../dist/assets/fonts/providers/local.js';
 import * as adobeEntrypoint from '../../../../dist/assets/fonts/providers/entrypoints/adobe.js';
 import * as bunnyEntrypoint from '../../../../dist/assets/fonts/providers/entrypoints/bunny.js';
 import * as fontshareEntrypoint from '../../../../dist/assets/fonts/providers/entrypoints/fontshare.js';
@@ -99,7 +96,7 @@ describe('fonts providers', () => {
 						src: ['./src/fonts/foo.woff2', './src/fonts/foo.ttf'],
 						weight: '400',
 						style: 'normal',
-						display: 'block'
+						display: 'block',
 					},
 				],
 			},
@@ -181,32 +178,6 @@ describe('fonts providers', () => {
 			},
 		]);
 		assert.deepStrictEqual(values, [fileURLToPath(new URL('./src/fonts/bar.eot', root))]);
-	});
-
-	it('LocalFontsWatcher', () => {
-		let updated = 0;
-		const watcher = new LocalFontsWatcher({
-			paths: ['foo', 'bar'],
-			update: () => {
-				updated++;
-			},
-		});
-
-		watcher.onUpdate('baz');
-		assert.equal(updated, 0);
-
-		watcher.onUpdate('foo');
-		watcher.onUpdate('bar');
-		assert.equal(updated, 2);
-
-		assert.doesNotThrow(() => watcher.onUnlink('baz'));
-		try {
-			watcher.onUnlink('foo');
-			assert.fail();
-		} catch (err) {
-			assert.equal(err instanceof Error, true);
-			assert.equal(err.message, 'A local font file referenced in your config has been deleted.');
-		}
 	});
 
 	describe('utils', () => {


### PR DESCRIPTION
## Changes

- Addresses feedback from Chris
- With this PR, we don't throw an error in dev if a local font file used is deleted. Instead we show a warning in the terminal
- Allows to remove a bunch of code

## Testing

Updated and manual

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
