### PR TITLE
feat(csp): add script-dynamic keyword support

### DIFF
--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -112,6 +112,7 @@ export type SSRManifestCSP = {
 	algorithm: CspAlgorithm;
 	scriptHashes: string[];
 	scriptResources: string[];
+	isStrictDynamic: boolean;
 	styleHashes: string[];
 	styleResources: string[];
 	directives: CspDirective[];

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -38,6 +38,7 @@ import {
 	trackStyleHashes,
 	getScriptResources,
 	getStyleResources,
+	getStrictDynamic,
 } from '../csp/common.js';
 import { NoPrerenderedRoutesWithDomains } from '../errors/errors-data.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
@@ -653,6 +654,7 @@ async function createBuildManifest(
 			scriptResources: getScriptResources(settings.config.experimental.csp),
 			algorithm,
 			directives: getDirectives(settings.config.experimental.csp),
+			isStrictDynamic: getStrictDynamic(settings.config.experimental.csp),
 		};
 	}
 	return {

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -23,6 +23,7 @@ import {
 	trackStyleHashes,
 	getScriptResources,
 	getStyleResources,
+	getStrictDynamic,
 } from '../../csp/common.js';
 import { encodeKey } from '../../encryption.js';
 import { fileExtension, joinPaths, prependForwardSlash } from '../../path.js';
@@ -307,6 +308,7 @@ async function buildManifest(
 			styleResources: getStyleResources(settings.config.experimental.csp),
 			algorithm,
 			directives: getDirectives(settings.config.experimental.csp),
+			isStrictDynamic: getStrictDynamic(settings.config.experimental.csp),
 		};
 	}
 

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -491,6 +491,7 @@ export const AstroConfigSchema = z.object({
 							.object({
 								resources: z.array(z.string()).optional(),
 								hashes: z.array(cspHashSchema).optional(),
+								strictDynamic: z.boolean().optional(),
 							})
 							.optional(),
 					}),

--- a/packages/astro/src/core/csp/common.ts
+++ b/packages/astro/src/core/csp/common.ts
@@ -58,6 +58,13 @@ export function getDirectives(csp: EnabledCsp): CspDirective[] {
 	return csp.directives ?? [];
 }
 
+export function getStrictDynamic(csp: EnabledCsp): boolean {
+	if (csp === true) {
+		return false;
+	}
+	return csp.scriptDirective?.strictDynamic ?? false;
+}
+
 export async function trackStyleHashes(
 	internals: BuildInternals,
 	settings: AstroSettings,

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -504,6 +504,7 @@ export class RenderContext {
 			styleHashes: manifest.csp?.styleHashes ? [...manifest.csp.styleHashes] : [],
 			styleResources: manifest.csp?.styleResources ? [...manifest.csp.styleResources] : [],
 			directives: manifest.csp?.directives ? [...manifest.csp.directives] : [],
+			isStrictDynamic: manifest.csp?.isStrictDynamic ?? false,
 		};
 
 		return result;

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -35,7 +35,8 @@ export function renderCspContent(result: SSRResult): string {
 		styleResources = result.styleResources.map((r) => `'${r}'`).join(' ');
 	}
 
-	const scriptSrc = `style-src ${styleResources} ${Array.from(finalStyleHashes).join(' ')};`;
+	const strictDynamic = result.isStrictDynamic ? ` strict-dynamic` : '';
+	const scriptSrc = `style-src ${styleResources} ${Array.from(finalStyleHashes).join(' ')}${strictDynamic};`;
 	const styleSrc = `script-src ${scriptResources} ${Array.from(finalScriptHashes).join(' ')};`;
 	return `${directives} ${scriptSrc} ${styleSrc}`;
 }

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2326,6 +2326,18 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 						 *
 						 */
 						resources?: string[];
+
+						/**
+						 * @name experimental.csp.scriptDirective.strictDynamic
+						 * @type {boolean}
+						 * @default `false`
+						 * @version 5.5.x
+						 * @description
+						 *
+						 * Enables the keyword `strict-dynamic`, to support the dynamic injection of scripts.
+						 *
+						 */
+						strictDynamic?: boolean;
 					};
 
 					/**

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -11,7 +11,7 @@ import type { AstroComponentFactory } from '../../runtime/server/index.js';
 import type { Params, RewritePayload } from './common.js';
 import type { ValidRedirectStatus } from './config.js';
 import type { AstroInstance, MDXInstance, MarkdownInstance } from './content.js';
-import type { CspDirective } from '../../core/csp/config.js';
+import type { CspDirective, CspHash } from '../../core/csp/config.js';
 
 /**
  * Astro global available in all contexts in .astro files
@@ -387,7 +387,7 @@ export interface AstroSharedContext<
 	 * ctx.insertStyleHash("sha256-1234567890abcdef1234567890")
 	 * ```
 	 */
-	insertStyleHash: (hash: string) => void;
+	insertStyleHash: (hash: CspHash) => void;
 
 	/**
 	 * It set the resource for the directive `script-src` in the route being rendered.
@@ -409,7 +409,7 @@ export interface AstroSharedContext<
 	 * ctx.insertScriptHash("sha256-1234567890abcdef1234567890")
 	 * ```
 	 */
-	insertScriptHash: (hash: string) => void;
+	insertScriptHash: (hash: CspHash) => void;
 }
 
 /**

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -257,6 +257,7 @@ export interface SSRResult {
 	styleHashes: SSRManifestCSP['styleHashes'];
 	styleResources: SSRManifestCSP['styleResources'];
 	directives: SSRManifestCSP['directives'];
+	isStrictDynamic: SSRManifestCSP['isStrictDynamic'];
 }
 
 /**

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -13,6 +13,7 @@ import {
 	getDirectives,
 	getScriptResources,
 	getStyleResources,
+	getStrictDynamic,
 } from '../core/csp/common.js';
 import { warnMissingAdapter } from '../core/dev/adapter-validation.js';
 import { createKey, getEnvironmentKey, hasEnvironmentKey } from '../core/encryption.js';
@@ -191,6 +192,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			styleResources: getStyleResources(settings.config.experimental.csp),
 			algorithm: getAlgorithm(settings.config.experimental.csp),
 			directives: getDirectives(settings.config.experimental.csp),
+			isStrictDynamic: getStrictDynamic(settings.config.experimental.csp),
 		};
 	}
 

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -66,11 +66,7 @@ describe('CSP', () => {
 	it('should generate the hash with the sha512 algorithm', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
-			adapter: testAdapter({
-				setManifest(_manifest) {
-					manifest = _manifest;
-				},
-			}),
+			adapter: testAdapter(),
 			experimental: {
 				csp: {
 					algorithm: 'SHA-512',
@@ -92,11 +88,7 @@ describe('CSP', () => {
 	it('should generate the hash with the sha384 algorithm', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
-			adapter: testAdapter({
-				setManifest(_manifest) {
-					manifest = _manifest;
-				},
-			}),
+			adapter: testAdapter(),
 			experimental: {
 				csp: {
 					algorithm: 'SHA-384',
@@ -118,11 +110,7 @@ describe('CSP', () => {
 	it('should render hashes provided by the user', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
-			adapter: testAdapter({
-				setManifest(_manifest) {
-					manifest = _manifest;
-				},
-			}),
+			adapter: testAdapter(),
 			experimental: {
 				csp: {
 					styleDirective: {
@@ -152,11 +140,7 @@ describe('CSP', () => {
 	it('should contain the additional directives', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
-			adapter: testAdapter({
-				setManifest(_manifest) {
-					manifest = _manifest;
-				},
-			}),
+			adapter: testAdapter(),
 			experimental: {
 				csp: {
 					directives: ["img-src 'self' 'https://example.com'"],
@@ -178,11 +162,7 @@ describe('CSP', () => {
 	it('should contain the custom resources for "script-src" and "style-src"', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
-			adapter: testAdapter({
-				setManifest(_manifest) {
-					manifest = _manifest;
-				},
-			}),
+			adapter: testAdapter(),
 			experimental: {
 				csp: {
 					styleDirective: {
@@ -220,11 +200,7 @@ describe('CSP', () => {
 	it('allows injecting custom script resources and hashes based on pages', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
-			adapter: testAdapter({
-				setManifest(_manifest) {
-					manifest = _manifest;
-				},
-			}),
+			adapter: testAdapter(),
 		});
 		await fixture.build();
 		app = await fixture.loadTestAdapterApp();
@@ -269,5 +245,29 @@ describe('CSP', () => {
 		assert.ok(meta.attr('content').toString().includes("script-src 'self'"));
 		// correctness for hashes
 		assert.ok(meta.attr('content').toString().includes("default-src 'self';"));
+	});
+
+	it('allows add `strict-dynamic` when enabled', async () => {
+		fixture = await loadFixture({
+			root: './fixtures/csp/',
+			adapter: testAdapter(),
+			experimental: {
+				csp: {
+					scriptDirective: {
+						strictDynamic: true,
+					},
+				},
+			},
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+
+		const request = new Request('http://example.com/index.html');
+		const response = await app.render(request);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+
+		const meta = $('meta[http-equiv="Content-Security-Policy"]');
+		assert.ok(meta.attr('content').toString().includes('strict-dynamic;'));
 	});
 });


### PR DESCRIPTION
## Changes

This PR implements the `strictDynamic` field from the RFC

## Testing

Added a new test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
