### PR TITLE
fix(runtime): check propagation hint for head in tree

### DIFF
--- a/.changeset/great-pugs-visit.md
+++ b/.changeset/great-pugs-visit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an internal bug where in some cases the head propagation wasn't correctly flagged.

--- a/packages/astro/src/runtime/server/render/astro/factory.ts
+++ b/packages/astro/src/runtime/server/render/astro/factory.ts
@@ -26,3 +26,14 @@ export function isAPropagatingComponent(
 	}
 	return hint === 'in-tree' || hint === 'self';
 }
+
+export function getPropagationHint(
+	result: SSRResult,
+	factory: AstroComponentFactory,
+): PropagationHint {
+	let hint: PropagationHint = factory.propagation || 'none';
+	if (factory.moduleId && result.componentMetadata.has(factory.moduleId) && hint === 'none') {
+		hint = result.componentMetadata.get(factory.moduleId)!.propagation;
+	}
+	return hint;
+}

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -6,6 +6,7 @@ import { isAstroComponentFactory } from './astro/index.js';
 import { renderToAsyncIterable, renderToReadableStream, renderToString } from './astro/render.js';
 import { encoder } from './common.js';
 import { isDeno, isNode } from './util.js';
+import { getPropagationHint } from './astro/factory.js';
 
 export async function renderPage(
 	result: SSRResult,
@@ -43,8 +44,9 @@ export async function renderPage(
 
 	// Mark if this page component contains a <head> within its tree. If it does
 	// We avoid implicit head injection entirely.
+	const propagationHint = getPropagationHint(result, componentFactory);
 	result._metadata.headInTree =
-		result.componentMetadata.get(componentFactory.moduleId!)?.containsHead ?? false;
+		result.componentMetadata.get(componentFactory.moduleId!)?.containsHead ?? propagationHint === 'in-tree';
 
 	let body: BodyInit | Response;
 	if (streaming) {


### PR DESCRIPTION
## Changes

While working with CSP and server islands, I found out that we don't use the `PropagationHint` to determine if the head is the tree of the components or not.

As explained here: 

https://github.com/withastro/astro/blob/90293de03320da51965f05cfa6923cbe5521f519/packages/astro/src/types/public/internal.ts#L251-L261

The `in-tree` hint should signal our rendering engine if there's a component that we must wait, so it can render the head. The wasn't done in the code base. When I added the check, I could see the server island was correctly awaited, and eventually the head was rendered. 

I preferred to send the fix here because it's unrelated to the work I've been doing.

## Testing

I tested it manually. We don't have special components that would trigger situation for now, so the CI should stay green.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

 N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
