### PR TITLE
fix: download attribute show boolean value for rendered HTML

### DIFF
--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -119,6 +119,9 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 	if (key === 'popover' && typeof value === 'boolean') {
 		return markHTMLString(value ? ` popover` : '');
 	}
+	if (key === 'download' && typeof value === 'boolean') {
+		return markHTMLString(value ? ` download` : '');
+	}
 
 	return markHTMLString(` ${key}="${toAttributeString(value, shouldEscape)}"`);
 }


### PR DESCRIPTION
## Changes

- What does this change?
 Fixes rendering of the `download` attribute when it has a boolean value

- Don't forget a changeset! `pnpm exec changeset`

## Testing

## Docs
--
