### PR TITLE
fix(fonts): lighter fallbacks

### DIFF
--- a/.changeset/red-parents-tease.md
+++ b/.changeset/red-parents-tease.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates fallback font generation to always read font files returned by font providers

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -123,7 +123,6 @@
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/markdown-remark": "workspace:*",
     "@astrojs/telemetry": "workspace:*",
-    "@capsizecss/metrics": "^3.5.0",
     "@capsizecss/unpack": "^2.4.0",
     "@oslojs/encoding": "^1.1.0",
     "@rollup/pluginutils": "^5.1.4",

--- a/packages/astro/src/assets/fonts/load.ts
+++ b/packages/astro/src/assets/fonts/load.ts
@@ -48,7 +48,7 @@ export async function loadFonts({
 	for (const family of families) {
 		const preloadData: PreloadData = [];
 		let css = '';
-		let fallbackFontData: GetMetricsForFamilyFont = null;
+		let fallbackFontData: GetMetricsForFamilyFont | null = null;
 
 		// When going through the urls/filepaths returned by providers,
 		// We save the hash and the associated original value so we can use

--- a/packages/astro/src/assets/fonts/metrics.ts
+++ b/packages/astro/src/assets/fonts/metrics.ts
@@ -1,10 +1,4 @@
-// Adapted from https://github.com/unjs/fontaine/
-import { fontFamilyToCamelCase } from '@capsizecss/metrics';
 import { type Font, fromBuffer } from '@capsizecss/unpack';
-
-const QUOTES_RE = /^["']|["']$/g;
-
-const withoutQuotes = (str: string) => str.trim().replace(QUOTES_RE, '');
 
 export type FontFaceMetrics = Pick<
 	Font,
@@ -27,30 +21,6 @@ function filterRequiredMetrics({
 		unitsPerEm,
 		xWidthAvg,
 	};
-}
-
-export async function getMetricsForFamily(family: string) {
-	family = withoutQuotes(family);
-
-	if (family in metricCache) return metricCache[family];
-
-	try {
-		const name = fontFamilyToCamelCase(family);
-		const { entireMetricsCollection } = await import('@capsizecss/metrics/entireMetricsCollection');
-		const metrics = entireMetricsCollection[name as keyof typeof entireMetricsCollection];
-
-		if (!('descent' in metrics)) {
-			metricCache[family] = null;
-			return null;
-		}
-
-		const filteredMetrics = filterRequiredMetrics(metrics);
-		metricCache[family] = filteredMetrics;
-		return filteredMetrics;
-	} catch {
-		metricCache[family] = null;
-		return null;
-	}
 }
 
 export async function readMetrics(family: string, buffer: Buffer) {

--- a/packages/astro/src/assets/fonts/utils.ts
+++ b/packages/astro/src/assets/fonts/utils.ts
@@ -78,14 +78,14 @@ export async function cache(
 	storage: Storage,
 	key: string,
 	cb: () => Promise<Buffer>,
-): Promise<{ cached: boolean; data: Buffer }> {
+): Promise<Buffer> {
 	const existing = await storage.getItemRaw(key);
 	if (existing) {
-		return { cached: true, data: existing };
+		return existing;
 	}
 	const data = await cb();
 	await storage.setItemRaw(key, data);
-	return { cached: false, data };
+	return data;
 }
 
 export interface ProxyURLOptions {
@@ -133,13 +133,13 @@ export function isGenericFontFamily(str: string): str is keyof typeof DEFAULT_FA
 export type GetMetricsForFamilyFont = {
 	hash: string;
 	url: string;
-} | null;
+};
 
 export type GetMetricsForFamily = (
 	name: string,
 	/** A remote url or local filepath to a font file. Used if metrics can't be resolved purely from the family name */
 	font: GetMetricsForFamilyFont,
-) => Promise<FontFaceMetrics | null>;
+) => Promise<FontFaceMetrics>;
 
 /**
  * Generates CSS for a given family fallbacks if possible.
@@ -157,7 +157,7 @@ export async function generateFallbacksCSS({
 	family: Pick<ResolvedFontFamily, 'name' | 'nameWithHash'>;
 	/** The family fallbacks */
 	fallbacks: Array<string>;
-	font: GetMetricsForFamilyFont;
+	font: GetMetricsForFamilyFont | null;
 	metrics: {
 		getMetricsForFamily: GetMetricsForFamily;
 		generateFontFace: typeof generateFallbackFontFace;
@@ -171,7 +171,7 @@ export async function generateFallbacksCSS({
 
 	let css = '';
 
-	if (!metrics) {
+	if (!fontData || !metrics) {
 		return { css, fallbacks };
 	}
 

--- a/packages/astro/test/units/assets/fonts/utils.test.js
+++ b/packages/astro/test/units/assets/fonts/utils.test.js
@@ -7,52 +7,11 @@ import {
 	extractFontType,
 	familiesToUnifontProviders,
 	generateFallbacksCSS,
-	cache as internalCache,
 	isFontType,
 	isGenericFontFamily,
 	proxyURL,
 	resolveFontFamily,
 } from '../../../../dist/assets/fonts/utils.js';
-
-function createSpyCache() {
-	/** @type {Map<string, Buffer>} */
-	const store = new Map();
-
-	const storage = {
-		/**
-		 * @param {string} key
-		 * @returns {Promise<Buffer | null>}
-		 */
-		getItemRaw: async (key) => {
-			return store.get(key) ?? null;
-		},
-		/**
-		 * @param {string} key
-		 * @param {Buffer} value
-		 * @returns {Promise<void>}
-		 */
-		setItemRaw: async (key, value) => {
-			store.set(key, value);
-		},
-	};
-
-	return {
-		/**
-		 *
-		 * @param {Parameters<typeof internalCache>[1]} key
-		 * @param {Parameters<typeof internalCache>[2]} cb
-		 * @returns
-		 */
-		cache: (key, cb) =>
-			internalCache(
-				// @ts-expect-error we only mock the required hooks
-				storage,
-				key,
-				cb,
-			),
-		getKeys: () => Array.from(store.keys()),
-	};
-}
 
 /**
  *
@@ -118,25 +77,6 @@ describe('fonts utils', () => {
 				}
 			}
 		}
-	});
-
-	it('cache()', async () => {
-		const { cache, getKeys } = createSpyCache();
-
-		assert.deepStrictEqual(getKeys(), []);
-
-		let buffer = Buffer.from('foo');
-		let res = await cache('foo', async () => buffer);
-		assert.equal(res.cached, false);
-		assert.equal(res.data, buffer);
-
-		assert.deepStrictEqual(getKeys(), ['foo']);
-
-		res = await cache('foo', async () => buffer);
-		assert.equal(res.cached, true);
-		assert.equal(res.data, buffer);
-
-		assert.deepStrictEqual(getKeys(), ['foo']);
 	});
 
 	it('proxyURL()', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,9 +477,6 @@ importers:
       '@astrojs/telemetry':
         specifier: workspace:*
         version: link:../telemetry
-      '@capsizecss/metrics':
-        specifier: ^3.5.0
-        version: 3.5.0
       '@capsizecss/unpack':
         specifier: ^2.4.0
         version: 2.4.0
@@ -6586,9 +6583,6 @@ packages:
     resolution: {integrity: sha512-v9f+ueUOKkZCDKiCm0yxKtYgYNLD9zlKarNux0NSXOvNm94QEYL3RlMpGKgD2hq44pbF2qWqEmHnCvmk56kPJw==}
     engines: {node: '>=18'}
 
-  '@capsizecss/metrics@3.5.0':
-    resolution: {integrity: sha512-Ju2I/Qn3c1OaU8FgeW4Tc22D4C9NwyVfKzNmzst59bvxBjPoLYNZMqFYn+HvCtn4MpXwiaDtCE8fNuQLpdi9yA==}
-
   '@capsizecss/unpack@2.4.0':
     resolution: {integrity: sha512-GrSU71meACqcmIUxPYOJvGKF0yryjN/L1aCuE9DViCTJI7bfkjgYDPD1zbNDcINJwSSP6UaBZY9GAbYDO7re0Q==}
 
@@ -10007,6 +10001,7 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:
@@ -12818,8 +12813,6 @@ snapshots:
   '@bluwy/giget-core@0.1.2':
     dependencies:
       tar: 6.2.1
-
-  '@capsizecss/metrics@3.5.0': {}
 
   '@capsizecss/unpack@2.4.0':
     dependencies:


### PR DESCRIPTION
## Changes

- RFC feedback
- Removes `@capsizecss/metrics` because it's heavy. Instead, we read the font files directly
- Simplifies the cache util

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
