### PR TITLE
fix: make session driver name optional

### DIFF
--- a/.changeset/neat-worlds-hide.md
+++ b/.changeset/neat-worlds-hide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a issue that caused errors when using an adapter-provided session driver with custom options

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -434,7 +434,7 @@ export const AstroConfigSchema = z.object({
 		.default(ASTRO_CONFIG_DEFAULTS.env),
 	session: z
 		.object({
-			driver: z.string(),
+			driver: z.string().optional(),
 			options: z.record(z.any()).optional(),
 			cookie: z
 				.object({

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -47,7 +47,8 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 	// The cookies object.
 	#cookies: AstroCookies;
 	// The session configuration.
-	#config: Omit<ResolvedSessionConfig<TDriver>, 'cookie'>;
+	#config: Omit<ResolvedSessionConfig<TDriver>, 'cookie'> &
+		{ driver: NonNullable<ResolvedSessionConfig<TDriver>["driver"]> };
 	// The cookie config
 	#cookieConfig?: AstroCookieSetOptions;
 	// The cookie name
@@ -79,9 +80,18 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 		{
 			cookie: cookieConfig = DEFAULT_COOKIE_NAME,
 			...config
-		}: Exclude<ResolvedSessionConfig<TDriver>, undefined>,
+		}: NonNullable<ResolvedSessionConfig<TDriver>>,
 		runtimeMode?: RuntimeMode,
 	) {
+		const { driver } = config;
+		if (!driver) {
+			throw new AstroError({
+				...SessionStorageInitError,
+				message: SessionStorageInitError.message(
+					'No driver was defined in the session configuration and the adapter did not provide a default driver.',
+				),
+			});
+		}
 		this.#cookies = cookies;
 		let cookieConfigObject: AstroCookieSetOptions | undefined;
 		if (typeof cookieConfig === 'object') {
@@ -98,7 +108,7 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 			...cookieConfigObject,
 			httpOnly: true,
 		};
-		this.#config = config;
+		this.#config = { ...config, driver };
 	}
 
 	/**
@@ -436,15 +446,6 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 			this.#config.options ??= {};
 			this.#config.driver = 'fs-lite';
 			(this.#config.options as BuiltinDriverOptions['fs-lite']).base ??= '.astro/session';
-		}
-
-		if (!this.#config?.driver) {
-			throw new AstroError({
-				...SessionStorageInitError,
-				message: SessionStorageInitError.message(
-					'No driver was defined in the session configuration and the adapter did not provide a default driver.',
-				),
-			});
 		}
 
 		let driver: ((config: SessionConfig<TDriver>['options']) => Driver) | null = null;

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -151,7 +151,7 @@ interface BuiltinSessionConfig<TDriver extends keyof BuiltinDriverOptions>
 
 interface CustomSessionConfig extends CommonSessionConfig {
 	/** Entrypoint for a custom session driver */
-	driver: string;
+	driver?: string;
 	options?: Record<string, unknown>;
 }
 

--- a/packages/integrations/cloudflare/test/sessions.test.js
+++ b/packages/integrations/cloudflare/test/sessions.test.js
@@ -2,11 +2,12 @@ import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import * as devalue from 'devalue';
-import { astroCli, wranglerCli } from './_test-utils.js';
+import { astroCli, wranglerCli, loadFixture } from './_test-utils.js';
+import cloudflare from '../dist/index.js';
 
 const root = new URL('./fixtures/sessions/', import.meta.url);
 
-describe('astro:env', () => {
+describe('sessions', () => {
 	let wrangler;
 
 	before(async () => {
@@ -89,5 +90,22 @@ describe('astro:env', () => {
 			secondData.message,
 			'Favorite URL set to https://example.com/ from https://domain.invalid/',
 		);
+	});
+});
+
+describe('sessions with custom options', () => {
+	it('can build with custom options', async () => {
+		let fixture;
+
+		await assert.doesNotReject(async () => {
+			fixture = await loadFixture({
+				root,
+				adapter: cloudflare({}),
+				session: {
+					cookie: 'custom-session',
+				},
+			});
+			await fixture.build();
+		}, undefined, 'Building with custom session options should not throw an error');
 	});
 });


### PR DESCRIPTION
## Changes

Currently the session config object is optional, but if provided it must have a driver specified. This caused issues when trying to provide custom configuration to an automatically-provided session driver, such as Cloudflare or Netlify. This PR makes the value optional. It still validates that a driver has been provided once it is first used, so this will catch cases where no driver is provided by either the user or the adapter.

Makes the session driver name optional in config. 

Fixes #13920

## Testing

Added a test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
