### PR TITLE
fix: renderers types

### DIFF
--- a/.changeset/tangy-eagles-train.md
+++ b/.changeset/tangy-eagles-train.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/svelte': patch
+'@astrojs/react': patch
+'@astrojs/vue': patch
+---
+
+Fixes SSR renderer type

--- a/packages/integrations/react/src/server-v17.ts
+++ b/packages/integrations/react/src/server-v17.ts
@@ -1,4 +1,4 @@
-import type { AstroComponentMetadata } from 'astro';
+import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
 import StaticHtml from './static-html.js';
@@ -36,11 +36,11 @@ function check(Component: any, props: Record<string, any>, children: any) {
 	return isReactComponent;
 }
 
-function renderToStaticMarkup(
+async function renderToStaticMarkup(
 	Component: any,
 	props: Record<string, any>,
 	{ default: children, ...slotted }: Record<string, any>,
-	metadata: AstroComponentMetadata,
+	metadata?: AstroComponentMetadata,
 ) {
 	delete props['class'];
 	const slots: Record<string, any> = {};
@@ -57,12 +57,12 @@ function renderToStaticMarkup(
 	if (newChildren != null) {
 		newProps.children = React.createElement(StaticHtml, {
 			// Adjust how this is hydrated only when the version of Astro supports `astroStaticSlot`
-			hydrate: metadata.astroStaticSlot ? !!metadata.hydrate : true,
+			hydrate: metadata?.astroStaticSlot ? !!metadata.hydrate : true,
 			value: newChildren,
 		});
 	}
 	const vnode = React.createElement(Component, newProps);
-	let html;
+	let html: string;
 	if (metadata?.hydrate) {
 		html = ReactDOM.renderToString(vnode);
 	} else {
@@ -71,9 +71,11 @@ function renderToStaticMarkup(
 	return { html };
 }
 
-export default {
+const renderer: NamedSSRLoadedRendererValue = {
 	name: '@astrojs/react',
 	check,
 	renderToStaticMarkup,
 	supportsAstroStaticSlot: true,
 };
+
+export default renderer;

--- a/packages/integrations/svelte/src/server.ts
+++ b/packages/integrations/svelte/src/server.ts
@@ -1,4 +1,4 @@
-import type { AstroComponentMetadata } from 'astro';
+import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
 import { createRawSnippet } from 'svelte';
 import { render } from 'svelte/server';
 import { incrementId } from './context.js';
@@ -13,9 +13,9 @@ function check(Component: any) {
 	return Component.toString().includes('$$payload');
 }
 
-function needsHydration(metadata: AstroComponentMetadata) {
+function needsHydration(metadata?: AstroComponentMetadata) {
 	// Adjust how this is hydrated only when the version of Astro supports `astroStaticSlot`
-	return metadata.astroStaticSlot ? !!metadata.hydrate : true;
+	return metadata?.astroStaticSlot ? !!metadata.hydrate : true;
 }
 
 async function renderToStaticMarkup(
@@ -23,7 +23,7 @@ async function renderToStaticMarkup(
 	Component: any,
 	props: Record<string, any>,
 	slotted: Record<string, any>,
-	metadata: AstroComponentMetadata,
+	metadata?: AstroComponentMetadata,
 ) {
 	const tagName = needsHydration(metadata) ? 'astro-slot' : 'astro-static-slot';
 
@@ -66,9 +66,11 @@ async function renderToStaticMarkup(
 	return { html: result.body };
 }
 
-export default {
+const renderer: NamedSSRLoadedRendererValue = {
 	name: '@astrojs/svelte',
 	check,
 	renderToStaticMarkup,
 	supportsAstroStaticSlot: true,
 };
+
+export default renderer;

--- a/packages/integrations/vue/src/server.ts
+++ b/packages/integrations/vue/src/server.ts
@@ -1,12 +1,12 @@
 import { setup } from 'virtual:@astrojs/vue/app';
-import type { AstroComponentMetadata } from 'astro';
+import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
 import { createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import { incrementId } from './context.js';
 import StaticHtml from './static-html.js';
 import type { RendererContext } from './types.js';
 
-function check(Component: any) {
+async function check(Component: any) {
 	return !!Component['ssrRender'] || !!Component['__ssrInlineRender'];
 }
 
@@ -15,13 +15,13 @@ async function renderToStaticMarkup(
 	Component: any,
 	inputProps: Record<string, any>,
 	slotted: Record<string, any>,
-	metadata: AstroComponentMetadata,
+	metadata?: AstroComponentMetadata,
 ) {
 	let prefix;
 	if (this && this.result) {
 		prefix = incrementId(this.result);
 	}
-	const attrs = { prefix };
+	const attrs: Record<string, any> = { prefix };
 
 	const slots: Record<string, any> = {};
 	const props = { ...inputProps };
@@ -32,7 +32,7 @@ async function renderToStaticMarkup(
 				value,
 				name: key === 'default' ? undefined : key,
 				// Adjust how this is hydrated only when the version of Astro supports `astroStaticSlot`
-				hydrate: metadata.astroStaticSlot ? !!metadata.hydrate : true,
+				hydrate: metadata?.astroStaticSlot ? !!metadata.hydrate : true,
 			});
 	}
 	const app = createSSRApp({ render: () => h(Component, props, slots) });
@@ -42,9 +42,11 @@ async function renderToStaticMarkup(
 	return { html, attrs };
 }
 
-export default {
+const renderer: NamedSSRLoadedRendererValue = {
 	name: '@astrojs/vue',
 	check,
 	renderToStaticMarkup,
 	supportsAstroStaticSlot: true,
 };
+
+export default renderer;


### PR DESCRIPTION
## Changes

- Closes #13712
- When migrating integrations to TS recently, the types were not 100% correct which could cause issues when using renderers with the Container API

## Testing

Build should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
