### PR TITLE
fix(fonts): component ordering

### DIFF
--- a/.changeset/thick-walls-open.md
+++ b/.changeset/thick-walls-open.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates the `<Font />` component so that preload links are generated before the style tag if `preload` is passed

--- a/packages/astro/components/Font.astro
+++ b/packages/astro/components/Font.astro
@@ -23,10 +23,10 @@ if (!data) {
 }
 ---
 
-<style set:html={data.css}></style>
 {
 	preload &&
 		data.preloadData.map(({ url, type }) => (
 			<link rel="preload" href={url} as="font" type={`font/${type}`} crossorigin />
 		))
 }
+<style set:html={data.css}></style>


### PR DESCRIPTION
## Changes

- According to capo, preload link should come before style tags
- Updated after feedback on the RFC

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
