### PR TITLE
fix(@astrojs/netlify): Handle SVGs properly with imageCDN enabled

### DIFF
--- a/.changeset/loud-brooms-kick.md
+++ b/.changeset/loud-brooms-kick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes an issue with SVGs not rendering with image-cdn enabled, due to invalid source path parsing.

--- a/packages/integrations/netlify/src/image-service.ts
+++ b/packages/integrations/netlify/src/image-service.ts
@@ -12,6 +12,12 @@ function removeLeadingForwardSlash(path: string) {
 
 const service: ExternalImageService = {
 	getURL(options) {
+		// For SVG files, return the original source path
+		if (isESMImportedImage(options.src) && options.src.format === 'svg') {
+			return options.src.src;
+		}
+
+		// For non-SVG files, continue with the Netlify's image processing
 		const query = new URLSearchParams();
 
 		const fileSrc = isESMImportedImage(options.src)


### PR DESCRIPTION
Fixes incorrect URL generation for SVGs with imageCDN enabled, for the netlify adapter. Fixes #13796 

## Changes

- Adds a check for SVG images in `astro/packages/integrations/netlify/src/image-service.ts` to handle the return of the original `src` path for them.

## Testing

- No specific tests were added since this is a fix between the image service logic of the netlify adapter, and existing tests should be enough.
- It was manually tested on a separate project, similar to how #13679 was handled.

## Docs

It's an internal bug fix for the netlify adapter and should not need any documentation. 