### PR TITLE
fix(svg): do not attach `svg` buffer to `imageMetadata`

### DIFF
--- a/.changeset/five-rings-smile.md
+++ b/.changeset/five-rings-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a memory leak when using SVG assets.

--- a/packages/astro/src/assets/utils/node/emitAsset.ts
+++ b/packages/astro/src/assets/utils/node/emitAsset.ts
@@ -54,12 +54,6 @@ export async function emitESMImage(
 		value: id,
 	});
 
-	// Attach file data for SVGs
-	// TODO: this is a workaround to prevent a memory leak, and it must be fixed before we remove the experimental flag, see
-	if (fileMetadata.format === 'svg' && experimentalSvgEnabled) {
-		emittedImage.contents = fileData;
-	}
-
 	// Build
 	let isBuild = typeof fileEmitter === 'function';
 	if (isBuild) {

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -1,3 +1,4 @@
+import type * as fsMod from 'node:fs';
 import { extname } from 'node:path';
 import MagicString from 'magic-string';
 import type * as vite from 'vite';
@@ -90,7 +91,7 @@ const addStaticImageFactory = (
 	};
 };
 
-export default function assets({ settings }: { settings: AstroSettings }): vite.Plugin[] {
+export default function assets({ fs, settings }: { fs: typeof fsMod; settings: AstroSettings }): vite.Plugin[] {
 	let resolvedConfig: vite.ResolvedConfig;
 	let shouldEmitFile = false;
 	let isBuild = false;
@@ -223,9 +224,9 @@ export default function assets({ settings }: { settings: AstroSettings }): vite.
 					}
 
 					if (settings.config.experimental.svg && /\.svg$/.test(id)) {
-						const { contents, ...metadata } = imageMetadata;
+						const contents = await fs.promises.readFile(imageMetadata.fsPath, { encoding: 'utf8' });
 						// We know that the contents are present, as we only emit this property for SVG files
-						return { code: makeSvgComponent(metadata, contents!) };
+						return { code: makeSvgComponent(imageMetadata, contents) };
 					}
 
 					// We can only reliably determine if an image is used on the server, as we need to track its usage throughout the entire build.

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -164,7 +164,7 @@ export async function createVite(
 			astroContentAssetPropagationPlugin({ settings }),
 			vitePluginMiddleware({ settings }),
 			vitePluginSSRManifest(),
-			astroAssetsPlugin({ settings }),
+			astroAssetsPlugin({ fs, settings }),
 			astroPrefetch({ settings }),
 			astroTransitions({ settings }),
 			astroDevToolbar({ settings, logger }),


### PR DESCRIPTION
## Changes

- adjusts `svg` handling to fix a memory leak
- see #12694 for original workaround, Erika's [suggestion on #12067](https://github.com/withastro/astro/pull/12067#discussion_r1780990317)
- unblocks #13578

## Testing

1. Tested with a modified version of the `benchmark` script that included 10,000 `svg` files.
2. Tested against the real-world [`cloudflare-docs`](https://github.com/cloudflare/cloudflare-docs) repo, where the original bug report was surfaced. It generates 5K+ page and has 1100+ `.svg` files. Before this change, I got an OOM error. After this change, I was able to build the site successfully. [See Discord thread for full fix verification updates](https://discord.com/channels/830184174198718474/1357286171578994821)

## Docs

Bug fix only