### PR TITLE
Load Prism language extras

### DIFF
--- a/.changeset/curly-things-grin.md
+++ b/.changeset/curly-things-grin.md
@@ -1,0 +1,8 @@
+---
+'@astrojs/prism': minor
+---
+
+Load Prism language extras
+
+Loads '-extras' for CSS, JS and PHP to add more
+tokens for styling.

--- a/packages/astro-prism/src/highlighter.ts
+++ b/packages/astro-prism/src/highlighter.ts
@@ -13,6 +13,9 @@ export function runHighlighterWithAstro(lang: string | undefined, code: string) 
 		if (language && !Prism.languages[language]) {
 			loadLanguages([language]);
 		}
+		if (/^css$|^js$|^php$/.test(language)) {
+			loadLanguages([language + "-extras"]);
+		}
 	};
 
 	if (languageMap.has(lang)) {


### PR DESCRIPTION
Loads '-extras' for CSS, JS and PHP to add more tokens for styling.

## Changes

When highlighting CSS, JS and PHP with Prism load the -extras for these to add additional tokens.

CSS example:

```css
code[class*="language-"] .token {
...
}
```

Without `css-extras`:

```html
<span class="token selector">
    code[class*="language-"] .token
</span>
```

With `css-extras`:

```html
<span class="token selector">
    code
    <span class="token attribute">
        <span class="token punctuation">[</span>
        <span class="token attr-name">class</span>
        <span class="token operator">*=</span>
        <span class="token attr-value">"language-"</span>
        <span class="token punctuation">]</span>
    </span>
    <span class="token class">.token</span>
</span>
```

## Testing

Tested with a local project using pnpm link.

## Docs

I don't believe this will break anything since it seems to just add some extras `<span class="token ..."></span>` inside
the existing ones. Any theme styling applied to outer existing `<span>`s would still apply even if not using the extra inner ones.
