### PR TITLE
fix(fonts): providers deduplication logic

### DIFF
--- a/.changeset/rich-dancers-sniff.md
+++ b/.changeset/rich-dancers-sniff.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where some font families would not be downloaded when using the same font provider several times, using the experimental fonts API

--- a/packages/astro/src/assets/fonts/utils.ts
+++ b/packages/astro/src/assets/fonts/utils.ts
@@ -333,9 +333,6 @@ export function familiesToUnifontProviders({
 				}),
 			),
 		);
-		if (hashes.has(hash)) {
-			continue;
-		}
 		// Makes sure every font uses the right instance of a given provider
 		// if this provider is provided several times with different options
 		// We have to mutate the unifont provider name because unifont deduplicates
@@ -344,8 +341,11 @@ export function familiesToUnifontProviders({
 		// We set the provider name so we can tell unifont what provider to use when
 		// resolving font faces
 		provider.name = unifontProvider._name;
-		hashes.add(hash);
-		providers.push(unifontProvider);
+
+		if (!hashes.has(hash)) {
+			hashes.add(hash);
+			providers.push(unifontProvider);
+		}
 	}
 
 	return { families, providers };

--- a/packages/astro/test/units/assets/fonts/utils.test.js
+++ b/packages/astro/test/units/assets/fonts/utils.test.js
@@ -411,7 +411,7 @@ describe('fonts utils', () => {
 					assert.equal(result.providers.length, length);
 				},
 				/**
-				 * @param {Array<string | undefined>} names
+				 * @param {Array<string>} names
 				 */
 				assertProvidersNames: (names) => {
 					assert.deepStrictEqual(
@@ -479,7 +479,7 @@ describe('fonts utils', () => {
 				},
 			]);
 			fixture.assertProvidersLength(1);
-			fixture.assertProvidersNames(['test-{"name":"test"}', undefined]);
+			fixture.assertProvidersNames(['test-{"name":"test"}', 'test-{"name":"test"}']);
 		});
 
 		it('deduplicates providers with the same config', () => {
@@ -504,7 +504,7 @@ describe('fonts utils', () => {
 				},
 			]);
 			fixture.assertProvidersLength(1);
-			fixture.assertProvidersNames(['test-{"name":"test","x":"y"}', undefined]);
+			fixture.assertProvidersNames(['test-{"name":"test","x":"y"}', 'test-{"name":"test","x":"y"}']);
 		});
 
 		it('does not deduplicate providers with different configs', () => {


### PR DESCRIPTION
## Changes

- Closes #13637 
- Unifont deduplicates providers based on the provider name. However in our case the same provider can be called with a different config (eg. adobe), so we have some logic to hash the config and dedupe
- However, the logic AND the tests were wrong because in certain cases, the family provider name was not assigned a value and as such, the family could not be resolved by unifont 

## Testing

Tests updated + manual

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
