### PR TITLE
feat(csp): resources for script and styles directives

### DIFF
--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -25,5 +25,5 @@ export default defineConfig({
 		build: {
 			assetsInlineLimit: 0,
 		},
-	},
+	}
 });

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -110,8 +110,10 @@ export type SSRManifestI18n = {
 
 export type SSRManifestCSP = {
 	algorithm: CspAlgorithm;
-	clientScriptHashes: string[];
-	clientStyleHashes: string[];
+	scriptHashes: string[];
+	scriptResources: string[];
+	styleHashes: string[];
+	styleResources: string[];
 	directives: CspDirective;
 };
 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -36,6 +36,8 @@ import {
 	shouldTrackCspHashes,
 	trackScriptHashes,
 	trackStyleHashes,
+	getScriptResources,
+	getStyleResources,
 } from '../csp/common.js';
 import { NoPrerenderedRoutesWithDomains } from '../errors/errors-data.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
@@ -635,18 +637,20 @@ async function createBuildManifest(
 
 	if (shouldTrackCspHashes(settings.config.experimental.csp)) {
 		const algorithm = getAlgorithm(settings.config.experimental.csp);
-		const clientScriptHashes = [
+		const scriptHashes = [
 			...getScriptHashes(settings.config.experimental.csp),
 			...(await trackScriptHashes(internals, settings, algorithm)),
 		];
-		const clientStyleHashes = [
+		const styleHashes = [
 			...getStyleHashes(settings.config.experimental.csp),
 			...(await trackStyleHashes(internals, settings, algorithm)),
 		];
 
 		csp = {
-			clientStyleHashes,
-			clientScriptHashes,
+			styleHashes,
+			styleResources: getStyleResources(settings.config.experimental.csp),
+			scriptHashes,
+			scriptResources: getScriptResources(settings.config.experimental.csp),
 			algorithm,
 			directives: getDirectives(settings.config.experimental.csp),
 		};

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -11,6 +11,7 @@ import type {
 	SSRManifestI18n,
 	SerializedRouteInfo,
 	SerializedSSRManifest,
+	SSRManifestCSP,
 } from '../../app/types.js';
 import {
 	getAlgorithm,
@@ -20,6 +21,8 @@ import {
 	shouldTrackCspHashes,
 	trackScriptHashes,
 	trackStyleHashes,
+	getScriptResources,
+	getStyleResources,
 } from '../../csp/common.js';
 import { encodeKey } from '../../encryption.js';
 import { fileExtension, joinPaths, prependForwardSlash } from '../../path.js';
@@ -284,22 +287,24 @@ async function buildManifest(
 		};
 	}
 
-	let csp = undefined;
+	let csp: SSRManifestCSP | undefined = undefined;
 
 	if (shouldTrackCspHashes(settings.config.experimental.csp)) {
 		const algorithm = getAlgorithm(settings.config.experimental.csp);
-		const clientScriptHashes = [
+		const scriptHashes = [
 			...getScriptHashes(settings.config.experimental.csp),
 			...(await trackScriptHashes(internals, settings, algorithm)),
 		];
-		const clientStyleHashes = [
+		const styleHashes = [
 			...getStyleHashes(settings.config.experimental.csp),
 			...(await trackStyleHashes(internals, settings, algorithm)),
 		];
 
 		csp = {
-			clientStyleHashes,
-			clientScriptHashes,
+			scriptHashes,
+			scriptResources: getScriptResources(settings.config.experimental.csp),
+			styleHashes,
+			styleResources: getStyleResources(settings.config.experimental.csp),
 			algorithm,
 			directives: getDirectives(settings.config.experimental.csp),
 		};

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { localFontFamilySchema, remoteFontFamilySchema } from '../../../assets/fonts/config.js';
 import { EnvSchema } from '../../../env/schema.js';
 import type { AstroUserConfig, ViteUserConfig } from '../../../types/public/config.js';
-import { ALLOWED_DIRECTIVES, cspAlgorithmSchema } from '../../csp/config.js';
+import { ALLOWED_DIRECTIVES, cspAlgorithmSchema, CspHashSchema } from '../../csp/config.js';
 
 // The below types are required boilerplate to workaround a Zod issue since v3.21.2. Since that version,
 // Zod's compiled TypeScript would "simplify" certain values to their base representation, causing references
@@ -480,8 +480,6 @@ export const AstroConfigSchema = z.object({
 					z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.csp),
 					z.object({
 						algorithm: cspAlgorithmSchema,
-						styleHashes: z.array(z.string()).optional(),
-						scriptHashes: z.array(z.string()).optional(),
 						directives: z
 							.array(
 								z.object({
@@ -489,6 +487,18 @@ export const AstroConfigSchema = z.object({
 									value: z.string(),
 								}),
 							)
+							.optional(),
+						styleDirective: z
+							.object({
+								resources: z.array(z.string()).optional(),
+								hashes: z.array(CspHashSchema).optional(),
+							})
+							.optional(),
+						scriptDirective: z
+							.object({
+								resources: z.array(z.string()).optional(),
+								hashes: z.array(CspHashSchema).optional(),
+							})
 							.optional(),
 					}),
 				])

--- a/packages/astro/src/core/config/schemas/refined.ts
+++ b/packages/astro/src/core/config/schemas/refined.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import type { AstroConfig } from '../../../types/public/config.js';
-import { ALGORITHM_VALUES } from '../../csp/config.js';
 
 export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((config, ctx) => {
 	if (
@@ -201,39 +200,6 @@ export const AstroConfigRefinedSchema = z.custom<AstroConfig>().superRefine((con
 					message: `**cssVariable** property "${cssVariable}" contains invalid characters for CSS variable generation. It must start with -- and be a valid indent: https://developer.mozilla.org/en-US/docs/Web/CSS/ident.`,
 					path: ['fonts', i, 'cssVariable'],
 				});
-			}
-		}
-	}
-
-	if (config.experimental.csp && typeof config.experimental.csp === 'object') {
-		const { scriptHashes, styleHashes } = config.experimental.csp;
-		if (scriptHashes) {
-			for (const hash of scriptHashes) {
-				const allowed = ALGORITHM_VALUES.some((allowedValue) => {
-					return hash.startsWith(allowedValue);
-				});
-				if (!allowed) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						message: `**scriptHashes** property "${hash}" must start with with one of following values: ${ALGORITHM_VALUES.join(', ')}.`,
-						path: ['experimental', 'csp', 'scriptHashes'],
-					});
-				}
-			}
-		}
-
-		if (styleHashes) {
-			for (const hash of styleHashes) {
-				const allowed = ALGORITHM_VALUES.some((allowedValue) => {
-					return hash.startsWith(allowedValue);
-				});
-				if (!allowed) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						message: `**styleHashes** property "${hash}" must start with with one of following values: ${ALGORITHM_VALUES.join(', ')}.`,
-						path: ['experimental', 'csp', 'styleHashes'],
-					});
-				}
 			}
 		}
 	}

--- a/packages/astro/src/core/csp/common.ts
+++ b/packages/astro/src/core/csp/common.ts
@@ -26,16 +26,29 @@ export function getScriptHashes(csp: EnabledCsp): string[] {
 	if (csp === true) {
 		return [];
 	} else {
-		return csp.scriptHashes ?? [];
+		return csp.scriptDirective?.hashes ?? [];
 	}
+}
+
+export function getScriptResources(csp: EnabledCsp): string[] {
+	if (csp === true) {
+		return [];
+	}
+	return csp.scriptDirective?.resources ?? [];
 }
 
 export function getStyleHashes(csp: EnabledCsp): string[] {
 	if (csp === true) {
 		return [];
-	} else {
-		return csp.styleHashes ?? [];
 	}
+	return csp.styleDirective?.hashes ?? [];
+}
+
+export function getStyleResources(csp: EnabledCsp): string[] {
+	if (csp === true) {
+		return [];
+	}
+	return csp.styleDirective?.resources ?? [];
 }
 
 export function getDirectives(csp: EnabledCsp): CspDirective {

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -30,6 +30,17 @@ export const cspAlgorithmSchema = z
 	.optional()
 	.default('SHA-256');
 
+export const CspHashSchema = z.custom<`${CspAlgorithmValue}${string}`>((value) => {
+	if (typeof value !== 'string') {
+		return false;
+	}
+	return ALGORITHM_VALUES.some((allowedValue) => {
+		return value.startsWith(allowedValue);
+	});
+});
+
+export type CspHash = z.infer<typeof CspHashSchema>;
+
 export const ALLOWED_DIRECTIVES = [
 	'base-uri',
 	'child-src',

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -12,7 +12,7 @@ type UnionToTuple<T> = UnionToIntersection<T extends never ? never : (t: T) => T
 	? [...UnionToTuple<Exclude<T, W>>, W]
 	: [];
 
-const ALGORITHMS = {
+export const ALGORITHMS = {
 	'SHA-256': 'sha256-',
 	'SHA-384': 'sha384-',
 	'SHA-512': 'sha512-',

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -21,9 +21,9 @@ const ALGORITHMS = {
 type Algorithms = typeof ALGORITHMS;
 
 export type CspAlgorithm = keyof Algorithms;
-export type CspAlgorithmValue = Algorithms[keyof Algorithms];
+type CspAlgorithmValue = Algorithms[keyof Algorithms];
 
-export const ALGORITHM_VALUES = Object.values(ALGORITHMS) as UnionToTuple<CspAlgorithmValue>;
+const ALGORITHM_VALUES = Object.values(ALGORITHMS) as UnionToTuple<CspAlgorithmValue>;
 
 export const cspAlgorithmSchema = z
 	.enum(Object.keys(ALGORITHMS) as UnionToTuple<CspAlgorithm>)

--- a/packages/astro/src/core/encryption.ts
+++ b/packages/astro/src/core/encryption.ts
@@ -1,5 +1,6 @@
 import { decodeBase64, decodeHex, encodeBase64, encodeHexUpperCase } from '@oslojs/encoding';
 import type { CspAlgorithm } from '../types/public/index.js';
+import { ALGORITHMS, type CspHash } from './csp/config.js';
 
 // Chose this algorithm for no particular reason, can change.
 // This algo does check against text manipulation though. See
@@ -116,20 +117,9 @@ export async function decryptString(key: CryptoKey, encoded: string) {
  * @param {string} data The string to hash.
  * @param {CspAlgorithm} algorithm The algorithm to use.
  */
-export async function generateCspDigest(data: string, algorithm: CspAlgorithm): Promise<string> {
+export async function generateCspDigest(data: string, algorithm: CspAlgorithm): Promise<CspHash> {
 	const hashBuffer = await crypto.subtle.digest(algorithm, encoder.encode(data));
 
 	const hash = encodeBase64(new Uint8Array(hashBuffer));
-
-	switch (algorithm) {
-		case 'SHA-256': {
-			return `sha256-${hash}`;
-		}
-		case 'SHA-512': {
-			return `sha512-${hash}`;
-		}
-		case 'SHA-384': {
-			return `sha384-${hash}`;
-		}
-	}
+	return `${ALGORITHMS[algorithm]}${hash}`;
 }

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -470,8 +470,10 @@ export class RenderContext {
 				propagators: new Set(),
 			},
 			shouldInjectCspMetaTags: !!manifest.csp,
-			clientScriptHashes: manifest.csp?.clientScriptHashes ?? [],
-			clientStyleHashes: manifest.csp?.clientStyleHashes ?? [],
+			scriptHashes: manifest.csp?.scriptHashes ?? [],
+			scriptResources: manifest.csp?.scriptResources ?? [],
+			styleHashes: manifest.csp?.styleHashes ?? [],
+			styleResources: manifest.csp?.styleResources ?? [],
 			cspAlgorithm: manifest.csp?.algorithm ?? 'SHA-256',
 			directives: manifest.csp?.directives ?? [],
 		};

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -4,11 +4,11 @@ export function renderCspContent(result: SSRResult): string {
 	const finalScriptHashes = new Set();
 	const finalStyleHashes = new Set();
 
-	for (const scriptHash of result.clientScriptHashes) {
+	for (const scriptHash of result.scriptHashes) {
 		finalScriptHashes.add(`'${scriptHash}'`);
 	}
 
-	for (const styleHash of result.clientStyleHashes) {
+	for (const styleHash of result.styleHashes) {
 		finalStyleHashes.add(`'${styleHash}'`);
 	}
 
@@ -24,7 +24,18 @@ export function renderCspContent(result: SSRResult): string {
 			return `${type} ${value}`;
 		})
 		.join(';');
-	const scriptSrc = `style-src 'self' ${Array.from(finalStyleHashes).join(' ')};`;
-	const styleSrc = `script-src 'self' ${Array.from(finalScriptHashes).join(' ')};`;
+
+	let scriptResources = 'self';
+	if (result.scriptResources.length > 0) {
+		scriptResources = result.scriptResources.map((r) => `'${r}'`).join(' ');
+	}
+
+	let styleResources = 'self';
+	if (result.styleResources.length > 0) {
+		styleResources = result.styleResources.map((r) => `'${r}'`).join(' ');
+	}
+
+	const scriptSrc = `style-src ${styleResources} ${Array.from(finalStyleHashes).join(' ')};`;
+	const styleSrc = `script-src ${scriptResources} ${Array.from(finalScriptHashes).join(' ')};`;
 	return `${directives} ${scriptSrc} ${styleSrc}`;
 }

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -25,12 +25,12 @@ export function renderCspContent(result: SSRResult): string {
 		})
 		.join(';');
 
-	let scriptResources = 'self';
+	let scriptResources = "'self'";
 	if (result.scriptResources.length > 0) {
 		scriptResources = result.scriptResources.map((r) => `'${r}'`).join(' ');
 	}
 
-	let styleResources = 'self';
+	let styleResources = "'self'";
 	if (result.styleResources.length > 0) {
 		styleResources = result.styleResources.map((r) => `'${r}'`).join(' ');
 	}

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -18,7 +18,7 @@ import type { AstroCookieSetOptions } from '../../core/cookies/cookies.js';
 import type { Logger, LoggerLevel } from '../../core/logger/core.js';
 import type { EnvSchema } from '../../env/schema.js';
 import type { AstroIntegration } from './integrations.js';
-import type { CspAlgorithm, CspAlgorithmValue, CspDirective } from '../../core/csp/config.js';
+import type { CspAlgorithm, CspDirective, CspHash } from '../../core/csp/config.js';
 
 export type Locales = (string | { codes: [string, ...string[]]; path: string })[];
 
@@ -2257,32 +2257,76 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					algorithm?: CspAlgorithm;
 
 					/**
-					 * @name experimental.csp.styleHashes
-					 * @type {string[]}
-					 * @default `[]`
+					 * @name experimental.csp.styleDirective
+					 * @type {CspHash[]}
+					 * @default `undefined`
 					 * @version 5.5.x
 					 * @description
 					 *
-					 * A list of style hashes to include in all pages. These hashes are added to the `style-src` policy.
-					 *
-					 * The default value is `[]`.
+					 * Allows controlling the `style-src` directive.
 					 *
 					 */
-					styleHashes?: `${CspAlgorithmValue}${string}`[];
+					styleDirective?: {
+						/**
+						 * @name experimental.csp.styleDirective.hashes
+						 * @type {CspHash[]}
+						 * @default `[]`
+						 * @version 5.5.x
+						 * @description
+						 *
+						 * A list of style hashes to include in all pages. These hashes are added to the `style-src` directive.
+						 *
+						 */
+						hashes?: CspHash[];
+
+						/**
+						 * @name experimental.csp.styleDirective.resources
+						 * @type {string[]}
+						 * @default `[]`
+						 * @version 5.5.x
+						 * @description
+						 *
+						 * A list of resources applied to the `style-src` directive.
+						 *
+						 */
+						resources?: string[];
+					};
 
 					/**
-					 * @name experimental.csp.scriptHashes
-					 * @type {string[]}
-					 * @default `[]`
+					 * @name experimental.csp.styleDirective
+					 * @type {CspHash[]}
+					 * @default `undefined`
 					 * @version 5.5.x
 					 * @description
 					 *
-					 * A list of script hashes to include in all pages. These hashes are added to the `script-src` policy.
-					 *
-					 * The default value is `[]`.
+					 * Allows controlling the `style-src` directive.
 					 *
 					 */
-					scriptHashes?: `${CspAlgorithmValue}${string}`[];
+					scriptDirective?: {
+						/**
+						 * @name experimental.csp.scriptDirective.hashes
+						 * @type {CspHash[]}
+						 * @default `[]`
+						 * @version 5.5.x
+						 * @description
+						 *
+						 * A list of script hashes to include in all pages. These hashes are added to the `script-src` directive.
+						 *
+						 */
+						hashes?: CspHash[];
+
+						/**
+						 * @name experimental.csp.scriptDirective.resources
+						 * @type {string[]}
+						 * @default `[]`
+						 * @version 5.5.x
+						 * @description
+						 *
+						 * A list of resources applied to the `script-src` directive.
+						 *
+						 */
+						resources?: string[];
+					};
 
 					/**
 					 * @name experimental.csp.directives

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -252,8 +252,10 @@ export interface SSRResult {
 	 */
 	shouldInjectCspMetaTags: boolean;
 	cspAlgorithm: SSRManifestCSP['algorithm'];
-	clientScriptHashes: SSRManifestCSP['clientScriptHashes'];
-	clientStyleHashes: SSRManifestCSP['clientStyleHashes'];
+	scriptHashes: SSRManifestCSP['scriptHashes'];
+	scriptResources: SSRManifestCSP['scriptResources'];
+	styleHashes: SSRManifestCSP['styleHashes'];
+	styleResources: SSRManifestCSP['styleResources'];
 	directives: SSRManifestCSP['directives'];
 }
 

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -10,7 +10,9 @@ import {
 	getScriptHashes,
 	getStyleHashes,
 	shouldTrackCspHashes,
-	getDirectives
+	getDirectives,
+	getScriptResources,
+	getStyleResources,
 } from '../core/csp/common.js';
 import { warnMissingAdapter } from '../core/dev/adapter-validation.js';
 import { createKey, getEnvironmentKey, hasEnvironmentKey } from '../core/encryption.js';
@@ -183,8 +185,10 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 
 	if (shouldTrackCspHashes(settings.config.experimental.csp)) {
 		csp = {
-			clientScriptHashes: getScriptHashes(settings.config.experimental.csp),
-			clientStyleHashes: getStyleHashes(settings.config.experimental.csp),
+			scriptHashes: getScriptHashes(settings.config.experimental.csp),
+			scriptResources: getScriptResources(settings.config.experimental.csp),
+			styleHashes: getStyleHashes(settings.config.experimental.csp),
+			styleResources: getStyleResources(settings.config.experimental.csp),
 			algorithm: getAlgorithm(settings.config.experimental.csp),
 			directives: getDirectives(settings.config.experimental.csp),
 		};

--- a/packages/astro/test/types/define-config.ts
+++ b/packages/astro/test/types/define-config.ts
@@ -179,20 +179,12 @@ describe('defineConfig()', () => {
 		defineConfig({
 			experimental: {
 				csp: {
-					scriptHashes: [
-						'sha256-xx',
-						'sha384-xx',
-						'sha512-xx',
-						// @ts-expect-error doesn't have the correct prefix
-						'fancy-1234567890',
-					],
-					styleHashes: [
-						'sha256-xx',
-						'sha384-xx',
-						'sha512-xx',
-						// @ts-expect-error doesn't have the correct prefix
-						'fancy-1234567890',
-					],
+					scriptDirective: {
+						hashes: ['sha256-xx', 'sha384-xx', 'sha512-xx'],
+					},
+					styleDirective: {
+						hashes: ['sha256-xx', 'sha384-xx', 'sha512-xx'],
+					},
 				},
 			},
 		});

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -485,34 +485,26 @@ describe('Config Validation', () => {
 			let configError = await validateConfig({
 				experimental: {
 					csp: {
-						scriptHashes: ['fancy-1234567890'],
+						scriptDirective: {
+							hashes: ['fancy-1234567890'],
+						},
 					},
 				},
 			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
-			assert.equal(
-				configError.errors[0].message.includes(
-					'**scriptHashes** property "fancy-1234567890" must start with with one of following values: sha256-, sha384-, sha512-.',
-				),
-				true,
-			);
 		});
 
 		it('should throw an error if incorrect styleHashes are passed', async () => {
 			let configError = await validateConfig({
 				experimental: {
 					csp: {
-						styleHashes: ['fancy-1234567890'],
+						styleDirective: {
+							hashes: ['fancy-1234567890'],
+						},
 					},
 				},
 			}).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
-			assert.equal(
-				configError.errors[0].message.includes(
-					'**styleHashes** property "fancy-1234567890" must start with with one of following values: sha256-, sha384-, sha512-.',
-				),
-				true,
-			);
 		});
 
 		it('should not throw an error for correct hashes', async () => {
@@ -520,7 +512,9 @@ describe('Config Validation', () => {
 				validateConfig({
 					experimental: {
 						csp: {
-							styleHashes: ['sha256-1234567890'],
+							styleDirective: {
+								hashes: ['sha256-1234567890'],
+							},
 						},
 					},
 				});


### PR DESCRIPTION
## Changes

This PR implements the following chapter of the RFC: https://github.com/withastro/roadmap/blob/feat/rfc-csp/proposals/0055-csp.md#customize-the-script-src-and-style-src-directives

Changes:
- The schema and validation of the hashes is now done via `z.custom`, which provides runtime validation and a better type check
- I did some internal renaming
- I refactored the code in order match the RFC. In the RFC I changed the structure of the configuration. From having `styleHashes` and `styleResources`, we now have `styleDirective.hash` and `styleDirective.resources`

## Testing

I updated the validation test, since now we don't raise a custom message anymore.
Added new integration tests and updated the current ones.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
