### PR TITLE
fix(astro): update wrong content in CSP meta tag

### DIFF
--- a/.changeset/orange-books-check.md
+++ b/.changeset/orange-books-check.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Fixes wrong contents in CSP meta tag.

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -36,7 +36,7 @@ export function renderCspContent(result: SSRResult): string {
 	}
 
 	const strictDynamic = result.isStrictDynamic ? ` strict-dynamic` : '';
-	const scriptSrc = `style-src ${styleResources} ${Array.from(finalStyleHashes).join(' ')}${strictDynamic};`;
-	const styleSrc = `script-src ${scriptResources} ${Array.from(finalScriptHashes).join(' ')};`;
+	const scriptSrc = `script-src ${scriptResources} ${Array.from(finalScriptHashes).join(' ')}${strictDynamic};`;
+	const styleSrc = `style-src ${styleResources} ${Array.from(finalStyleHashes).join(' ')};`;
 	return `${directives} ${scriptSrc} ${styleSrc}`;
 }


### PR DESCRIPTION
## Changes

Fixed a bug where the script source and style source were reversed.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

should pass

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

N/A

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
