### PR TITLE
fix: improve external redirects message

### DIFF
--- a/.changeset/flat-chicken-shout.md
+++ b/.changeset/flat-chicken-shout.md
@@ -1,0 +1,5 @@
+
+'astro': patch
+---
+
+Improves the `UnsupportedExternalRedirect` error message to include more details such as the concerned destination

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -976,7 +976,7 @@ export const RedirectWithNoLocation = {
 export const UnsupportedExternalRedirect = {
 	name: 'UnsupportedExternalRedirect',
 	title: 'Unsupported or malformed URL.',
-	message: (from: string, to: string) => `The external redirect from "${from}" to "${to}" is invalid.`,
+	message: (from: string, to: string) => `The destination URL in the external redirect from "${from}" to "${to}" is unsupported.`,
 	hint: 'An external redirect must start with http or https, and must be a valid URL.',
 } satisfies ErrorData;
 

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -976,7 +976,8 @@ export const RedirectWithNoLocation = {
 export const UnsupportedExternalRedirect = {
 	name: 'UnsupportedExternalRedirect',
 	title: 'Unsupported or malformed URL.',
-	message: 'An external redirect must start with http or https, and must be a valid URL.',
+	message: (from: string, to: string) => `The external redirect from "${from}" to "${to}" is invalid.`,
+	hint: 'An external redirect must start with http or https, and must be a valid URL.',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -359,7 +359,10 @@ function createRedirectRoutes(
 
 		// check if the link starts with http or https; if not, throw an error
 		if (URL.canParse(destination) && !/^https?:\/\//.test(destination)) {
-			throw new AstroError(UnsupportedExternalRedirect);
+			throw new AstroError({
+				...UnsupportedExternalRedirect,
+				message: UnsupportedExternalRedirect.message(from, destination),
+			});
 		}
 
 		routes.push({


### PR DESCRIPTION
## Changes

- It has been reported several times that people with complex redirects couldn't find the failing ones
- This PR makes it so that the corresponding error includes the origin and the destination

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
