### PR TITLE
fix(fonts): windows test

### DIFF
--- a/packages/astro/test/units/assets/fonts/orchestrate.test.js
+++ b/packages/astro/test/units/assets/fonts/orchestrate.test.js
@@ -24,6 +24,7 @@ import {
 	fakeHasher,
 	simpleErrorHandler,
 } from './utils.js';
+import { joinPaths } from '../../../../../internal-helpers/dist/path.js';
 
 describe('fonts orchestrate()', () => {
 	it('works with local fonts', async () => {
@@ -90,7 +91,7 @@ describe('fonts orchestrate()', () => {
 		const entry = consumableMap.get('--test');
 		assert.deepStrictEqual(entry?.preloadData, [
 			{
-				url: '/test' + fileURLToPath(new URL('my-font.woff2.woff2', root)),
+				url: joinPaths('/test', fileURLToPath(new URL('my-font.woff2.woff2', root))),
 				type: 'woff2',
 			},
 		]);


### PR DESCRIPTION
## Changes

- Test is failing on main on windows 22. This PR fixes the affected test (it's once again caused by paths)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
