### PR TITLE
fix: improve autocomplete for session keys

### DIFF
--- a/.changeset/young-peaches-serve.md
+++ b/.changeset/young-peaches-serve.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve autocomplete for session keys

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -102,7 +102,7 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 	/**
 	 * Gets a session value. Returns `undefined` if the session or value does not exist.
 	 */
-	async get<T = void, K extends string = string>(
+	async get<T = void, K extends string = keyof App.SessionData | (string & {}) >(
 		key: K,
 	): Promise<
 		(T extends void ? (K extends keyof App.SessionData ? App.SessionData[K] : any) : T) | undefined
@@ -153,7 +153,7 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 	 * Sets a session value. The session is created if it does not exist.
 	 */
 
-	set<T = void, K extends string = string>(
+	set<T = void, K extends string = keyof App.SessionData | (string & {})>(
 		key: K,
 		value: T extends void
 			? K extends keyof App.SessionData


### PR DESCRIPTION
## Changes

Use the `| (string & {})` trick to ensure that key autocomplete always works

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
