### PR TITLE
[docs] better text/links in config ref adapter entry

### DIFF
--- a/.changeset/purple-horses-talk.md
+++ b/.changeset/purple-horses-talk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves the configuration reference docs for the `adapter` entry with more relevant text and links.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -363,9 +363,9 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 	 * @see output
 	 * @description
 	 *
-	 * Deploy to your favorite server, serverless, or edge host with build adapters. Import one of our first-party adapters for [Netlify](https://docs.astro.build/en/guides/deploy/netlify/#adapter-for-ssr), [Vercel](https://docs.astro.build/en/guides/deploy/vercel/#adapter-for-ssr), and more to engage Astro SSR.
+	 * Deploy to your favorite server, serverless, or edge host with build adapters. Import one of our first-party adapters ([Cloudflare](/en/guides/integrations-guide/cloudflare/), [Netlify](/en/guides/integrations-guide/netlify/), [Node.js](/en/guides/integrations-guide/node/), [Vercel](/en/guides/integrations-guide/vercel/)) or explore [community adapters](https://astro.build/integrations/2/?search=&categories%5B%5D=adapters) to enable on-demand rendering in your Astro project.
 	 *
-	 * [See our On-demand Rendering guide](https://docs.astro.build/en/guides/on-demand-rendering/) for more on SSR, and [our deployment guides](https://docs.astro.build/en/guides/deploy/) for a complete list of hosts.
+	 * See our [on-demand rendering guide](/en/guides/on-demand-rendering/) for more on Astro's server rendering options.
 	 *
 	 * ```js
 	 * import netlify from '@astrojs/netlify';


### PR DESCRIPTION
## Changes

This update some vocabulary and links in the configuration reference `adapter` entry.

The vocabulary changes are consistent with us moving away from the term "SSR" and being in "SSR mode". The links also point to the full adapter integration documents themselves, rather than a section in the deploy guides.

## Testing

No tests. Just docs improvements

## Docs

Only affects docs!
