### PR TITLE
fix(fonts): google config

### DIFF
--- a/.changeset/slick-eggs-laugh.md
+++ b/.changeset/slick-eggs-laugh.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `fontProviders.google()` so it can forward options to the unifont provider, when using the experimental fonts API

--- a/packages/astro/src/assets/fonts/providers/index.ts
+++ b/packages/astro/src/assets/fonts/providers/index.ts
@@ -34,9 +34,10 @@ function fontsource() {
 // This provider downloads too many files when there's a variable font
 // available. This is bad because it doesn't align with our default font settings
 /** [Google](https://fonts.google.com/) */
-function google() {
+function google(config: Parameters<typeof providers.google>[0]) {
 	return defineAstroFontProvider({
 		entrypoint: 'astro/assets/fonts/providers/google',
+		config,
 	});
 }
 

--- a/packages/astro/src/assets/fonts/providers/index.ts
+++ b/packages/astro/src/assets/fonts/providers/index.ts
@@ -34,7 +34,7 @@ function fontsource() {
 // This provider downloads too many files when there's a variable font
 // available. This is bad because it doesn't align with our default font settings
 /** [Google](https://fonts.google.com/) */
-function google(config: Parameters<typeof providers.google>[0]) {
+function google(config?: Parameters<typeof providers.google>[0]) {
 	return defineAstroFontProvider({
 		entrypoint: 'astro/assets/fonts/providers/google',
 		config,


### PR DESCRIPTION
## Changes

- The google config was not passed to the unifont provider (reported on Discord)

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset, https://github.com/withastro/docs/pull/11484

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
