### PR TITLE
fix(a11y): Remove pre tags from a11y-no-noninteractive-tabindex flag

### DIFF
--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -506,7 +506,9 @@ export const a11y: AuditRuleWithSelector[] = [
 			// See: https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/proposed/
 			const isScrollable =
 				element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth;
-			if (isScrollable) return false;
+				if (isScrollable) return false;
+
+			if (element.localName === 'pre') return false;
 
 			if (!isInteractive(element)) return false;
 


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

Fixes #13793

Adds check for `pre` tags within `a11y-no-noninteractive-tabindex` a11y audit check.

tabindex on pre tags is actually good for accessibility as it gives keyboard users the ability to scroll a code block. Shiki adds the tabindex attribute to pre tags by default.

Currently it is only checking for the element being scrollable, which might not always be the case in codeblocks. So we explicitly check for pre tags. 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
