### PR TITLE
chore: deprecate `emitESMImage` function

### DIFF
--- a/.changeset/good-worms-heal.md
+++ b/.changeset/good-worms-heal.md
@@ -14,4 +14,4 @@ Please replace it with the new function`emitImageMetadata()` as soon as you are 
 + import { emitImageMetadata } from "astro/assets/utils";
 ```
 
-The new function returns the same signature as the previous one, however the new function drops some deprecated arguments that weren't meant to be exposed to users;`_watchMode` and `experimentalSvgEnabled` are removed and you may need to check if your code works as intended. 
+The new function returns the same signature as the previous one. However, the new function removes two deprecated arguments that were not meant to be exposed for public use: `_watchMode` and `experimentalSvgEnabled`. Since it was possible to access these with the old function, you may need to verify that your code still works as intended with `emitImageMetadata()`.

--- a/.changeset/good-worms-heal.md
+++ b/.changeset/good-worms-heal.md
@@ -1,5 +1,4 @@
 ---
-'@astrojs/markdoc': patch
 'astro': patch
 ---
 

--- a/.changeset/good-worms-heal.md
+++ b/.changeset/good-worms-heal.md
@@ -3,11 +3,15 @@
 'astro': patch
 ---
 
-The function
-`emitESMImage` has been deprecated, and it will be removed in a next major release of Astro. Use the function
-`emitImageMetadata` instead.
+Deprecates the asset utility function `emitESMImage()` and adds a new `emitImageMetadata()` to be used instead
+
+The function `emitESMImage()` is now deprecated. It will continue to function, but it is no longer recommended nor supported. This function will be completely removed in a next major release of Astro. 
+
+Please replace it with the new function`emitImageMetadata()` as soon as you are able to do so:
 
 ```diff
 - import {emitESMImage} from "astro/assets/utils";
 + import {emitImageMetadata} from "astro/assets/utils";
 ```
+
+The new function was created to operate the same way as the old function, and should work interchangeably in your code. However, its signature is not identical and you may need to check that your code is working as intended.

--- a/.changeset/good-worms-heal.md
+++ b/.changeset/good-worms-heal.md
@@ -1,0 +1,13 @@
+---
+'@astrojs/markdoc': patch
+'astro': patch
+---
+
+The function
+`emitESMImage` has been deprecated, and it will be removed in a next major release of Astro. Use the function
+`emitImageMetadata` instead.
+
+```diff
+- import {emitESMImage} from "astro/assets/utils";
++ import {emitImageMetadata} from "astro/assets/utils";
+```

--- a/.changeset/good-worms-heal.md
+++ b/.changeset/good-worms-heal.md
@@ -4,13 +4,14 @@
 
 Deprecates the asset utility function `emitESMImage()` and adds a new `emitImageMetadata()` to be used instead
 
-The function `emitESMImage()` is now deprecated. It will continue to function, but it is no longer recommended nor supported. This function will be completely removed in a next major release of Astro. 
+The function
+`emitESMImage()` is now deprecated. It will continue to function, but it is no longer recommended nor supported. This function will be completely removed in a next major release of Astro.
 
 Please replace it with the new function`emitImageMetadata()` as soon as you are able to do so:
 
 ```diff
-- import {emitESMImage} from "astro/assets/utils";
-+ import {emitImageMetadata} from "astro/assets/utils";
+- import { emitESMImage } from "astro/assets/utils";
++ import { emitImageMetadata } from "astro/assets/utils";
 ```
 
-The new function was created to operate the same way as the old function, and should work interchangeably in your code. However, its signature is not identical and you may need to check that your code is working as intended.
+The new function returns the same signature as the previous one, however the new function drops some deprecated arguments that weren't meant to be exposed to users;`_watchMode` and `experimentalSvgEnabled` are removed and you may need to check if your code works as intended. 

--- a/packages/astro/src/assets/utils/index.ts
+++ b/packages/astro/src/assets/utils/index.ts
@@ -5,7 +5,13 @@
  * If some functions don't need to be exposed, just import the file that contains the functions.
  */
 
-export { emitESMImage, emitImageMetadata } from './node/emitAsset.js';
+export {
+	/**
+	 * @deprecated
+	 */
+	emitESMImage,
+	emitImageMetadata,
+} from './node/emitAsset.js';
 export { isESMImportedImage, isRemoteImage } from './imageKind.js';
 export { imageMetadata } from './metadata.js';
 export { getOrigQueryParams } from './queryParams.js';

--- a/packages/astro/src/assets/utils/index.ts
+++ b/packages/astro/src/assets/utils/index.ts
@@ -5,7 +5,7 @@
  * If some functions don't need to be exposed, just import the file that contains the functions.
  */
 
-export { emitESMImage } from './node/emitAsset.js';
+export { emitESMImage, emitImageMetadata } from './node/emitAsset.js';
 export { isESMImportedImage, isRemoteImage } from './imageKind.js';
 export { imageMetadata } from './metadata.js';
 export { getOrigQueryParams } from './queryParams.js';

--- a/packages/astro/src/assets/utils/node/emitAsset.ts
+++ b/packages/astro/src/assets/utils/node/emitAsset.ts
@@ -17,8 +17,8 @@ type ImageMetadataWithContents = ImageMetadata & { contents?: Buffer };
  * @param {boolean} experimentalSvgEnabled - A flag to enable experimental handling of SVG files. Embeds SVG file data if set to true.
  * @param {FileEmitter | undefined} [fileEmitter] - Function for emitting files during the build process. May throw in certain scenarios.
  * @return {Promise<ImageMetadataWithContents | undefined>} Resolves to metadata with optional image contents or `undefined` if processing fails.
- * @deprecated Use `emitImageMetadata` instead.
  */
+// We want to internally use this function until we fix the memory in the SVG features
 export async function emitESMImage(
 	id: string | undefined,
 	/** @deprecated */

--- a/packages/astro/src/assets/utils/node/emitAsset.ts
+++ b/packages/astro/src/assets/utils/node/emitAsset.ts
@@ -17,6 +17,7 @@ type ImageMetadataWithContents = ImageMetadata & { contents?: Buffer };
  * @param {boolean} experimentalSvgEnabled - A flag to enable experimental handling of SVG files. Embeds SVG file data if set to true.
  * @param {FileEmitter | undefined} [fileEmitter] - Function for emitting files during the build process. May throw in certain scenarios.
  * @return {Promise<ImageMetadataWithContents | undefined>} Resolves to metadata with optional image contents or `undefined` if processing fails.
+ * @deprecated Use `emitImageMetadata` instead.
  */
 export async function emitESMImage(
 	id: string | undefined,
@@ -58,6 +59,75 @@ export async function emitESMImage(
 	if (fileMetadata.format === 'svg' && experimentalSvgEnabled) {
 		emittedImage.contents = fileData;
 	}
+
+	// Build
+	let isBuild = typeof fileEmitter === 'function';
+	if (isBuild) {
+		const pathname = decodeURI(url.pathname);
+		const filename = path.basename(pathname, path.extname(pathname) + `.${fileMetadata.format}`);
+
+		try {
+			// fileEmitter throws in dev
+			const handle = fileEmitter!({
+				name: filename,
+				source: await fs.readFile(url),
+				type: 'asset',
+			});
+
+			emittedImage.src = `__ASTRO_ASSET_IMAGE__${handle}__`;
+		} catch {
+			isBuild = false;
+		}
+	}
+
+	if (!isBuild) {
+		// Pass the original file information through query params so we don't have to load the file twice
+		url.searchParams.append('origWidth', fileMetadata.width.toString());
+		url.searchParams.append('origHeight', fileMetadata.height.toString());
+		url.searchParams.append('origFormat', fileMetadata.format);
+
+		emittedImage.src = `/@fs` + prependForwardSlash(fileURLToNormalizedPath(url));
+	}
+
+	return emittedImage as ImageMetadataWithContents;
+}
+
+/**
+ * Processes an image file and emits its metadata and optionally its contents. This function supports both build and development modes.
+ *
+ * @param {string | undefined} id - The identifier or path of the image file to process. If undefined, the function returns immediately.
+ * @param {FileEmitter | undefined} [fileEmitter] - Function for emitting files during the build process. May throw in certain scenarios.
+ * @return {Promise<ImageMetadataWithContents | undefined>} Resolves to metadata with optional image contents or `undefined` if processing fails.
+ */
+export async function emitImageMetadata(
+	id: string | undefined,
+	fileEmitter?: FileEmitter,
+): Promise<ImageMetadataWithContents | undefined> {
+	if (!id) {
+		return undefined;
+	}
+
+	const url = pathToFileURL(id);
+	let fileData: Buffer;
+	try {
+		fileData = await fs.readFile(url);
+	} catch {
+		return undefined;
+	}
+
+	const fileMetadata = await imageMetadata(fileData, id);
+
+	const emittedImage: Omit<ImageMetadataWithContents, 'fsPath'> = {
+		src: '',
+		...fileMetadata,
+	};
+
+	// Private for now, we generally don't want users to rely on filesystem paths, but we need it so that we can maybe remove the original asset from the build if it's unused.
+	Object.defineProperty(emittedImage, 'fsPath', {
+		enumerable: false,
+		writable: false,
+		value: id,
+	});
 
 	// Build
 	let isBuild = typeof fileEmitter === 'function';

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -5,7 +5,7 @@ import { parseFrontmatter } from '@astrojs/markdown-remark';
 import type { Config as MarkdocConfig, Node } from '@markdoc/markdoc';
 import Markdoc from '@markdoc/markdoc';
 import type { AstroConfig, ContentEntryType } from 'astro';
-import { emitESMImage } from 'astro/assets/utils';
+import { emitImageMetadata } from 'astro/assets/utils';
 import type { Rollup, ErrorPayload as ViteErrorPayload } from 'vite';
 import type { ComponentConfig } from './config.js';
 import { htmlTokenTransform } from './html/transform/html-token-transform.js';
@@ -315,12 +315,7 @@ async function emitOptimizedImages(
 				const resolved = await ctx.pluginContext.resolve(node.attributes.src, ctx.filePath);
 
 				if (resolved?.id && fs.existsSync(new URL(prependForwardSlash(resolved.id), 'file://'))) {
-					const src = await emitESMImage(
-						resolved.id,
-						ctx.pluginContext.meta.watchMode,
-						!!ctx.astroConfig.experimental.svg,
-						ctx.pluginContext.emitFile,
-					);
+					const src = await emitImageMetadata(resolved.id, ctx.pluginContext.emitFile);
 
 					const fsPath = resolved.id;
 

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -5,7 +5,7 @@ import { parseFrontmatter } from '@astrojs/markdown-remark';
 import type { Config as MarkdocConfig, Node } from '@markdoc/markdoc';
 import Markdoc from '@markdoc/markdoc';
 import type { AstroConfig, ContentEntryType } from 'astro';
-import { emitImageMetadata } from 'astro/assets/utils';
+import { emitESMImage } from 'astro/assets/utils';
 import type { Rollup, ErrorPayload as ViteErrorPayload } from 'vite';
 import type { ComponentConfig } from './config.js';
 import { htmlTokenTransform } from './html/transform/html-token-transform.js';
@@ -315,7 +315,12 @@ async function emitOptimizedImages(
 				const resolved = await ctx.pluginContext.resolve(node.attributes.src, ctx.filePath);
 
 				if (resolved?.id && fs.existsSync(new URL(prependForwardSlash(resolved.id), 'file://'))) {
-					const src = await emitImageMetadata(resolved.id, ctx.pluginContext.emitFile);
+					const src = await emitESMImage(
+						resolved.id,
+						ctx.pluginContext.meta.watchMode,
+						!!ctx.astroConfig.experimental.svg,
+						ctx.pluginContext.emitFile,
+					);
 
 					const fsPath = resolved.id;
 


### PR DESCRIPTION
## Changes

Due to some mistake we've made, the utility function `emitESMImage` - which is exposed as public API - is broken. 

To remedy the mistake, we will expose a new function to userland, which has a different signature (we removed the things we don't need).

I updated `@astrojs/mdx` to use the new function.

## Testing

CI should stay green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I will send a PR to update the docs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
