### PR TITLE
fix: client directive on astro component warning

### DIFF
--- a/.changeset/slick-pillows-smash.md
+++ b/.changeset/slick-pillows-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the warning shown when client directives are used on Astro components

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -86,10 +86,11 @@ export class AstroComponentInstance {
 }
 
 // Issue warnings for invalid props for Astro components
-function validateComponentProps(props: any, displayName: string) {
+function validateComponentProps(props: any, clientDirectives: string[], displayName: string) {
 	if (props != null) {
+		const directives = clientDirectives.map((directive) => `client:${directive}`);
 		for (const prop of Object.keys(props)) {
-			if (prop.startsWith('client:')) {
+			if (directives.includes(prop)) {
 				console.warn(
 					`You are attempting to render <${displayName} ${prop} />, but ${displayName} is an Astro component. Astro components do not render in the client and should not have a hydration directive. Please use a framework component for client rendering.`,
 				);
@@ -105,7 +106,7 @@ export function createAstroComponentInstance(
 	props: ComponentProps,
 	slots: any = {},
 ) {
-	validateComponentProps(props, displayName);
+	validateComponentProps(props, [...result.clientDirectives.keys()], displayName);
 	const instance = new AstroComponentInstance(result, props, slots, factory);
 	if (isAPropagatingComponent(result, factory)) {
 		result._metadata.propagators.add(instance);

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -86,9 +86,13 @@ export class AstroComponentInstance {
 }
 
 // Issue warnings for invalid props for Astro components
-function validateComponentProps(props: any, clientDirectives: string[], displayName: string) {
+function validateComponentProps(
+	props: any,
+	clientDirectives: SSRResult['clientDirectives'],
+	displayName: string,
+) {
 	if (props != null) {
-		const directives = clientDirectives.map((directive) => `client:${directive}`);
+		const directives = [...clientDirectives.keys()].map((directive) => `client:${directive}`);
 		for (const prop of Object.keys(props)) {
 			if (directives.includes(prop)) {
 				console.warn(
@@ -106,7 +110,7 @@ export function createAstroComponentInstance(
 	props: ComponentProps,
 	slots: any = {},
 ) {
-	validateComponentProps(props, [...result.clientDirectives.keys()], displayName);
+	validateComponentProps(props, result.clientDirectives, displayName);
 	const instance = new AstroComponentInstance(result, props, slots, factory);
 	if (isAPropagatingComponent(result, factory)) {
 		result._metadata.propagators.add(instance);

--- a/packages/astro/test/units/render/rendering.test.js
+++ b/packages/astro/test/units/render/rendering.test.js
@@ -9,6 +9,10 @@ import {
 	renderTemplate,
 } from '../../../dist/runtime/server/index.js';
 
+const DEFAULT_RESULT = {
+	clientDirectives: new Map(),
+};
+
 describe('rendering', () => {
 	const evaluated = [];
 
@@ -38,7 +42,7 @@ describe('rendering', () => {
 			</nested>`;
 		});
 
-		const result = await renderToString(Root({}, { id: 'root' }, {}));
+		const result = await renderToString(Root(DEFAULT_RESULT, { id: 'root' }, {}));
 		const rendered = getRenderedIds(result);
 
 		assert.deepEqual(evaluated, [
@@ -71,7 +75,7 @@ describe('rendering', () => {
 			</root>`;
 		});
 
-		const result = renderToString(Root({}, { id: 'root' }, {}));
+		const result = renderToString(Root(DEFAULT_RESULT, { id: 'root' }, {}));
 		assert.ok(!isPromise(result));
 
 		const rendered = getRenderedIds(result);
@@ -110,7 +114,7 @@ describe('rendering', () => {
 			</asyncnested>`;
 		});
 
-		const result = await renderToString(Root({}, { id: 'root' }, {}));
+		const result = await renderToString(Root(DEFAULT_RESULT, { id: 'root' }, {}));
 
 		const rendered = getRenderedIds(result);
 
@@ -148,7 +152,7 @@ describe('rendering', () => {
 			</asyncnested>`;
 		});
 
-		const awaitableResult = renderToString(Root({}, { id: 'root' }, {}));
+		const awaitableResult = renderToString(Root(DEFAULT_RESULT, { id: 'root' }, {}));
 
 		assert.deepEqual(evaluated, ['root', 'root/asyncnested_1', 'root/asyncnested_2']);
 
@@ -183,7 +187,7 @@ describe('rendering', () => {
 			return renderTemplate`${message}`;
 		});
 
-		const renderInstance = await renderComponent({}, '', Root, {});
+		const renderInstance = await renderComponent(DEFAULT_RESULT, '', Root, {});
 
 		const chunks = [];
 		const destination = {
@@ -226,7 +230,7 @@ describe('rendering', () => {
 			</root>`;
 		});
 
-		const result = await renderToString(Root({}, { id: 'root' }, {}));
+		const result = await renderToString(Root(DEFAULT_RESULT, { id: 'root' }, {}));
 
 		const rendered = getRenderedIds(result);
 


### PR DESCRIPTION
## Changes

- Closes #13856
- The check was too loose, because there are internal props starting with `client:`

## Testing

Manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
