### PR TITLE
fix(routing): origin pathname when using rewrites

### DIFF
--- a/.changeset/moody-lines-clean.md
+++ b/.changeset/moody-lines-clean.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where `Astro.originPathname` wasn't returning the correct value when using rewrites.

--- a/packages/astro/src/core/middleware/sequence.ts
+++ b/packages/astro/src/core/middleware/sequence.ts
@@ -6,6 +6,7 @@ import { AstroError } from '../errors/index.js';
 import { apiContextRoutesSymbol } from '../render-context.js';
 import { type Pipeline, getParams } from '../render/index.js';
 import { defineMiddleware } from './index.js';
+import { setOriginPathname } from '../routing/rewrite.js';
 
 // From SvelteKit: https://github.com/sveltejs/kit/blob/master/packages/kit/src/exports/hooks/sequence.js
 /**
@@ -46,6 +47,7 @@ export function sequence(...handlers: MiddlewareHandler[]): MiddlewareHandler {
 								handleContext.request,
 							);
 						}
+						const oldPathname = handleContext.url.pathname;
 						const pipeline: Pipeline = Reflect.get(handleContext, apiContextRoutesSymbol);
 						const { routeData, pathname } = await pipeline.tryRewrite(
 							payload,
@@ -76,6 +78,7 @@ export function sequence(...handlers: MiddlewareHandler[]): MiddlewareHandler {
 						handleContext.url = new URL(newRequest.url);
 						handleContext.cookies = new AstroCookies(newRequest);
 						handleContext.params = getParams(routeData, pathname);
+						setOriginPathname(handleContext.request, oldPathname);
 					}
 					return applyHandle(i + 1, handleContext);
 				} else {

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -153,6 +153,7 @@ export class RenderContext {
 		}
 		const lastNext = async (ctx: APIContext, payload?: RewritePayload) => {
 			if (payload) {
+				const oldPathname = this.pathname;
 				pipeline.logger.debug('router', 'Called rewriting to:', payload);
 				// we intentionally let the error bubble up
 				const {
@@ -197,6 +198,7 @@ export class RenderContext {
 				this.params = getParams(routeData, pathname);
 				this.pathname = pathname;
 				this.status = 200;
+				setOriginPathname(this.request, oldPathname);
 			}
 			let response: Response;
 
@@ -296,6 +298,7 @@ export class RenderContext {
 
 	async #executeRewrite(reroutePayload: RewritePayload) {
 		this.pipeline.logger.debug('router', 'Calling rewrite: ', reroutePayload);
+		const oldPathname = this.pathname;
 		const { routeData, componentInstance, newUrl, pathname } = await this.pipeline.tryRewrite(
 			reroutePayload,
 			this.request,
@@ -331,6 +334,7 @@ export class RenderContext {
 		this.isRewriting = true;
 		// we found a route and a component, we can change the status code to 200
 		this.status = 200;
+		setOriginPathname(this.request, oldPathname);
 		return await this.render(componentInstance);
 	}
 

--- a/packages/astro/test/fixtures/reroute/src/pages/index.astro
+++ b/packages/astro/test/fixtures/reroute/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 const auth = Astro.locals.auth;
+const origin = Astro.originPathname;
 ---
 <html>
 	<head>
@@ -8,5 +9,6 @@ const auth = Astro.locals.auth;
 	<body>
 		<h1>Index</h1>
 		{auth ? <p>Called auth</p>: ""}
+		<h2>Origin: {origin}</h2>
 	</body>
 </html>

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -25,6 +25,7 @@ describe('Dev reroute', () => {
 		const $ = cheerioLoad(html);
 
 		assert.equal($('h1').text(), 'Index');
+		assert.equal($('h2').text(), 'Origin: /reroute');
 	});
 
 	it('should render the index page when navigating /blog/hello ', async () => {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/13555

When creating a new request during the rewrite, the symbol was lost. This PR makes sure to add the symbol again with the correct value.

## Testing

I updated one of the existing tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

`Astro.originPathname` isn't documented, I will send a PR later

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
