### PR TITLE
fix: request should be propery cloned first then copy to modified in middleware

### DIFF
--- a/.changeset/real-mice-joke.md
+++ b/.changeset/real-mice-joke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix: sequence middleware should properly copy request

--- a/packages/astro/src/core/middleware/sequence.ts
+++ b/packages/astro/src/core/middleware/sequence.ts
@@ -40,11 +40,11 @@ export function sequence(...handlers: MiddlewareHandler[]): MiddlewareHandler {
 						if (payload instanceof Request) {
 							newRequest = payload;
 						} else if (payload instanceof URL) {
-							newRequest = new Request(payload, handleContext.request);
+							newRequest = new Request(payload, handleContext.request.clone());
 						} else {
 							newRequest = new Request(
 								new URL(payload, handleContext.url.origin),
-								handleContext.request,
+								handleContext.request.clone(),
 							);
 						}
 						const oldPathname = handleContext.url.pathname;

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'astro/config';
+import tailwindcss from "@tailwindcss/vite"
+
+// https://astro.build/config
+export default defineConfig({
+	vite: {
+		plugins: [tailwindcss()],
+	}
+});

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/astro.config.mjs
@@ -1,9 +1,8 @@
 import { defineConfig } from 'astro/config';
-import tailwindcss from "@tailwindcss/vite"
 
 // https://astro.build/config
 export default defineConfig({
 	vite: {
-		plugins: [tailwindcss()],
+		plugins: [],
 	}
 });

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/package.json
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/middleware-sequence-request-clone",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
@@ -1,0 +1,15 @@
+import { sequence, defineMiddleware } from 'astro/middleware';
+
+const middleware1 = defineMiddleware((_, next) => next());
+
+const middleware2 = defineMiddleware(async ({ request }, next) => {
+	console.log(await request.clone().text());
+	return next();
+});
+
+const middleware3 = defineMiddleware(async ({ request }, next) => {
+	await request.clone();
+	return next();
+});
+
+export const onRequest = sequence(middleware1, middleware2, middleware3);

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
@@ -1,6 +1,6 @@
 import { sequence, defineMiddleware } from 'astro/middleware';
 
-const middleware1 = defineMiddleware((_, next) => next());
+const middleware1 = defineMiddleware((_, next) => next('/'));
 
 const middleware2 = defineMiddleware(async ({ request }, next) => {
 	console.log(await request.clone().text());

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/src/pages/index.astro
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/src/pages/index.astro
@@ -1,0 +1,1 @@
+<h1>Hello Sequence and Request Clone</h1>

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -388,3 +388,21 @@ describe('Middleware with tailwind', () => {
 		assert.equal(bundledCSS.includes('--tw'), true);
 	});
 });
+
+describe('Middleware should support clone request', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/middleware-sequence-request-clone/',
+		});
+		await fixture.build();
+	});
+
+	it('should correctly render page', async () => {
+		const res = await fixture.fetch('/clone');
+		const html = await res.text();
+		assert.equal(html.includes('Hello Sequence and Request Clone'), true);
+	});
+});

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -392,16 +392,24 @@ describe('Middleware with tailwind', () => {
 describe('Middleware should support clone request', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
+	let devServer;
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/middleware-sequence-request-clone/',
 		});
-		await fixture.build();
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
 	});
 
 	it('should correctly render page', async () => {
-		const res = await fixture.fetch('/clone');
+		const res = await fixture.fetch('/', {
+			method: 'POST',
+			body: 'TEST BODY'
+		});
 		const html = await res.text();
 		assert.equal(html.includes('Hello Sequence and Request Clone'), true);
 	});


### PR DESCRIPTION
## Changes

- Make `sequence` properly copy request to Closed: #13844 

## Root Cause

`Request` has a `body` field, it is a `ReadableStream`. If using new Request to copy an existing request like
https://github.com/withastro/astro/blob/d2d04b02773f82103db75076fcdd1f089503770a/packages/astro/src/core/middleware/sequence.ts#L42-L47

`newRequest` won't be automatically assigned a copied new body stream, but the two request would **SHARE** the same one ReadableStream.

So when user's middleware return a new URL then clone request in their middleware like the issue described, the final code would be same like:
```
// astro core code -- new Request first
const newRequest = new Request('/newUrl', originalRequest);

// user middleware -- clone created request then
const clonedRequest = newRequest.clone();

```

it would cause:
1. originalRequest.body **locked**. 
   1.1.  JS would complain that `Response body object should not be disturbed or locked` 
   1.2  a minimal reproducible example in here:  https://stackblitz.com/edit/github-8mju777p-9q9os8pj?file=src%2Fmiddleware.ts  You can input anything and click the submit button
   1.3 the error is throwed from below part, it is not enough to just check bodyUsed in here, also need to check body.locked. but I think it is not related to this issue, so just paste the thought in here  and not add the code in this PR, to see if it is worth to disscuss and add https://github.com/withastro/astro/blob/d2d04b02773f82103db75076fcdd1f089503770a/packages/astro/src/core/routing/rewrite.ts#L129-L142
2. when consuming clonedRequest, you can find originalRequest also be consumed.  That's why astro would throw RewriteBodyUsed Error like https://github.com/withastro/astro/issues/13844 posted.



There is a PoC code to prove it, you can copy-paste it into browser's console to see the result:
```js
const originalRequest = new Request('https://example.com/', {
  method: 'POST',
  body: 'payload=123',
  headers: {
    'Content-Type': 'application/x-www-form-urlencoded',
  },
});

console.log('Before new Request:');
console.log('originalRequest.bodyUsed:', originalRequest.bodyUsed);           // false
console.log('originalRequest.body.locked:', originalRequest.body.locked);     // false

// Create a new Request based on originalRequest
const newRequest = new Request('https://example.com/other', originalRequest);

console.log('\nAfter new Request (but before reading body):');
console.log('originalRequest.bodyUsed:', originalRequest.bodyUsed);           // false
console.log('originalRequest.body.locked:', originalRequest.body.locked);     // false

// --- Above all is easy to understand, but below are amazing thing: ---

// Clone reqeust from newRequest
const clonedRequest = newRequest.clone();
console.log('\nAfter clone newRequest:');
console.log('originalRequest.bodyUsed:', originalRequest.bodyUsed);           // false
console.log('originalRequest.body.locked:', originalRequest.body.locked);     // NOTICE: true

// NOTICE: Only consume clonedRequest, but the originalRequest...
await clonedRequest.text();
console.log('\nAfter consume clonedRequest:');
console.log('originalRequest.bodyUsed:', originalRequest.bodyUsed);           // NOICE: true
console.log('originalRequest.body.locked:', originalRequest.body.locked);    // true


```
## Testing

I added a new test to cover the two sceneraios. 

## Docs
No additional docs needed I guess, it is a fix.
