### PR TITLE
fix(errors): handle servers returning error docs with compression

### DIFF
--- a/.changeset/cold-views-mix.md
+++ b/.changeset/cold-views-mix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix bug where error pages would return invalid bodies if the upstream response was compressed


### PR DESCRIPTION
## Changes

When Astro serves an error page, it may use `fetch` to retrieve the prerendered error document from the origin that serves the original request. The returned error page is then forwarded to the client.

This PR drops the `Content-Encoding` and `Content-Length` headers from the forwarded response. This is because `fetch` implementations will return a decoded body in the body property. When the upstream `Content-Encoding` and `Content-Length` headers are added to that decoded response, a mismatch is created (e.g. plain text served with a `gzip` header). The browser will then try to decode the plain text as `gzip` and fail, pictured below is a failure to decode a 404 page:

![Screenshot of Safari failing to load a page with the error "cannot decode raw data"](https://github.com/user-attachments/assets/ce6a2b00-fff1-4957-8874-3ea90e3f597c)

*This PR allows Astro to successfully serve the error page even when the error document was compressed.* This is especially prone to happen when a reverse proxy like NGINX is deployed in front of Astro, so that the user-facing origin is the compressing reverse proxy.

Also see https://github.com/nodejs/undici/issues/2514

## Testing

I have applied these changes as a patch to my Astro version and saw the problem resolved.

I was unsure where to add the test and how to modify the response object that Astro is served.

## Docs

This PR does not include user-facing changes in behavior, especially if the error page is fetched from Astro itself. In general, I think that the docs on the error page serving behavior could be improved. That the error documents are retrieved via the network unless the adapter specifies another `prerenderedErrorPageFetch` using the disk was surprising for me given the docs on this page: https://docs.astro.build/en/basics/astro-pages/#custom-404-error-page
