### PR TITLE
feat(csp): allow additional directives

### DIFF
--- a/packages/astro/src/actions/runtime/utils.ts
+++ b/packages/astro/src/actions/runtime/utils.ts
@@ -40,6 +40,7 @@ export type ActionAPIContext = Pick<
 	| 'preferredLocaleList'
 	| 'originPathname'
 	| 'session'
+	| 'insertDirective'
 > & {
 	// TODO: remove in Astro 6.0
 	/**

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -16,6 +16,7 @@ import type {
 	SSRResult,
 } from '../../types/public/internal.js';
 import type { SinglePageBuiltModule } from '../build/types.js';
+import type { CspDirective } from '../csp/config.js';
 
 type ComponentPath = string;
 
@@ -111,7 +112,7 @@ export type SSRManifestCSP = {
 	algorithm: CspAlgorithm;
 	clientScriptHashes: string[];
 	clientStyleHashes: string[];
-	directives: string[];
+	directives: CspDirective;
 };
 
 /** Public type exposed through the `astro:build:ssr` integration hook */

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -111,6 +111,7 @@ export type SSRManifestCSP = {
 	algorithm: CspAlgorithm;
 	clientScriptHashes: string[];
 	clientStyleHashes: string[];
+	directives: string[];
 };
 
 /** Public type exposed through the `astro:build:ssr` integration hook */

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -648,7 +648,7 @@ async function createBuildManifest(
 			clientStyleHashes,
 			clientScriptHashes,
 			algorithm,
-			directives: getDirectives(settings.config),
+			directives: getDirectives(settings.config.experimental.csp),
 		};
 	}
 	return {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -32,6 +32,7 @@ import {
 	getAlgorithm,
 	getScriptHashes,
 	getStyleHashes,
+	getDirectives,
 	shouldTrackCspHashes,
 	trackScriptHashes,
 	trackStyleHashes,
@@ -647,6 +648,7 @@ async function createBuildManifest(
 			clientStyleHashes,
 			clientScriptHashes,
 			algorithm,
+			directives: getDirectives(settings.config),
 		};
 	}
 	return {

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -301,7 +301,7 @@ async function buildManifest(
 			clientStyleHashes,
 			clientScriptHashes,
 			algorithm,
-			directives: getDirectives(settings.config),
+			directives: getDirectives(settings.config.experimental.csp),
 		};
 	}
 

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -16,6 +16,7 @@ import {
 	getAlgorithm,
 	getScriptHashes,
 	getStyleHashes,
+	getDirectives,
 	shouldTrackCspHashes,
 	trackScriptHashes,
 	trackStyleHashes,
@@ -300,6 +301,7 @@ async function buildManifest(
 			clientStyleHashes,
 			clientScriptHashes,
 			algorithm,
+			directives: getDirectives(settings.config),
 		};
 	}
 

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -482,6 +482,7 @@ export const AstroConfigSchema = z.object({
 						algorithm: cspAlgorithmSchema,
 						styleHashes: z.array(z.string()).optional(),
 						scriptHashes: z.array(z.string()).optional(),
+						directives: z.array(z.string()).optional(),
 					}),
 				])
 				.optional()

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { localFontFamilySchema, remoteFontFamilySchema } from '../../../assets/fonts/config.js';
 import { EnvSchema } from '../../../env/schema.js';
 import type { AstroUserConfig, ViteUserConfig } from '../../../types/public/config.js';
-import { cspAlgorithmSchema } from '../../csp/config.js';
+import { ALLOWED_DIRECTIVES, cspAlgorithmSchema } from '../../csp/config.js';
 
 // The below types are required boilerplate to workaround a Zod issue since v3.21.2. Since that version,
 // Zod's compiled TypeScript would "simplify" certain values to their base representation, causing references
@@ -482,7 +482,14 @@ export const AstroConfigSchema = z.object({
 						algorithm: cspAlgorithmSchema,
 						styleHashes: z.array(z.string()).optional(),
 						scriptHashes: z.array(z.string()).optional(),
-						directives: z.array(z.string()).optional(),
+						directives: z
+							.array(
+								z.object({
+									type: z.enum(ALLOWED_DIRECTIVES),
+									value: z.string(),
+								}),
+							)
+							.optional(),
 					}),
 				])
 				.optional()

--- a/packages/astro/src/core/config/schemas/refined.ts
+++ b/packages/astro/src/core/config/schemas/refined.ts
@@ -209,28 +209,30 @@ export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((con
 		const { scriptHashes, styleHashes } = config.experimental.csp;
 		if (scriptHashes) {
 			for (const hash of scriptHashes) {
-				for (const allowedValue of ALGORITHM_VALUES) {
-					if (!hash.startsWith(allowedValue)) {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							message: `**scriptHashes** property "${hash}" must start with with one of following values: ${ALGORITHM_VALUES.join(', ')}.`,
-							path: ['experimental', 'csp', 'scriptHashes'],
-						});
-					}
+				const allowed = ALGORITHM_VALUES.some((allowedValue) => {
+					return hash.startsWith(allowedValue);
+				});
+				if (!allowed) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: `**scriptHashes** property "${hash}" must start with with one of following values: ${ALGORITHM_VALUES.join(', ')}.`,
+						path: ['experimental', 'csp', 'scriptHashes'],
+					});
 				}
 			}
 		}
 
 		if (styleHashes) {
 			for (const hash of styleHashes) {
-				for (const allowedValue of ALGORITHM_VALUES) {
-					if (!hash.startsWith(allowedValue)) {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							message: `**styleHashes** property "${hash}" must start with with one of following values: ${ALGORITHM_VALUES.join(', ')}.`,
-							path: ['experimental', 'csp', 'styleHashes'],
-						});
-					}
+				const allowed = ALGORITHM_VALUES.some((allowedValue) => {
+					return hash.startsWith(allowedValue);
+				});
+				if (!allowed) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: `**styleHashes** property "${hash}" must start with with one of following values: ${ALGORITHM_VALUES.join(', ')}.`,
+						path: ['experimental', 'csp', 'styleHashes'],
+					});
 				}
 			}
 		}

--- a/packages/astro/src/core/config/schemas/refined.ts
+++ b/packages/astro/src/core/config/schemas/refined.ts
@@ -237,19 +237,4 @@ export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((con
 			}
 		}
 	}
-
-	if (config.experimental.csp && typeof config.experimental.csp === 'object') {
-		const { directives } = config.experimental.csp;
-		if (directives) {
-			for (const directive of directives) {
-				if (directive.includes('script-src') || directive.includes('style-src')) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						message: `**directives** contains "script-src" or "style-src" directive, which are handled by Astro. Adding your own directives will risk to make the hashes invalid. Use **scriptDirectives** or **styleDirectives** instead.'`,
-						path: ['experimental', 'csp', 'directives'],
-					});
-				}
-			}
-		}
-	}
 });

--- a/packages/astro/src/core/config/schemas/refined.ts
+++ b/packages/astro/src/core/config/schemas/refined.ts
@@ -235,4 +235,19 @@ export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((con
 			}
 		}
 	}
+
+	if (config.experimental.csp && typeof config.experimental.csp === 'object') {
+		const { directives } = config.experimental.csp;
+		if (directives) {
+			for (const directive of directives) {
+				if (directive.includes('script-src') || directive.includes('style-src')) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: `**directives** contains "script-src" or "style-src" directive, which are handled by Astro. Adding your own directives will risk to make the hashes invalid. Use **scriptDirectives** or **styleDirectives** instead.'`,
+						path: ['experimental', 'csp', 'directives'],
+					});
+				}
+			}
+		}
+	}
 });

--- a/packages/astro/src/core/csp/common.ts
+++ b/packages/astro/src/core/csp/common.ts
@@ -37,20 +37,11 @@ export function getStyleHashes(csp: EnabledCsp): string[] {
 	}
 }
 
-/**
- * Use this function when after you checked that CSP is enabled, or it throws an error.
- * @param config
- */
-export function getDirectives(config: AstroConfig): string[] {
-	if (!config.experimental?.csp) {
-		// A regular error is fine here because this code should never be reached
-		// if CSP is not enabled
-		throw new Error('CSP is not enabled');
-	}
-	if (config.experimental.csp === true) {
+export function getDirectives(csp: EnabledCsp): string[] {
+	if (csp === true) {
 		return [];
 	}
-	return config.experimental.csp.directives ?? [];
+	return csp.directives ?? [];
 }
 
 export async function trackStyleHashes(

--- a/packages/astro/src/core/csp/common.ts
+++ b/packages/astro/src/core/csp/common.ts
@@ -37,6 +37,22 @@ export function getStyleHashes(csp: EnabledCsp): string[] {
 	}
 }
 
+/**
+ * Use this function when after you checked that CSP is enabled, or it throws an error.
+ * @param config
+ */
+export function getDirectives(config: AstroConfig): string[] {
+	if (!config.experimental?.csp) {
+		// A regular error is fine here because this code should never be reached
+		// if CSP is not enabled
+		throw new Error('CSP is not enabled');
+	}
+	if (config.experimental.csp === true) {
+		return [];
+	}
+	return config.experimental.csp.directives ?? [];
+}
+
 export async function trackStyleHashes(
 	internals: BuildInternals,
 	settings: AstroSettings,

--- a/packages/astro/src/core/csp/common.ts
+++ b/packages/astro/src/core/csp/common.ts
@@ -7,6 +7,7 @@ import type { AstroSettings } from '../../types/astro.js';
 import type { AstroConfig, CspAlgorithm } from '../../types/public/index.js';
 import type { BuildInternals } from '../build/internal.js';
 import { generateCspDigest } from '../encryption.js';
+import type { CspDirective } from './config.js';
 
 type EnabledCsp = Exclude<AstroConfig['experimental']['csp'], false>;
 
@@ -37,7 +38,7 @@ export function getStyleHashes(csp: EnabledCsp): string[] {
 	}
 }
 
-export function getDirectives(csp: EnabledCsp): string[] {
+export function getDirectives(csp: EnabledCsp): CspDirective {
 	if (csp === true) {
 		return [];
 	}

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -29,3 +29,33 @@ export const cspAlgorithmSchema = z
 	.enum(Object.keys(ALGORITHMS) as UnionToTuple<CspAlgorithm>)
 	.optional()
 	.default('SHA-256');
+
+export const ALLOWED_DIRECTIVES = [
+	'base-uri',
+	'child-src',
+	'connect-src',
+	'default-src',
+	'fenced-frame-src',
+	'font-src',
+	'form-action',
+	'frame-ancestors',
+	'frame-src',
+	'img-src',
+	'manifest-src',
+	'media-src',
+	'object-src',
+	'referrer',
+	'report-to',
+	'require-trusted-types-for',
+	'sandbox',
+	'trusted-types',
+	'upgrade-insecure-requests',
+	'worker-src',
+] as const;
+
+export type AllowedDirectives = (typeof ALLOWED_DIRECTIVES)[number];
+
+export type CspDirective = {
+	type: AllowedDirectives;
+	value: string;
+}[];

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -53,7 +53,7 @@ export const ALLOWED_DIRECTIVES = [
 	'worker-src',
 ] as const;
 
-export type AllowedDirectives = (typeof ALLOWED_DIRECTIVES)[number];
+type AllowedDirectives = (typeof ALLOWED_DIRECTIVES)[number];
 
 export type CspDirective = {
 	type: AllowedDirectives;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1382,6 +1382,19 @@ export const FontFamilyNotFound = {
 
 /**
  * @docs
+ * @description
+ * The CSP feature isn't enabled
+ * @message
+ * The `experimental.csp` configuration isn't enabled.
+ */
+export const CspNotEnabled = {
+	name: 'CspNotEnabled',
+	title: "CSP feature isn't enabled",
+	message: "The `experimental.csp` configuration isn't enabled.",
+} satisfies ErrorData;
+
+/**
+ * @docs
  * @kind heading
  * @name CSS Errors
  */

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -123,6 +123,7 @@ function createContext({
 		set locals(_) {
 			throw new AstroError(AstroErrorData.LocalsReassigned);
 		},
+		insertDirective() {},
 	};
 	return Object.assign(context, {
 		getActionResult: createGetActionResult(context.locals),

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -467,6 +467,7 @@ export class RenderContext {
 			clientScriptHashes: manifest.csp?.clientScriptHashes ?? [],
 			clientStyleHashes: manifest.csp?.clientStyleHashes ?? [],
 			cspAlgorithm: manifest.csp?.algorithm ?? 'SHA-256',
+			directives: manifest.csp?.directives ?? [],
 		};
 
 		return result;

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -26,7 +26,7 @@ import {
 } from './constants.js';
 import { AstroCookies, attachCookiesToResponse } from './cookies/index.js';
 import { getCookiesFromResponse } from './cookies/response.js';
-import { ForbiddenRewrite } from './errors/errors-data.js';
+import { CspNotEnabled, ForbiddenRewrite } from './errors/errors-data.js';
 import { AstroError, AstroErrorData } from './errors/index.js';
 import { callMiddleware } from './middleware/callMiddleware.js';
 import { sequence } from './middleware/index.js';
@@ -394,6 +394,12 @@ export class RenderContext {
 				}
 				return renderContext.session;
 			},
+			insertDirective(_payload) {
+				if (!!pipeline.manifest.csp === false) {
+					throw new AstroError(CspNotEnabled);
+				}
+				// 	TODO: add the directive
+			},
 		};
 	}
 
@@ -606,6 +612,12 @@ export class RenderContext {
 			url,
 			get originPathname() {
 				return getOriginPathname(renderContext.request);
+			},
+			insertDirective(_payload) {
+				if (!!pipeline.manifest.csp === false) {
+					throw new AstroError(CspNotEnabled);
+				}
+				// 	TODO: add the directive
 			},
 		};
 	}

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -19,7 +19,11 @@ export function renderCspContent(result: SSRResult): string {
 	for (const scriptHash of result._metadata.extraScriptHashes) {
 		finalScriptHashes.add(`'${scriptHash}'`);
 	}
-	const directives = result.directives.join(';');
+	const directives = result.directives
+		.map(({ type, value }) => {
+			return `${type} ${value}`;
+		})
+		.join(';');
 	const scriptSrc = `style-src 'self' ${Array.from(finalStyleHashes).join(' ')};`;
 	const styleSrc = `script-src 'self' ${Array.from(finalScriptHashes).join(' ')};`;
 	return `${directives} ${scriptSrc} ${styleSrc}`;

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -19,8 +19,8 @@ export function renderCspContent(result: SSRResult): string {
 	for (const scriptHash of result._metadata.extraScriptHashes) {
 		finalScriptHashes.add(`'${scriptHash}'`);
 	}
-
+	const directives = result.directives.join(';');
 	const scriptSrc = `style-src 'self' ${Array.from(finalStyleHashes).join(' ')};`;
 	const styleSrc = `script-src 'self' ${Array.from(finalScriptHashes).join(' ')};`;
-	return `${scriptSrc} ${styleSrc}`;
+	return `${directives} ${scriptSrc} ${styleSrc}`;
 }

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2283,6 +2283,36 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					 *
 					 */
 					scriptHashes?: `${CspAlgorithmValue}${string}`[];
+
+					/**
+					 * @name experimental.csp.directives
+					 * @type {string[]}
+					 * @default `[]`
+					 * @version 5.5.x
+					 * @description
+					 *
+					 * An array of additional directives to add the content of the `Content-Security-Policy` `<meta>` element.
+					 *
+					 * Use this configuration to add other directive definitions such as `default-src`, `image-src`, etc.
+					 *
+					 * ##### Example
+					 *
+					 * You can define a directive to fetch images only from a CDN `cdn.example.com`.
+					 *
+					 * ```js
+					 * export default defineConfig({
+					 * 	experimental: {
+					 * 		csp: {
+					 * 			directives: [
+					 * 				"image-src: 'https://cdn.example.com'"
+					 * 			]
+					 * 		}
+					 * 	}
+					 * })
+					 * ```
+					 *
+					 */
+					directives?: string[];
 			  };
 
 		/**

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -18,7 +18,7 @@ import type { AstroCookieSetOptions } from '../../core/cookies/cookies.js';
 import type { Logger, LoggerLevel } from '../../core/logger/core.js';
 import type { EnvSchema } from '../../env/schema.js';
 import type { AstroIntegration } from './integrations.js';
-import type { CspAlgorithm, CspAlgorithmValue } from '../../core/csp/config.js';
+import type { CspAlgorithm, CspAlgorithmValue, CspDirective } from '../../core/csp/config.js';
 
 export type Locales = (string | { codes: [string, ...string[]]; path: string })[];
 
@@ -2303,16 +2303,17 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					 * export default defineConfig({
 					 * 	experimental: {
 					 * 		csp: {
-					 * 			directives: [
-					 * 				"image-src: 'https://cdn.example.com'"
-					 * 			]
+					 * 			directives: [{
+					 * 				type: "image-src"
+					 * 				content:	'https://cdn.example.com'"
+					 * 			}]
 					 * 		}
 					 * 	}
 					 * })
 					 * ```
 					 *
 					 */
-					directives?: string[];
+					directives?: CspDirective;
 			  };
 
 		/**

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -11,6 +11,7 @@ import type { AstroComponentFactory } from '../../runtime/server/index.js';
 import type { Params, RewritePayload } from './common.js';
 import type { ValidRedirectStatus } from './config.js';
 import type { AstroInstance, MDXInstance, MarkdownInstance } from './content.js';
+import type { CspDirective } from '../../core/csp/config.js';
 
 /**
  * Astro global available in all contexts in .astro files
@@ -354,6 +355,12 @@ export interface AstroSharedContext<
 	 * Whether the current route is prerendered or not.
 	 */
 	isPrerendered: boolean;
+
+	/**
+	 * When CSP is enabled, it allows
+	 * @param payload
+	 */
+	insertDirective: (payload: CspDirective) => void;
 }
 
 /**

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -254,6 +254,7 @@ export interface SSRResult {
 	cspAlgorithm: SSRManifestCSP['algorithm'];
 	clientScriptHashes: SSRManifestCSP['clientScriptHashes'];
 	clientStyleHashes: SSRManifestCSP['clientStyleHashes'];
+	directives: SSRManifestCSP['directives'];
 }
 
 /**

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -186,7 +186,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			clientScriptHashes: getScriptHashes(settings.config.experimental.csp),
 			clientStyleHashes: getStyleHashes(settings.config.experimental.csp),
 			algorithm: getAlgorithm(settings.config.experimental.csp),
-			directives: getDirectives(settings.config),
+			directives: getDirectives(settings.config.experimental.csp),
 		};
 	}
 

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -10,6 +10,7 @@ import {
 	getScriptHashes,
 	getStyleHashes,
 	shouldTrackCspHashes,
+	getDirectives
 } from '../core/csp/common.js';
 import { warnMissingAdapter } from '../core/dev/adapter-validation.js';
 import { createKey, getEnvironmentKey, hasEnvironmentKey } from '../core/encryption.js';
@@ -185,6 +186,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			clientScriptHashes: getScriptHashes(settings.config.experimental.csp),
 			clientStyleHashes: getStyleHashes(settings.config.experimental.csp),
 			algorithm: getAlgorithm(settings.config.experimental.csp),
+			directives: getDirectives(settings.config),
 		};
 	}
 

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import {  describe, it } from 'node:test';
+import { describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
@@ -134,36 +134,36 @@ describe('CSP', () => {
 			assert.fail('Should have the manifest');
 		}
 	});
-	//
-	// it.skip('should contain the additional directives', async () => {
-	// 	fixture = await loadFixture({
-	// 		root: './fixtures/csp/',
-	// 		adapter: testAdapter({
-	// 			setManifest(_manifest) {
-	// 				manifest = _manifest;
-	// 			},
-	// 		}),
-	// 		experimental: {
-	// 			csp: {
-	// 				directives: ["image-src: 'self' 'https://example.com'"],
-	// 			},
-	// 		},
-	// 	});
-	// 	await fixture.build();
-	// 	app = await fixture.loadTestAdapterApp();
-	//
-	// 	if (manifest) {
-	// 		const request = new Request('http://example.com/index.html');
-	// 		const response = await app.render(request);
-	// 		const html = await response.text();
-	// 		const $ = cheerio.load(html);
-	//
-	// 		const meta = $('meta[http-equiv="Content-Security-Policy"]');
-	// 		assert.ok(
-	// 			meta.attr('content').toString().includes("image-src: 'self' 'https://example.com'"),
-	// 		);
-	// 	} else {
-	// 		assert.fail('Should have the manifest');
-	// 	}
-	// });
+
+	it('should contain the additional directives', async () => {
+		fixture = await loadFixture({
+			root: './fixtures/csp/',
+			adapter: testAdapter({
+				setManifest(_manifest) {
+					manifest = _manifest;
+				},
+			}),
+			experimental: {
+				csp: {
+					directives: ["image-src: 'self' 'https://example.com'"],
+				},
+			},
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+
+		if (manifest) {
+			const request = new Request('http://example.com/index.html');
+			const response = await app.render(request);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+
+			const meta = $('meta[http-equiv="Content-Security-Policy"]');
+			assert.ok(
+				meta.attr('content').toString().includes("image-src: 'self' 'https://example.com'"),
+			);
+		} else {
+			assert.fail('Should have the manifest');
+		}
+	});
 });

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -136,4 +136,36 @@ describe('CSP', () => {
 			assert.fail('Should have the manifest');
 		}
 	});
+
+	it('should contain the additional directives', async () => {
+		fixture = await loadFixture({
+			root: './fixtures/csp/',
+			adapter: testAdapter({
+				setManifest(_manifest) {
+					manifest = _manifest;
+				},
+			}),
+			experimental: {
+				csp: {
+					directives: ["image-src: 'self' 'https://example.com'"],
+				},
+			},
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+
+		if (manifest) {
+			const request = new Request('http://example.com/index.html');
+			const response = await app.render(request);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+
+			const meta = $('meta[http-equiv="Content-Security-Policy"]');
+			assert.ok(
+				meta.attr('content').toString().includes("image-src: 'self' 'https://example.com'"),
+			);
+		} else {
+			assert.fail('Should have the manifest');
+		}
+	});
 });

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import {  describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
@@ -12,7 +12,8 @@ describe('CSP', () => {
 	let manifest;
 	/** @type {import('./test-utils.js').Fixture} */
 	let fixture;
-	before(async () => {
+
+	it('should contain the meta style hashes when CSS is imported from Astro component', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
 			adapter: testAdapter({
@@ -23,9 +24,6 @@ describe('CSP', () => {
 		});
 		await fixture.build();
 		app = await fixture.loadTestAdapterApp();
-	});
-
-	it('should contain the meta style hashes when CSS is imported from Astro component', async () => {
 		if (manifest) {
 			const request = new Request('http://example.com/index.html');
 			const response = await app.render(request);
@@ -136,36 +134,36 @@ describe('CSP', () => {
 			assert.fail('Should have the manifest');
 		}
 	});
-
-	it('should contain the additional directives', async () => {
-		fixture = await loadFixture({
-			root: './fixtures/csp/',
-			adapter: testAdapter({
-				setManifest(_manifest) {
-					manifest = _manifest;
-				},
-			}),
-			experimental: {
-				csp: {
-					directives: ["image-src: 'self' 'https://example.com'"],
-				},
-			},
-		});
-		await fixture.build();
-		app = await fixture.loadTestAdapterApp();
-
-		if (manifest) {
-			const request = new Request('http://example.com/index.html');
-			const response = await app.render(request);
-			const html = await response.text();
-			const $ = cheerio.load(html);
-
-			const meta = $('meta[http-equiv="Content-Security-Policy"]');
-			assert.ok(
-				meta.attr('content').toString().includes("image-src: 'self' 'https://example.com'"),
-			);
-		} else {
-			assert.fail('Should have the manifest');
-		}
-	});
+	//
+	// it.skip('should contain the additional directives', async () => {
+	// 	fixture = await loadFixture({
+	// 		root: './fixtures/csp/',
+	// 		adapter: testAdapter({
+	// 			setManifest(_manifest) {
+	// 				manifest = _manifest;
+	// 			},
+	// 		}),
+	// 		experimental: {
+	// 			csp: {
+	// 				directives: ["image-src: 'self' 'https://example.com'"],
+	// 			},
+	// 		},
+	// 	});
+	// 	await fixture.build();
+	// 	app = await fixture.loadTestAdapterApp();
+	//
+	// 	if (manifest) {
+	// 		const request = new Request('http://example.com/index.html');
+	// 		const response = await app.render(request);
+	// 		const html = await response.text();
+	// 		const $ = cheerio.load(html);
+	//
+	// 		const meta = $('meta[http-equiv="Content-Security-Policy"]');
+	// 		assert.ok(
+	// 			meta.attr('content').toString().includes("image-src: 'self' 'https://example.com'"),
+	// 		);
+	// 	} else {
+	// 		assert.fail('Should have the manifest');
+	// 	}
+	// });
 });

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -145,7 +145,12 @@ describe('CSP', () => {
 			}),
 			experimental: {
 				csp: {
-					directives: ["image-src: 'self' 'https://example.com'"],
+					directives: [
+						{
+							type: 'img-src',
+							value: "'self' 'https://example.com'",
+						},
+					],
 				},
 			},
 		});
@@ -159,9 +164,7 @@ describe('CSP', () => {
 			const $ = cheerio.load(html);
 
 			const meta = $('meta[http-equiv="Content-Security-Policy"]');
-			assert.ok(
-				meta.attr('content').toString().includes("image-src: 'self' 'https://example.com'"),
-			);
+			assert.ok(meta.attr('content').toString().includes("img-src 'self' 'https://example.com'"));
 		} else {
 			assert.fail('Should have the manifest');
 		}

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -515,6 +515,18 @@ describe('Config Validation', () => {
 			);
 		});
 
+		it('should not throw an error for correct hashes', async () => {
+			assert.doesNotThrow(() => {
+				validateConfig({
+					experimental: {
+						csp: {
+							styleHashes: ['sha256-1234567890'],
+						},
+					},
+				});
+			});
+		});
+
 		it('should not throw an error when the directives are correct', () => {
 			assert.doesNotThrow(() =>
 				validateConfig({

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -514,5 +514,17 @@ describe('Config Validation', () => {
 				true,
 			);
 		});
+
+		it('should not throw an error when the directives are correct', () => {
+			assert.doesNotThrow(() =>
+				validateConfig({
+					experimental: {
+						csp: {
+							directives: ["image-src 'self'"],
+						},
+					},
+				}).catch((err) => err),
+			);
+		});
 	});
 });


### PR DESCRIPTION
## Changes

This PR adds support for additional directives inside the `<meta>` tag. As for now, Astro is only responsible for customising the `script-src` and `style-src` directives, however other directives aren't provided.

A user can always provide additional directives via the `Response` header; however, to avoid the use of multiple values (Response headers and meta data), and incurr in situations where the browser picks a different directive, Astro now allows user to add additional directives, which will be eventually rendered in the meta tag.

There's a very tiny level of validation, where if directives start with `script-src` or `style-src`, we throw an error. 

We will provide additional configurations in case users need to customise `script-src` and `style-src` directives.

To note that I updated the RFC to use the term "directive". Initially I chose the term "policy". Directive is the right term.

https://github.com/withastro/roadmap/blob/feat/rfc-csp/proposals/0055-csp.md#configuration-apis


> [!NOTE]
> The API is different from the RFC, I changed it now to make it strictly typed. I will update the RFC once we merge this PR

## Testing

Added new tests 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
