### PR TITLE
feat(fonts): update unifont

### DIFF
--- a/.changeset/cyan-games-jog.md
+++ b/.changeset/cyan-games-jog.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates unifont to latest and adds support for `fetch` options from remote providers when using the experimental fonts API

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -160,7 +160,7 @@
     "tinyglobby": "^0.2.12",
     "tsconfck": "^3.1.5",
     "ultrahtml": "^1.6.0",
-    "unifont": "~0.2.0",
+    "unifont": "~0.4.0",
     "unist-util-visit": "^5.0.0",
     "unstorage": "^1.15.0",
     "vfile": "^6.0.3",

--- a/packages/astro/src/assets/fonts/definitions.ts
+++ b/packages/astro/src/assets/fonts/definitions.ts
@@ -47,6 +47,7 @@ export interface UrlProxy {
 		url: string;
 		collectPreload: boolean;
 		data: Partial<unifont.FontFaceData>;
+		init: RequestInit | null;
 	}) => string;
 }
 
@@ -58,6 +59,7 @@ export interface DataCollector {
 	collect: (input: {
 		originalUrl: string;
 		hash: string;
+		init: RequestInit | null;
 		data: Partial<unifont.FontFaceData>;
 		preload: PreloadData | null;
 	}) => void;
@@ -86,8 +88,14 @@ export interface SystemFallbacksProvider {
 	getMetricsForLocalFont: (family: string) => FontFaceMetrics;
 }
 
+export interface FontFetcherInput {
+	hash: string;
+	url: string;
+	init: RequestInit | null;
+}
+
 export interface FontFetcher {
-	fetch: (hash: string, url: string) => Promise<Buffer>;
+	fetch: (input: FontFetcherInput) => Promise<Buffer>;
 }
 
 export interface FontTypeExtractor {

--- a/packages/astro/src/assets/fonts/definitions.ts
+++ b/packages/astro/src/assets/fonts/definitions.ts
@@ -1,7 +1,13 @@
 import type * as unifont from 'unifont';
 import type { CollectedFontForMetrics } from './logic/optimize-fallbacks.js';
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import type { AstroFontProvider, FontType, PreloadData, ResolvedFontProvider } from './types.js';
+import type {
+	AstroFontProvider,
+	FontFileData,
+	FontType,
+	PreloadData,
+	ResolvedFontProvider,
+} from './types.js';
 import type { FontFaceMetrics, GenericFallbackName } from './types.js';
 
 export interface Hasher {
@@ -43,12 +49,12 @@ export interface ErrorHandler {
 }
 
 export interface UrlProxy {
-	proxy: (input: {
-		url: string;
-		collectPreload: boolean;
-		data: Partial<unifont.FontFaceData>;
-		init: RequestInit | null;
-	}) => string;
+	proxy: (
+		input: Pick<FontFileData, 'url' | 'init'> & {
+			collectPreload: boolean;
+			data: Partial<unifont.FontFaceData>;
+		},
+	) => string;
 }
 
 export interface UrlProxyContentResolver {
@@ -56,13 +62,12 @@ export interface UrlProxyContentResolver {
 }
 
 export interface DataCollector {
-	collect: (input: {
-		originalUrl: string;
-		hash: string;
-		init: RequestInit | null;
-		data: Partial<unifont.FontFaceData>;
-		preload: PreloadData | null;
-	}) => void;
+	collect: (
+		input: FontFileData & {
+			data: Partial<unifont.FontFaceData>;
+			preload: PreloadData | null;
+		},
+	) => void;
 }
 
 export type CssProperties = Record<string, string | undefined>;
@@ -88,14 +93,8 @@ export interface SystemFallbacksProvider {
 	getMetricsForLocalFont: (family: string) => FontFaceMetrics;
 }
 
-export interface FontFetcherInput {
-	hash: string;
-	url: string;
-	init: RequestInit | null;
-}
-
 export interface FontFetcher {
-	fetch: (input: FontFetcherInput) => Promise<Buffer>;
+	fetch: (input: FontFileData) => Promise<Buffer>;
 }
 
 export interface FontTypeExtractor {

--- a/packages/astro/src/assets/fonts/implementations/data-collector.ts
+++ b/packages/astro/src/assets/fonts/implementations/data-collector.ts
@@ -8,9 +8,9 @@ export function createDataCollector({
 	saveFontData,
 }: Omit<CreateUrlProxyParams, 'local'>): DataCollector {
 	return {
-		collect({ originalUrl, hash, preload, data }) {
+		collect({ originalUrl, hash, preload, data, init }) {
 			if (!hasUrl(hash)) {
-				saveUrl(hash, originalUrl);
+				saveUrl({ hash, url: originalUrl, init });
 				if (preload) {
 					savePreload(preload);
 				}
@@ -19,6 +19,7 @@ export function createDataCollector({
 				hash,
 				url: originalUrl,
 				data,
+				init,
 			});
 		},
 	};

--- a/packages/astro/src/assets/fonts/implementations/data-collector.ts
+++ b/packages/astro/src/assets/fonts/implementations/data-collector.ts
@@ -8,19 +8,14 @@ export function createDataCollector({
 	saveFontData,
 }: Omit<CreateUrlProxyParams, 'local'>): DataCollector {
 	return {
-		collect({ originalUrl, hash, preload, data, init }) {
+		collect({ hash, url, init, preload, data }) {
 			if (!hasUrl(hash)) {
-				saveUrl({ hash, url: originalUrl, init });
+				saveUrl({ hash, url, init });
 				if (preload) {
 					savePreload(preload);
 				}
 			}
-			saveFontData({
-				hash,
-				url: originalUrl,
-				data,
-				init,
-			});
+			saveFontData({ hash, url, data, init });
 		},
 	};
 }

--- a/packages/astro/src/assets/fonts/implementations/font-fetcher.ts
+++ b/packages/astro/src/assets/fonts/implementations/font-fetcher.ts
@@ -11,19 +11,17 @@ export function createCachedFontFetcher({
 }: {
 	storage: Storage;
 	errorHandler: ErrorHandler;
-	fetch: (url: string) => Promise<Response>;
+	fetch: (url: string, init?: RequestInit) => Promise<Response>;
 	readFile: (url: string) => Promise<Buffer>;
 }): FontFetcher {
 	return {
-		async fetch(hash, url) {
+		async fetch({ hash, url, init }) {
 			return await cache(storage, hash, async () => {
 				try {
 					if (isAbsolute(url)) {
 						return await readFile(url);
 					}
-					// TODO: find a way to pass headers
-					// https://github.com/unjs/unifont/issues/143
-					const response = await fetch(url);
+					const response = await fetch(url, init ?? undefined);
 					if (!response.ok) {
 						throw new Error(`Response was not successful, received status code ${response.status}`);
 					}

--- a/packages/astro/src/assets/fonts/implementations/font-metrics-resolver.ts
+++ b/packages/astro/src/assets/fonts/implementations/font-metrics-resolver.ts
@@ -36,8 +36,8 @@ export function createCapsizeFontMetricsResolver({
 	const cache: Record<string, FontFaceMetrics | null> = {};
 
 	return {
-		async getMetrics(name, { hash, url }) {
-			cache[name] ??= filterRequiredMetrics(await fromBuffer(await fontFetcher.fetch(hash, url)));
+		async getMetrics(name, input) {
+			cache[name] ??= filterRequiredMetrics(await fromBuffer(await fontFetcher.fetch(input)));
 			return cache[name];
 		},
 		// Source: https://github.com/unjs/fontaine/blob/f00f84032c5d5da72c8798eae4cd68d3ddfbf340/src/css.ts#L170

--- a/packages/astro/src/assets/fonts/implementations/url-proxy.ts
+++ b/packages/astro/src/assets/fonts/implementations/url-proxy.ts
@@ -20,7 +20,7 @@ export function createUrlProxy({
 	fontTypeExtractor: FontTypeExtractor;
 }): UrlProxy {
 	return {
-		proxy({ url: originalUrl, data, collectPreload }) {
+		proxy({ url: originalUrl, data, collectPreload, init }) {
 			const type = fontTypeExtractor.extract(originalUrl);
 			const hash = `${hasher.hashString(contentResolver.resolve(originalUrl))}.${type}`;
 			const url = base + hash;
@@ -30,6 +30,7 @@ export function createUrlProxy({
 				hash,
 				preload: collectPreload ? { url, type } : null,
 				data,
+				init,
 			});
 
 			return url;

--- a/packages/astro/src/assets/fonts/implementations/url-proxy.ts
+++ b/packages/astro/src/assets/fonts/implementations/url-proxy.ts
@@ -26,7 +26,7 @@ export function createUrlProxy({
 			const url = base + hash;
 
 			dataCollector.collect({
-				originalUrl,
+				url: originalUrl,
 				hash,
 				preload: collectPreload ? { url, type } : null,
 				data,

--- a/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
+++ b/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
@@ -35,6 +35,7 @@ export function normalizeRemoteFontFaces({
 									weight: font.weight,
 									style: font.style,
 								},
+								init: font.meta?.init ?? null,
 							}),
 						};
 						index++;

--- a/packages/astro/src/assets/fonts/logic/optimize-fallbacks.ts
+++ b/packages/astro/src/assets/fonts/logic/optimize-fallbacks.ts
@@ -1,11 +1,13 @@
-import type { FontMetricsResolver, SystemFallbacksProvider } from '../definitions.js';
+import type {
+	FontFetcherInput,
+	FontMetricsResolver,
+	SystemFallbacksProvider,
+} from '../definitions.js';
 import type { ResolvedFontFamily } from '../types.js';
 import { isGenericFontFamily, unifontFontFaceDataToProperties } from '../utils.js';
 import type * as unifont from 'unifont';
 
-export interface CollectedFontForMetrics {
-	hash: string;
-	url: string;
+export interface CollectedFontForMetrics extends FontFetcherInput {
 	data: Partial<unifont.FontFaceData>;
 }
 
@@ -64,14 +66,14 @@ export async function optimizeFallbacks({
 	let css = '';
 
 	for (const { font, name } of localFontsMappings) {
-		for (const { hash, url, data } of collectedFonts) {
+		for (const collected of collectedFonts) {
 			// We generate a fallback for each font collected, which is per weight and style
 			css += fontMetricsResolver.generateFontFace({
-				metrics: await fontMetricsResolver.getMetrics(family.name, { hash, url, data }),
+				metrics: await fontMetricsResolver.getMetrics(family.name, collected),
 				fallbackMetrics: systemFallbacksProvider.getMetricsForLocalFont(font),
 				font,
 				name,
-				properties: unifontFontFaceDataToProperties(data),
+				properties: unifontFontFaceDataToProperties(collected.data),
 			});
 		}
 	}

--- a/packages/astro/src/assets/fonts/logic/optimize-fallbacks.ts
+++ b/packages/astro/src/assets/fonts/logic/optimize-fallbacks.ts
@@ -1,13 +1,9 @@
-import type {
-	FontFetcherInput,
-	FontMetricsResolver,
-	SystemFallbacksProvider,
-} from '../definitions.js';
+import type { FontMetricsResolver, SystemFallbacksProvider } from '../definitions.js';
 import type * as unifont from 'unifont';
-import type { ResolvedFontFamily } from '../types.js';
+import type { FontFileData, ResolvedFontFamily } from '../types.js';
 import { isGenericFontFamily, unifontFontFaceDataToProperties } from '../utils.js';
 
-export interface CollectedFontForMetrics extends FontFetcherInput {
+export interface CollectedFontForMetrics extends FontFileData {
 	data: Partial<unifont.FontFaceData>;
 }
 

--- a/packages/astro/src/assets/fonts/orchestrate.ts
+++ b/packages/astro/src/assets/fonts/orchestrate.ts
@@ -84,7 +84,7 @@ export async function orchestrate({
 	 * Holds associations of hash and original font file URLs, so they can be
 	 * downloaded whenever the hash is requested.
 	 */
-	const hashToUrlMap = new Map<string, string>();
+	const hashToUrlMap = new Map<string, { url: string; init: RequestInit | null }>();
 	/**
 	 * Holds associations of CSS variables and preloadData/css to be passed to the virtual module.
 	 */
@@ -107,8 +107,8 @@ export async function orchestrate({
 		const urlProxy = createUrlProxy({
 			local: family.provider === LOCAL_PROVIDER_NAME,
 			hasUrl: (hash) => hashToUrlMap.has(hash),
-			saveUrl: (hash, url) => {
-				hashToUrlMap.set(hash, url);
+			saveUrl: ({ hash, url, init }) => {
+				hashToUrlMap.set(hash, { url, init });
 			},
 			savePreload: (preload) => {
 				preloadData.push(preload);

--- a/packages/astro/src/assets/fonts/orchestrate.ts
+++ b/packages/astro/src/assets/fonts/orchestrate.ts
@@ -68,7 +68,10 @@ export async function orchestrate({
 	fontTypeExtractor: FontTypeExtractor;
 	createUrlProxy: (params: CreateUrlProxyParams) => UrlProxy;
 	defaults: Defaults;
-}) {
+}): Promise<{
+	fontFileDataMap: FontFileDataMap;
+	consumableMap: ConsumableMap;
+}> {
 	let resolvedFamilies = await resolveFamilies({
 		families,
 		hasher,
@@ -87,7 +90,14 @@ export async function orchestrate({
 		storage,
 	});
 
+	/**
+	 * Holds associations of hash and original font file URLs, so they can be
+	 * downloaded whenever the hash is requested.
+	 */
 	const fontFileDataMap: FontFileDataMap = new Map();
+	/**
+	 * Holds associations of CSS variables and preloadData/css to be passed to the virtual module.
+	 */
 	const consumableMap: ConsumableMap = new Map();
 
 	for (const family of resolvedFamilies) {

--- a/packages/astro/src/assets/fonts/providers/local.ts
+++ b/packages/astro/src/assets/fonts/providers/local.ts
@@ -28,6 +28,7 @@ export function resolveLocalFont({ family, urlProxy, fontTypeExtractor }: Option
 						weight: variant.weight,
 						style: variant.style,
 					},
+					init: null
 				}),
 				format: FONT_FORMAT_MAP[fontTypeExtractor.extract(source.url)],
 				tech: source.tech,

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -8,7 +8,6 @@ import type {
 } from './config.js';
 import type { FONT_TYPES, GENERIC_FALLBACK_NAMES } from './constants.js';
 import type { CollectedFontForMetrics } from './logic/optimize-fallbacks.js';
-import type { FontFetcherInput } from './definitions.js';
 
 export type AstroFontProvider = z.infer<typeof fontProviderSchema>;
 
@@ -78,10 +77,27 @@ export type Defaults = Partial<
 	>
 >;
 
+export interface FontFileData {
+	hash: string;
+	url: string;
+	init: RequestInit | null;
+}
+
 export interface CreateUrlProxyParams {
 	local: boolean;
 	hasUrl: (hash: string) => boolean;
-	saveUrl: (input: FontFetcherInput) => void;
+	saveUrl: (input: FontFileData) => void;
 	savePreload: (preload: PreloadData) => void;
 	saveFontData: (collected: CollectedFontForMetrics) => void;
 }
+
+/**
+ * Holds associations of hash and original font file URLs, so they can be
+ * downloaded whenever the hash is requested.
+ */
+export type FontFileDataMap = Map<FontFileData['hash'], Pick<FontFileData, 'url' | 'init'>>;
+
+/**
+ * Holds associations of CSS variables and preloadData/css to be passed to the virtual module.
+ */
+export type ConsumableMap = Map<string, { preloadData: Array<PreloadData>; css: string }>;

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -8,6 +8,7 @@ import type {
 import type { FONT_TYPES, GENERIC_FALLBACK_NAMES } from './constants.js';
 import type { Font } from '@capsizecss/unpack';
 import type { CollectedFontForMetrics } from './logic/optimize-fallbacks.js';
+import type { FontFetcherInput } from './definitions.js';
 
 export type AstroFontProvider = z.infer<typeof fontProviderSchema>;
 
@@ -80,7 +81,7 @@ export type Defaults = Partial<
 export interface CreateUrlProxyParams {
 	local: boolean;
 	hasUrl: (hash: string) => boolean;
-	saveUrl: (hash: string, url: string) => void;
+	saveUrl: (input: FontFetcherInput) => void;
 	savePreload: (preload: PreloadData) => void;
 	saveFontData: (collected: CollectedFontForMetrics) => void;
 }

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -80,10 +80,10 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 	const baseUrl = removeTrailingForwardSlash(settings.config.base) + URL_PREFIX;
 
 	let resolvedMap: Map<string, { preloadData: Array<PreloadData>; css: string }> | null = null;
-	// Key is `${hash}.${ext}`, value is a URL.
+	// Key is `${hash}.${ext}`
 	// When a font file is requested (eg. /_astro/fonts/abc.woff), we use the hash
 	// to download the original file, or retrieve it from cache
-	let hashToUrlMap: Map<string, string> | null = null;
+	let hashToUrlMap: Map<string, { url: string; init: RequestInit | null }> | null = null;
 	let isBuild: boolean;
 	let fontFetcher: FontFetcher | null = null;
 	let fontTypeExtractor: FontTypeExtractor | null = null;
@@ -190,7 +190,9 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 			});
 			// The map is always defined at this point. Its values contains urls from remote providers
 			// as well as local paths for the local provider. We filter them to only keep the filepaths
-			const localPaths = [...hashToUrlMap!.values()].filter((url) => isAbsolute(url));
+			const localPaths = [...hashToUrlMap!.values()]
+				.filter(({ url }) => isAbsolute(url))
+				.map((v) => v.url);
 			server.watcher.on('change', (path) => {
 				if (localPaths.includes(path)) {
 					logger.info('assets', 'Font file updated');
@@ -214,8 +216,8 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 					return next();
 				}
 				const hash = req.url.slice(1);
-				const url = hashToUrlMap?.get(hash);
-				if (!url) {
+				const associatedData = hashToUrlMap?.get(hash);
+				if (!associatedData) {
 					return next();
 				}
 				// We don't want the request to be cached in dev because we cache it already internally,
@@ -228,7 +230,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 					// Storage should be defined at this point since initialize it called before registering
 					// the middleware. hashToUrlMap is defined at the same time so if it's not set by now,
 					// no url will be matched and this line will not be reached.
-					const data = await fontFetcher!.fetch(hash, url);
+					const data = await fontFetcher!.fetch({ hash, ...associatedData });
 
 					res.setHeader('Content-Length', data.length);
 					res.setHeader('Content-Type', `font/${fontTypeExtractor!.extract(hash)}`);
@@ -276,8 +278,8 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 				if (hashToUrlMap) {
 					logger.info('assets', 'Copying fonts...');
 					await Promise.all(
-						Array.from(hashToUrlMap.entries()).map(async ([hash, url]) => {
-							const data = await fontFetcher!.fetch(hash, url);
+						Array.from(hashToUrlMap.entries()).map(async ([hash, associatedData]) => {
+							const data = await fontFetcher!.fetch({ hash, ...associatedData });
 							try {
 								writeFileSync(new URL(hash, fontsDir), data);
 							} catch (cause) {

--- a/packages/astro/test/units/assets/fonts/logic.test.js
+++ b/packages/astro/test/units/assets/fonts/logic.test.js
@@ -389,21 +389,24 @@ describe('fonts logic', () => {
 					url: '/',
 					collectPreload: true,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/ignored',
 					collectPreload: false,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/2',
 					collectPreload: true,
 					data: { weight: '500', style: 'normal' },
+					init: null,
 				},
 			]);
 		});
 
-		it('collect preloads correctly', () => {
+		it('collects preloads correctly', () => {
 			const { collected, urlProxy } = createSpyUrlProxy();
 			normalizeRemoteFontFaces({
 				urlProxy,
@@ -425,21 +428,25 @@ describe('fonts logic', () => {
 					url: '/',
 					collectPreload: true,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/ignored',
 					collectPreload: false,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/2',
 					collectPreload: true,
 					data: { weight: '500', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/also-ignored',
 					collectPreload: false,
 					data: { weight: '500', style: 'normal' },
+					init: null,
 				},
 			]);
 		});
@@ -458,7 +465,7 @@ describe('fonts logic', () => {
 				await optimizeFallbacks({
 					family,
 					fallbacks: [],
-					collectedFonts: [{ url: '', hash: '', data: {} }],
+					collectedFonts: [{ url: '', hash: '', data: {}, init: null }],
 					enabled: true,
 					systemFallbacksProvider,
 					fontMetricsResolver,
@@ -472,7 +479,7 @@ describe('fonts logic', () => {
 				await optimizeFallbacks({
 					family,
 					fallbacks: ['foo'],
-					collectedFonts: [{ url: '', hash: '', data: {} }],
+					collectedFonts: [{ url: '', hash: '', data: {}, init: null }],
 					enabled: false,
 					systemFallbacksProvider,
 					fontMetricsResolver,
@@ -500,7 +507,7 @@ describe('fonts logic', () => {
 				await optimizeFallbacks({
 					family,
 					fallbacks: ['foo'],
-					collectedFonts: [{ url: '', hash: '', data: {} }],
+					collectedFonts: [{ url: '', hash: '', data: {}, init: null }],
 					enabled: true,
 					systemFallbacksProvider,
 					fontMetricsResolver,
@@ -514,7 +521,7 @@ describe('fonts logic', () => {
 				await optimizeFallbacks({
 					family,
 					fallbacks: ['cursive'],
-					collectedFonts: [{ url: '', hash: '', data: {} }],
+					collectedFonts: [{ url: '', hash: '', data: {}, init: null }],
 					enabled: true,
 					systemFallbacksProvider,
 					fontMetricsResolver,
@@ -531,7 +538,7 @@ describe('fonts logic', () => {
 						nameWithHash: 'Arial-xxx',
 					},
 					fallbacks: ['sans-serif'],
-					collectedFonts: [{ url: '', hash: '', data: {} }],
+					collectedFonts: [{ url: '', hash: '', data: {}, init: null }],
 					enabled: true,
 					systemFallbacksProvider,
 					fontMetricsResolver,
@@ -544,7 +551,7 @@ describe('fonts logic', () => {
 			const result = await optimizeFallbacks({
 				family,
 				fallbacks: ['foo', 'sans-serif'],
-				collectedFonts: [{ url: '', hash: '', data: {} }],
+				collectedFonts: [{ url: '', hash: '', data: {}, init: null }],
 				enabled: true,
 				systemFallbacksProvider,
 				fontMetricsResolver,
@@ -557,8 +564,8 @@ describe('fonts logic', () => {
 				family,
 				fallbacks: ['foo', 'sans-serif'],
 				collectedFonts: [
-					{ url: '', hash: '', data: { weight: '400' } },
-					{ url: '', hash: '', data: { weight: '500' } },
+					{ url: '', hash: '', data: { weight: '400' }, init: null },
+					{ url: '', hash: '', data: { weight: '500' }, init: null },
 				],
 				enabled: true,
 				systemFallbacksProvider,

--- a/packages/astro/test/units/assets/fonts/orchestrate.test.js
+++ b/packages/astro/test/units/assets/fonts/orchestrate.test.js
@@ -29,7 +29,7 @@ describe('fonts orchestrate()', () => {
 		const errorHandler = simpleErrorHandler;
 		const fontTypeExtractor = createFontTypeExtractor({ errorHandler });
 		const hasher = fakeHasher;
-		const { hashToUrlMap, resolvedMap } = await orchestrate({
+		const { fontFileDataMap, consumableMap } = await orchestrate({
 			families: [
 				{
 					name: 'Test',
@@ -70,20 +70,20 @@ describe('fonts orchestrate()', () => {
 			defaults: DEFAULTS,
 		});
 		assert.deepStrictEqual(
-			[...hashToUrlMap.entries()],
+			[...fontFileDataMap.entries()],
 			[
 				[
 					fileURLToPath(new URL('my-font.woff2.woff2', root)),
-					fileURLToPath(new URL('my-font.woff2', root)),
+					{ url: fileURLToPath(new URL('my-font.woff2', root)), init: null },
 				],
 				[
 					fileURLToPath(new URL('my-font.woff.woff', root)),
-					fileURLToPath(new URL('my-font.woff', root)),
+					{ url: fileURLToPath(new URL('my-font.woff', root)), init: null },
 				],
 			],
 		);
-		assert.deepStrictEqual([...resolvedMap.keys()], ['--test']);
-		const entry = resolvedMap.get('--test');
+		assert.deepStrictEqual([...consumableMap.keys()], ['--test']);
+		const entry = consumableMap.get('--test');
 		assert.deepStrictEqual(entry?.preloadData, [
 			{
 				url: '/test' + fileURLToPath(new URL('my-font.woff2.woff2', root)),
@@ -126,7 +126,7 @@ describe('fonts orchestrate()', () => {
 		const errorHandler = simpleErrorHandler;
 		const fontTypeExtractor = createFontTypeExtractor({ errorHandler });
 		const hasher = fakeHasher;
-		const { hashToUrlMap, resolvedMap } = await orchestrate({
+		const { fontFileDataMap, consumableMap } = await orchestrate({
 			families: [
 				{
 					name: 'Test',
@@ -166,14 +166,17 @@ describe('fonts orchestrate()', () => {
 		});
 
 		assert.deepStrictEqual(
-			[...hashToUrlMap.entries()],
+			[...fontFileDataMap.entries()],
 			[
-				['https://example.com/foo.woff2.woff2', 'https://example.com/foo.woff2'],
-				['https://example.com/foo.woff.woff', 'https://example.com/foo.woff'],
+				[
+					'https://example.com/foo.woff2.woff2',
+					{ url: 'https://example.com/foo.woff2', init: null },
+				],
+				['https://example.com/foo.woff.woff', { url: 'https://example.com/foo.woff', init: null }],
 			],
 		);
-		assert.deepStrictEqual([...resolvedMap.keys()], ['--test']);
-		const entry = resolvedMap.get('--test');
+		assert.deepStrictEqual([...consumableMap.keys()], ['--test']);
+		const entry = consumableMap.get('--test');
 		assert.deepStrictEqual(entry?.preloadData, [
 			{ url: 'https://example.com/foo.woff2.woff2', type: 'woff2' },
 		]);

--- a/packages/astro/test/units/assets/fonts/orchestrate.test.js
+++ b/packages/astro/test/units/assets/fonts/orchestrate.test.js
@@ -111,6 +111,11 @@ describe('fonts orchestrate()', () => {
 								],
 								weight: '400',
 								style: 'normal',
+								meta: {
+									init: {
+										method: 'POST',
+									},
+								},
 							},
 						],
 					};
@@ -170,9 +175,12 @@ describe('fonts orchestrate()', () => {
 			[
 				[
 					'https://example.com/foo.woff2.woff2',
-					{ url: 'https://example.com/foo.woff2', init: null },
+					{ url: 'https://example.com/foo.woff2', init: { method: 'POST' } },
 				],
-				['https://example.com/foo.woff.woff', { url: 'https://example.com/foo.woff', init: null }],
+				[
+					'https://example.com/foo.woff.woff',
+					{ url: 'https://example.com/foo.woff', init: { method: 'POST' } },
+				],
 			],
 		);
 		assert.deepStrictEqual([...consumableMap.keys()], ['--test']);

--- a/packages/astro/test/units/assets/fonts/providers.test.js
+++ b/packages/astro/test/units/assets/fonts/providers.test.js
@@ -89,16 +89,19 @@ describe('fonts providers', () => {
 					url: '/test.woff2',
 					collectPreload: true,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/ignored.woff',
 					collectPreload: false,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/2.woff2',
 					collectPreload: true,
 					data: { weight: '500', style: 'normal' },
+					init: null,
 				},
 			]);
 		});
@@ -132,21 +135,25 @@ describe('fonts providers', () => {
 					url: '/test.woff2',
 					collectPreload: true,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/ignored.woff',
 					collectPreload: false,
 					data: { weight: '400', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/2.woff2',
 					collectPreload: true,
 					data: { weight: '500', style: 'normal' },
+					init: null,
 				},
 				{
 					url: '/also-ignored.woff',
 					collectPreload: false,
 					data: { weight: '500', style: 'normal' },
+					init: null,
 				},
 			]);
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,8 +605,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       unifont:
-        specifier: ~0.2.0
-        version: 0.2.0
+        specifier: ~0.4.0
+        version: 0.4.0
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -9969,6 +9969,7 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:
@@ -11806,8 +11807,8 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unifont@0.2.0:
-    resolution: {integrity: sha512-RoF14/tOhLvDa7R5K6A3PjsfJVFKvadvRpWjfV1ttabUe9704P1ie9z1ABLWEts/8SxrBVePav/XhgeFNltpsw==}
+  unifont@0.4.0:
+    resolution: {integrity: sha512-wbc8b02b+K7WRHSxD+YQRYS31iVwOd0dRF7Nv73nolzyQ5n4qMtuJ4OdJSe1hEB7XT+lPb2Qk7FHxOrMReh9lw==}
 
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -18607,7 +18608,7 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unifont@0.2.0:
+  unifont@0.4.0:
     dependencies:
       css-tree: 3.1.0
       ohash: 2.0.11


### PR DESCRIPTION
## Changes

- Updates unifont to 0.4.0 (latest)
- Adds support for passing fetch init (see https://github.com/unjs/unifont/pull/155)
- Refactors types a bit to avoid duplication
- For `init`, I chose to use `null` instead of an optional property to make sure we pass it through everything

## Testing

- Updated tests so they still pass and TS is happy
- Updated the `orchestrate` test to make sure `init` is well forwarded to the end

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
