### PR TITLE
chore: lock knip in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,6 +65,7 @@
   "ignoreDeps": [
     // manually bumping deps
     "@biomejs/biome",
+    "knip",
     "@types/node",
     
     // TODO: investigate upgrade (zod import issues with atproto)

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "lint:fix": "biome lint --write --unsafe",
     "publint": "pnpm -r --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --no-bail exec publint",
     "version": "changeset version && node ./scripts/deps/update-example-versions.js && pnpm install --no-frozen-lockfile && pnpm run format",
-    "preinstall": "npx only-allow pnpm",
-    "knip": "knip"
+    "preinstall": "npx only-allow pnpm"
   },
   "workspaces": [
     "packages/markdown/*",


### PR DESCRIPTION
## Changes

This PR locks knip in renovate. I also removed a script that isn't needed

## Testing

Linting should work

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
