### PR TITLE
feat: add cache hint support to live loaders

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1614,8 +1614,9 @@ export const InvalidContentEntryDataError = {
 	title: 'Content entry data does not match schema.',
 	message(collection: string, entryId: string, error: ZodError) {
 		return [
-			`**${String(collection)} → ${String(entryId)}** data does not match collection schema.`,
-			...error.errors.map((zodError) => zodError.message),
+			`**${String(collection)} → ${String(entryId)}** data does not match collection schema.\n`,
+			...error.errors.map((zodError) => `  **${zodError.path.join('.')}**: ${zodError.message}`),
+			'',
 		].join('\n');
 	},
 	hint: 'See https://docs.astro.build/en/guides/content-collections/ for more information on content schemas.',
@@ -1665,11 +1666,37 @@ export const ContentEntryDataError = {
 	title: 'Content entry data does not match schema.',
 	message(collection: string, entryId: string, error: ZodError) {
 		return [
-			`**${String(collection)} → ${String(entryId)}** data does not match collection schema.`,
-			...error.errors.map((zodError) => zodError.message),
+			`**${String(collection)} → ${String(entryId)}** data does not match collection schema.\n`,
+			...error.errors.map((zodError) => `  **${zodError.path.join('.')}**: ${zodError.message}`),
+			'',
 		].join('\n');
 	},
 	hint: 'See https://docs.astro.build/en/guides/content-collections/ for more information on content schemas.',
+} satisfies ErrorData;
+
+/**
+ * @docs
+ * @message
+ * **Example error message:**<br/>
+ * **blog** → **post** returned an invalid cache hint.<br/>
+ * **maxAge**: Expected number, received string
+ * @description
+ * The loader for a live content collection returned an invalid cache hint.
+ * Make sure that if you are using a cache hint, it is a valid object.
+ * @see
+ * - [Experimental live content](https://astro.build/en/reference/experimental-flags/live-content/)
+ */
+export const InvalidCacheHintError = {
+	name: 'InvalidCacheHintError',
+	title: 'Invalid cache hint.',
+	message(collection: string, entryId: string | undefined, error: ZodError) {
+		return [
+			`**${String(collection)}${entryId ? ` → ${String(entryId)}` : ''}** returned an invalid cache hint.\n`,
+			...error.errors.map((zodError) => `  **${zodError.path.join('.')}**: ${zodError.message}`),
+			'',
+		].join('\n');
+	},
+	hint: 'See https://docs.astro.build/en/reference/experimental-flags/live-content/ for more information.',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1682,7 +1682,7 @@ export const ContentEntryDataError = {
  * **maxAge**: Expected number, received string
  * @description
  * The loader for a live content collection returned an invalid cache hint.
- * Make sure that if you are using a cache hint, it is a valid object.
+ * Make sure that `cacheHint` is an object with the correct properties, or is undefined.
  * @see
  * - [Experimental live content](https://astro.build/en/reference/experimental-flags/live-content/)
  */

--- a/packages/astro/src/types/public/content.ts
+++ b/packages/astro/src/types/public/content.ts
@@ -125,16 +125,26 @@ export interface DataEntryType {
 
 export type GetDataEntryInfoReturnType = { data: Record<string, unknown>; rawData?: string };
 
+export interface CacheHint {
+	/** Cache tags */
+	tags?: Array<string>;
+	/** Maximum age of the response in seconds */
+	maxAge?: number;
+}
+
 export interface LiveDataEntry<TData extends Record<string, unknown> = Record<string, unknown>> {
 	/** The ID of the entry. Unique per collection. */
 	id: string;
 	/** The parsed entry data */
 	data: TData;
+	/** A hint for how to cache this entry */
+	cacheHint?: CacheHint;
 }
 
 export interface LiveDataCollection<
 	TData extends Record<string, unknown> = Record<string, unknown>,
 > {
 	entries: Array<LiveDataEntry<TData>>;
-	// TODO: pagination etc.
+	/** A hint for how to cache this collection. Individual entries can also have cache hints */
+	cacheHint?: CacheHint;
 }

--- a/packages/astro/test/fixtures/live-loaders/src/live.config.ts
+++ b/packages/astro/test/fixtures/live-loaders/src/live.config.ts
@@ -14,11 +14,21 @@ const entries = {
 const loader: LiveLoader<Entry, { id: keyof typeof entries }> = {
 	name: 'test-loader',
 	loadEntry: async (context) => {
-		return entries[context.filter.id] || null;
+		return {
+			...(entries[context.filter.id] || null),
+			cacheHint: {
+				tags: [`page:${context.filter.id}`],
+				maxAge: 60,
+			},
+		};
 	},
 	loadCollection: async (context) => {
 		return {
 			entries: Object.values(entries),
+			cacheHint: {
+				tags: ['page'],
+				maxAge: 60,
+			},
 		};
 	},
 };

--- a/packages/astro/test/fixtures/live-loaders/src/live.config.ts
+++ b/packages/astro/test/fixtures/live-loaders/src/live.config.ts
@@ -14,8 +14,11 @@ const entries = {
 const loader: LiveLoader<Entry, { id: keyof typeof entries }> = {
 	name: 'test-loader',
 	loadEntry: async (context) => {
+		if(!entries[context.filter.id]) {
+			return;
+		}
 		return {
-			...(entries[context.filter.id] || null),
+			...entries[context.filter.id],
 			cacheHint: {
 				tags: [`page:${context.filter.id}`],
 				maxAge: 60,


### PR DESCRIPTION
## Changes

Adds support for returning a `cacheHint` object with entries and collections. This can be used to suggest cache tags or ttl for the data, and in future could be integrated with route caching

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Added new error for invalid cache hints

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
