### PR TITLE
ignore lightningcss global pseudo-class warning

### DIFF
--- a/.changeset/cyan-doodles-wish.md
+++ b/.changeset/cyan-doodles-wish.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-ignore lightningcss unsupported pseudo-class warning. fixes #13658
+Ignores lightningcss unsupported pseudo-class warning. 

--- a/.changeset/cyan-doodles-wish.md
+++ b/.changeset/cyan-doodles-wish.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+ignore lightningcss unsupported pseudo-class warning. fixes #13658

--- a/packages/astro/src/core/logger/vite.ts
+++ b/packages/astro/src/core/logger/vite.ts
@@ -21,6 +21,8 @@ const viteBuildMsg = /vite.*building.*for production/;
 const viteShortcutTitleMsg = /^\s*Shortcuts\s*$/;
 // capture "press * + enter to ..." messages
 const viteShortcutHelpMsg = /press (.+?) to (.+)$/s;
+// 'global' is not recognized as a valid pseudo-class
+const lightningcssUnsupportedPseudoMsg = /\[lightningcss\] 'global'.*not recognized.*pseudo-class/s;
 
 export function createViteLogger(
 	astroLogger: AstroLogger,
@@ -62,6 +64,8 @@ export function createViteLogger(
 		},
 		warn(msg) {
 			if (!isLogLevelEnabled(viteLogLevel, 'warn')) return;
+
+			if (lightningcssUnsupportedPseudoMsg.test(msg)) return;
 
 			logger.hasWarned = true;
 			astroLogger.warn('vite', msg);


### PR DESCRIPTION
## Changes

ignore lightningcss unsupported pseudo-class warning. fixes #13658

## Testing

there's no testing for logger

## Docs
no need to updated docs, no affect on user’s behavior
