### PR TITLE
Fix relative redirects regression. Closes #13607

### DIFF
--- a/.changeset/tasty-cities-warn.md
+++ b/.changeset/tasty-cities-warn.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Relative redirects work again after regression introduced in #12979
+Fixes a regression where relative static redirects didn't work as expected.

--- a/.changeset/tasty-cities-warn.md
+++ b/.changeset/tasty-cities-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Relative redirects work again after regression introduced in #12979

--- a/.changeset/tasty-cities-warn.md
+++ b/.changeset/tasty-cities-warn.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 Relative redirects work again after regression introduced in #12979

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -357,12 +357,9 @@ function createRedirectRoutes(
 			destination = to.destination;
 		}
 
-		// URLs that don't start with leading slash should be considered external
-		if (!destination.startsWith('/')) {
-			// check if the link starts with http or https; if not, log a warning
-			if (!/^https?:\/\//.test(destination) && !URL.canParse(destination)) {
-				throw new AstroError(UnsupportedExternalRedirect);
-			}
+		// check if the link starts with http or https; if not, throw an error
+		if (URL.canParse(destination) && !/^https?:\/\//.test(destination)) {
+			throw new AstroError(UnsupportedExternalRedirect);
 		}
 
 		routes.push({

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -131,6 +131,7 @@ describe('Astro.redirect', () => {
 						'/more/old/[dynamic]/[route]': '/more/[dynamic]/[route]',
 						'/more/old/[...spread]': '/more/new/[...spread]',
 						'/external/redirect': 'https://example.com/',
+						'/relative/redirect': '../../test',
 					},
 				});
 				await fixture.build();
@@ -213,6 +214,12 @@ describe('Astro.redirect', () => {
 				const html = await fixture.readFile('/external/redirect/index.html');
 				assert.equal(html.includes('http-equiv="refresh'), true);
 				assert.equal(html.includes('url=https://example.com/'), true);
+			});
+
+			it('supports redirecting to a relative destination', async () => {
+				const html = await fixture.readFile('/relative/redirect/index.html');
+				assert.equal(html.includes('http-equiv="refresh'), true);
+				assert.equal(html.includes('url=../../test'), true);
 			});
 		});
 


### PR DESCRIPTION
## Changes

As per #13607, redirects had a regression with relative redirects introduced in #12979. This PR fixes it.

Fixes #13607

## Testing

- Unit tests
- Tested with my local side project using the new changes
  <!-- How was this change tested? -->
  <!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

/cc @withastro/maintainers-docs for feedback! This was never documented but always worked since early versions of Astro so as mentioned by @ematipico on #13607 we should probaly update the docs. Happy to have a stab at it if you want too.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
