### PR TITLE
chore: check `knip` first

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:e2e:match": "cd packages/astro && pnpm playwright install chromium firefox && pnpm run test:e2e:match",
     "test:e2e:hosts": "turbo run test:hosted",
     "benchmark": "astro-benchmark",
-    "lint": "biome lint && eslint . --report-unused-disable-directives-severity=warn && knip",
+    "lint": "biome lint && knip && eslint . --report-unused-disable-directives-severity=warn",
     "lint:ci": "biome ci --formatter-enabled=false --organize-imports-enabled=false --reporter=github && eslint . --report-unused-disable-directives-severity=warn && knip",
     "lint:fix": "biome lint --write --unsafe",
     "publint": "pnpm -r --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --no-bail exec publint",


### PR DESCRIPTION
## Changes

This updates the `lint` check, and runs `knip` before `eslint`. The `eslint` is the slowest of checks, so it's best to run the fastest ones first to get a quicker feedback on CI

## Testing

CI should stay green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
