### PR TITLE
fix: devtoolbar data unset

### DIFF
--- a/.changeset/sixty-nights-drive.md
+++ b/.changeset/sixty-nights-drive.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where the dev toolbar would crash if it could not retrieve some essential data

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/astro.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/astro.ts
@@ -92,8 +92,7 @@ export default {
 				},
 			];
 
-			const hasNewerVersion = (window as DevToolbarMetadata).__astro_dev_toolbar__
-				.latestAstroVersion;
+			const { latestAstroVersion, version, debugInfo } = (window as DevToolbarMetadata).__astro_dev_toolbar__ ?? {}
 
 			const windowComponent = createWindowElement(
 				`<style>
@@ -336,14 +335,10 @@ export default {
 			<header>
 				<section>
 				${astroLogo}
-				<astro-dev-toolbar-badge badge-style="gray" size="large">${
-					(window as DevToolbarMetadata).__astro_dev_toolbar__.version
-				}</astro-dev-toolbar-badge>
+				<astro-dev-toolbar-badge badge-style="gray" size="large">${version}</astro-dev-toolbar-badge>
 				${
-					hasNewerVersion
-						? `<astro-dev-toolbar-badge badge-style="green" size="large">${
-								(window as DevToolbarMetadata).__astro_dev_toolbar__.latestAstroVersion
-							} available!</astro-dev-toolbar-badge>
+					latestAstroVersion
+						? `<astro-dev-toolbar-badge badge-style="green" size="large">${latestAstroVersion} available!</astro-dev-toolbar-badge>
 						`
 						: ''
 				}
@@ -384,7 +379,7 @@ export default {
 
 			copyDebugButton?.addEventListener('click', () => {
 				navigator.clipboard.writeText(
-					'```\n' + (window as DevToolbarMetadata).__astro_dev_toolbar__.debugInfo + '\n```',
+					'```\n' + debugInfo + '\n```',
 				);
 				copyDebugButton.textContent = 'Copied to clipboard!';
 


### PR DESCRIPTION
## Changes

- Closes #13841
- A browser extension could block a script we inject, breaking the devtoolbar
- This PR handles the case where `__astro_dev_toolbar__` is not set

## Testing

N/A. Couldn't get the user to test it

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
