### PR TITLE
fix: loosen the BaseSchema type

### DIFF
--- a/.changeset/bright-breads-report.md
+++ b/.changeset/bright-breads-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Loosen content layer schema types

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -45,22 +45,7 @@ declare module 'astro:content' {
 		has: (key: string) => boolean;
 	}
 
-	type BaseAtomicSchema = import('astro/zod').AnyZodObject;
-
-	type BaseCompositeSchema =
-		| import('astro/zod').ZodUnion<[BaseAtomicSchema, ...BaseAtomicSchema[]]>
-		| import('astro/zod').ZodDiscriminatedUnion<string, BaseAtomicSchema[]>
-		// If we have a union of unions, give up on trying to type-check it all. You're on your own.
-		| import('astro/zod').ZodUnion<[import('astro/zod').ZodUnion<z.any>, ...z.any[]]>;
-
-	type BaseSchemaWithoutEffects =
-		| BaseAtomicSchema
-		| BaseCompositeSchema
-		| import('astro/zod').ZodIntersection<BaseAtomicSchema, BaseAtomicSchema | BaseCompositeSchema>;
-
-	export type BaseSchema =
-		| BaseSchemaWithoutEffects
-		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
+	export type BaseSchema = import('astro/zod').ZodType
 
 	export type SchemaContext = { image: ImageFunction };
 


### PR DESCRIPTION
## Changes

Previously `BaseSchema` used recursive type definitions to try to define "any Zod object, or wrapper type that contains objects". This contained self-referencing types that collapsed to `any`, meaning there was no typechecking for schema defintions. #13706 fixed that by refactoring out the self-references. However this caused Starlight typechecks to fail (and presumably other sites). At its core, this is because Zod types are inherently recursive, so it's impossible to accurately type them without using recursive types, unless you manually define an arbitrary number of depth of reference. There will always be another layer of abstraction that some user (or more likely integration or library) wants to create.

This PR throws it all away, and simply types `BaseSchema` as `ZodType`. This is wider than we actually want: it accepts primitives other than objects. However, so does `any`, so this is an improvement over that. 

Fixes #13713

## Testing

The Starlight typecheck that was failing in ecosystem-ci is now passing.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
