### PR TITLE
feat(db): Enable transaction types

### DIFF
--- a/.changeset/silent-states-shout.md
+++ b/.changeset/silent-states-shout.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Modify Database type to allow transactions to be properly typed now that Astro Studio has sunset.

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -12,7 +12,7 @@ import {
 import type { DBColumn, DBTable } from '../core/types.js';
 import { type SerializedSQL, isSerializedSQL } from './types.js';
 import { pathToFileURL } from './utils.js';
-export type Database = Omit<LibSQLDatabase, 'transaction'>;
+export type Database = LibSQLDatabase;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
 


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

Now that Astro Studio has sunset, `db.transaction()` which has been previously un-typed, can now once again be typed. this PR removes the Omit<> that removes the transaction type from the DB client.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No functional changes have been made, only type changes

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs are needed as there is no functional change, but could be included now that transactions are properly typed.