### PR TITLE
fix: isPrerendered now set correctly in static configured redirects.

### DIFF
--- a/.changeset/sharp-vans-greet.md
+++ b/.changeset/sharp-vans-greet.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an edge case where `isPrerendered` was incorrectly set to `false` when statically building configured redirects.

--- a/.changeset/sharp-vans-greet.md
+++ b/.changeset/sharp-vans-greet.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixed an edge case where `isPrerendered` was incorrectly set to `false` when statically building configured redirects.
+Fixes an edge case where `isPrerendered` was incorrectly set to `false` for static redirects.

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -376,7 +376,7 @@ function createRedirectRoutes(
 			component: from,
 			generate,
 			pathname: pathname || void 0,
-			prerender: false,
+			prerender: getPrerenderDefault(config),
 			redirect: to,
 			redirectRoute: routeMap.get(destination),
 			fallbackRoutes: [],

--- a/packages/astro/test/fixtures/static-redirect/astro.config.mjs
+++ b/packages/astro/test/fixtures/static-redirect/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+  redirects: {
+    '/configured-redirect': '/',
+  },
+});

--- a/packages/astro/test/fixtures/static-redirect/package.json
+++ b/packages/astro/test/fixtures/static-redirect/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/static-redirect",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/static-redirect/src/middleware.ts
+++ b/packages/astro/test/fixtures/static-redirect/src/middleware.ts
@@ -1,0 +1,8 @@
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware(({ isPrerendered }, next) => {
+	if (!isPrerendered) {
+		throw new Error('This middleware should only run in prerendered mode.');
+	}
+	return next();
+});

--- a/packages/astro/test/fixtures/static-redirect/src/pages/index.astro
+++ b/packages/astro/test/fixtures/static-redirect/src/pages/index.astro
@@ -1,0 +1,7 @@
+<html>
+<head>
+</head>
+<body>
+    <p>Hello Astro!</p>
+</body>
+</html>

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -205,3 +205,16 @@ describe('Static build SSR', () => {
 		assert.ok(await fixture.readFile('/client/.well-known/apple-app-site-association'));
 	});
 });
+
+describe('Static build with configured redirects', () => {
+	it('Sets isPrerendered true in middleware', async () => {
+		const fixture = await loadFixture({
+			root: './fixtures/static-redirect/',
+		});
+
+		await assert.doesNotReject(
+			fixture.build(),
+			'isPrerendered unexpectedly true during static build',
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4189,6 +4189,12 @@ importers:
 
   packages/astro/test/fixtures/static-build/pkg: {}
 
+  packages/astro/test/fixtures/static-redirect:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/streaming:
     dependencies:
       '@astrojs/react':


### PR DESCRIPTION
## Changes

Closes #13875

Previously, `isPrerendered` would be `false` in statically built configured redirects (notably in middleware).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I added a test, happy to expand or reorganize. Additionally I've run the full test suite locally and I don't have any new failures (rosetta + devcontainers likely the culprit #12704).

## Docs

This is a fix, so I don't think docs are necessary?

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
