### PR TITLE
Fix(Type): Add loading behavior option to ImageSharedProps type

### DIFF
--- a/.changeset/lazy-trains-switch.md
+++ b/.changeset/lazy-trains-switch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add loading behavior option to ImageSharedProps type

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -210,7 +210,10 @@ type ImageSharedProps<T> = T & {
 				 * ```
 				 */
 				priority?: boolean;
-
+				/**
+				 * Loading behavior for the image, e.g., "lazy" or "eager".
+				 */
+				loading?: string;
 				/**
 				 * A list of widths to generate images for. The value of this property will be used to assign the `srcset` property on the final `img` element.
 				 *

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -219,6 +219,16 @@ type ImageSharedProps<T> = T & {
 				 *
 				 * This attribute is incompatible with `densities`.
 				 */
+	    	title?: string;
+		    /** 
+		     * Class name for the image element. This will be passed to the `class` attribute of the final `img` element.
+		    */
+		    class?: string;
+		    /**
+		     * A list of widths to generate images for. The value of this property will be used to assign the `srcset` property on the final `img` element.
+		     *
+		     * This attribute is incompatible with `densities`.
+		     */
 				widths?: number[];
 				densities?: never;
 		  }


### PR DESCRIPTION
## Changes

The property 'loading' does not exist on type 'IntrinsicAttributes & Props'. ts(2322)t`

## Testing

* No specific tests were added
* Tested on local repo and with pnpm run test

## Docs

No documentation required
