### PR TITLE
Add option to suppress adapter feature support log

### DIFF
--- a/packages/astro/src/types/public/integrations.ts
+++ b/packages/astro/src/types/public/integrations.ts
@@ -67,6 +67,15 @@ export type AdapterSupportsKind =
 export type AdapterSupportWithMessage = {
 	support: Exclude<AdapterSupportsKind, 'stable'>;
 	message: string;
+	/**
+	 * Determines if a feature support warning/error in the adapter should be suppressed:
+	 * - `"default"`: Suppresses the default warning/error message.
+	 * - `"all"`: Suppresses both the custom and the default warning/error message.
+	 *
+	 * This is useful when the warning/error might not be aplicable in certain contexts.
+	 * Or the default message might cause confusion and conflict with the custom one.
+	 */
+	suppress?: 'all' | 'default';
 };
 
 export type AdapterSupport = AdapterSupportsKind | AdapterSupportWithMessage;

--- a/packages/astro/test/fixtures/feature-support-message-suppresion/astro.config.mjs
+++ b/packages/astro/test/fixtures/feature-support-message-suppresion/astro.config.mjs
@@ -1,0 +1,29 @@
+import { defineConfig } from 'astro/config';
+export default defineConfig({
+  integrations: [
+    {
+      name: 'astro-test-feature-support-message-suppression',
+      hooks: {
+        'astro:config:done': ({ setAdapter }) => {
+          setAdapter({
+            name: 'astro-test-feature-support-message-suppression',
+            supportedAstroFeatures: {
+              staticOutput: "stable",
+              hybridOutput: "stable",
+              serverOutput: {
+                support: "experimental",
+                message: "This should be logged.",
+                suppress: "default",
+              },
+              sharpImageService: {
+                support: 'limited',
+                message: 'This shouldn\'t be logged.',
+                suppress: "all",
+              },
+            }
+          })
+        },
+      },
+    },
+  ],
+});

--- a/packages/astro/test/fixtures/feature-support-message-suppresion/package.json
+++ b/packages/astro/test/fixtures/feature-support-message-suppresion/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@test/feature-support-message-suppresion",
+  "type": "module",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3086,6 +3086,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/feature-support-message-suppresion:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/fetch:
     dependencies:
       '@astrojs/preact':


### PR DESCRIPTION
## Changes

This adds a new `suppress` option to the `supportedAstroFeatures` of `setAdapter` in core. You can either set `"all"` to suppress both the default and custom log, or `"default"` to only suppress the default log.

The idea is that integration authors can suppress the log if a feature is supported in a specific condition, or if the default log can be conflicting and confuse users. You can take https://github.com/withastro/astro/pull/13817 as an example of when this happens.

Originally, I intended to make `suppress` a boolean option while also changing so you only log the custom message if provided, but doing so would imply a breaking change (I think?). So I went with this solution.

 
## Testing
Added a new fixture: `packages/astro/test/fixtures/feature-support-message-suppresion`

Not sure how I'd go about testing this automatically, but manually:

```bash
pnpm install
pnpm build
cd packages/astro/test/fixtures/feature-support-message-suppresion
pnpm dev
```

You should see that the dev server has only a "This should be logged." warning from `[adapter]`. You can see in the fixture that there's an example of both using a `suppress: "default"` and `suppress: "all"`.
```ts
setAdapter({
  name: 'astro-test-feature-support-message-suppression',
  supportedAstroFeatures: {
    staticOutput: "stable",
    hybridOutput: "stable",
    serverOutput: {
      support: "experimental",
      message: "This should be logged.",
      suppress: "default",
    },
    sharpImageService: {
      support: 'limited',
      message: 'This shouldn\'t be logged.',
      suppress: "all",
    },
  }
})
``` 
 

## Docs

I'll make a docs PR once we achieve some sort of consensus on the API, it should only need to update the types shown in [Building an adapter](https://docs.astro.build/en/reference/adapter-reference/#building-an-adapter).
