### PR TITLE
fix(fonts): take build config into account

### DIFF
--- a/.changeset/soft-memes-sin.md
+++ b/.changeset/soft-memes-sin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the experimental fonts API to correctly take `config.base`, `config.build.assets` and `config.build.assetsPrefix` into account

--- a/packages/astro/src/assets/fonts/constants.ts
+++ b/packages/astro/src/assets/fonts/constants.ts
@@ -14,8 +14,7 @@ export const DEFAULTS: Defaults = {
 export const VIRTUAL_MODULE_ID = 'virtual:astro:assets/fonts/internal';
 export const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
 
-// Requires a trailing slash
-export const URL_PREFIX = '/_astro/fonts/';
+export const ASSETS_DIR = 'fonts';
 export const CACHE_DIR = './fonts/';
 
 export const FONT_TYPES = ['woff2', 'woff', 'otf', 'ttf', 'eot'] as const;

--- a/packages/astro/src/assets/fonts/definitions.ts
+++ b/packages/astro/src/assets/fonts/definitions.ts
@@ -60,6 +60,10 @@ export interface UrlProxy {
 	) => string;
 }
 
+export interface UrlResolver {
+	resolve: (hash: string) => string;
+}
+
 export interface UrlProxyContentResolver {
 	resolve: (url: string) => string;
 }

--- a/packages/astro/src/assets/fonts/implementations/url-proxy.ts
+++ b/packages/astro/src/assets/fonts/implementations/url-proxy.ts
@@ -1,20 +1,26 @@
-import type { DataCollector, Hasher, UrlProxy, UrlProxyContentResolver } from '../definitions.js';
+import type {
+	DataCollector,
+	Hasher,
+	UrlProxy,
+	UrlProxyContentResolver,
+	UrlResolver,
+} from '../definitions.js';
 
 export function createUrlProxy({
 	contentResolver,
 	hasher,
 	dataCollector,
-	getUrl,
+	urlResolver,
 }: {
 	contentResolver: UrlProxyContentResolver;
 	hasher: Hasher;
 	dataCollector: DataCollector;
-	getUrl: (hash: string) => string;
+	urlResolver: UrlResolver;
 }): UrlProxy {
 	return {
 		proxy({ url: originalUrl, type, data, collectPreload, init }) {
 			const hash = `${hasher.hashString(contentResolver.resolve(originalUrl))}.${type}`;
-			const url = getUrl(hash);
+			const url = urlResolver.resolve(hash);
 
 			dataCollector.collect({
 				url: originalUrl,

--- a/packages/astro/src/assets/fonts/implementations/url-proxy.ts
+++ b/packages/astro/src/assets/fonts/implementations/url-proxy.ts
@@ -1,20 +1,20 @@
 import type { DataCollector, Hasher, UrlProxy, UrlProxyContentResolver } from '../definitions.js';
 
 export function createUrlProxy({
-	base,
 	contentResolver,
 	hasher,
 	dataCollector,
+	getUrl,
 }: {
-	base: string;
 	contentResolver: UrlProxyContentResolver;
 	hasher: Hasher;
 	dataCollector: DataCollector;
+	getUrl: (hash: string) => string;
 }): UrlProxy {
 	return {
 		proxy({ url: originalUrl, type, data, collectPreload, init }) {
 			const hash = `${hasher.hashString(contentResolver.resolve(originalUrl))}.${type}`;
-			const url = base + hash;
+			const url = getUrl(hash);
 
 			dataCollector.collect({
 				url: originalUrl,

--- a/packages/astro/src/assets/fonts/implementations/url-resolver.ts
+++ b/packages/astro/src/assets/fonts/implementations/url-resolver.ts
@@ -1,5 +1,5 @@
 import type { UrlResolver } from '../definitions.js';
-import { joinPaths, prependForwardSlash } from '../../../core/path.js';
+import { fileExtension, joinPaths, prependForwardSlash } from '../../../core/path.js';
 import type { AssetsPrefix } from '../../../types/public/index.js';
 import { getAssetsPrefix } from '../../utils/getAssetsPrefix.js';
 
@@ -17,7 +17,7 @@ export function createBuildUrlResolver({
 }: { base: string; assetsPrefix: AssetsPrefix }): UrlResolver {
 	return {
 		resolve(hash) {
-			const prefix = assetsPrefix ? getAssetsPrefix(hash, assetsPrefix) : undefined;
+			const prefix = assetsPrefix ? getAssetsPrefix(fileExtension(hash), assetsPrefix) : undefined;
 			if (prefix) {
 				return joinPaths(prefix, base, hash);
 			}

--- a/packages/astro/src/assets/fonts/implementations/url-resolver.ts
+++ b/packages/astro/src/assets/fonts/implementations/url-resolver.ts
@@ -1,0 +1,27 @@
+import type { UrlResolver } from '../definitions.js';
+import { joinPaths, prependForwardSlash } from '../../../core/path.js';
+import type { AssetsPrefix } from '../../../types/public/index.js';
+import { getAssetsPrefix } from '../../utils/getAssetsPrefix.js';
+
+export function createDevUrlResolver({ base }: { base: string }): UrlResolver {
+	return {
+		resolve(hash) {
+			return prependForwardSlash(joinPaths(base, hash));
+		},
+	};
+}
+
+export function createBuildUrlResolver({
+	base,
+	assetsPrefix,
+}: { base: string; assetsPrefix: AssetsPrefix }): UrlResolver {
+	return {
+		resolve(hash) {
+			const prefix = assetsPrefix ? getAssetsPrefix(hash, assetsPrefix) : undefined;
+			if (prefix) {
+				return joinPaths(prefix, base, hash);
+			}
+			return prependForwardSlash(joinPaths(base, hash));
+		},
+	};
+}

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -77,9 +77,8 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 		};
 	}
 
-	// We don't need to take the trailing slash and build output configuration options
-	// into account because we only serve (dev) or write (build) static assets (equivalent
-	// to trailingSlash: never)
+	// We don't need to worry about config.trailingSlash because we are dealing with
+	// static assets only, ie. trailingSlash: 'never'
 	const assetsDir = prependForwardSlash(
 		appendForwardSlash(joinPaths(settings.config.build.assets, ASSETS_DIR)),
 	);

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -80,7 +80,9 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 	// We don't need to take the trailing slash and build output configuration options
 	// into account because we only serve (dev) or write (build) static assets (equivalent
 	// to trailingSlash: never)
-	const assetsDir = joinPaths(settings.config.build.assets, ASSETS_DIR);
+	const assetsDir = prependForwardSlash(
+		appendForwardSlash(joinPaths(settings.config.build.assets, ASSETS_DIR)),
+	);
 	const baseUrl = joinPaths(settings.config.base, assetsDir);
 
 	let fontFileDataMap: FontFileDataMap | null = null;
@@ -219,46 +221,43 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 				}
 			});
 
-			server.middlewares.use(
-				prependForwardSlash(appendForwardSlash(assetsDir)),
-				async (req, res, next) => {
-					if (!req.url) {
-						return next();
-					}
-					const hash = req.url.slice(1);
-					const associatedData = fontFileDataMap?.get(hash);
-					if (!associatedData) {
-						return next();
-					}
-					// We don't want the request to be cached in dev because we cache it already internally,
-					// and it makes it easier to debug without needing hard refreshes
-					res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
-					res.setHeader('Pragma', 'no-cache');
-					res.setHeader('Expires', 0);
+			server.middlewares.use(assetsDir, async (req, res, next) => {
+				if (!req.url) {
+					return next();
+				}
+				const hash = req.url.slice(1);
+				const associatedData = fontFileDataMap?.get(hash);
+				if (!associatedData) {
+					return next();
+				}
+				// We don't want the request to be cached in dev because we cache it already internally,
+				// and it makes it easier to debug without needing hard refreshes
+				res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+				res.setHeader('Pragma', 'no-cache');
+				res.setHeader('Expires', 0);
 
-					try {
-						// Storage should be defined at this point since initialize it called before registering
-						// the middleware. hashToUrlMap is defined at the same time so if it's not set by now,
-						// no url will be matched and this line will not be reached.
-						const data = await fontFetcher!.fetch({ hash, ...associatedData });
+				try {
+					// Storage should be defined at this point since initialize it called before registering
+					// the middleware. hashToUrlMap is defined at the same time so if it's not set by now,
+					// no url will be matched and this line will not be reached.
+					const data = await fontFetcher!.fetch({ hash, ...associatedData });
 
-						res.setHeader('Content-Length', data.length);
-						res.setHeader('Content-Type', `font/${fontTypeExtractor!.extract(hash)}`);
+					res.setHeader('Content-Length', data.length);
+					res.setHeader('Content-Type', `font/${fontTypeExtractor!.extract(hash)}`);
 
-						res.end(data);
-					} catch (err) {
-						logger.error('assets', 'Cannot download font file');
-						if (isAstroError(err)) {
-							logger.error(
-								'SKIP_FORMAT',
-								formatErrorMessage(collectErrorMetadata(err), logger.level() === 'debug'),
-							);
-						}
-						res.statusCode = 500;
-						res.end();
+					res.end(data);
+				} catch (err) {
+					logger.error('assets', 'Cannot download font file');
+					if (isAstroError(err)) {
+						logger.error(
+							'SKIP_FORMAT',
+							formatErrorMessage(collectErrorMetadata(err), logger.level() === 'debug'),
+						);
 					}
-				},
-			);
+					res.statusCode = 500;
+					res.end();
+				}
+			});
 		},
 		resolveId(id) {
 			if (id === VIRTUAL_MODULE_ID) {
@@ -280,7 +279,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 
 			try {
 				const dir = getClientOutputDirectory(settings);
-				const fontsDir = new URL(`.${prependForwardSlash(baseUrl)}`, dir);
+				const fontsDir = new URL(`.${assetsDir}`, dir);
 				try {
 					mkdirSync(fontsDir, { recursive: true });
 				} catch (cause) {

--- a/packages/astro/test/fonts.test.js
+++ b/packages/astro/test/fonts.test.js
@@ -1,76 +1,110 @@
 // @ts-check
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { describe, it } from 'node:test';
 import { fontProviders } from 'astro/config';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
-describe('astro:fonts', () => {
-	/** @type {import('./test-utils.js').Fixture} */
-	let fixture;
-	/** @type {import('./test-utils.js').DevServer} */
-	let devServer;
+/**
+ * @param {Omit<import("./test-utils.js").AstroInlineConfig, 'root'>} inlineConfig
+ */
+async function createDevFixture(inlineConfig) {
+	const fixture = await loadFixture({ root: './fixtures/fonts/', ...inlineConfig });
+	const devServer = await fixture.startDevServer();
 
-	describe('<Font /> component', () => {
-		// TODO: remove once fonts are stabilized
-		describe('Fonts are not enabled', () => {
-			before(async () => {
-				fixture = await loadFixture({
-					root: './fixtures/fonts/',
-				});
-				devServer = await fixture.startDevServer();
-			});
-
-			after(async () => {
+	return {
+		fixture,
+		devServer,
+		run: async (/** @type {() => any} */ cb) => {
+			try {
+				return await cb();
+			} finally {
 				await devServer.stop();
-			});
+			}
+		},
+	};
+}
+/**
+ * @param {Omit<import("./test-utils.js").AstroInlineConfig, 'root'>} inlineConfig
+ */
+async function createBuildFixture(inlineConfig) {
+	const fixture = await loadFixture({ root: './fixtures/fonts/', ...inlineConfig });
+	await fixture.build({});
 
-			it('Throws an error if fonts are not enabled', async () => {
+	return {
+		fixture,
+	};
+}
+
+/*
+TODO: clean up
+dev
+- respects build.assets
+- respects build.assetsPrefix
+build
+- respects build.assets
+- respects build.assetsPrefix
+*/
+
+describe('astro fonts', () => {
+	describe('dev', () => {
+		it('Includes styles', async () => {
+			const { fixture, run } = await createDevFixture({
+				experimental: {
+					fonts: [
+						{
+							name: 'Roboto',
+							cssVariable: '--font-roboto',
+							provider: fontProviders.fontsource(),
+						},
+					],
+				},
+			});
+			await run(async () => {
 				const res = await fixture.fetch('/');
-				const body = await res.text();
-				assert.equal(
-					body.includes('<script type="module" src="/@vite/client">'),
-					true,
-					'Body does not include Vite error overlay script',
-				);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+				assert.equal(html.includes('<style>'), true);
+				assert.equal($('link[rel=preload][type=font/woff2]').attr('href'), undefined);
 			});
 		});
 
-		describe('Fonts are enabled', () => {
-			before(async () => {
-				fixture = await loadFixture({
-					root: './fixtures/fonts/',
-					experimental: {
-						fonts: [
-							{
-								name: 'Roboto',
-								cssVariable: '--font-roboto',
-								provider: fontProviders.fontsource(),
-							},
-						],
-					},
-				});
-				devServer = await fixture.startDevServer();
+		it('Includes links when preloading', async () => {
+			const { fixture, run } = await createDevFixture({
+				experimental: {
+					fonts: [
+						{
+							name: 'Roboto',
+							cssVariable: '--font-roboto',
+							provider: fontProviders.fontsource(),
+						},
+					],
+				},
 			});
-
-			after(async () => {
-				await devServer.stop();
-			});
-
-			it('Includes styles', async () => {
-				const res = await fixture.fetch('/');
-				const html = await res.text();
-				assert.equal(html.includes('<style>'), true);
-			});
-
-			it('Includes links when preloading', async () => {
+			await run(async () => {
 				const res = await fixture.fetch('/preload');
 				const html = await res.text();
-				assert.equal(html.includes('<link rel="preload"'), true);
+				const $ = cheerio.load(html);
+				const href = $('link[rel=preload][type=font/woff2]').attr('href');
+				assert.equal(href?.startsWith('/_astro/fonts/'), true);
+			});
+		});
+
+		it('Has correct headers in dev', async () => {
+			const { fixture, run } = await createDevFixture({
+				experimental: {
+					fonts: [
+						{
+							name: 'Roboto',
+							cssVariable: '--font-roboto',
+							provider: fontProviders.fontsource(),
+						},
+					],
+				},
 			});
 
-			it('Has correct headers in dev', async () => {
-				let res = await fixture.fetch('/preload');
+			await run(async () => {
+				const res = await fixture.fetch('/preload');
 				const html = await res.text();
 				const $ = cheerio.load(html);
 				const href = $('link[rel=preload][type^=font/woff2]').attr('href');
@@ -89,6 +123,44 @@ describe('astro:fonts', () => {
 				assert.equal(headers.get('Pragma'), 'no-cache');
 				assert.equal(headers.get('Expires'), '0');
 			});
+		});
+	});
+
+	describe('build', () => {
+		it('Includes styles', async () => {
+			const { fixture } = await createBuildFixture({
+				experimental: {
+					fonts: [
+						{
+							name: 'Roboto',
+							cssVariable: '--font-roboto',
+							provider: fontProviders.fontsource(),
+						},
+					],
+				},
+			});
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			assert.equal(html.includes('<style>'), true);
+			assert.equal($('link[rel=preload][type=font/woff2]').attr('href'), undefined);
+		});
+
+		it('Includes links when preloading', async () => {
+			const { fixture } = await createBuildFixture({
+				experimental: {
+					fonts: [
+						{
+							name: 'Roboto',
+							cssVariable: '--font-roboto',
+							provider: fontProviders.fontsource(),
+						},
+					],
+				},
+			});
+			const html = await fixture.readFile('/preload/index.html');
+			const $ = cheerio.load(html);
+			const href = $('link[rel=preload][type=font/woff2]').attr('href');
+			assert.equal(href?.startsWith('/_astro/fonts/'), true);
 		});
 	});
 });

--- a/packages/astro/test/fonts.test.js
+++ b/packages/astro/test/fonts.test.js
@@ -40,7 +40,7 @@ async function createBuildFixture(inlineConfig) {
 TODO: clean up
 dev
 - respects build.assets
-- respects build.assetsPrefix
+- build.assetsPrefix is not taken into account
 build
 - respects build.assets
 - respects build.assetsPrefix

--- a/packages/astro/test/units/assets/fonts/implementations.test.js
+++ b/packages/astro/test/units/assets/fonts/implementations.test.js
@@ -13,6 +13,10 @@ import { createAstroErrorHandler } from '../../../../dist/assets/fonts/implement
 import { createCachedFontFetcher } from '../../../../dist/assets/fonts/implementations/font-fetcher.js';
 import { createCapsizeFontMetricsResolver } from '../../../../dist/assets/fonts/implementations/font-metrics-resolver.js';
 import { createFontTypeExtractor } from '../../../../dist/assets/fonts/implementations/font-type-extractor.js';
+import {
+	createBuildUrlResolver,
+	createDevUrlResolver,
+} from '../../../../dist/assets/fonts/implementations/url-resolver.js';
 import { createSpyStorage, simpleErrorHandler } from './utils.js';
 
 describe('fonts implementations', () => {
@@ -342,5 +346,51 @@ describe('fonts implementations', () => {
 				}
 			}
 		}
+	});
+
+	it('createDevUrlResolver()', () => {
+		assert.equal(
+			createDevUrlResolver({ base: 'base/_astro/fonts' }).resolve('xxx.woff2'),
+			'/base/_astro/fonts/xxx.woff2',
+		);
+	});
+
+	describe('createBuildUrlResolver()', () => {
+		const base = 'foo/_custom/fonts';
+
+		it('works with no assetsPrefix', () => {
+			assert.equal(
+				createBuildUrlResolver({ base, assetsPrefix: undefined }).resolve('abc.ttf'),
+				'/foo/_custom/fonts/abc.ttf',
+			);
+		});
+
+		it('works with assetsPrefix as string', () => {
+			assert.equal(
+				createBuildUrlResolver({ base, assetsPrefix: 'https://cdn.example.com' }).resolve(
+					'foo.woff',
+				),
+				'https://cdn.example.com/foo/_custom/fonts/foo.woff',
+			);
+		});
+
+		it('works with assetsPrefix object', () => {
+			const resolver = createBuildUrlResolver({
+				base,
+				assetsPrefix: {
+					woff2: 'https://fonts.cdn.example.com',
+					fallback: 'https://cdn.example.com',
+				},
+			});
+
+			assert.equal(
+				resolver.resolve('bar.woff2'),
+				'https://fonts.cdn.example.com/foo/_custom/fonts/bar.woff2',
+			);
+			assert.equal(
+				resolver.resolve('xyz.ttf'),
+				'https://cdn.example.com/foo/_custom/fonts/xyz.ttf',
+			);
+		});
 	});
 });

--- a/packages/astro/test/units/assets/fonts/orchestrate.test.js
+++ b/packages/astro/test/units/assets/fonts/orchestrate.test.js
@@ -23,6 +23,7 @@ import {
 	simpleErrorHandler,
 } from './utils.js';
 import { defaultLogger } from '../../test-utils.js';
+import { createDevUrlResolver } from '../../../../dist/assets/fonts/implementations/url-resolver.js';
 
 describe('fonts orchestrate()', () => {
 	it('works with local fonts', async () => {
@@ -64,7 +65,7 @@ describe('fonts orchestrate()', () => {
 				const dataCollector = createDataCollector(params);
 				const contentResolver = createRemoteUrlProxyContentResolver();
 				return createUrlProxy({
-					getUrl: (hash) => `/test${hash}`,
+					urlResolver: createDevUrlResolver({ base: 'test' }),
 					contentResolver,
 					hasher,
 					dataCollector,
@@ -165,7 +166,9 @@ describe('fonts orchestrate()', () => {
 				const dataCollector = createDataCollector(params);
 				const contentResolver = createRemoteUrlProxyContentResolver();
 				return createUrlProxy({
-					getUrl: (hash) => hash,
+					urlResolver: {
+						resolve: (hash) => hash,
+					},
 					contentResolver,
 					hasher,
 					dataCollector,

--- a/packages/astro/test/units/assets/fonts/orchestrate.test.js
+++ b/packages/astro/test/units/assets/fonts/orchestrate.test.js
@@ -22,6 +22,7 @@ import {
 	fakeHasher,
 	simpleErrorHandler,
 } from './utils.js';
+import { defaultLogger } from '../../test-utils.js';
 
 describe('fonts orchestrate()', () => {
 	it('works with local fonts', async () => {
@@ -58,11 +59,12 @@ describe('fonts orchestrate()', () => {
 			fontMetricsResolver: fakeFontMetricsResolver,
 			fontTypeExtractor,
 			fontFileReader: createFontaceFontFileReader({ errorHandler }),
+			logger: defaultLogger,
 			createUrlProxy: ({ local, ...params }) => {
 				const dataCollector = createDataCollector(params);
 				const contentResolver = createRemoteUrlProxyContentResolver();
 				return createUrlProxy({
-					base: '/test',
+					getUrl: (hash) => `/test${hash}`,
 					contentResolver,
 					hasher,
 					dataCollector,
@@ -158,11 +160,12 @@ describe('fonts orchestrate()', () => {
 			fontMetricsResolver: fakeFontMetricsResolver,
 			fontTypeExtractor,
 			fontFileReader: createFontaceFontFileReader({ errorHandler }),
+			logger: defaultLogger,
 			createUrlProxy: ({ local, ...params }) => {
 				const dataCollector = createDataCollector(params);
 				const contentResolver = createRemoteUrlProxyContentResolver();
 				return createUrlProxy({
-					base: '',
+					getUrl: (hash) => hash,
 					contentResolver,
 					hasher,
 					dataCollector,


### PR DESCRIPTION
## Changes

- Closes #13779
- Updates the vite plugin to take `config.build.assets` and `config.build.assetsPrefix` into account. This required updating most paths handling as it was not robust enough
- Refactors the fixture test

## Testing

- Updates existing unit tests
- Adds unit tests
- Refactors the fixture tests
- Adds fixture tests
- Manually tested

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
