### PR TITLE
feat(netlify): add experimental support for static headers

### DIFF
--- a/.changeset/huge-crabs-remain.md
+++ b/.changeset/huge-crabs-remain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/underscore-redirects': minor
+---
+
+Adds a new method called `createHostedRouteDefinition`, which returns a `HostRoute` type from a `IntegrationResolvedRoute`.

--- a/.changeset/silver-windows-accept.md
+++ b/.changeset/silver-windows-accept.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/underscore-redirects': minor
+---
+
+Adds a new method called `printAsRedirects` to print `HostRoutes` as redirects for the `_redirects` file.

--- a/.changeset/sixty-icons-camp.md
+++ b/.changeset/sixty-icons-camp.md
@@ -1,0 +1,14 @@
+---
+'@astrojs/underscore-redirects': major
+---
+
+- The type `Redirects` has been renamed to `HostRoutes`.
+- `RouteDefinition.target` is now optional
+- `RouteDefinition.weight` is now optional
+- `Redirects.print` has been removed. Now you need to pass `Redirects` type to the `print` function
+
+```diff
+- redirects.print()
++ import { printAsRedirects } from "@astrojs/underscore-redirects"
++ printAsRedirects(redirects)
+```

--- a/.changeset/sweet-hotels-cross.md
+++ b/.changeset/sweet-hotels-cross.md
@@ -4,7 +4,7 @@
 
 Adds the experimental support for the [static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
 
-When the feature is enabled via option `experimentalStaticHeaders`, and CSP is enabled, the integration will the CSP headers to the `config.json` file.
+When the feature is enabled via option `experimentalUseStaticHeaders`, and CSP is enabled, the integration will the CSP headers to the `config.json` file.
 
 ```js
 import { defineConfig } from "astro/config";
@@ -12,7 +12,7 @@ import netlify from "@astrojs/netlify";
 
 export default defineConfig({
   adapter: netlify({
-    experimentalStaticHeaders: true
+    experimentalUseStaticHeaders: true
   }),
   experimental: {
     cps: true

--- a/.changeset/sweet-hotels-cross.md
+++ b/.changeset/sweet-hotels-cross.md
@@ -1,0 +1,21 @@
+---
+'@astrojs/netlify': minor
+---
+
+Adds the experimental support for the [static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
+
+When the feature is enabled via option `experimentalStaticHeaders`, and CSP is enabled, the integration will the CSP headers to the `config.json` file.
+
+```js
+import { defineConfig } from "astro/config";
+import netlify from "@astrojs/netlify";
+
+export default defineConfig({
+  adapter: netlify({
+    experimentalStaticHeaders: true
+  }),
+  experimental: {
+    cps: true
+  }
+})
+```

--- a/.changeset/sweet-hotels-cross.md
+++ b/.changeset/sweet-hotels-cross.md
@@ -4,7 +4,7 @@
 
 Adds support for the [experimental static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
 
-When the feature is enabled via option `experimentalUseStaticHeaders`, and CSP is enabled, the integration will the CSP headers to the `config.json` file.
+When the feature is enabled via option `experimentalUseStaticHeaders`, and CSP is enabled, the integration will save the CSP headers to the `config.json` file.
 
 ```js
 import { defineConfig } from "astro/config";

--- a/.changeset/sweet-hotels-cross.md
+++ b/.changeset/sweet-hotels-cross.md
@@ -4,7 +4,7 @@
 
 Adds support for the [experimental static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
 
-When the feature is enabled via option `experimentalUseStaticHeaders`, and CSP is enabled, the integration will save the CSP headers to the `config.json` file.
+When the feature is enabled via option `experimentalStaticHeaders`, and CSP is enabled, the integration will save the CSP headers to the `config.json` file.
 
 ```js
 import { defineConfig } from "astro/config";
@@ -12,7 +12,7 @@ import netlify from "@astrojs/netlify";
 
 export default defineConfig({
   adapter: netlify({
-    experimentalUseStaticHeaders: true
+    experimentalStaticHeaders: true
   }),
   experimental: {
     cps: true

--- a/.changeset/sweet-hotels-cross.md
+++ b/.changeset/sweet-hotels-cross.md
@@ -4,7 +4,7 @@
 
 Adds support for the [experimental static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
 
-When the feature is enabled via option `experimentalStaticHeaders`, and CSP is enabled, the integration will save the CSP headers to the `config.json` file.
+When the feature is enabled via option `experimentalStaticHeaders`, and [experimental Content Security Policy](https://docs.astro.build/en/reference/experimental-flags/csp/) is enabled, the adapter will generate `Response` headers for static pages, which allows support for CSP directives that are not supported inside a `<meta>` tag (e.g. `frame-ancestors`).
 
 ```js
 import { defineConfig } from "astro/config";

--- a/.changeset/sweet-hotels-cross.md
+++ b/.changeset/sweet-hotels-cross.md
@@ -2,7 +2,7 @@
 '@astrojs/netlify': minor
 ---
 
-Adds the experimental support for the [static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
+Adds support for the [experimental static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
 
 When the feature is enabled via option `experimentalUseStaticHeaders`, and CSP is enabled, the integration will the CSP headers to the `config.json` file.
 

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -228,7 +228,7 @@ describe('CSP', () => {
 		const $ = cheerio.load(html);
 
 		const meta = $('meta[http-equiv="Content-Security-Policy"]');
-		assert.ok(meta.attr('content').toString().includes("'strict-dynamic;'"));
+		assert.ok(meta.attr('content').toString().includes("'strict-dynamic';"));
 	});
 
 	it('should serve hashes via headers for dynamic pages, when the strategy is "auto"', async () => {

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -228,7 +228,7 @@ describe('CSP', () => {
 		const $ = cheerio.load(html);
 
 		const meta = $('meta[http-equiv="Content-Security-Policy"]');
-		assert.ok(meta.attr('content').toString().includes('strict-dynamic;'));
+		assert.ok(meta.attr('content').toString().includes("'strict-dynamic;'"));
 	});
 
 	it('should serve hashes via headers for dynamic pages, when the strategy is "auto"', async () => {

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -15,7 +15,7 @@ import {
 	prependForwardSlash,
 	removeLeadingForwardSlash,
 } from '@astrojs/internal-helpers/path';
-import { createRedirectsFromAstroRoutes } from '@astrojs/underscore-redirects';
+import { createRedirectsFromAstroRoutes, printAsRedirects } from '@astrojs/underscore-redirects';
 import { AstroError } from 'astro/errors';
 import { defaultClientConditions } from 'vite';
 import { type GetPlatformProxyOptions, getPlatformProxy } from 'wrangler';
@@ -408,7 +408,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
 
 				if (!trueRedirects.empty()) {
 					try {
-						await appendFile(new URL('./_redirects', _config.outDir), trueRedirects.print());
+						await appendFile(
+							new URL('./_redirects', _config.outDir),
+							printAsRedirects(trueRedirects),
+						);
 					} catch (_error) {
 						logger.error('Failed to write _redirects file');
 					}

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -29,6 +29,7 @@
     "dist"
   ],
   "scripts": {
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "pnpm run test-fn && pnpm run test-static",

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -245,7 +245,7 @@ export interface NetlifyIntegrationConfig {
 	 * Here the list of the headers that are added:
 	 * - The CSP header of the static pages is added when CSP support is enabled.
 	 */
-	experimentalStaticHeaders?: boolean;
+	experimentalUseStaticHeaders?: boolean;
 }
 
 export default function netlifyIntegration(
@@ -259,7 +259,7 @@ export default function netlifyIntegration(
 	let outDir: URL;
 	let rootDir: URL;
 	let astroMiddlewareEntryPoint: URL | undefined = undefined;
-	let _experimentalStaticHeaders: Map<IntegrationResolvedRoute, Headers> | undefined = undefined;
+	let staticHeadersMap: Map<IntegrationResolvedRoute, Headers> | undefined = undefined;
 	// Extra files to be merged with `includeFiles` during build
 	const extraFilesToInclude: URL[] = [];
 	// Secret used to verify that the caller is the astro-generated edge middleware and not a third-party
@@ -619,7 +619,7 @@ export default function netlifyIntegration(
 				finalBuildOutput = buildOutput;
 
 				const edgeMiddleware = integrationConfig?.edgeMiddleware ?? false;
-				const experimentalStaticHeaders = integrationConfig?.experimentalStaticHeaders ?? false;
+				const experimentalStaticHeaders = integrationConfig?.experimentalUseStaticHeaders ?? false;
 
 				setAdapter({
 					name: '@astrojs/netlify',
@@ -640,7 +640,7 @@ export default function netlifyIntegration(
 				});
 			},
 			'astro:build:generated': ({ experimentalRouteToHeaders }) => {
-				_experimentalStaticHeaders = experimentalRouteToHeaders;
+				staticHeadersMap = experimentalRouteToHeaders;
 			},
 			'astro:build:ssr': async ({ middlewareEntryPoint }) => {
 				astroMiddlewareEntryPoint = middlewareEntryPoint;
@@ -662,7 +662,7 @@ export default function netlifyIntegration(
 					logger.info('Generated Middleware Edge Function');
 				}
 
-				await writeNetlifyFrameworkConfig(_config, _experimentalStaticHeaders, logger);
+				await writeNetlifyFrameworkConfig(_config, staticHeadersMap, logger);
 			},
 
 			// local dev

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -245,7 +245,7 @@ export interface NetlifyIntegrationConfig {
 	 * Here the list of the headers that are added:
 	 * - The CSP header of the static pages is added when CSP support is enabled.
 	 */
-	experimentalUseStaticHeaders?: boolean;
+	experimentalStaticHeaders?: boolean;
 }
 
 export default function netlifyIntegration(
@@ -618,16 +618,16 @@ export default function netlifyIntegration(
 
 				finalBuildOutput = buildOutput;
 
-				const edgeMiddleware = integrationConfig?.edgeMiddleware ?? false;
-				const experimentalStaticHeaders = integrationConfig?.experimentalUseStaticHeaders ?? false;
+				const useEdgeMiddleware = integrationConfig?.edgeMiddleware ?? false;
+				const useStaticHeaders = integrationConfig?.experimentalStaticHeaders ?? false;
 
 				setAdapter({
 					name: '@astrojs/netlify',
 					serverEntrypoint: '@astrojs/netlify/ssr-function.js',
 					exports: ['default'],
 					adapterFeatures: {
-						edgeMiddleware,
-						experimentalStaticHeaders,
+						edgeMiddleware: useEdgeMiddleware,
+						experimentalStaticHeaders: useStaticHeaders,
 					},
 					args: { middlewareSecret } satisfies Args,
 					supportedAstroFeatures: {

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -144,15 +144,18 @@ async function writeNetlifyFrameworkConfig(
 			}
 
 			const definition = createHostedRouteDefinition(route, config);
-			const csp = routeHeaders.get('Content-Security-Policy');
 
-			if (csp) {
-				headers.push({
-					for: definition.input,
-					values: {
-						'Content-Security-Policy': csp,
-					},
-				});
+			if (config.experimental.csp) {
+				const csp = routeHeaders.get('Content-Security-Policy');
+
+				if (csp) {
+					headers.push({
+						for: definition.input,
+						values: {
+							'Content-Security-Policy': csp,
+						},
+					});
+				}
 			}
 		}
 	}

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -3,7 +3,11 @@ import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import type { IncomingMessage } from 'node:http';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { emptyDir } from '@astrojs/internal-helpers/fs';
-import { createRedirectsFromAstroRoutes } from '@astrojs/underscore-redirects';
+import {
+	createHostedRouteDefinition,
+	createRedirectsFromAstroRoutes,
+	printAsRedirects,
+} from '@astrojs/underscore-redirects';
 import type { Context } from '@netlify/functions';
 import type {
 	AstroConfig,
@@ -103,7 +107,11 @@ export function remotePatternToRegex(
 	return regexStr;
 }
 
-async function writeNetlifyFrameworkConfig(config: AstroConfig, logger: AstroIntegrationLogger) {
+async function writeNetlifyFrameworkConfig(
+	config: AstroConfig,
+	staticHeaders: Map<IntegrationResolvedRoute, Headers> | undefined,
+	logger: AstroIntegrationLogger,
+) {
 	const remoteImages: Array<string> = [];
 	// Domains get a simple regex match
 	remoteImages.push(
@@ -116,16 +124,38 @@ async function writeNetlifyFrameworkConfig(config: AstroConfig, logger: AstroInt
 			.filter(Boolean as unknown as (pattern?: string) => pattern is string),
 	);
 
-	const headers = config.build.assetsPrefix
-		? undefined
-		: [
-				{
-					for: `${config.base}${config.base.endsWith('/') ? '' : '/'}${config.build.assets}/*`,
+	const headers = [];
+	if (!config.build.assetsPrefix) {
+		headers.push({
+			for: `${config.base}${config.base.endsWith('/') ? '' : '/'}${config.build.assets}/*`,
+			values: {
+				'Cache-Control': 'public, max-age=31536000, immutable',
+			},
+		});
+	}
+
+	if (staticHeaders && staticHeaders.size > 0) {
+		for (const [route, routeHeaders] of staticHeaders.entries()) {
+			if (!route.isPrerendered) {
+				continue;
+			}
+			if (route.redirect) {
+				continue;
+			}
+
+			const definition = createHostedRouteDefinition(route, config);
+			const csp = routeHeaders.get('Content-Security-Policy');
+
+			if (csp) {
+				headers.push({
+					for: definition.input,
 					values: {
-						'Cache-Control': 'public, max-age=31536000, immutable',
+						'Content-Security-Policy': csp,
 					},
-				},
-			];
+				});
+			}
+		}
+	}
 
 	// See https://docs.netlify.com/image-cdn/create-integration/
 	const deployConfigDir = new URL('.netlify/v1/', config.root);
@@ -205,6 +235,14 @@ export interface NetlifyIntegrationConfig {
 	 * @default {true}
 	 */
 	imageCDN?: boolean;
+
+	/**
+	 * If enabled, the adapter will save [static headers in the framework API file](https://docs.netlify.com/frameworks-api/#headers).
+	 *
+	 * Here the list of the headers that are added:
+	 * - The CSP header of the static pages is added when CSP support is enabled.
+	 */
+	experimentalStaticHeaders?: boolean;
 }
 
 export default function netlifyIntegration(
@@ -218,6 +256,7 @@ export default function netlifyIntegration(
 	let outDir: URL;
 	let rootDir: URL;
 	let astroMiddlewareEntryPoint: URL | undefined = undefined;
+	let _experimentalStaticHeaders: Map<IntegrationResolvedRoute, Headers> | undefined = undefined;
 	// Extra files to be merged with `includeFiles` during build
 	const extraFilesToInclude: URL[] = [];
 	// Secret used to verify that the caller is the astro-generated edge middleware and not a third-party
@@ -271,7 +310,7 @@ export default function netlifyIntegration(
 		});
 
 		if (!redirects.empty()) {
-			await appendFile(new URL('_redirects', outDir), `\n${redirects.print()}\n`);
+			await appendFile(new URL('_redirects', outDir), `\n${printAsRedirects(redirects)}\n`);
 		}
 	}
 
@@ -570,15 +609,14 @@ export default function netlifyIntegration(
 			'astro:routes:resolved': (params) => {
 				routes = params.routes;
 			},
-			'astro:config:done': async ({ config, setAdapter, logger, buildOutput }) => {
+			'astro:config:done': async ({ config, setAdapter, buildOutput }) => {
 				rootDir = config.root;
 				_config = config;
 
 				finalBuildOutput = buildOutput;
 
-				await writeNetlifyFrameworkConfig(config, logger);
-
 				const edgeMiddleware = integrationConfig?.edgeMiddleware ?? false;
+				const experimentalStaticHeaders = integrationConfig?.experimentalStaticHeaders ?? false;
 
 				setAdapter({
 					name: '@astrojs/netlify',
@@ -586,6 +624,7 @@ export default function netlifyIntegration(
 					exports: ['default'],
 					adapterFeatures: {
 						edgeMiddleware,
+						experimentalStaticHeaders,
 					},
 					args: { middlewareSecret } satisfies Args,
 					supportedAstroFeatures: {
@@ -596,6 +635,9 @@ export default function netlifyIntegration(
 						envGetSecret: 'stable',
 					},
 				});
+			},
+			'astro:build:generated': ({ experimentalRouteToHeaders }) => {
+				_experimentalStaticHeaders = experimentalRouteToHeaders;
 			},
 			'astro:build:ssr': async ({ middlewareEntryPoint }) => {
 				astroMiddlewareEntryPoint = middlewareEntryPoint;
@@ -616,6 +658,8 @@ export default function netlifyIntegration(
 					await writeMiddleware(astroMiddlewareEntryPoint);
 					logger.info('Generated Middleware Edge Function');
 				}
+
+				await writeNetlifyFrameworkConfig(_config, _experimentalStaticHeaders, logger);
 			},
 
 			// local dev

--- a/packages/integrations/netlify/test/static/fixtures/static-headers/astro.config.mjs
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers/astro.config.mjs
@@ -1,0 +1,13 @@
+import netlify from '@astrojs/netlify';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	output: 'static',
+	adapter: netlify({
+		experimentalStaticHeaders: true
+	}),
+	site: "http://example.com",
+	experimental: {
+		csp: true
+	}
+});

--- a/packages/integrations/netlify/test/static/fixtures/static-headers/astro.config.mjs
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers/astro.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
 	output: 'static',
 	adapter: netlify({
-		experimentalUseStaticHeaders: true
+		experimentalStaticHeaders: true
 	}),
 	site: "http://example.com",
 	experimental: {

--- a/packages/integrations/netlify/test/static/fixtures/static-headers/astro.config.mjs
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers/astro.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
 	output: 'static',
 	adapter: netlify({
-		experimentalStaticHeaders: true
+		experimentalUseStaticHeaders: true
 	}),
 	site: "http://example.com",
 	experimental: {

--- a/packages/integrations/netlify/test/static/fixtures/static-headers/package.json
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/netlify-static-headers",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/netlify": "workspace:"
+  }
+}

--- a/packages/integrations/netlify/test/static/fixtures/static-headers/src/components/Island.astro
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers/src/components/Island.astro
@@ -1,0 +1,1 @@
+<p>I am a Server Island</p>

--- a/packages/integrations/netlify/test/static/fixtures/static-headers/src/pages/index.astro
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+import Island  from "../components/Island.astro"
+---
+<html>
+<head><title>Index</title></head>
+<body>
+<h1>Index</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/netlify/test/static/static-headers.test.js
+++ b/packages/integrations/netlify/test/static/static-headers.test.js
@@ -25,13 +25,5 @@ describe('Static headers', () => {
 			index.values['Content-Security-Policy'].includes('script-src'),
 			'must contain the script-src directive because of the server island',
 		);
-		// assert.deepEqual(headers, [
-		// 	{
-		// 		for: '/index',
-		// 		values: {
-		// 			'Conte': 'public, max-age=31536000, immutable',
-		// 		},
-		// 	},
-		// ]);
 	});
 });

--- a/packages/integrations/netlify/test/static/static-headers.test.js
+++ b/packages/integrations/netlify/test/static/static-headers.test.js
@@ -1,0 +1,37 @@
+import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from '../../../../astro/test/test-utils.js';
+
+describe('Static headers', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: new URL('./fixtures/static-headers/', import.meta.url) });
+		await fixture.build();
+	});
+
+	it('CSP headers are added when CSP is enabled', async () => {
+		const config = await fixture.readFile('../.netlify/v1/config.json');
+		const headers = JSON.parse(config).headers;
+		const index = headers.find((x) => x.for === '/');
+
+		assert.notEqual(index, undefined, 'the index must have CSP headers');
+		assert.notEqual(
+			index.values['Content-Security-Policy'],
+			undefined,
+			'the index must have CSP headers',
+		);
+		assert.ok(
+			index.values['Content-Security-Policy'].includes('script-src'),
+			'must contain the script-src directive because of the server island',
+		);
+		// assert.deepEqual(headers, [
+		// 	{
+		// 		for: '/index',
+		// 		values: {
+		// 			'Conte': 'public, max-age=31536000, immutable',
+		// 		},
+		// 	},
+		// ]);
+	});
+});

--- a/packages/underscore-redirects/src/host-route.ts
+++ b/packages/underscore-redirects/src/host-route.ts
@@ -1,19 +1,20 @@
-import { print } from './print.js';
-
-export type RedirectDefinition = {
+export type HostRouteDefinition = {
 	dynamic: boolean;
 	input: string;
-	target: string;
+	/**
+	 * An optional target
+	 */
+	target?: string;
 	// Allows specifying a weight to the definition.
 	// This allows insertion of definitions out of order but having
 	// a priority once inserted.
-	weight: number;
+	weight?: number;
 	status: number;
 	force?: boolean;
 };
 
-export class Redirects {
-	public definitions: RedirectDefinition[] = [];
+export class HostRoutes {
+	public definitions: HostRouteDefinition[] = [];
 	public minInputLength = 4;
 	public minTargetLength = 4;
 
@@ -22,25 +23,28 @@ export class Redirects {
 	 * prioritized by the given weight. This keeps higher priority definitions
 	 * At the top of the list once printed.
 	 */
-	add(definition: RedirectDefinition) {
+	add(definition: HostRouteDefinition) {
 		// Find the longest input, so we can format things nicely
 		if (definition.input.length > this.minInputLength) {
 			this.minInputLength = definition.input.length;
 		}
 		// Same for the target
-		if (definition.target.length > this.minTargetLength) {
+		if (definition.target && definition.target.length > this.minTargetLength) {
 			this.minTargetLength = definition.target.length;
 		}
 
 		binaryInsert(this.definitions, definition, (a, b) => {
-			return a.weight > b.weight;
+			if (a.weight && b.weight) {
+				return a.weight > b.weight;
+			} else {
+				return false;
+			}
 		});
 	}
 
-	print(): string {
-		return print(this.definitions, this.minInputLength, this.minTargetLength);
-	}
-
+	/**
+	 * Removes all the saved route definitions
+	 */
 	empty(): boolean {
 		return this.definitions.length === 0;
 	}

--- a/packages/underscore-redirects/src/index.ts
+++ b/packages/underscore-redirects/src/index.ts
@@ -1,2 +1,5 @@
-export { createRedirectsFromAstroRoutes } from './astro.js';
-export { Redirects, type RedirectDefinition } from './redirects.js';
+export { printAsRedirects } from './print.js';
+export {
+	createRedirectsFromAstroRoutes,
+	createHostedRouteDefinition,
+} from './astro.js';

--- a/packages/underscore-redirects/src/index.ts
+++ b/packages/underscore-redirects/src/index.ts
@@ -3,3 +3,4 @@ export {
 	createRedirectsFromAstroRoutes,
 	createHostedRouteDefinition,
 } from './astro.js';
+export { HostRoutes } from './host-route.js';

--- a/packages/underscore-redirects/src/print.ts
+++ b/packages/underscore-redirects/src/print.ts
@@ -1,4 +1,4 @@
-import type { RedirectDefinition } from './redirects.js';
+import type { HostRoutes } from './host-route.js';
 
 /**
  * Pretty print a list of definitions into the output format. Keeps
@@ -9,16 +9,18 @@ import type { RedirectDefinition } from './redirects.js';
  * /team/articles/*    /team/articles/*\/index.html    200
  * /blog/*             /team/articles/*\/index.html    301
  */
-export function print(
-	definitions: RedirectDefinition[],
-	minInputLength: number,
-	minTargetLength: number,
-) {
+export function printAsRedirects(hostRoutes: HostRoutes) {
+	const definitions = hostRoutes.definitions;
+	const minInputLength = hostRoutes.minInputLength;
+	const minTargetLength = hostRoutes.minTargetLength;
 	let _redirects = '';
 
 	// Loop over the definitions
 	for (let i = 0; i < definitions.length; i++) {
 		const definition = definitions[i];
+		if (!definition.target) {
+			continue;
+		}
 		// Figure out the number of spaces to add. We want at least 4 spaces
 		// after the input. This ensure that all targets line up together.
 		const inputSpaces = minInputLength - definition.input.length + 4;

--- a/packages/underscore-redirects/test/print.test.js
+++ b/packages/underscore-redirects/test/print.test.js
@@ -1,10 +1,10 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { Redirects } from '../dist/index.js';
+import { HostRoutes, printAsRedirects } from '../dist/index.js';
 
 describe('Printing', () => {
 	it('Formats long lines in a pretty way', () => {
-		const _redirects = new Redirects();
+		const _redirects = new HostRoutes();
 		_redirects.add({
 			dynamic: false,
 			input: '/a',
@@ -19,7 +19,7 @@ describe('Printing', () => {
 			weight: 0,
 			status: 200,
 		});
-		let out = _redirects.print();
+		let out = printAsRedirects(_redirects);
 
 		let [lineOne, lineTwo] = out.split('\n');
 
@@ -33,7 +33,7 @@ describe('Printing', () => {
 	});
 
 	it('Properly prints dynamic routes', () => {
-		const _redirects = new Redirects();
+		const _redirects = new HostRoutes();
 		_redirects.add({
 			dynamic: true,
 			input: '/pets/:cat',
@@ -41,7 +41,7 @@ describe('Printing', () => {
 			status: 200,
 			weight: 1,
 		});
-		let out = _redirects.print();
+		let out = printAsRedirects(_redirects);
 		let parts = out.split(/\s+/);
 
 		const expectedParts = ['/pets/:cat', '/pets/:cat/index.html', '200'];
@@ -49,7 +49,7 @@ describe('Printing', () => {
 	});
 
 	it('Properly handles force redirects', () => {
-		const _redirects = new Redirects();
+		const _redirects = new HostRoutes();
 		_redirects.add({
 			dynamic: false,
 			input: '/a',
@@ -58,7 +58,7 @@ describe('Printing', () => {
 			weight: 1,
 			force: true,
 		});
-		let out = _redirects.print();
+		let out = printAsRedirects(_redirects);
 		let parts = out.split(/\s+/);
 
 		const expectedParts = ['/a', '/b', '200!'];

--- a/packages/underscore-redirects/test/weight.test.js
+++ b/packages/underscore-redirects/test/weight.test.js
@@ -1,10 +1,10 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { Redirects } from '../dist/index.js';
+import { HostRoutes } from '../dist/index.js';
 
 describe('Weight', () => {
 	it('Puts higher weighted definitions on top', () => {
-		const _redirects = new Redirects();
+		const _redirects = new HostRoutes();
 		_redirects.add({
 			dynamic: false,
 			input: '/a',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5395,6 +5395,12 @@ importers:
         specifier: 'workspace:'
         version: link:../../../..
 
+  packages/integrations/netlify/test/static/fixtures/static-headers:
+    dependencies:
+      '@astrojs/netlify':
+        specifier: 'workspace:'
+        version: link:../../../..
+
   packages/integrations/node:
     dependencies:
       '@astrojs/internal-helpers':


### PR DESCRIPTION
## Changes

This PR adds support for static headers for the Netlify adapter. The initial implementation supports the experimental CSP feature. In the future, this may change, and we will update the documentation as needed.

### `@astrojs/underscore-redirects`

To implement the feature, I had to make some breaking changes within `underscore-redirects`. The package is mostly for internal usage, so we don't have strong documentation and it's mostly for our needs, so the changesets are mostly technical. 

The functionality for redirects must stay the same. 

The printing logic has been removed from `Redirects`, instead consumers need to use `printAsRedirects` instead. The core functionality hasn't changed much, it now accounts for `.target`, because it's now optional.

### `@astrojs/netlify`

The function that creates `config.json` is now called in the `astro:build:done` hook, because we need to collect the static headers from the hook `astro:build:generated`. 

The new logic now loops through the new static headers, and if `cps` is enabled, they are added to the final `config.json`.

## Testing

Added a new test. Existing tests should still pass.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
