### PR TITLE
chore: type check components

### DIFF
--- a/packages/astro/components/Font.astro
+++ b/packages/astro/components/Font.astro
@@ -13,7 +13,7 @@ interface Props {
 	preload?: boolean;
 }
 
-const { cssVariable, preload = false } = Astro.props;
+const { cssVariable, preload = false } = Astro.props as Props;
 const data = fontsData.get(cssVariable);
 if (!data) {
 	throw new AstroError({

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -54,6 +54,7 @@ if (useResponsive) {
 
 for (const key in props) {
 	if (key.startsWith('data-astro-cid')) {
+		// @ts-expect-error
 		pictureAttributes[key] = props[key];
 	}
 }

--- a/packages/astro/components/env.d.ts
+++ b/packages/astro/components/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="../client.d.ts" />
+/// <reference path="../dev-only.d.ts" />

--- a/packages/astro/components/tsconfig.json
+++ b/packages/astro/components/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "jsx": "preserve"
+  }
+}

--- a/packages/astro/dev-only.d.ts
+++ b/packages/astro/dev-only.d.ts
@@ -3,3 +3,7 @@
 declare module 'virtual:astro:env/internal' {
 	export const schema: import('./src/env/schema.js').EnvSchema;
 }
+
+declare module 'virtual:astro:assets/fonts/internal' {
+	export const fontsData: import('./src/assets/fonts/types.js').ConsumableMap;
+}

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -52,7 +52,8 @@
     "./app/node": "./dist/core/app/node.js",
     "./client/*": "./dist/runtime/client/*",
     "./components": "./components/index.ts",
-    "./components/*": "./components/*",
+    "./components/*": "./components/*.astro",
+    "./components/viewtransitions.css": "./components/viewtransitions.css",
     "./toolbar": "./dist/toolbar/index.js",
     "./actions/runtime/*": "./dist/actions/runtime/*",
     "./assets": "./dist/assets/index.js",
@@ -80,7 +81,7 @@
     "astro": "astro.js"
   },
   "files": [
-    "components",
+    "components/*.{astro,css,ts}",
     "tsconfigs",
     "dist",
     "types",
@@ -99,7 +100,7 @@
   ],
   "scripts": {
     "prebuild": "astro-scripts prebuild --to-string \"src/runtime/server/astro-island.ts\" \"src/runtime/client/{idle,load,media,only,visible}.ts\"",
-    "build": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm && tsc",
+    "build": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm && tsc && astro-check --root ./components",
     "build:ci": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm",
     "dev": "astro-scripts dev --copy-wasm --prebuild \"src/runtime/server/astro-island.ts\" --prebuild \"src/runtime/client/{idle,load,media,only,visible}.ts\" \"src/**/*.{ts,js}\"",
     "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:types",
@@ -210,6 +211,7 @@
     "remark-code-titles": "^0.1.2",
     "rollup": "^4.37.0",
     "sass": "^1.86.0",
+    "typescript": "^5.8.3",
     "undici": "^7.5.0",
     "unified": "^11.0.5",
     "vitest": "^3.0.9"

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
+  "include": ["src", "dev-only.d.ts"],
   "compilerOptions": {
     "allowJs": true,
     "declarationDir": "./dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -740,6 +740,9 @@ importers:
       sass:
         specifier: ^1.86.0
         version: 1.86.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
       undici:
         specifier: ^7.5.0
         version: 7.6.0
@@ -10512,6 +10515,7 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
## Changes

- Until now, types under `packages/astro/components` have always been hard to work with
- Now, TS works correctly there and `.astro` files are checked using `@astrojs/check`

## Testing

Manually:
- I ran `pnpm build` locally without issues
- I run `pnpm pack` in `packages/astro` to make sure we don't export unwanted files (eg. `components/tsconfig.json`)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
