### PR TITLE
Fix `create-astro` pnpm dependencies installation

### DIFF
--- a/.changeset/wicked-beds-sniff.md
+++ b/.changeset/wicked-beds-sniff.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes an issue when installing dependencies with `pnpm`.

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -91,7 +91,7 @@ async function astroAdd({
 
 async function install({ packageManager, cwd }: { packageManager: string; cwd: string }) {
 	if (packageManager === 'yarn') await ensureYarnLock({ cwd });
-	return shell(packageManager, ['add'], { cwd, timeout: 90_000, stdio: 'ignore' });
+	return shell(packageManager, ['install'], { cwd, timeout: 90_000, stdio: 'ignore' });
 }
 
 /**


### PR DESCRIPTION
## Changes

When running the latest version of `create-astro` with pnpm, I'm getting the following error:

```
▲  error Error
▲  error Dependencies failed to install, please run npm install to install them manually after setup.
✔  Project initialized!
■ Template copied
■ Dependencies installed
```

After adding some logging, the underlying issue seems to be:

```
ERR_PNPM_MISSING_PACKAGE_NAME  `pnpm add` requires the package name
```

In #13395, the `install()` function was [updated to use `pnpm add` instead of `pnpm install`](https://github.com/withastro/astro/pull/13395/files#diff-41323e82da8edaf2f79a8d30ef557e3bc4eed01c7e24fee06146c7fcca28f846) without a changeset so it ended up being released 2 days ago with version [`4.11.2`](https://github.com/withastro/astro/blob/main/packages/create-astro/CHANGELOG.md#4112). This PR reverts that change.

The `install()` function seems to only be meant to install all dependencies (and never a single package) so I'm not sure if there is a reason I'm potentially missing for the change or not.

## Testing

I tested locally using `node create-astro.mjs` but I don't know how to force a specific package manager with this method so I temporarily hardcoded `pnpm`. Without the fix, I properly reproduced the error. After the fix, the issue seems to be resolved.

Looks like most of the tests for `create-astro` are using `dryRun: true` so not sure if/how we should add a test for this.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This is a bug fix that does not require any documentation change.