### PR TITLE
refactor(astro): Replaced generic `Error` throws with `AstroError`

### DIFF
--- a/.changeset/thin-regions-know.md
+++ b/.changeset/thin-regions-know.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+refactor: replace Error with AstroError

--- a/.changeset/thin-regions-know.md
+++ b/.changeset/thin-regions-know.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-refactor: replace Error with AstroError
+Improved the error handling of certain error cases. 

--- a/packages/astro/src/content/loaders/file.ts
+++ b/packages/astro/src/content/loaders/file.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 import { posixRelative } from '../utils.js';
 import type { Loader, LoaderContext } from './types.js';
+import { AstroError } from '../../core/errors/index.js';
 
 interface FileOptions {
 	/**
@@ -21,8 +22,10 @@ interface FileOptions {
  */
 export function file(fileName: string, options?: FileOptions): Loader {
 	if (fileName.includes('*')) {
-		// TODO: AstroError
-		throw new Error('Glob patterns are not supported in `file` loader. Use `glob` loader instead.');
+		throw new AstroError({
+			name: 'Glob Pattern Error',
+			message: 'Glob patterns are not supported in `file` loader. Use `glob` loader instead.',
+		});
 	}
 
 	let parse: ((text: string) => any) | null = null;
@@ -39,10 +42,10 @@ export function file(fileName: string, options?: FileOptions): Loader {
 	if (options?.parser) parse = options.parser;
 
 	if (parse === null) {
-		// TODO: AstroError
-		throw new Error(
-			`No parser found for file '${fileName}'. Try passing a parser to the \`file\` loader.`,
-		);
+		throw new AstroError({
+			name: 'Parser Not Found',
+			message: `No parser found for file '${fileName}'. Try passing a parser to the \`file\` loader.`,
+		});
 	}
 
 	async function syncData(filePath: string, { logger, parseData, store, config }: LoaderContext) {


### PR DESCRIPTION
## Changes
- remove todo comments
- **Replaced generic `Error` throws with `AstroError`** in `packages/astro/src/content/loader/file.ts`.
  - Adds contextual error names and messages:
    - `Glob Pattern Error` for disallowing `*` in `file()` loader paths.
    - `Parser Not Found` when no parser is available for the file extension.
  - Imports `AstroError` from `core/errors` so all runtime errors funnel through our unified error-handling layer.
- **Changeset included** (`pnpm exec changeset`) to surface in release notes.

## Testing

- Ran the full test suite: `pnpm test` – all existing tests pass.
- Manual sanity check:
  1. Created a sample project with a bad `data/*.json` glob; verified the new *Glob Pattern Error* message surfaces in the terminal with the Astro error banner.
  2. Pointed the loader to an `.xml` file; saw the *Parser Not Found* message and helpful suggestion.

*No additional tests added* because logic remains identical; only the error-reporting wrapper changed.

## Docs

No user-facing API changes. Docs remain valid.

<!-- If future troubleshooting docs ever reference these specific error names, we can update then. -->
