### PR TITLE
chore: fix name in jsdoc

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1369,7 +1369,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		experimentalBreakpoints?: number[];
 		/**
 		 * @docs
-		 * @name experimentalDefaultStyles
+		 * @name image.experimentalDefaultStyles
 		 * @type {boolean}
 		 * @default `true`
 		 * @description


### PR DESCRIPTION
## Changes

Fixes the name in the config references jsdoc

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
