### PR TITLE
Remove `data-astro-source-file` and `data-astro-source-loc` attributes in dev mode

### DIFF
--- a/.changeset/poor-ends-count.md
+++ b/.changeset/poor-ends-count.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates the [Audit](http://docs.astro.build/en/guides/dev-toolbar/#audit) dev toolbar app to automatically strip `data-astro-source-file` and `data-astro-source-loc` attributes in dev mode.

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/annotations.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/annotations.ts
@@ -1,0 +1,30 @@
+export interface Annotation {
+    file: string;
+    location: string;
+}
+const ELEMENT_ANNOTATIONS = new WeakMap<Element, Annotation>();
+export function getAnnotationsForElement(element: Element) {
+    return ELEMENT_ANNOTATIONS.get(element);
+}
+
+const ANNOTATION_MAP: Record<string, keyof Annotation> = {
+    'data-astro-source-file': 'file',
+    'data-astro-source-loc': 'location',
+}
+function extractAnnotations(element: Element) {
+    const annotations: Annotation = {} as any;
+    for (const [attr, key] of Object.entries(ANNOTATION_MAP) as [string, keyof Annotation][]) {
+        annotations[key] = element.getAttribute(attr)!;
+    }
+    for (const attr of Object.keys(ANNOTATION_MAP)) {
+        element.removeAttribute(attr);
+    }
+    return annotations;
+}
+
+
+export function processAnnotations() {
+    for (const element of document.querySelectorAll(`[data-astro-source-file]`)) {
+        ELEMENT_ANNOTATIONS.set(element, extractAnnotations(element));
+    }
+}

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/ui/audit-ui.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/ui/audit-ui.ts
@@ -8,6 +8,7 @@ import {
 import type { Audit } from '../index.js';
 import { type ResolvedAuditRule, resolveAuditRule } from '../rules/index.js';
 import type { DevToolbarAuditListItem } from './audit-list-item.js';
+import { getAnnotationsForElement } from '../annotations.js';
 
 function truncate(val: string, maxLength: number): string {
 	return val.length > maxLength ? val.slice(0, maxLength - 1) + '&hellip;' : val;
@@ -71,8 +72,7 @@ function buildAuditTooltip(rule: ResolvedAuditRule, element: Element) {
 		},
 	];
 
-	const elementFile = element.getAttribute('data-astro-source-file');
-	const elementPosition = element.getAttribute('data-astro-source-loc');
+	const { file: elementFile, location: elementPosition } = getAnnotationsForElement(element) ?? {};
 
 	if (elementFile) {
 		const elementFileWithPosition = elementFile + (elementPosition ? ':' + elementPosition : '');


### PR DESCRIPTION
## Changes

- To support the [Audit](https://docs.astro.build/en/guides/dev-toolbar/#audit) dev toolbar app, Astro's compiler injects `data-astro-source-file` and `data-astro-source-loc` attributes on every element in dev mode.
- In this PR, the Audit app has been updated to extract the data from these attributes, store them in a `WeakMap` that is keyed by each `Element`, and then remove the attributes.
- This should improve the dev mode experience by simplifying the markup when inspecting the page.
- Changeset added.

## Impact
This admittedly might break some third-party dev toolbar apps that rely on these annotations. Ideally we would expose a public API to get the annotation info for an element.

[Searching all of GitHub for `data-astro-source-file`](https://github.com/search?q=data-astro-source-file&type=code) yields a decent number of repos, but the vast majority of uses are workarounds to remove the attributes.

## Testing

Tested manually because it involves dev mode-specific client-side script behavior, which would be flaky to run in CI.

## Docs

As far as I can tell, this is an internal API that we've never documented!

These attributes were added in #9016 and first released in `astro@3.5.0` in November 2023. I assume users have gotten used to ignoring them, but they're still visual noise. Since this approach allows us to reduce noise without removing functionality, I think we should.