### PR TITLE
fix(fonts): relative protocol urls

### DIFF
--- a/.changeset/mean-lands-pull.md
+++ b/.changeset/mean-lands-pull.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where font sources with relative protocol URLs would fail when using the experimental fonts API

--- a/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
+++ b/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
@@ -23,7 +23,8 @@ export function normalizeRemoteFontFaces({
 						if ('name' in source) {
 							return source;
 						}
-						// We handle protocol relative URLs here by defaulting to https
+						// We handle protocol relative URLs here, otherwise they're considered absolute by the font
+						// fetcher which will try to read them from the file system
 						const url = source.url.startsWith('//') ? `https:${source.url}` : source.url;
 						const proxied = {
 							...source,

--- a/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
+++ b/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
@@ -23,11 +23,13 @@ export function normalizeRemoteFontFaces({
 						if ('name' in source) {
 							return source;
 						}
+						// We handle protocol relative URLs here by defaulting to https
+						const url = source.url.startsWith('//') ? `https:${source.url}` : source.url;
 						const proxied = {
 							...source,
-							originalURL: source.url,
+							originalURL: url,
 							url: urlProxy.proxy({
-								url: source.url,
+								url,
 								// We only collect the first URL to avoid preloading fallback sources (eg. we only
 								// preload woff2 if woff is available)
 								collectPreload: index === 0,

--- a/packages/astro/test/units/assets/fonts/logic.test.js
+++ b/packages/astro/test/units/assets/fonts/logic.test.js
@@ -450,6 +450,54 @@ describe('fonts logic', () => {
 				},
 			]);
 		});
+
+		it('turns relative protocols into https', () => {
+			const { collected, urlProxy } = createSpyUrlProxy();
+			const fonts = normalizeRemoteFontFaces({
+				urlProxy,
+				fonts: [
+					{
+						weight: '400',
+						style: 'normal',
+						src: [{ url: '//example.com/font.woff2' }, { url: 'http://example.com/font.woff' }],
+					},
+				],
+			});
+
+			assert.deepStrictEqual(
+				fonts,
+				[
+					{
+						src: [
+							{
+								originalURL: 'https://example.com/font.woff2',
+								url: 'https://example.com/font.woff2',
+							},
+							{
+								originalURL: 'http://example.com/font.woff',
+								url: 'http://example.com/font.woff',
+							},
+						],
+						style: 'normal',
+						weight: '400',
+					},
+				],
+			);
+			assert.deepStrictEqual(collected, [
+				{
+					url: 'https://example.com/font.woff2',
+					collectPreload: true,
+					data: { weight: '400', style: 'normal' },
+					init: null,
+				},
+				{
+					url: 'http://example.com/font.woff',
+					collectPreload: false,
+					data: { weight: '400', style: 'normal' },
+					init: null,
+				},
+			]);
+		});
 	});
 
 	describe('optimizeFallbacks()', () => {


### PR DESCRIPTION
## Changes

- Closes #13754
- Some remote font providers return protocol relative URLs (starting with `//`), which are then considered absolute by the font fetcher and fails
- Now when we normalize remote font data, we default this kind of URL to `https`

## Testing

Unit + manual

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
