### PR TITLE
feat(csp): create hashes of tracked scripts and hashes

### DIFF
--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -165,6 +165,10 @@ function createManifest(
 		checkOrigin: false,
 		middleware: manifest?.middleware ?? middlewareInstance,
 		key: createKey(),
+		clientScriptHashes: manifest?.clientScriptHashes ?? [],
+		clientStyleHashes: manifest?.clientStyleHashes ?? [],
+		shouldInjectCspMetaTags: manifest?.shouldInjectCspMetaTags ?? false,
+		astroIslandHashes: manifest?.astroIslandHashes ?? [],
 	};
 }
 
@@ -250,6 +254,10 @@ type AstroContainerManifest = Pick<
 	| 'publicDir'
 	| 'outDir'
 	| 'cacheDir'
+	| 'clientScriptHashes'
+	| 'clientStyleHashes'
+	| 'shouldInjectCspMetaTags'
+	| 'astroIslandHashes'
 >;
 
 type AstroContainerConstructor = {

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -86,6 +86,13 @@ export type SSRManifest = {
 	publicDir: string | URL;
 	buildClientDir: string | URL;
 	buildServerDir: string | URL;
+	clientScriptHashes: string[];
+	clientStyleHashes: string[];
+	/**
+	 * When enabled, Astro tracks the hashes of script and styles, and eventually it will render the `<meta>` tag
+	 */
+	shouldInjectCspMetaTags: boolean;
+	astroIslandHashes: string[];
 };
 
 export type SSRActions = {

--- a/packages/astro/src/core/astro-islands-hashes.ts
+++ b/packages/astro/src/core/astro-islands-hashes.ts
@@ -1,10 +1,11 @@
 // This file is code-generated, please don't change it manually
-export default [
+export const ASTRO_ISLAND_HASHES = [
 	"GI/D8grziRZwfj/Mqmn+dcgU/i8sylHSR/IfobqcUT4=",
 	"HDWxd14AUw8OvjrhhRRyyZFHCGnzxXGDrg59Qi8ayhc=",
 	"XN6a2Vn8uvpBr/WhdYPdK0jVeCzlcOD2XYaP10veV4Y=",
 	"ZR0ZAU8UNTzLmo/ApeWH0y1mVLT+XtFkvZ5nw32W8jI=",
 	"cSNmhdbFlyTDRozeu9HPjo+B2S4QAeMp0RO41PqgAcA=",
 	"mH3H4wSoDVWMXJKrmeBKYJQMdAZQ3dArB2N66JomkzI=",
-	"mH3H4wSoDVWMXJKrmeBKYJQMdAZQ3dArB2N66JomkzI="
+	"mH3H4wSoDVWMXJKrmeBKYJQMdAZQ3dArB2N66JomkzI=",
+	"s81ZcLcyAa7P/Jh5M5hUxYthTGwW+iZY3e6aHrQ8H9E="
 ];

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -19,7 +19,6 @@ import { NOOP_MIDDLEWARE_FN } from './middleware/noop-middleware.js';
 import { sequence } from './middleware/sequence.js';
 import { RouteCache } from './render/route-cache.js';
 import { createDefaultRoutes } from './routing/default.js';
-import crypto from 'node:crypto';
 
 /**
  * The `Pipeline` represents the static parts of rendering that do not change between requests.

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -19,6 +19,7 @@ import { NOOP_MIDDLEWARE_FN } from './middleware/noop-middleware.js';
 import { sequence } from './middleware/sequence.js';
 import { RouteCache } from './render/route-cache.js';
 import { createDefaultRoutes } from './routing/default.js';
+import crypto from 'node:crypto';
 
 /**
  * The `Pipeline` represents the static parts of rendering that do not change between requests.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -49,7 +49,6 @@ import type {
 	StylesheetAsset,
 } from './types.js';
 import { getTimeStat, shouldAppendForwardSlash } from './util.js';
-import crypto from 'node:crypto';
 import { shouldTrackCspHashes, trackScriptHashes, trackStyleHashes } from '../csp/common.js';
 import { ASTRO_ISLAND_HASHES } from '../astro-islands-hashes.js';
 

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -23,9 +23,7 @@ import { type BuildInternals, cssOrder, mergeInlineCss } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import type { StaticBuildOptions } from '../types.js';
 import { makePageDataKey } from './util.js';
-import crypto from 'node:crypto';
 import { shouldTrackCspHashes, trackScriptHashes, trackStyleHashes } from '../../csp/common.js';
-import type { AstroSettings } from '../../../types/astro.js';
 import { ASTRO_ISLAND_HASHES } from '../../astro-islands-hashes.js';
 
 const manifestReplace = '@@ASTRO_MANIFEST_REPLACE@@';

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -23,6 +23,10 @@ import { type BuildInternals, cssOrder, mergeInlineCss } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import type { StaticBuildOptions } from '../types.js';
 import { makePageDataKey } from './util.js';
+import crypto from 'node:crypto';
+import { shouldTrackCspHashes, trackScriptHashes, trackStyleHashes } from '../../csp/common.js';
+import type { AstroSettings } from '../../../types/astro.js';
+import { ASTRO_ISLAND_HASHES } from '../../astro-islands-hashes.js';
 
 const manifestReplace = '@@ASTRO_MANIFEST_REPLACE@@';
 const replaceExp = new RegExp(`['"]${manifestReplace}['"]`, 'g');
@@ -275,6 +279,14 @@ function buildManifest(
 		};
 	}
 
+	let clientScriptHashes: string[] = [];
+	let clientStyleHashes: string[] = [];
+
+	if (shouldTrackCspHashes(settings.config)) {
+		clientScriptHashes = trackScriptHashes(internals, opts.settings);
+		clientStyleHashes = trackStyleHashes(internals);
+	}
+
 	return {
 		hrefRoot: opts.settings.config.root.toString(),
 		cacheDir: opts.settings.config.cacheDir.toString(),
@@ -304,5 +316,9 @@ function buildManifest(
 		serverIslandNameMap: Array.from(settings.serverIslandNameMap),
 		key: encodedKey,
 		sessionConfig: settings.config.session,
+		shouldInjectCspMetaTags: shouldTrackCspHashes(opts.settings.config),
+		clientStyleHashes,
+		clientScriptHashes,
+		astroIslandHashes: ASTRO_ISLAND_HASHES,
 	};
 }

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -103,6 +103,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 		session: false,
 		headingIdCompat: false,
 		preserveScriptOrder: false,
+		csp: false,
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -626,6 +627,7 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.preserveScriptOrder),
+			csp: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.csp),
 		})
 		.strict(
 			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/experimental-flags/ for a list of all current experiments.`,

--- a/packages/astro/src/core/csp/common.ts
+++ b/packages/astro/src/core/csp/common.ts
@@ -1,0 +1,40 @@
+import type { AstroConfig } from '../../types/public/index.js';
+import type { BuildInternals } from '../build/internal.js';
+import crypto from 'node:crypto';
+import type { AstroSettings } from '../../types/astro.js';
+
+export function shouldTrackCspHashes(config: AstroConfig): boolean {
+	return config.experimental?.csp === true;
+}
+
+export function trackStyleHashes(internals: BuildInternals): string[] {
+	const clientStyleHashes: string[] = [];
+	for (const [_, page] of internals.pagesByViteID.entries()) {
+		for (const style of page.styles) {
+			if (style.sheet.type === 'inline') {
+				clientStyleHashes.push(
+					crypto.createHash('sha256').update(style.sheet.content).digest('base64'),
+				);
+			}
+		}
+	}
+
+	return clientStyleHashes;
+}
+
+export function trackScriptHashes(internals: BuildInternals, settings: AstroSettings): string[] {
+	const clientScriptHashes: string[] = [];
+
+	for (const script of internals.inlinedScripts.values()) {
+		clientScriptHashes.push(crypto.createHash('sha256').update(script).digest('base64'));
+	}
+
+	for (const script of settings.scripts) {
+		const { content, stage } = script;
+		if (stage === 'head-inline' || stage === 'before-hydration') {
+			clientScriptHashes.push(crypto.createHash('sha256').update(content).digest('base64'));
+		}
+	}
+
+	return clientScriptHashes;
+}

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -443,6 +443,9 @@ export class RenderContext {
 				extraHead: [],
 				propagators: new Set(),
 			},
+			shouldInjectCspMetaTags: manifest.shouldInjectCspMetaTags,
+			clientScriptHashes: manifest.clientScriptHashes,
+			clientStyleHashes: manifest.clientStyleHashes,
 		};
 
 		return result;

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -34,7 +34,6 @@ import type {
 } from '../types/public/integrations.js';
 import type { RouteData } from '../types/public/internal.js';
 import { validateSupportedFeatures } from './features-validation.js';
-import type { Pipeline } from '../core/base-pipeline.js';
 
 async function withTakingALongTimeMsg<T>({
 	name,

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -34,6 +34,7 @@ import type {
 } from '../types/public/integrations.js';
 import type { RouteData } from '../types/public/internal.js';
 import { validateSupportedFeatures } from './features-validation.js';
+import type { Pipeline } from '../core/base-pipeline.js';
 
 async function withTakingALongTimeMsg<T>({
 	name,
@@ -129,19 +130,21 @@ export function normalizeInjectedTypeFilename(filename: string, integrationName:
 	return `${normalizeCodegenDir(integrationName)}${filename.replace(SAFE_CHARS_RE, '_')}`;
 }
 
+interface RunHookConfigSetup {
+	settings: AstroSettings;
+	command: 'dev' | 'build' | 'preview' | 'sync';
+	logger: Logger;
+	isRestart?: boolean;
+	fs?: typeof fsMod;
+}
+
 export async function runHookConfigSetup({
 	settings,
 	command,
 	logger,
 	isRestart = false,
 	fs = fsMod,
-}: {
-	settings: AstroSettings;
-	command: 'dev' | 'build' | 'preview' | 'sync';
-	logger: Logger;
-	isRestart?: boolean;
-	fs?: typeof fsMod;
-}): Promise<AstroSettings> {
+}: RunHookConfigSetup): Promise<AstroSettings> {
 	// An adapter is an integration, so if one is provided add it to the list of integrations.
 	if (settings.config.adapter) {
 		settings.config.integrations.unshift(settings.config.adapter);

--- a/packages/astro/src/runtime/server/astro-island-styles.ts
+++ b/packages/astro/src/runtime/server/astro-island-styles.ts
@@ -1,2 +1,2 @@
-// NOTE: if you change the value inside the style tag, you must update `prebuild.js` too
-export const ISLAND_STYLES = `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>`;
+export const ISLAND_STYLES =
+	'<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>';

--- a/packages/astro/src/runtime/server/astro-island-styles.ts
+++ b/packages/astro/src/runtime/server/astro-island-styles.ts
@@ -1,0 +1,2 @@
+// NOTE: if you change the value inside the style tag, you must update `prebuild.js` too
+export const ISLAND_STYLES = `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>`;

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -1,5 +1,4 @@
 import type { RenderInstruction } from './instruction.js';
-
 import type { SSRResult } from '../../../types/public/internal.js';
 import type { HTMLBytes, HTMLString } from '../escape.js';
 import { markHTMLString } from '../escape.js';
@@ -99,6 +98,7 @@ function stringifyChunk(
 				}
 				return '';
 			}
+
 			default: {
 				throw new Error(`Unknown chunk type: ${(chunk as any).type}`);
 			}

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -51,6 +51,27 @@ export function renderAllHeadContent(result: SSRResult) {
 		}
 	}
 
+	const hashes = [];
+
+	if (result.shouldInjectCspMetaTags) {
+		for (const scriptHash of [...result.clientScriptHashes, ...result.clientStyleHashes]) {
+			hashes.push(
+				renderElement(
+					'meta',
+					{
+						props: {
+							'http-equiv': 'content-security-policy',
+							content: scriptHash,
+						},
+						children: '',
+					},
+					false,
+				),
+			);
+		}
+	}
+	content += hashes.join('\n');
+
 	return markHTMLString(content);
 }
 

--- a/packages/astro/src/runtime/server/scripts.ts
+++ b/packages/astro/src/runtime/server/scripts.ts
@@ -1,8 +1,7 @@
 import type { SSRResult } from '../../types/public/internal.js';
 import islandScriptDev from './astro-island.prebuilt-dev.js';
 import islandScript from './astro-island.prebuilt.js';
-
-const ISLAND_STYLES = `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>`;
+import { ISLAND_STYLES } from './astro-island-styles.js';
 
 export function determineIfNeedsHydrationScript(result: SSRResult): boolean {
 	if (result._metadata.hasHydrationScript) {

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2170,6 +2170,13 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 */
 		headingIdCompat?: boolean;
 
+
+		/**
+		 * 
+		 */
+		// TODO: add docs once we are reaching the end
+		csp?: boolean,
+
 		/**
 		 * @name experimental.preserveScriptOrder
 		 * @type {boolean}

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -246,6 +246,12 @@ export interface SSRResult {
 	trailingSlash: AstroConfig['trailingSlash'];
 	key: Promise<CryptoKey>;
 	_metadata: SSRMetadata;
+	/**
+	 * Whether Astro should inject the CSP <meta> tag into the head of the component.
+	 */
+	shouldInjectCspMetaTags: boolean;
+	clientScriptHashes: string[];
+	clientStyleHashes: string[];
 }
 
 /**

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -25,6 +25,8 @@ import { DevPipeline } from './pipeline.js';
 import { handleRequest } from './request.js';
 import { setRouteError } from './server-state.js';
 import { trailingSlashMiddleware } from './trailing-slash.js';
+import { ASTRO_ISLAND_HASHES } from '../core/astro-islands-hashes.js';
+import { shouldTrackCspHashes } from '../core/csp/common.js';
 
 export interface AstroPluginOptions {
 	settings: AstroSettings;
@@ -100,8 +102,7 @@ export default function createVitePluginAstroServer({
 						});
 				const store = localStorage.getStore();
 				if (store instanceof IncomingMessage) {
-					const request = store;
-					setRouteError(controller.state, request.url!, error);
+					setRouteError(controller.state, store.url!, error);
 				}
 				const { errorWithMetadata } = recordServerError(loader, settings.config, pipeline, error);
 				setTimeout(
@@ -207,5 +208,9 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			};
 		},
 		sessionConfig: settings.config.experimental.session ? settings.config.session : undefined,
+		clientScriptHashes: [],
+		clientStyleHashes: [],
+		shouldInjectCspMetaTags: shouldTrackCspHashes(settings.config),
+		astroIslandHashes: ASTRO_ISLAND_HASHES,
 	};
 }

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -1,0 +1,42 @@
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+import assert from 'node:assert/strict';
+import * as cheerio from 'cheerio';
+
+describe('CSP', () => {
+	let app;
+	/**
+	 * @type {import('../dist/core/build/types.js').SSGManifest}
+	 */
+	let manifest;
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/csp/',
+			adapter: testAdapter({
+				setManifest(_manifest) {
+					manifest = _manifest;
+				},
+			}),
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it('should contain the meta style hashes when CSS is imported from Astro component', async () => {
+		if (manifest) {
+			const request = new Request('http://example.com/index.html');
+			const response = await app.render(request);
+			const $ = cheerio.load(await response.text());
+
+			for (const hash of manifest.clientStyleHashes) {
+				let meta = $('meta[http-equiv="Content-Security-Policy"][content="' + hash + '"]');
+				assert.equal(meta.length, 1, `Should have a CSP meta tag for ${hash}`);
+			}
+		} else {
+			assert.fail('Should have the manifest');
+		}
+	});
+});

--- a/packages/astro/test/fixtures/csp/astro.config.mjs
+++ b/packages/astro/test/fixtures/csp/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	experimental: {
+		csp: true,
+	}
+});
+

--- a/packages/astro/test/fixtures/csp/package.json
+++ b/packages/astro/test/fixtures/csp/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/csp",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/csp/src/pages/index.astro
+++ b/packages/astro/test/fixtures/csp/src/pages/index.astro
@@ -1,0 +1,16 @@
+---
+import "./index.css"
+---
+
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<meta name="viewport" content="width=device-width"/>
+	<title>Index</title>
+</head>
+<body>
+<main>
+	<h1>Index</h1>
+</main>
+</body>
+</html>

--- a/packages/astro/test/fixtures/csp/src/pages/index.css
+++ b/packages/astro/test/fixtures/csp/src/pages/index.css
@@ -1,0 +1,5 @@
+.content {
+	display: flex;
+	background: red;
+	border: 1px solid blue;
+}

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -26,6 +26,7 @@ export default function ({
 	setEntryPoints,
 	setMiddlewareEntryPoint,
 	setRoutes,
+	setManifest,
 	env,
 } = {}) {
 	return {
@@ -107,7 +108,7 @@ export default function ({
 					exports: ['manifest', 'createApp'],
 					supportedAstroFeatures: {
 						serverOutput: 'stable',
-						envGetSecret: 'experimental',
+						envGetSecret: 'stable',
 						staticOutput: 'stable',
 						hybridOutput: 'stable',
 						assets: 'stable',
@@ -119,12 +120,15 @@ export default function ({
 					...extendAdapter,
 				});
 			},
-			'astro:build:ssr': ({ entryPoints, middlewareEntryPoint }) => {
+			'astro:build:ssr': ({ entryPoints, middlewareEntryPoint, manifest }) => {
 				if (setEntryPoints) {
 					setEntryPoints(entryPoints);
 				}
 				if (setMiddlewareEntryPoint) {
 					setMiddlewareEntryPoint(middlewareEntryPoint);
+				}
+				if (setManifest) {
+					setManifest(manifest);
 				}
 			},
 			'astro:build:done': ({ routes }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2781,6 +2781,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/csp:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/csrf-check-origin:
     dependencies:
       astro:

--- a/scripts/cmd/prebuild.js
+++ b/scripts/cmd/prebuild.js
@@ -10,7 +10,8 @@ function escapeTemplateLiterals(str) {
 	return str.replace(/\`/g, '\\`').replace(/\$\{/g, '\\${');
 }
 
-const ASTRO_ISLAND_STYLE = `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>`;
+const ASTRO_ISLAND_STYLE_REGEX = /'([^']*)'/;
+
 export default async function prebuild(...args) {
 	let buildToString = args.indexOf('--to-string');
 	if (buildToString !== -1) {
@@ -121,7 +122,12 @@ export default \`${generatedCode}\`;`;
 		await prebuildFile(entrypoint);
 	}
 
-	hashes.push(crypto.createHash('sha256').update(ASTRO_ISLAND_STYLE).digest('base64'));
+	const fileContent = await fs.promises.readFile(
+		new URL('../../packages/astro/src/runtime/server/astro-island-styles.ts', import.meta.url),
+		'utf-8',
+	);
+	const styleContent = fileContent.match(ASTRO_ISLAND_STYLE_REGEX)[1];
+	hashes.push(crypto.createHash('sha256').update(styleContent).digest('base64'));
 	hashes.sort();
 	const entries = hashes.map((hash) => `"${hash}"`);
 	const content = `// This file is code-generated, please don't change it manually


### PR DESCRIPTION
## Changes

This PR updates Astro to use the information we already have of scripts and styles to create hashes and render them in the emitted HTML page.

This PR focus only SSG for now, I will follow up with another PR to implement the same logic for SSR.

- `SSRManifest` has been extended to track new information, such as hashes coming from scripts and styles. I prefer to keep them separated because we handle them differently throughout the code base.
-  `SSRResult` has been extended to pass the hashes during the rendering phase. As for now, these hashes are always injected. **I will change that later**, and inject them only for static outputs. I need to find a way to test the static output with predictable hashes.
- `ASTRO_STYLES` has been moved into a separate file, so I could add a better warning about its value. The script `prebuild.js` has been updated to track the hash of the styles of astro islands
- The hashes of the astro island scripts are now compiled into a TS file, and it's imported when creating the manifest (they aren't used yet)

At the moment, the hashes of scripts and styles aren't grouped by page, but I believe we can achieve that. 

## Testing

I created a test for SSG, where we verify that the hashes we have in the manifest are the same of the one rendered in the final HTML file.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
