### PR TITLE
fix: respect the outdir option in the netlify integration

### DIFF
--- a/.changeset/fine-needles-send.md
+++ b/.changeset/fine-needles-send.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-Fix to let the integration respect the set AstroConfig.outDir
+Fixes an issue where the adapter didn't take into consideration the `outDir` configuration.

--- a/.changeset/fine-needles-send.md
+++ b/.changeset/fine-needles-send.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fix to let the integration respect the set AstroConfig.outDir

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -515,7 +515,7 @@ export default function netlifyIntegration(
 				rootDir = config.root;
 				await cleanFunctions();
 
-				outDir = new URL('./dist/', rootDir);
+				outDir = new URL(config.outDir, rootDir);
 
 				const enableImageCDN = isRunningInNetlify && (integrationConfig?.imageCDN ?? true);
 


### PR DESCRIPTION
## Changes

Replaces the set constant `./dist/` with the output directory option from `AstroConfig.outdir` in the netlify integration.
Closes #13726 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Simple fix to a previously set constant. No additional tests were required.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Doesn't need documentation, since it is a simple patch.