### PR TITLE
Fix(db): update db-client connection options parsing

### DIFF
--- a/.changeset/calm-drinks-beg.md
+++ b/.changeset/calm-drinks-beg.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Fix options parsing for the libsql client connection to ensure that proper values are being set when adding URLSearchParams to the `ASTRO_DB_REMOTE_URL`

--- a/packages/db/src/runtime/db-client.ts
+++ b/packages/db/src/runtime/db-client.ts
@@ -89,9 +89,9 @@ function createRemoteLibSQLClient(appToken: string, remoteDbURL: URL, rawUrl: st
 		return {
 			... config,
 			syncInterval: config.syncInterval ? parseInt(options.syncInterval) : undefined,
-			readYourWrites: config.readYourWrites ? !!config.readYourWrites : undefined,
-			offline: config.offline ? !!config.offline : undefined,
-			tls: config.tls ? !!config.tls : undefined,
+			readYourWrites: 'readYourWrites' in config ? config.readYourWrites !== 'false' : undefined,
+			offline: 'offline' in config ? config.offline !== 'false' : undefined,
+			tls: 'tls' in config ? config.tls !== 'false' : undefined,
 			concurrency: config.concurrency ? parseInt(options.concurrency) : undefined,
 			authToken: appToken,
 			url,

--- a/packages/db/src/runtime/db-client.ts
+++ b/packages/db/src/runtime/db-client.ts
@@ -63,11 +63,11 @@ export function createRemoteDatabaseClient(options: RemoteDbClientOptions) {
 export function parseOpts(config: Record<string, string>): Partial<LibSQLConfig> {
 	return {
 		... config,
-		syncInterval: config.syncInterval ? parseInt(config.syncInterval) : undefined,
-		readYourWrites: 'readYourWrites' in config ? config.readYourWrites !== 'false' : undefined,
-		offline: 'offline' in config ? config.offline !== 'false' : undefined,
-		tls: 'tls' in config ? config.tls !== 'false' : undefined,
-		concurrency: config.concurrency ? parseInt(config.concurrency) : undefined,
+		...(config.syncInterval ? { syncInterval: parseInt(config.syncInterval) } : {}),
+		...('readYourWrites' in config ? { readYourWrites: config.readYourWrites !== 'false' } : {}),
+		...('offline' in config ? { offline: config.offline !== 'false' } : {}),
+		...('tls' in config ? { tls: config.tls !== 'false' } : {}),
+		...(config.concurrency ? { concurrency: parseInt(config.concurrency) } : {}),
 	}
 }
 

--- a/packages/db/test/unit/db-client.test.js
+++ b/packages/db/test/unit/db-client.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert';
+import test, { describe } from 'node:test';
+import { parseOpts } from '../../dist/runtime/db-client.js';
+
+describe('db client config', () => {
+    test('parse config options from URL (docs example url)', () => {
+        const remoteURLToParse = new URL('file://local-copy.db?encryptionKey=your-encryption-key&syncInterval=60&syncUrl=libsql%3A%2F%2Fyour.server.io');
+        const options = Object.fromEntries(remoteURLToParse.searchParams.entries());
+
+        const config = parseOpts(options);
+
+        assert.deepEqual(config, {
+            encryptionKey: "your-encryption-key",
+            syncInterval: 60,
+            syncUrl: "libsql://your.server.io",
+        })
+    });
+
+    test('parse config options from URL (test booleans without value)', () => {
+        const remoteURLToParse = new URL('file://local-copy.db?readYourWrites&offline&tls');
+        const options = Object.fromEntries(remoteURLToParse.searchParams.entries());
+
+        const config = parseOpts(options);
+
+        assert.deepEqual(config, {
+            readYourWrites: true,
+            offline: true,
+            tls: true
+        })
+    })
+
+    test('parse config options from URL (test booleans with value)', () => {
+        const remoteURLToParse = new URL('file://local-copy.db?readYourWrites=true&offline=true&tls=true');
+        const options = Object.fromEntries(remoteURLToParse.searchParams.entries());
+
+        const config = parseOpts(options);
+
+        assert.deepEqual(config, {
+            readYourWrites: true,
+            offline: true,
+            tls: true
+        })
+    })
+
+    test('parse config options from URL (test numbers)', () => {
+        const remoteURLToParse = new URL('file://local-copy.db?syncInterval=60&concurrency=2');
+        const options = Object.fromEntries(remoteURLToParse.searchParams.entries());
+
+        const config = parseOpts(options);
+
+        assert.deepEqual(config, {
+            syncInterval: 60,
+            concurrency: 2
+        })
+    })
+})


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

This PR ensures proper params are being parsed and sent to the libsql Client, due to URLSearchParams being a `Record<string, string>` this object requires parsing to ensure the values are being parsed to number or boolean.

See https://discord.com/channels/830184174198718474/1370190284855705680 for context.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added a new unit test for ensuring the URL parsing is correct in various circumstances.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This PR corrects internal logic to reflect the information on the docs.  No docs changes needed.