### PR TITLE
refactor(csp): avoid apostrophe

### DIFF
--- a/.changeset/loose-cameras-prove.md
+++ b/.changeset/loose-cameras-prove.md
@@ -1,0 +1,40 @@
+---
+'astro': patch
+---
+
+**BREAKING CHANGE to the experimental feature CSP only**
+
+Astro **won't** add apostrophes to the hashes anymore, which means that user-provided hash must contain them:
+
+```diff
+// astro.config.mjs
+
+export default defineConfig({
+  experimental: {
+    csp: {
+      styleDirective: {
+        hashes: [
+-          "sha256-hashvalue"
++          "'sha256-hashvalue'"
+        ]
+      },
+      scriptDirective: {
+        hashes: [
+-          "sha256-hashvalue"
++          "'sha256-hashvalue'"
+        ]
+      }      
+    }
+  }
+})
+```
+
+```diff
+- Astro.insertStyleHash("sha256-hashvalue")
++ Astro.insertStyleHash("'sha256-hashvalue'")
+```
+
+```diff
+- Astro.insertScriptHash("sha256-hashvalue")
++ Astro.insertScriptHash("'sha256-hashvalue'")
+```

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -30,12 +30,12 @@ export const cspAlgorithmSchema = z
 	.optional()
 	.default('SHA-256');
 
-export const cspHashSchema = z.custom<`${CspAlgorithmValue}${string}`>((value) => {
+export const cspHashSchema = z.custom<`'${CspAlgorithmValue}${string}'`>((value) => {
 	if (typeof value !== 'string') {
 		return false;
 	}
 	return ALGORITHM_VALUES.some((allowedValue) => {
-		return value.startsWith(allowedValue);
+		return value.startsWith("'") && value.endsWith("'") && value.includes(allowedValue);
 	});
 });
 

--- a/packages/astro/src/core/encryption.ts
+++ b/packages/astro/src/core/encryption.ts
@@ -121,5 +121,5 @@ export async function generateCspDigest(data: string, algorithm: CspAlgorithm): 
 	const hashBuffer = await crypto.subtle.digest(algorithm, encoder.encode(data));
 
 	const hash = encodeBase64(new Uint8Array(hashBuffer));
-	return `${ALGORITHMS[algorithm]}${hash}`;
+	return `'${ALGORITHMS[algorithm]}${hash}'`;
 }

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -5,19 +5,19 @@ export function renderCspContent(result: SSRResult): string {
 	const finalStyleHashes = new Set();
 
 	for (const scriptHash of result.scriptHashes) {
-		finalScriptHashes.add(`'${scriptHash}'`);
+		finalScriptHashes.add(`'${scriptHash}`);
 	}
 
 	for (const styleHash of result.styleHashes) {
-		finalStyleHashes.add(`'${styleHash}'`);
+		finalStyleHashes.add(`${styleHash}`);
 	}
 
 	for (const styleHash of result._metadata.extraStyleHashes) {
-		finalStyleHashes.add(`'${styleHash}'`);
+		finalStyleHashes.add(`${styleHash}`);
 	}
 
 	for (const scriptHash of result._metadata.extraScriptHashes) {
-		finalScriptHashes.add(`'${scriptHash}'`);
+		finalScriptHashes.add(`${scriptHash}`);
 	}
 
 	let directives = '';

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -114,10 +114,10 @@ describe('CSP', () => {
 			experimental: {
 				csp: {
 					styleDirective: {
-						hashes: ['sha512-hash1', 'sha384-hash2'],
+						hashes: ["'sha512-hash1'", "'sha384-hash2'"],
 					},
 					scriptDirective: {
-						hashes: ['sha512-hash3', 'sha384-hash4'],
+						hashes: ["'sha512-hash3'", "'sha384-hash4'"],
 					},
 				},
 			},

--- a/packages/astro/test/fixtures/csp/src/pages/scripts.astro
+++ b/packages/astro/test/fixtures/csp/src/pages/scripts.astro
@@ -1,6 +1,6 @@
 ---
 Astro.insertScriptResource("https://scripts.cdn.example.com");
-Astro.insertScriptHash('sha256-customHash');
+Astro.insertScriptHash("'sha256-customHash'");
 Astro.insertDirective("default-src 'self'");
 ---
 

--- a/packages/astro/test/fixtures/csp/src/pages/styles.astro
+++ b/packages/astro/test/fixtures/csp/src/pages/styles.astro
@@ -1,6 +1,6 @@
 ---
 Astro.insertStyleResource("https://styles.cdn.example.com");
-Astro.insertStyleHash('sha256-customHash');
+Astro.insertStyleHash("'sha256-customHash'");
 Astro.insertDirective("default-src 'self'");
 ---
 


### PR DESCRIPTION
## Changes

This PR removes the automatic addition of apostrophes to the user-provided hashes. Which means that users must provide hashes with the apostrophe. 

This change was driven by the fact that the content of the CSP header/meta isn't consistent, for example, full URLs don't need any apostrophes. Also, since CSP is an advanced topic, it's safe to assume that users have some prior knowledge of the topic

## Testing

Tests updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

The RFC has been updated already 

https://github.com/withastro/docs/pull/11882

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
