### PR TITLE
fix: server island fallback not being deleted

### DIFF
--- a/.changeset/silly-peas-smash.md
+++ b/.changeset/silly-peas-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix fallback not being removed when server island is rendered

--- a/packages/astro/e2e/fixtures/server-islands/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/server-islands/src/pages/index.astro
@@ -29,6 +29,10 @@ export const prerender = false;
 			<Island server:defer secret="test" content={content} />
 		</div>
 
+		<Island server:defer>
+			<p slot="fallback" id="fallback">I am a fallback</p>
+		</Island>
+
 		<div id="error-test">
 			<HTMLError server:defer>
 				<script is:inline slot="fallback">

--- a/packages/astro/e2e/server-islands.test.js
+++ b/packages/astro/e2e/server-islands.test.js
@@ -79,6 +79,13 @@ test.describe('Server islands', () => {
 			let el = page.locator('#first');
 			await expect(el).toHaveCount(1);
 		});
+
+		test('Fallback is deleted when server island is rendered', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/base/'));
+			await page.waitForLoadState('networkidle');
+			let el = page.locator('#fallback');
+			await expect(el).toHaveCount(0);
+		});
 	});
 
 	test.describe('Development - trailingSlash: ignore', () => {

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -149,14 +149,14 @@ let response = await fetch('${serverIslandUrl}', {
 		return createThinHead();
 	}
 	async render(destination: RenderDestination) {
+		destination.write(createRenderInstruction({ type: 'server-island-runtime' }));
+		destination.write('<!--[if astro]>server-island-start<![endif]-->');
 		// Render the slots
 		for (const name in this.slots) {
 			if (name === 'fallback') {
 				await renderChild(destination, this.slots.fallback(this.result));
 			}
 		}
-		destination.write(createRenderInstruction({ type: 'server-island-runtime' }));
-		destination.write('<!--[if astro]>server-island-start<![endif]-->');
 		destination.write(
 			`<script type="module" data-astro-rerun data-island-id="${this.hostId}">${this.islandContent}</script>`,
 		);


### PR DESCRIPTION
## Changes

- Fixes fallback not being removed/deleted when server island is rendered.
- Fixes #13895

## Testing

- Tested locally
- Added E2E test to check that fallback does not exist after server island renders

## Docs

Bugfix, no new features or changes
