### PR TITLE
Unify isESMImportedImage in image service adapters

### DIFF
--- a/.changeset/forty-peaches-talk.md
+++ b/.changeset/forty-peaches-talk.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/netlify': patch
+---
+
+Unify imported images detection across adapters

--- a/packages/integrations/cloudflare/src/entrypoints/image-service.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/image-service.ts
@@ -2,7 +2,8 @@ import type { ExternalImageService } from 'astro';
 
 import { joinPaths } from '@astrojs/internal-helpers/path';
 import { baseService } from 'astro/assets';
-import { isESMImportedImage, isRemoteAllowed } from '../utils/assets.js';
+import { isESMImportedImage } from 'astro/assets/utils';
+import { isRemoteAllowed } from '../utils/assets.js';
 
 const service: ExternalImageService = {
 	...baseService,

--- a/packages/integrations/cloudflare/src/utils/assets.ts
+++ b/packages/integrations/cloudflare/src/utils/assets.ts
@@ -1,9 +1,6 @@
 import { isRemotePath } from '@astrojs/internal-helpers/path';
-import type { AstroConfig, ImageMetadata, RemotePattern } from 'astro';
+import type { AstroConfig, RemotePattern } from 'astro';
 
-export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
-	return typeof src === 'object';
-}
 function matchHostname(url: URL, hostname?: string, allowWildcard?: boolean) {
 	if (!hostname) {
 		return true;

--- a/packages/integrations/netlify/src/image-service.ts
+++ b/packages/integrations/netlify/src/image-service.ts
@@ -1,13 +1,10 @@
-import type { ExternalImageService, ImageMetadata } from 'astro';
+import type { ExternalImageService } from 'astro';
 import { baseService } from 'astro/assets';
+import { isESMImportedImage } from 'astro/assets/utils';
 import { AstroError } from 'astro/errors';
 
 const SUPPORTED_FORMATS = ['avif', 'jpg', 'png', 'webp'];
 const QUALITY_NAMES: Record<string, number> = { low: 25, mid: 50, high: 90, max: 100 };
-
-export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
-	return typeof src === 'object';
-}
 
 function removeLeadingForwardSlash(path: string) {
 	return path.startsWith('/') ? path.substring(1) : path;


### PR DESCRIPTION
## Changes

- Uses the `isESMImportedImage` function from the core package
- Removes inconsistent resolution of imported images
- Fixes https://github.com/withastro/astro/issues/13722

## Testing

Existing tests should cover it

## Docs

It's a fix
