### PR TITLE
fix(routing): handle base path with trailing slash 'never' configuration

### DIFF
--- a/.changeset/puny-masks-laugh.md
+++ b/.changeset/puny-masks-laugh.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Fix routing with base paths when trailingSlash is set to 'never'. This ensures requests to '/base' are correctly matched when the base path is set to '/base', without requiring a trailing slash.

--- a/.changeset/puny-masks-laugh.md
+++ b/.changeset/puny-masks-laugh.md
@@ -1,5 +1,5 @@
 ---
-'astro': major
+'astro': patch
 ---
 
 Fix routing with base paths when trailingSlash is set to 'never'. This ensures requests to '/base' are correctly matched when the base path is set to '/base', without requiring a trailing slash.

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -52,28 +52,45 @@ export function findRouteToRewrite({
 	}
 
 	let pathname = newUrl.pathname;
-
 	const shouldAppendSlash = shouldAppendForwardSlash(trailingSlash, buildFormat);
+	
+	// Special handling for base path
+	if (base !== '/') {
+		// Check if this is a request to the base path
+		const isBasePathRequest = newUrl.pathname === base || 
+			newUrl.pathname === removeTrailingForwardSlash(base);
 
-	if (base !== '/' && newUrl.pathname.startsWith(base)) {
-		pathname = shouldAppendSlash
-			? appendForwardSlash(newUrl.pathname)
-			: removeTrailingForwardSlash(newUrl.pathname);
-		pathname = pathname.slice(base.length);
+		if (isBasePathRequest) {
+			// For root path requests at the base URL
+			// When trailingSlash is 'never', we should match '' (empty string pathname)
+			// When trailingSlash is 'always', we should match '/' pathname
+			pathname = shouldAppendSlash ? '/' : '';
+		} else if (newUrl.pathname.startsWith(base)) {
+			// For non-root paths under the base
+			pathname = shouldAppendSlash
+				? appendForwardSlash(newUrl.pathname)
+				: removeTrailingForwardSlash(newUrl.pathname);
+			pathname = pathname.slice(base.length);
+		}
 	}
 
+	// Ensure pathname starts with '/' when needed
 	if (!pathname.startsWith('/') && shouldAppendSlash && newUrl.pathname.endsWith('/')) {
-		// when base is in the rewrite call and trailingSlash is 'always' this is needed or it will 404.
 		pathname = prependForwardSlash(pathname);
 	}
 
-	if (pathname === '/' && base !== '/' && !shouldAppendSlash) {
-		// when rewriting to index and trailingSlash is 'never' this is needed or it will 404
-		// in this case the pattern will look for '/^$/' so '/' will never match
+	// Convert '/' to '' for trailingSlash: 'never'
+	if (pathname === '/' && !shouldAppendSlash) {
 		pathname = '';
 	}
 
-	newUrl.pathname = joinPaths(...[base, pathname].filter(Boolean));
+	// Set the final URL pathname
+	if (base !== '/' && (pathname === '' || pathname === '/') && !shouldAppendSlash) {
+		// Special case for root path at base URL with trailingSlash: 'never'
+		newUrl.pathname = removeTrailingForwardSlash(base);
+	} else {
+		newUrl.pathname = joinPaths(...[base, pathname].filter(Boolean));
+	}
 
 	const decodedPathname = decodeURI(pathname);
 	let foundRoute;


### PR DESCRIPTION
## Changes
Closes: #13585 
- What does this change?

Fixes routing with base paths when `trailingSlash` is set to 'never', ensuring requests to '/base' are correctly matched when the base path is set to '/base'. The fix also maintains compatibility with rewrites, with all rewrite tests passing successfully.

## Testing

I've added 2 🤏🏻 tests 🫡

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
