### PR TITLE
fix: set height: auto for responsive images

### DIFF
--- a/.changeset/fuzzy-laws-kick.md
+++ b/.changeset/fuzzy-laws-kick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes height for responsive images

--- a/packages/astro/components/image.css
+++ b/packages/astro/components/image.css
@@ -1,6 +1,7 @@
 :where([data-astro-image]) {
 	object-fit: var(--fit);
 	object-position: var(--pos);
+	height: auto;
 }
 :where([data-astro-image='full-width']) {
 	width: 100%;


### PR DESCRIPTION
## Changes

The "simplified" responsive image styles simpified things a bit far, and was causing the images to not correctly maontain aspect ratio in some cases. This PR adds `height: auto` back in, which fixes it

Fixes #13709

## Testing

Tested manually. This shows we need e2e tests for images.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
