### PR TITLE
Fonts: fix typing for disabled fallbacks (empty array)

### DIFF
--- a/.changeset/chatty-taxes-retire.md
+++ b/.changeset/chatty-taxes-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where empty fallbacks could not be provided when using the experimental fonts API

--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -60,7 +60,7 @@ const fallbacksSchema = z.object({
 
 	 * If the last font in the `fallbacks` array is a [generic family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name), an [optimized fallback](https://developer.chrome.com/blog/font-fallbacks) using font metrics will be generated. To disable this optimization, set `optimizedFallbacks` to false.
 	 */
-	fallbacks: z.array(z.string()).nonempty().optional(),
+	fallbacks: z.array(z.string()).optional(),
 	/**
 	 * @default `true`
 	 *

--- a/packages/astro/test/types/define-config.ts
+++ b/packages/astro/test/types/define-config.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { expectTypeOf } from 'expect-type';
 import type { AstroFontProvider, FontFamily } from '../../dist/assets/fonts/types.js';
-import { defineAstroFontProvider } from '../../dist/config/entrypoint.js';
+import { defineAstroFontProvider, fontProviders } from '../../dist/config/entrypoint.js';
 import { defineConfig } from '../../dist/config/index.js';
 import type { AstroUserConfig } from '../../dist/types/public/index.js';
 
@@ -134,6 +134,42 @@ describe('defineConfig()', () => {
 							readonly provider: AstroFontProvider;
 						},
 					]
+				>();
+			},
+		);
+	});
+
+	it('Allows disabling font fallbacks', () => {
+		assertType(
+			defineConfig({
+				experimental: {
+					fonts: [
+						{
+							provider: fontProviders.google(),
+							name: 'Roboto',
+							fallbacks: [],
+							cssVariable: '--font-roboto',
+						},
+					],
+				},
+			}),
+			(config) => {
+				expectTypeOf(config).toEqualTypeOf<
+					AstroUserConfig<
+						never,
+						never,
+						[
+							{
+								readonly provider: {
+									entrypoint: string | URL;
+									config?: Record<string, any> | undefined;
+								};
+								readonly name: 'Roboto';
+								readonly fallbacks: [];
+								readonly cssVariable: '--font-roboto';
+							},
+						]
+					>
 				>();
 			},
 		);

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { stripVTControlCharacters } from 'node:util';
 import { z } from 'zod';
 import { validateConfig as _validateConfig } from '../../../dist/core/config/validate.js';
+import { fontProviders } from '../../../dist/assets/fonts/providers/index.js';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
 import { envField } from '../../../dist/env/config.js';
 
@@ -456,6 +457,23 @@ describe('Config Validation', () => {
 				validateConfig({
 					experimental: {
 						fonts: [{ name: 'Roboto', cssVariable: '--test', provider: { entrypoint: '' } }],
+					},
+				}),
+			);
+		});
+
+		it('Should allow empty font fallbacks', () => {
+			assert.doesNotThrow(() =>
+				validateConfig({
+					experimental: {
+						fonts: [
+							{
+								provider: fontProviders.google(),
+								name: 'Roboto',
+								fallbacks: [],
+								cssVariable: '--font-roboto',
+							},
+						],
 					},
 				}),
 			);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,10 @@ importers:
       zod-to-ts:
         specifier: ^1.2.0
         version: 1.2.0(typescript@5.8.3)(zod@3.24.2)
+    optionalDependencies:
+      sharp:
+        specifier: ^0.33.3
+        version: 0.33.5
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
@@ -746,10 +750,6 @@ importers:
       vitest:
         specifier: ^3.0.9
         version: 3.1.1(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.5.1)
-    optionalDependencies:
-      sharp:
-        specifier: ^0.33.3
-        version: 0.33.5
 
   packages/astro-prism:
     dependencies:


### PR DESCRIPTION
## Changes

Regarding experimental fonts, the documentation says:

> To disable fallback fonts completely, configure an empty array:
>
> fallbacks: []

But I get a Typescript error if I do that. This is a simple typing issue, not a behavioral one, so in this PR I am:

- fixing the type so an empty array is allowed, to match the doc

Closes #13659

## Testing

Added a type test that fails before this change and succeeds after:

BEFORE:
> $ pnpm test:types
> test/types/define-config.ts:150:8 - error TS2322: Type '[]' is not assignable to type '[string, ...string[]]'.
>   Source has 0 element(s) but target requires 1.
>
> 150        fallbacks: [],
>            ~~~~~~~~~

AFTER:
> $ pnpm test:types
succeeds

## Docs

Bringing types in line with docs, no doc updates needed

<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
