### PR TITLE
Add the minimal example to `create astro` options

### DIFF
--- a/.changeset/tricky-adults-jump.md
+++ b/.changeset/tricky-adults-jump.md
@@ -4,4 +4,4 @@
 
 Adds the minimal starter template to the list of `create astro` options
 
-Good news if you're taking the introductory tutorial in docs, making a minimal reproduction, or just want to start a project with as little to rip out as possible. Astro's `minimal` (empty) template is now back as one of the options when running `create astro@latest` and staring a new project!
+Good news if you're taking the introductory tutorial in docs, making a minimal reproduction, or just want to start a project with as little to rip out as possible. Astro's `minimal` (empty) template is now back as one of the options when running `create astro@latest` and starting a new project!

--- a/.changeset/tricky-adults-jump.md
+++ b/.changeset/tricky-adults-jump.md
@@ -1,0 +1,7 @@
+---
+"astro": patch
+---
+
+Adds the minimal starter template to the list of `create astro` options
+
+Good news if you're taking the introductory tutorial in docs, making a minimal reproduction, or just want to start a project with as little to rip out as possible. Astro's `minimal` (empty) template is now back as one of the options when running `create astro@latest` and staring a new project!

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -21,9 +21,10 @@ export async function template(
 			message: 'How would you like to start your new project?',
 			initial: 'basics',
 			choices: [
-				{ value: 'basics', label: 'A basic, minimal starter', hint: '(recommended)' },
+				{ value: 'basics', label: 'A basic, helpful starter project', hint: '(recommended)' },
 				{ value: 'blog', label: 'Use blog template' },
 				{ value: 'starlight', label: 'Use docs (Starlight) template' },
+				{ value: 'minimal', label: 'A minimal (empty) starter' },
 			],
 		});
 		ctx.template = tmpl;


### PR DESCRIPTION
## Changes

Update the list of available choices when running `create astro` to include the `minimal` starter.

This is useful for people taking the introductory tutorial in docs, creating minimal reproductions, and for experienced users starting projects from scratch.

In particular, it avoids needing to document workarounds to installing the minimal template for the tutorial via a template flag. (For example, Powershell users cannot follow the command as provided. This leads to them choosing the wrong template at the start of the tutorial, and is confusing when their code doesn't match the tutorial instructions.)

Closes Docs Issue https://github.com/withastro/docs/issues/10843

## Testing

Not tested! 

## Docs

The tutorial docs will be updated (simplified) to no longer require installing the minimal starter using a template flag. (Can be updated separately, as the existing instructions will still work.)
