### PR TITLE
test: skip test due to some regression

### DIFF
--- a/packages/astro/e2e/dev-toolbar.test.js
+++ b/packages/astro/e2e/dev-toolbar.test.js
@@ -257,7 +257,8 @@ test.describe('Dev Toolbar', () => {
 		}
 	});
 
-	test('tooltip is rendered behind audit list window', async ({ page, astro }) => {
+	// FIXME: This PR caused a regression in this test https://github.com/withastro/astro/pull/13383
+	test.skip('tooltip is rendered behind audit list window', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/tooltip-position'));
 
 		const toolbar = page.locator('astro-dev-toolbar');


### PR DESCRIPTION
## Changes

This PR skips the test introduced in https://github.com/withastro/astro/pull/13373/

It seems that the PR https://github.com/withastro/astro/pull/13383 caused some regressions

## Testing

e2e should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
