### PR TITLE
Fix changelog heading levels

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -17,7 +17,7 @@
   <a href="/checkout">🛒 {cart?.length ?? 0} items</a>
   ```
 
-  ## Configuring session storage
+  #### Configuring session storage
 
   Sessions require a storage driver to store the data. The Node, Cloudflare and Netlify adapters automatically configure a default driver for you, but other adapters currently require you to specify a custom storage driver in your configuration.
 
@@ -35,7 +35,7 @@
   });
   ```
 
-  ## Using sessions
+  #### Using sessions
 
   Sessions are available in on-demand rendered pages, API endpoints, actions and middleware.
 
@@ -67,7 +67,7 @@
   ---
   ```
 
-  ## Upgrading from Experimental to Stable
+  #### Upgrading from Experimental to Stable
 
   If you were previously using the experimental API, please remove the `experimental.session` flag from your configuration:
 

--- a/packages/integrations/cloudflare/CHANGELOG.md
+++ b/packages/integrations/cloudflare/CHANGELOG.md
@@ -17,7 +17,7 @@
   <a href="/checkout">🛒 {cart?.length ?? 0} items</a>
   ```
 
-  ## Configuring session storage
+  #### Configuring session storage
 
   Sessions require a storage driver to store the data. The Node, Cloudflare and Netlify adapters automatically configure a default driver for you, but other adapters currently require you to specify a custom storage driver in your configuration.
 
@@ -35,7 +35,7 @@
   });
   ```
 
-  ## Using sessions
+  #### Using sessions
 
   Sessions are available in on-demand rendered pages, API endpoints, actions and middleware.
 
@@ -67,7 +67,7 @@
   ---
   ```
 
-  ## Upgrading from Experimental to Stable
+  #### Upgrading from Experimental to Stable
 
   If you were previously using the experimental API, please remove the `experimental.session` flag from your configuration:
 

--- a/packages/integrations/netlify/CHANGELOG.md
+++ b/packages/integrations/netlify/CHANGELOG.md
@@ -17,7 +17,7 @@
   <a href="/checkout">🛒 {cart?.length ?? 0} items</a>
   ```
 
-  ## Configuring session storage
+  #### Configuring session storage
 
   Sessions require a storage driver to store the data. The Node, Cloudflare and Netlify adapters automatically configure a default driver for you, but other adapters currently require you to specify a custom storage driver in your configuration.
 
@@ -35,7 +35,7 @@
   });
   ```
 
-  ## Using sessions
+  #### Using sessions
 
   Sessions are available in on-demand rendered pages, API endpoints, actions and middleware.
 
@@ -67,7 +67,7 @@
   ---
   ```
 
-  ## Upgrading from Experimental to Stable
+  #### Upgrading from Experimental to Stable
 
   If you were previously using the experimental API, please remove the `experimental.session` flag from your configuration:
 

--- a/packages/integrations/node/CHANGELOG.md
+++ b/packages/integrations/node/CHANGELOG.md
@@ -17,7 +17,7 @@
   <a href="/checkout">🛒 {cart?.length ?? 0} items</a>
   ```
 
-  ## Configuring session storage
+  #### Configuring session storage
 
   Sessions require a storage driver to store the data. The Node, Cloudflare and Netlify adapters automatically configure a default driver for you, but other adapters currently require you to specify a custom storage driver in your configuration.
 
@@ -35,7 +35,7 @@
   });
   ```
 
-  ## Using sessions
+  #### Using sessions
 
   Sessions are available in on-demand rendered pages, API endpoints, actions and middleware.
 
@@ -67,7 +67,7 @@
   ---
   ```
 
-  ## Upgrading from Experimental to Stable
+  #### Upgrading from Experimental to Stable
 
   If you were previously using the experimental API, please remove the `experimental.session` flag from your configuration:
 


### PR DESCRIPTION
## Changes

The 5.7.0 changelog includes `<h2>` headings in the sessions details which is inconsistent with other headings in the changelog and is breaking some automated tooling that attempts to display a version’s notes (see e.g. this Renovate PR: https://github.com/withastro/astro.build/pull/1529)

## Testing
n/a

## Docs
n/a