### PR TITLE
feat(vite-server): handle vite virtual module ids

### DIFF
--- a/.changeset/open-melons-start.md
+++ b/.changeset/open-melons-start.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where vite virtual module ids were incorrectly added in the dev server

--- a/packages/astro/e2e/fixtures/vite-virtual-modules/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/vite-virtual-modules/astro.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'astro/config';
+
+import virtual from "./src/plugins/virtual";
+
+// https://astro.build/config
+export default defineConfig({
+    vite: {
+        plugins: [virtual],
+    },
+});

--- a/packages/astro/e2e/fixtures/vite-virtual-modules/package.json
+++ b/packages/astro/e2e/fixtures/vite-virtual-modules/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/vite-virtual-modules",
+	"type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/e2e/fixtures/vite-virtual-modules/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/vite-virtual-modules/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import "virtual:dynamic.css";
+---
+
+<html lang="en">
+    <head>
+        <!-- Head Stuff -->
+    </head>
+    <body>
+        <h1>Astro</h1>
+    </body>
+</html>

--- a/packages/astro/e2e/fixtures/vite-virtual-modules/src/plugins/virtual.ts
+++ b/packages/astro/e2e/fixtures/vite-virtual-modules/src/plugins/virtual.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from "vite";
+
+const VIRTUAL_MODULE_ID = "virtual:dynamic.css";
+const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
+
+export default {
+    name: VIRTUAL_MODULE_ID,
+    resolveId(source) {
+        if (!source.startsWith(VIRTUAL_MODULE_ID)) return;
+
+        return RESOLVED_VIRTUAL_MODULE_ID;
+    },
+    load(id) {
+        if (!id.startsWith(RESOLVED_VIRTUAL_MODULE_ID)) return;
+
+        return "body { background: red; }";
+    },
+} satisfies Plugin;

--- a/packages/astro/e2e/vite-virtual-modules.test.js
+++ b/packages/astro/e2e/vite-virtual-modules.test.js
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test';
+import { testFactory } from './test-utils.js';
+
+const test = testFactory(import.meta.url, { root: './fixtures/vite-virtual-modules/' });
+const VIRTUAL_MODULE_ID = '/@id/__x00__virtual:dynamic.css';
+
+let devServer;
+
+test.beforeAll(async ({ astro }) => {
+	devServer = await astro.startDevServer();
+});
+
+test.afterAll(async () => {
+	await devServer.stop();
+});
+
+/**
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} element
+ * @param {string} attribute
+ * @returns {Promise<import("@playwright/test").Locator>}
+ */
+async function getElemForVirtual(page, element, attribute) {
+	const elements = await page.locator(element).all();
+
+	for (const elem of elements) {
+		const attr = await elem.getAttribute(attribute);
+
+		if (attr !== VIRTUAL_MODULE_ID) continue;
+
+		return elem;
+	}
+}
+
+test.describe('Vite Virtual Modules', () => {
+	test('contains style tag with virtual module id', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const style = await getElemForVirtual(page, 'style', 'data-vite-dev-id');
+
+		expect(style).not.toBeUndefined();
+	});
+
+	test('contains script tag with virtual module id', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const script = await getElemForVirtual(page, 'script', 'src');
+
+		expect(script).not.toBeUndefined();
+	});
+});

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -101,6 +101,7 @@ export function viteID(filePath: URL): string {
 
 export const VALID_ID_PREFIX = `/@id/`;
 const NULL_BYTE_PLACEHOLDER = `__x00__`;
+const NULL_BYTE_REGEX = /^\0/;
 
 // Strip valid id prefix and replace null byte placeholder. Both are prepended to resolved ids
 // as they are not valid browser import specifiers (by the Vite's importAnalysis plugin)
@@ -108,6 +109,11 @@ export function unwrapId(id: string): string {
 	return id.startsWith(VALID_ID_PREFIX)
 		? id.slice(VALID_ID_PREFIX.length).replace(NULL_BYTE_PLACEHOLDER, '\0')
 		: id;
+}
+
+// Reverses `unwrapId` function
+export function wrapId(id: string): string {
+	return id.replace(NULL_BYTE_REGEX, `${VALID_ID_PREFIX}${NULL_BYTE_PLACEHOLDER}`);
 }
 
 export function resolvePages(config: AstroConfig) {

--- a/packages/astro/src/vite-plugin-astro-server/css.ts
+++ b/packages/astro/src/vite-plugin-astro-server/css.ts
@@ -1,5 +1,5 @@
 import type { ModuleLoader } from '../core/module-loader/index.js';
-import { viteID } from '../core/util.js';
+import { viteID, wrapId } from '../core/util.js';
 import { isBuildableCSSRequest } from './util.js';
 import { crawlGraph } from './vite.js';
 
@@ -55,8 +55,8 @@ export async function getStylesForURL(
 			}
 
 			importedStylesMap.set(importedModule.url, {
-				id: importedModule.id ?? importedModule.url,
-				url: importedModule.url,
+				id: wrapId(importedModule.id ?? importedModule.url),
+				url: wrapId(importedModule.url),
 				content: css,
 			});
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1648,6 +1648,12 @@ importers:
         specifier: ^3.5.13
         version: 3.5.16(typescript@5.8.3)
 
+  packages/astro/e2e/fixtures/vite-virtual-modules:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/e2e/fixtures/vue-component:
     dependencies:
       '@astrojs/mdx':


### PR DESCRIPTION
## Changes

fixes #13879

Converts `\0virtual:module.css` to `/@id/__x00__virtual:module.css`, this is the direct reversal of the `unwrapId` function in `core/utils.ts`

## Testing

The `vite-virtual-modules` e2e test has been added.
This tests if the dev server response contains `style` and `script` tags with proper `data-vite-dev-id` and `src` values respectively.

## Docs

This is a correctness change in the internal vite-astro-server plugin which does not have public facing documentation.
