### PR TITLE
fix(types): add `server.allowedHosts` docs comment to `AstroUserConfig`

### DIFF
--- a/.changeset/dull-teeth-cut.md
+++ b/.changeset/dull-teeth-cut.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds `server.allowedHosts` docs comment to `AstroUserConfig`

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -908,6 +908,26 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 
 	/**
 	 * @docs
+	 * @name server.allowedHosts
+	 * @type {string[] | true}
+	 * @default `[]`
+	 * @version 5.4.0
+	 * @description
+	 *
+	 * A list of hostnames that Astro is allowed to respond to. When the value is set to `true`, any
+	 * hostname is allowed.
+	 *
+	 * ```js
+	 * {
+	 *   server: {
+	 *   	allowedHosts: ['staging.example.com', 'qa.example.com']
+	 *   }
+	 * }
+	 * ```
+	 */
+
+	/**
+	 * @docs
 	 * @name server.open
 	 * @type {string | boolean}
 	 * @default `false`


### PR DESCRIPTION
## Changes

- This PR adds `server.allowedHosts` docs comment to `AstroUserConfig`

## Testing

- N/A

## Docs

- Closes https://github.com/withastro/docs/issues/11336