### PR TITLE
add missing `message` to a Fonts API error

### DIFF
--- a/packages/astro/src/assets/fonts/utils.ts
+++ b/packages/astro/src/assets/fonts/utils.ts
@@ -57,9 +57,15 @@ export function extractFontType(str: string): FontType {
 	// Extname includes a leading dot
 	const extension = extname(str).slice(1);
 	if (!isFontType(extension)) {
-		throw new AstroError(AstroErrorData.CannotExtractFontType, {
-			cause: `Unexpected extension, got "${extension}"`,
-		});
+		throw new AstroError(
+			{
+				...AstroErrorData.CannotExtractFontType,
+				message: AstroErrorData.CannotExtractFontType.message(str),
+			},
+			{
+				cause: `Unexpected extension, got "${extension}"`,
+			},
+		);
 	}
 	return extension;
 }

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1297,10 +1297,13 @@ export const UnknownFilesystemError = {
  * @docs
  * @description
  * Cannot extract the font type from the given URL.
+ * @message
+ * An error occured while trying to extract the font type from the given URL.
  */
 export const CannotExtractFontType = {
 	name: 'CannotExtractFontType',
 	title: 'Cannot extract the font type from the given URL.',
+	message: (url: string) => `An error occurred while trying to extract the font type from ${url}`,
 	hint: 'Open an issue at https://github.com/withastro/astro/issues.',
 } satisfies ErrorData;
 


### PR DESCRIPTION
## Changes

This adds the `@message` property (and `message` to the ErrorData object) for one of the new error messages. @florian-lefebvre or someone please correct/verify the actual content!

## Testing

Not tested, but the `@message` property is the one that generates the error message block in docs. Without it, we only get a "What went wrong?" section. (This might also affect the error message people see?)

e.g. without: (we had one slip by earlier!)
![image](https://github.com/user-attachments/assets/18cc47b5-2472-49fa-87d9-ecf71b9d6653)

vs most other error messages:
![image](https://github.com/user-attachments/assets/06156e99-01f5-408d-bd02-2df11d2cb31a)


## Docs

All for docs!
