### PR TITLE
Fix missing type-attribute in xml-stylesheet with xslt extension

### DIFF
--- a/.changeset/huge-islands-fold.md
+++ b/.changeset/huge-islands-fold.md
@@ -2,4 +2,4 @@
 '@astrojs/rss': patch
 ---
 
-Fix missing type-attribute in xml-stylesheet with xslt extension
+Fixes a missing type attribute when providing a XSLT stylesheet

--- a/.changeset/huge-islands-fold.md
+++ b/.changeset/huge-islands-fold.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Fix missing type-attribute in xml-stylesheet with xslt extension

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -173,7 +173,7 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 	const parser = new XMLParser(xmlOptions);
 	const root: any = { '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' } };
 	if (typeof rssOptions.stylesheet === 'string') {
-		const isXSL = /\.xsl$/i.test(rssOptions.stylesheet);
+		const isXSL = /\.xslt?$/i.test(rssOptions.stylesheet);
 		root['?xml-stylesheet'] = {
 			'@_href': rssOptions.stylesheet,
 			...(isXSL && { '@_type': 'text/xsl' }),

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -35,6 +35,8 @@ const validXmlWithCustomDataResult = `<?xml version="1.0" encoding="UTF-8"?><rss
 const validXmlWithStylesheet = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet href="/feedstylesheet.css"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link></channel></rss>`;
 // biome-ignore format: keep in one line
 const validXmlWithXSLStylesheet = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet href="/feedstylesheet.xsl" type="text/xsl"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link></channel></rss>`;
+// biome-ignore format: keep in one line
+const validXmlWithXSLTStylesheet = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet href="/feedstylesheet.xslt" type="text/xsl"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link></channel></rss>`;
 
 function assertXmlDeepEqual(a, b) {
 	const parsedA = parseXmlString(a);
@@ -161,7 +163,23 @@ describe('getRssString', () => {
 			stylesheet: '/feedstylesheet.xsl',
 		});
 
+		// xml2js doesn't parse processing instructions. Assert the type is present.
+		assert.equal(str.includes('type="text/xsl"'), true);
 		assertXmlDeepEqual(str, validXmlWithXSLStylesheet);
+	});
+
+	it('should include xml-stylesheet instruction with xslt type when stylesheet is set to xslt file', async () => {
+		const str = await getRssString({
+			title,
+			description,
+			items: [],
+			site,
+			stylesheet: '/feedstylesheet.xslt',
+		});
+
+		// xml2js doesn't parse processing instructions. Assert the type is present.
+		assert.equal(str.includes('type="text/xsl"'), true);
+		assertXmlDeepEqual(str, validXmlWithXSLTStylesheet);
 	});
 
 	it('should preserve self-closing tags on `customData`', async () => {


### PR DESCRIPTION
## Changes

Adds the `type="text/xsl"` attribute to xml-stylesheet processing instruction in rss when passing an xslt stylesheet.

Fixes #13866

## Testing

Add test `should include xml-stylesheet instruction with xslt type when stylesheet is set to xslt file` which is based of `should include xml-stylesheet instruction with xsl type when stylesheet is set to xsl file` in the same file.

Do a string includes assert to have this processing instruction since the parser used (xml2js) doesn't process processing-instruction. See issue here: https://github.com/Leonidas-from-XIV/node-xml2js/issues/339. Should change parser or add extra tests for processing instructions.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
Could update the docs to highlight which stylesheets are supported. Looking at the tests:
https://github.com/withastro/astro/blob/de2fc9b3c406c21683b8a692fafa3cbc77ca552b/packages/astro-rss/test/rss.test.js#L143
https://github.com/withastro/astro/blob/de2fc9b3c406c21683b8a692fafa3cbc77ca552b/packages/astro-rss/test/rss.test.js#L155

It supports both css and xsl (and with this change, xslt). Not even sure if you can use css for this.

<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
