### PR TITLE
bug fix for lost view transition names introduced by 5.9.0

### DIFF
--- a/.changeset/shy-showers-care.md
+++ b/.changeset/shy-showers-care.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused view transition names to be lost.

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1582,7 +1582,6 @@ test.describe('View Transitions', () => {
 		await expect(p, 'should have content').toHaveText('Page 1');
 	});
 
-	// It weirdly fails
 	test('animation get canceled when view transition is interrupted', async ({
 		page,
 		astro,

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -738,8 +738,7 @@ test.describe('View Transitions', () => {
 		await expect(h, 'should have content').toHaveAttribute('style', 'background-color: green');
 		await expect(h, 'should have content').toHaveAttribute('data-other-name', 'value');
 		await expect(h, 'should have content').toHaveAttribute('data-astro-fake', 'value');
-		// TODO: check this assertion
-		// await expect(h, 'should have content').toHaveAttribute('data-astro-transition', 'forward');
+		await expect(h, 'should have content').toHaveAttribute('data-astro-transition', 'forward');
 		await expect(h, 'should have swap rest of data-astro-* attributes').toHaveAttribute(
 			'data-astro-transition-scope',
 			'scope-y',
@@ -1419,8 +1418,7 @@ test.describe('View Transitions', () => {
 		expect(loads.length, 'There should only be 1 page load').toEqual(1);
 	});
 
-	// TODO: investigate, it weirdly fails
-	test.skip('transition:name should be escaped correctly', async ({ page, astro }) => {
+	test('transition:name should be escaped correctly', async ({ page, astro }) => {
 		// view-transition-name errors on browser w/o native support
 		if (!(await nativeViewTransition(page))) return;
 		const expectedAnimations = new Set();
@@ -1585,7 +1583,7 @@ test.describe('View Transitions', () => {
 	});
 
 	// It weirdly fails
-	test.skip('animation get canceled when view transition is interrupted', async ({
+	test('animation get canceled when view transition is interrupted', async ({
 		page,
 		astro,
 	}) => {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -113,7 +113,7 @@
     "test:integration": "astro-scripts test \"test/*.test.js\""
   },
   "dependencies": {
-    "@astrojs/compiler": "^2.12.0",
+    "@astrojs/compiler": "^2.12.1",
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/markdown-remark": "workspace:*",
     "@astrojs/telemetry": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,8 +467,8 @@ importers:
   packages/astro:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^2.12.0
-        version: 2.12.0
+        specifier: ^2.12.1
+        version: 2.12.1
       '@astrojs/internal-helpers':
         specifier: workspace:*
         version: link:../internal-helpers
@@ -6365,8 +6365,8 @@ packages:
     resolution: {integrity: sha512-bVzyKzEpIwqjihBU/aUzt1LQckJuHK0agd3/ITdXhPUYculrc6K1/K7H+XG4rwjXtg+ikT3PM05V1MVYWiIvQw==}
     engines: {node: '>=18.14.1'}
 
-  '@astrojs/compiler@2.12.0':
-    resolution: {integrity: sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA==}
+  '@astrojs/compiler@2.12.1':
+    resolution: {integrity: sha512-WDSyVIiz7sNcJcCJxJFITu6XjfGhJ50Z0auyaWsrM+xb07IlhBLFtQuDkNy0caVHWNcKTM2LISAaHhgkRqGAVg==}
 
   '@astrojs/language-server@2.15.0':
     resolution: {integrity: sha512-wJHSjGApm5X8Rg1GvkevoatZBfvaFizY4kCPvuSYgs3jGCobuY3KstJGKC1yNLsRJlDweHruP+J54iKn9vEKoA==}
@@ -13517,11 +13517,11 @@ snapshots:
       log-update: 5.0.1
       sisteransi: 1.0.5
 
-  '@astrojs/compiler@2.12.0': {}
+  '@astrojs/compiler@2.12.1': {}
 
   '@astrojs/language-server@2.15.0(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.8.3)':
     dependencies:
-      '@astrojs/compiler': 2.12.0
+      '@astrojs/compiler': 2.12.1
       '@astrojs/yaml2ts': 0.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
       '@volar/kit': 2.4.6(typescript@5.8.3)
@@ -19483,7 +19483,7 @@ snapshots:
 
   prettier-plugin-astro@0.14.1:
     dependencies:
-      '@astrojs/compiler': 2.12.0
+      '@astrojs/compiler': 2.12.1
       prettier: 3.5.3
       sass-formatter: 0.7.9
 


### PR DESCRIPTION
## Changes

Updates compiler and reactivates some view transition e2e tests 
Fixes https://github.com/withastro/compiler/issues/1079


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Reactivates skipped view transition e2e tests 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

n.a.: bug fix.
