### PR TITLE
feat: Deno v2.0 support

### DIFF
--- a/packages/upgrade/src/actions/install.ts
+++ b/packages/upgrade/src/actions/install.ts
@@ -142,6 +142,7 @@ async function runInstallCommand(
 						installCommand.command,
 						[
 							...installCommand.args,
+              installCommand.command === "deno" ? "--npm" : "",
 							...dependencies.map(
 								({ name, targetVersion }) => `${name}@${targetVersion.replace(/^\^/, '')}`,
 							),


### PR DESCRIPTION
## Changes

I was told to:
```console
 update  ▶ New version of Astro available: 5.9.3
  Run deno run npm:@astrojs/upgrade to update
```

When I did it it failed and told me to run manually `deno add @astrojs/rss@4.0.12 @astrojs/sitemap@3.4.1 astro@5.9.3` which would also fail because I need to specify that they are npm packages with the prefix `npm:` before each package, or, as of a recent feature added to Deno, use the `--npm` flag to say all packages are from npm.

## Testing

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
