### PR TITLE
fix(markdoc): fix variable passing in partials

### DIFF
--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -211,7 +211,18 @@ async function resolvePartials({
 				});
 			}
 			if (pluginContext.meta.watchMode) pluginContext.addWatchFile(partialPath);
-			let partialTokens = tokenizer.tokenize(partialContents);
+			
+			// Manually substitute variables in the partial content BEFORE parsing
+			const variables = node.attributes.variables || {};
+			let processedPartialContents = partialContents;
+			
+			// Replace {% $varname %} patterns in the raw content
+			for (const [varName, varValue] of Object.entries(variables)) {
+				const pattern = new RegExp(`{%\\s*\\$${varName}\\s*%}`, 'g');
+				processedPartialContents = processedPartialContents.replace(pattern, String(varValue));
+			}
+			
+			let partialTokens = tokenizer.tokenize(processedPartialContents);
 			if (allowHTML) {
 				partialTokens = htmlTokenTransform(tokenizer, partialTokens);
 			}

--- a/packages/integrations/markdoc/test/fixtures/partials-variables/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/partials-variables/astro.config.mjs
@@ -1,0 +1,7 @@
+import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [markdoc()],
+});

--- a/packages/integrations/markdoc/test/fixtures/partials-variables/package.json
+++ b/packages/integrations/markdoc/test/fixtures/partials-variables/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/markdoc-partials-variables",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/markdoc": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/markdoc/test/fixtures/partials-variables/src/content/config.ts
+++ b/packages/integrations/markdoc/test/fixtures/partials-variables/src/content/config.ts
@@ -1,0 +1,9 @@
+import { defineCollection, z } from 'astro:content';
+
+const docs = defineCollection({
+	schema: z.object({
+		title: z.string(),
+	})
+});
+
+export const collections = { docs };

--- a/packages/integrations/markdoc/test/fixtures/partials-variables/src/content/docs/_partial.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/partials-variables/src/content/docs/_partial.mdoc
@@ -1,0 +1,13 @@
+## Foo
+
+We have **{% $name %}** that links to [Link]({% $name %}.example.com).
+
+Again:
+- Name: {% $name %}
+- Link: {% $name %}.example.com
+
+## Bar
+
+Version: {% $version %}
+
+## Baz ({% $test %})

--- a/packages/integrations/markdoc/test/fixtures/partials-variables/src/content/docs/test.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/partials-variables/src/content/docs/test.mdoc
@@ -1,0 +1,20 @@
+---
+title: Test
+---
+
+## Before
+
+The partial is about to be injected.
+
+{% partial
+     file="./_partial.mdoc"
+     variables={
+       name: "foo",
+       version: 42,
+       test: true,
+     }
+/%}
+
+## After
+
+The partial has been injected.

--- a/packages/integrations/markdoc/test/fixtures/partials-variables/src/pages/test.astro
+++ b/packages/integrations/markdoc/test/fixtures/partials-variables/src/pages/test.astro
@@ -1,0 +1,16 @@
+---
+import { getEntry } from 'astro:content';
+
+const entry = await getEntry('docs', 'test');
+const { Content } = await entry.render();
+---
+
+<html>
+<head>
+    <title>{entry.data.title}</title>
+</head>
+<body>
+    <h1>{entry.data.title}</h1>
+    <Content />
+</body>
+</html>

--- a/packages/integrations/markdoc/test/partials-variables.test.js
+++ b/packages/integrations/markdoc/test/partials-variables.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+import markdoc from '../dist/index.js';
+
+const root = new URL('./fixtures/partials-variables/', import.meta.url);
+
+describe('Markdoc - Partials with Variables', () => {
+	let baseFixture;
+
+	before(async () => {
+		baseFixture = await loadFixture({
+			root,
+			integrations: [markdoc()],
+		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await baseFixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('substitutes variables in partials correctly', async () => {
+			const res = await baseFixture.fetch('/test');
+			const html = await res.text();
+			const { document } = parseHTML(html);
+			
+			// Check that the page title is correct
+			assert.equal(document.querySelector('h1')?.textContent, 'Test');
+			
+			// Check that "Before" and "After" sections are present
+			const h2Elements = Array.from(document.querySelectorAll('h2'));
+			const h2Texts = h2Elements.map(el => el.textContent);
+			assert.ok(h2Texts.includes('Before'));
+			assert.ok(h2Texts.includes('After'));
+			assert.ok(h2Texts.includes('Foo'));
+			assert.ok(h2Texts.includes('Bar'));
+			assert.ok(h2Texts.includes('Baz (true)'));
+			
+			// Check variable substitutions in text content
+			const bodyText = document.body.textContent;
+			
+			// Check that variables were substituted (not left as {% $var %})
+			assert.ok(!bodyText.includes('{% $name %}'));
+			assert.ok(!bodyText.includes('{% $version %}'));
+			assert.ok(!bodyText.includes('{% $test %}'));
+			
+			// Check that the actual values appear
+			assert.ok(bodyText.includes('We have foo that links'));
+			assert.ok(bodyText.includes('Name: foo'));
+			assert.ok(bodyText.includes('Version: 42'));
+			
+			// Check that markdown formatting in variables works
+			const links = Array.from(document.querySelectorAll('a'));
+			const linkFound = links.some(link => 
+				link.getAttribute('href') === 'foo.example.com' && 
+				link.textContent === 'Link'
+			);
+			assert.ok(linkFound, 'Markdown link with variable should be rendered correctly');
+			
+			// Check that bold formatting works with variables
+			const strongElements = Array.from(document.querySelectorAll('strong'));
+			const boldFound = strongElements.some(strong => strong.textContent === 'foo');
+			assert.ok(boldFound, 'Bold formatting with variable should work');
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await baseFixture.build();
+		});
+
+		it('substitutes variables in partials correctly', async () => {
+			const html = await baseFixture.readFile('/test/index.html');
+			const { document } = parseHTML(html);
+			
+			// Check that the page title is correct
+			assert.equal(document.querySelector('h1')?.textContent, 'Test');
+			
+			// Check that "Before" and "After" sections are present
+			const h2Elements = Array.from(document.querySelectorAll('h2'));
+			const h2Texts = h2Elements.map(el => el.textContent);
+			assert.ok(h2Texts.includes('Before'));
+			assert.ok(h2Texts.includes('After'));
+			assert.ok(h2Texts.includes('Foo'));
+			assert.ok(h2Texts.includes('Bar'));
+			assert.ok(h2Texts.includes('Baz (true)'));
+			
+			// Check variable substitutions in text content
+			const bodyText = document.body.textContent;
+			
+			// Check that variables were substituted (not left as {% $var %})
+			assert.ok(!bodyText.includes('{% $name %}'));
+			assert.ok(!bodyText.includes('{% $version %}'));
+			assert.ok(!bodyText.includes('{% $test %}'));
+			
+			// Check that the actual values appear
+			assert.ok(bodyText.includes('We have foo that links'));
+			assert.ok(bodyText.includes('Name: foo'));
+			assert.ok(bodyText.includes('Version: 42'));
+			
+			// Check that markdown formatting in variables works
+			const links = Array.from(document.querySelectorAll('a'));
+			const linkFound = links.some(link => 
+				link.getAttribute('href') === 'foo.example.com' && 
+				link.textContent === 'Link'
+			);
+			assert.ok(linkFound, 'Markdown link with variable should be rendered correctly');
+			
+			// Check that bold formatting works with variables
+			const strongElements = Array.from(document.querySelectorAll('strong'));
+			const boldFound = strongElements.some(strong => strong.textContent === 'foo');
+			assert.ok(boldFound, 'Bold formatting with variable should work');
+		});
+	});
+});


### PR DESCRIPTION
# Fix variable substitution in Markdoc partials

Fixes #13575

## Issue

Variables in Markdoc partials were not being substituted, rendering as empty strings instead of their values. Additionally, Markdown syntax within variable values was not processed correctly.

**Example of broken behavior:**

Partial file:
```markdoc
Name: {% $name %} ([Link]({% $name %}.example.com))
Version: {% $version %}
```

Usage:
```markdoc
{% partial
     file="./_partial.mdoc"
     variables={
       name: "foo",
       version: 42
     }
/%}
```

**Expected:** Name: foo ([Link](foo.example.com))  
**Actual:** Name:  ([Link](.example.com))

## Root Cause

Variable substitution was happening after Markdown parsing. At that point, syntax like `[Link]({% $name %}.example.com)` had already been tokenized into separate nodes, so variable replacement couldn't reconstruct proper Markdown links.

## Fix

Move variable substitution to occur before Markdown tokenization by processing the raw content string:

```typescript
// In resolvePartials function
const variables = node.attributes.variables || {};
let processedPartialContents = partialContents;

for (const [varName, varValue] of Object.entries(variables)) {
  const pattern = new RegExp(`{%\\s*\\$${varName}\\s*%}`, 'g');
  processedPartialContents = processedPartialContents.replace(pattern, String(varValue));
}

let partialTokens = tokenizer.tokenize(processedPartialContents);
```

## Why Regex

Using regex for pattern replacement allows substitution to happen on the raw content before any parsing. This preserves Markdown syntax integrity and is simpler than AST manipulation. The pattern `{%\s*\$${varName}\s*%}` matches the Markdoc variable syntax with optional whitespace.

## Testing

Added `test/partials-variables.test.js` with comprehensive coverage:

- Tests string, number, and boolean variable substitution
- Verifies Markdown syntax within variables renders as HTML
- Validates both dev and build modes
- Confirms no unsubstituted `{% $variable %}` patterns remain

All tests pass in both development and build modes.