### PR TITLE
fix(errors): update a broken link in `errors-data.ts`

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1819,7 +1819,7 @@ export const UnsupportedConfigTransformError = {
 /**
  * @docs
  * @see
- *  - [Passing a `parser` to the `file` loader](https://docs.astro.build/en/guides/imports/#parsers)
+ *  - [Passing a `parser` to the `file` loader](https://docs.astro.build/en/guides/content-collections/#parser-function)
  * @description
  * The `file` loader can’t determine which parser to use. Please provide a custom parser (e.g. `toml.parse` or `csv-parse`) to create a collection from your file type.
  */


### PR DESCRIPTION
The automated PR generated to update errors in Astro Docs (https://github.com/withastro/docs/pull/11666) fails because of a broken link in the errors list.

## Changes

Replaces a link in `FileParserNotFound` error: the link doesn't exist and the error is not related to imports but to the `file()` loader.

I think a link to [the guide](https://docs.astro.build/en/guides/content-collections/#parser-function) will be more useful than [using the reference](https://docs.astro.build/en/reference/content-loader-reference/#parser).

## Testing

N/A, just docs.

## Docs

This is docs so
/cc @withastro/maintainers-docs for feedback!

No changeset added because this is part of https://github.com/withastro/astro/pull/13761 which is not yet released.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
