### PR TITLE
fix: ponyfill import.meta.resolve

### DIFF
--- a/.changeset/fruity-pugs-cross.md
+++ b/.changeset/fruity-pugs-cross.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where session modules would fail to resolve in Node.js < 20.6

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -143,6 +143,7 @@
     "github-slugger": "^2.0.0",
     "html-escaper": "3.0.3",
     "http-cache-semantics": "^4.1.1",
+    "import-meta-resolve": "^4.1.0",
     "js-yaml": "^4.1.0",
     "kleur": "^4.1.5",
     "magic-string": "^0.30.17",

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -31,7 +31,7 @@ const replaceExp = new RegExp(`['"]${manifestReplace}['"]`, 'g');
 export const SSR_MANIFEST_VIRTUAL_MODULE_ID = '@astrojs-manifest';
 export const RESOLVED_SSR_MANIFEST_VIRTUAL_MODULE_ID = '\0' + SSR_MANIFEST_VIRTUAL_MODULE_ID;
 
-export function resolveSessionDriver(driver: string | undefined): string | null {
+function resolveSessionDriver(driver: string | undefined): string | null {
 	if (!driver) {
 		return null;
 	}

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -1,6 +1,8 @@
 import { fileURLToPath } from 'node:url';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import type { OutputChunk } from 'rollup';
 import { glob } from 'tinyglobby';
+import { builtinDrivers, type BuiltinDriverName } from 'unstorage';
 import type { Plugin as VitePlugin } from 'vite';
 import { getAssetsPrefix } from '../../../assets/utils/getAssetsPrefix.js';
 import { normalizeTheLocale } from '../../../i18n/index.js';
@@ -16,7 +18,6 @@ import { encodeKey } from '../../encryption.js';
 import { fileExtension, joinPaths, prependForwardSlash } from '../../path.js';
 import { DEFAULT_COMPONENTS } from '../../routing/default.js';
 import { serializeRouteData } from '../../routing/index.js';
-import { resolveSessionDriver } from '../../session.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import { getOutFile, getOutFolder } from '../common.js';
 import { type BuildInternals, cssOrder, mergeInlineCss } from '../internal.js';
@@ -29,6 +30,27 @@ const replaceExp = new RegExp(`['"]${manifestReplace}['"]`, 'g');
 
 export const SSR_MANIFEST_VIRTUAL_MODULE_ID = '@astrojs-manifest';
 export const RESOLVED_SSR_MANIFEST_VIRTUAL_MODULE_ID = '\0' + SSR_MANIFEST_VIRTUAL_MODULE_ID;
+
+export function resolveSessionDriver(driver: string | undefined): string | null {
+	if (!driver) {
+		return null;
+	}
+	try {
+		if (driver === 'fs') {
+			return importMetaResolve(builtinDrivers.fsLite, import.meta.url);
+		}
+		if (driver in builtinDrivers) {
+			return importMetaResolve(
+				builtinDrivers[driver as BuiltinDriverName],
+				import.meta.url,
+			);
+		}
+	} catch {
+		return null;
+	}
+
+	return driver;
+}
 
 function vitePluginManifest(options: StaticBuildOptions, internals: BuildInternals): VitePlugin {
 	return {

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -1,4 +1,6 @@
 import { stringify as rawStringify, unflatten as rawUnflatten } from 'devalue';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+
 import {
 	type BuiltinDriverOptions,
 	type Driver,
@@ -507,10 +509,13 @@ export async function resolveSessionDriver(driver: string | undefined): Promise<
 	}
 	try {
 		if (driver === 'fs') {
-			return await import.meta.resolve(builtinDrivers.fsLite);
+			return importMetaResolve(builtinDrivers.fsLite, import.meta.url);
 		}
 		if (driver in builtinDrivers) {
-			return await import.meta.resolve(builtinDrivers[driver as keyof typeof builtinDrivers]);
+			return importMetaResolve(
+				builtinDrivers[driver as keyof typeof builtinDrivers],
+				import.meta.url,
+			);
 		}
 	} catch {
 		return null;

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -505,7 +505,7 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 	}
 }
 
-export function resolveSessionDriverName(driver: string | undefined): string | null {
+function resolveSessionDriverName(driver: string | undefined): string | null {
 	if (!driver) {
 		return null;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,6 +553,9 @@ importers:
       http-cache-semantics:
         specifier: ^4.1.1
         version: 4.1.1
+      import-meta-resolve:
+        specifier: ^4.1.0
+        version: 4.1.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
## Changes

Ponyfills `import.meta.resolve`, because it's behind a flag in Node.js 20.3-20.5. The `import-meta-resolve` package is already a dep of `@astrojs/markdown-remark`. We can't use it at runtime because of node builtins, so we split it into different functions, where the runtime one doesn't resolve the name and we import it directly. It's only important at build time, as it allows us to bundle the driver.

Fixes #13800

## Testing

Session tests pass. Tested with Node 20.4

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
