### PR TITLE
Fix cookies set after middleware called `next(url)` not being…

### DIFF
--- a/.changeset/little-jokes-rhyme.md
+++ b/.changeset/little-jokes-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix cookies set after middleware did a rewrite with `next(url)` not being applied

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -194,7 +194,6 @@ export class RenderContext {
 				}
 				this.isRewriting = true;
 				this.url = new URL(this.request.url);
-				this.cookies = new AstroCookies(this.request);
 				this.params = getParams(routeData, pathname);
 				this.pathname = pathname;
 				this.status = 200;

--- a/packages/astro/test/astro-cookies.test.js
+++ b/packages/astro/test/astro-cookies.test.js
@@ -194,5 +194,12 @@ describe('Astro.cookies', () => {
 			assert.equal(response.status, 200);
 			assert.match(response.headers.get('Set-Cookie'), /test=value/);
 		});
+		
+		it('can set cookies in a rewritten endpoint request from middleware', async () => {
+			const request = new Request('http://example.com/rewrite-me');
+			const response = await app.render(request, { addCookieHeader: true });
+			assert.equal(response.status, 200);
+			assert.match(response.headers.get('Set-Cookie'), /my_cookie=value/);
+		});
 	});
 });

--- a/packages/astro/test/fixtures/astro-cookies/src/middleware.ts
+++ b/packages/astro/test/fixtures/astro-cookies/src/middleware.ts
@@ -1,0 +1,9 @@
+import { defineMiddleware } from "astro:middleware";
+
+export const onRequest = defineMiddleware((ctx, next) => {
+	if (ctx.url.pathname === "/rewrite-me") {
+		return next("/rewrite-target");
+	} else {
+		return next();
+	}
+})


### PR DESCRIPTION
Fix #13723

## Changes


- When a middleware called `next(url)` and subsequent code changed cookies, those cookies would not be saved
- This is because previously, when a rewrite happened, a new `AstroCookies` instance was setup, but when rendering the response, it used the previous `cookies` value.

## Testing

- I added a testcase

## Docs

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
