### PR TITLE
fix(fonts): properly throw error

### DIFF
--- a/.changeset/petite-rockets-relax.md
+++ b/.changeset/petite-rockets-relax.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where an error would not be thrown when using the `<Font />` component from the experimental fonts API without adding fonts in the Astro config

--- a/packages/astro/components/Font.astro
+++ b/packages/astro/components/Font.astro
@@ -1,8 +1,9 @@
 ---
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
-import { fontsData } from 'virtual:astro:assets/fonts/internal';
+import * as mod from 'virtual:astro:assets/fonts/internal';
 
 // TODO: remove check when fonts are stabilized
+const { fontsData } = mod;
 if (!fontsData) {
 	throw new AstroError(AstroErrorData.ExperimentalFontsNotEnabled);
 }

--- a/packages/astro/components/Font.astro
+++ b/packages/astro/components/Font.astro
@@ -1,10 +1,11 @@
 ---
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
+import { fontsData } from 'virtual:astro:assets/fonts/internal';
 
-// TODO: remove dynamic import when fonts are stabilized
-const { fontsData } = await import('virtual:astro:assets/fonts/internal').catch(() => {
+// TODO: remove check when fonts are stabilized
+if (!fontsData) {
 	throw new AstroError(AstroErrorData.ExperimentalFontsNotEnabled);
-});
+}
 
 interface Props {
 	/** The `cssVariable` registered in your Astro configuration. */


### PR DESCRIPTION
## Changes

- In #13674, I updated the vite plugin to return en empty module if the fonts are not enabled. This caused the error in the Font component not to be thrown because the module always exists
- Now, I check if `fontsData` is properly set

## Testing

Manual

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
