### PR TITLE
fix: clone actionAPIContext preserving accessors

### DIFF
--- a/.changeset/dirty-dryers-rush.md
+++ b/.changeset/dirty-dryers-rush.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused a session error to be logged when using actions without sessions

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -300,13 +300,21 @@ export function getActionContext(context: APIContext): AstroActionContext {
 					}
 					throw e;
 				}
-				const {
-					props: _props,
-					getActionResult: _getActionResult,
-					callAction: _callAction,
-					redirect: _redirect,
-					...actionAPIContext
-				} = context;
+
+				const omitKeys = ['props', 'getActionResult', 'callAction', 'redirect'];
+
+				// Clones the context, preserving accessors and methods but omitting
+				// the properties that are not needed in the action handler.
+				const actionAPIContext = Object.create(
+					Object.getPrototypeOf(context),
+					Object.fromEntries(
+						Object.entries(Object.getOwnPropertyDescriptors(context))
+							.filter(([key]) =>
+								!omitKeys.includes(key)
+							)
+					)
+				);
+
 				Reflect.set(actionAPIContext, ACTION_API_CONTEXT_SYMBOL, true);
 				const handler = baseAction.bind(actionAPIContext satisfies ActionAPIContext);
 				return handler(input);


### PR DESCRIPTION
## Changes

Currently the action API context is created by destructuring the unused properties of the context object. This was causing warnings to be logged because it copies by value, meaning the session get method was being called.

This PR switches to using `Object.create` and `getOwnPropertyDescriptors`, which preserves the accessors on the object, menaing the `session` getter isn't called unless the user accesses it.

Fixes #13644

## Testing
Tested with the repro for #13644 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
