### PR TITLE
feat(fonts): warn if local font is in public dir

### DIFF
--- a/.changeset/social-bats-kiss.md
+++ b/.changeset/social-bats-kiss.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds warnings when using local font files in the `publicDir` when using the experimental fonts API
+Adds warnings about using local font files in the `publicDir` when the experimental fonts API is enabled.

--- a/.changeset/social-bats-kiss.md
+++ b/.changeset/social-bats-kiss.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds warnings when using local font files in the `publicDir` when using the experimental fonts API

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -142,7 +142,10 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 		}
 
 		for (const path of [...pathsToWarn]) {
-			logger.warn('assets', `The font file ${JSON.stringify(path)} used by a local family is located in \`config.public\`. This will result in duplicated files in the output.`)
+			logger.warn(
+				'assets',
+				`The font file ${JSON.stringify(path)} used by a local family is located in \`config.publicDir\`. This will result in duplicated files in the output.`,
+			);
 		}
 
 		await loadFonts({

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -142,6 +142,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 		}
 
 		for (const path of [...pathsToWarn]) {
+			// TODO: remove when stabilizing
 			logger.warn(
 				'assets',
 				`Found a local font file ${JSON.stringify(path)} in the \`public/\` folder. To avoid duplicated files in the build output, move this file into \`src/\``,

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -144,7 +144,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 		for (const path of [...pathsToWarn]) {
 			logger.warn(
 				'assets',
-				`The font file ${JSON.stringify(path)} used by a local family is located in \`config.publicDir\`. This will result in duplicated files in the output.`,
+				`Found a local font file ${JSON.stringify(path)} in the \`public/\` folder. To avoid duplicated files in the build output, move this file into \`src/\``,
 			);
 		}
 

--- a/packages/astro/test/units/assets/fonts/utils.test.js
+++ b/packages/astro/test/units/assets/fonts/utils.test.js
@@ -11,6 +11,7 @@ import {
 	isGenericFontFamily,
 	proxyURL,
 	renderFontSrc,
+	resolveEntrypoint,
 	resolveFontFamily,
 	toCSS,
 } from '../../../../dist/assets/fonts/utils.js';
@@ -280,6 +281,7 @@ describe('fonts utils', () => {
 					resolveMod: async () => ({ provider: () => {} }),
 					generateNameWithHash: (family) => `${family.name}-x`,
 					root,
+					resolveLocalEntrypoint: (url) => fileURLToPath(resolveEntrypoint(root, url)),
 				}),
 				{
 					name: 'Custom',
@@ -313,6 +315,7 @@ describe('fonts utils', () => {
 					resolveMod: async () => ({ provider: () => {} }),
 					generateNameWithHash: (family) => `${family.name}-x`,
 					root,
+					resolveLocalEntrypoint: (url) => fileURLToPath(resolveEntrypoint(root, url)),
 				}),
 				{
 					name: 'Custom',
@@ -341,6 +344,7 @@ describe('fonts utils', () => {
 				resolveMod: (id) => import(id),
 				generateNameWithHash: (family) => `${family.name}-x`,
 				root,
+				resolveLocalEntrypoint: (url) => fileURLToPath(resolveEntrypoint(root, url)),
 			});
 			assert.equal(res.name, 'Custom');
 			// Required to make TS happy
@@ -358,6 +362,7 @@ describe('fonts utils', () => {
 				resolveMod: (id) => import(id),
 				generateNameWithHash: (family) => `${family.name}-x`,
 				root,
+				resolveLocalEntrypoint: (url) => fileURLToPath(resolveEntrypoint(root, url)),
 			});
 			assert.equal(res.name, 'Custom');
 			// Required to make TS happy
@@ -379,6 +384,7 @@ describe('fonts utils', () => {
 				resolveMod: async () => ({ provider: () => Object.assign(() => {}, { _name: 'test' }) }),
 				generateNameWithHash: (family) => `${family.name}-x`,
 				root,
+				resolveLocalEntrypoint: (url) => fileURLToPath(resolveEntrypoint(root, url)),
 			});
 			assert.equal(res.name, 'Custom');
 			if (res.provider !== 'local') {


### PR DESCRIPTION
## Changes

- RFC feedback
- People migrating to the fonts API with local fonts tend to leave their fonts in `public`, but this is not recommended as we copy fonts so files are effectively duplicated in the build output

## Testing

Manual

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/11511 + changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
