### PR TITLE
fix(prerender): revert dynamic entry chunks included in server bundle

### DIFF
--- a/.changeset/brown-lines-talk.md
+++ b/.changeset/brown-lines-talk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression that allowed prerendered code to leak into the server bundle.

--- a/packages/astro/src/core/build/plugins/plugin-prerender.ts
+++ b/packages/astro/src/core/build/plugins/plugin-prerender.ts
@@ -57,9 +57,6 @@ function getNonPrerenderOnlyChunks(bundle: Rollup.OutputBundle, internals: Build
 
 			nonPrerenderOnlyEntryChunks.add(chunk);
 		}
-		if (chunk.type === 'chunk' && chunk.isDynamicEntry) {
-			nonPrerenderOnlyEntryChunks.add(chunk);
-		}
 	}
 
 	// From the `nonPrerenderedEntryChunks`, we crawl all the imports/dynamicImports to find all


### PR DESCRIPTION
## Changes

- (Potentially) fixes a regression introduced by #13519
- User on Discord reported a build failure introduced between [`5.6.0` and `5.6.1`](https://github.com/withastro/astro/compare/astro%405.6.0...astro%405.6.1). The cause seemed to be `astro-icon` chunks, which should only be prerendered, were leaking into the server bundle.
Looking through the commits, the only suspicious commit seems to be #13519, which ported over [the following lines](https://github.com/withastro/astro/pull/13519/files#r2020561968).
- Originally, this change was introduced by [an ecosystem patch to improve Rolldown compat](https://github.com/vitejs/vite-ecosystem-ci/blob/rolldown-vite/tests-patches/astro/astro.patch#L244-L249), but we don't have insight into what bug was being fixed. We're asking around for the context!
- Patch changeset added

## Testing

Going to confirm the fix with a preview release, but it would be a good idea to make a prerender chunk test to prevent future regressions

## Docs

N/A, bug fix