### PR TITLE
feat(vercel): experimental static headers

### DIFF
--- a/.changeset/curly-masks-retire.md
+++ b/.changeset/curly-masks-retire.md
@@ -1,0 +1,21 @@
+---
+'@astrojs/vercel': minor
+---
+
+Adds support for the [experimental static headers Astro feature](https://docs.astro.build/en/reference/adapter-reference/#experimentalstaticheaders).
+
+When the feature is enabled via option `experimentalStaticHeaders`, and [experimental Content Security Policy](https://docs.astro.build/en/reference/experimental-flags/csp/) is enabled, the adapter will generate `Response` headers for static pages, which allows support for CSP directives that are not supported inside a `<meta>` tag (e.g. `frame-ancestors`).
+
+```js
+import { defineConfig } from "astro/config";
+import vercel from "@astrojs/vercel";
+
+export default defineConfig({
+  adapter: vercel({
+    experimentalStaticHeaders: true
+  }),
+  experimental: {
+    cps: true
+  }
+})
+```

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -41,6 +41,7 @@
     "types.d.ts"
   ],
   "scripts": {
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "astro-scripts test --timeout 50000 \"test/**/!(hosted).test.js\"",
@@ -53,7 +54,8 @@
     "@vercel/nft": "^0.29.2",
     "@vercel/routing-utils": "^5.0.4",
     "esbuild": "^0.25.0",
-    "tinyglobby": "^0.2.13"
+    "tinyglobby": "^0.2.13",
+    "@astrojs/underscore-redirects": "workspace:*"
   },
   "peerDependencies": {
     "astro": "^5.0.0"

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -2,7 +2,12 @@ import { cpSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { emptyDir, removeDir, writeJson } from '@astrojs/internal-helpers/fs';
-import { type Route, getTransformedRoutes, normalizeRoutes } from '@vercel/routing-utils';
+import {
+	type Header,
+	type Route,
+	getTransformedRoutes,
+	normalizeRoutes,
+} from '@vercel/routing-utils';
 import type {
 	AstroAdapter,
 	AstroConfig,
@@ -27,6 +32,7 @@ import {
 	getInjectableWebAnalyticsContent,
 } from './lib/web-analytics.js';
 import { generateEdgeMiddleware } from './serverless/middleware.js';
+import { createHostedRouteDefinition } from '@astrojs/underscore-redirects';
 
 const PACKAGE_NAME = '@astrojs/vercel';
 
@@ -74,11 +80,13 @@ function getAdapter({
 	middlewareSecret,
 	skewProtection,
 	buildOutput,
+	experimentalStaticHeaders,
 }: {
 	buildOutput: 'server' | 'static';
-	edgeMiddleware: boolean;
+	edgeMiddleware: NonNullable<VercelServerlessConfig['edgeMiddleware']>;
 	middlewareSecret: string;
 	skewProtection: boolean;
+	experimentalStaticHeaders: NonNullable<VercelServerlessConfig['experimentalStaticHeaders']>;
 }): AstroAdapter {
 	return {
 		name: PACKAGE_NAME,
@@ -88,6 +96,7 @@ function getAdapter({
 		adapterFeatures: {
 			edgeMiddleware,
 			buildOutput,
+			experimentalStaticHeaders,
 		},
 		supportedAstroFeatures: {
 			hybridOutput: 'stable',
@@ -131,6 +140,14 @@ export interface VercelServerlessConfig {
 	 * It enables Vercel skew protection: https://vercel.com/docs/deployments/skew-protection
 	 */
 	skewProtection?: boolean;
+
+	/**
+	 * If enabled, the adapter will save [static headers in the framework API file](https://docs.netlify.com/frameworks-api/#headers).
+	 *
+	 * Here the list of the headers that are added:
+	 * - The CSP header of the static pages is added when CSP support is enabled.
+	 */
+	experimentalStaticHeaders?: boolean;
 }
 
 interface VercelISRConfig {
@@ -171,6 +188,7 @@ export default function vercelAdapter({
 	maxDuration,
 	isr = false,
 	skewProtection = false,
+	experimentalStaticHeaders = false,
 }: VercelServerlessConfig = {}): AstroIntegration {
 	if (maxDuration) {
 		if (typeof maxDuration !== 'number') {
@@ -186,6 +204,7 @@ export default function vercelAdapter({
 	let _serverEntry: string;
 	let _entryPoints: Map<Pick<IntegrationResolvedRoute, 'entrypoint' | 'patternRegex'>, URL>;
 	let _middlewareEntryPoint: URL | undefined;
+	let _routeToHeaders: Map<IntegrationResolvedRoute, Headers> | undefined = undefined;
 	// Extra files to be merged with `includeFiles` during build
 	const extraFilesToInclude: URL[] = [];
 	// Secret used to verify that the caller is the astro-generated edge middleware and not a third-party
@@ -290,6 +309,7 @@ export default function vercelAdapter({
 							edgeMiddleware,
 							middlewareSecret,
 							skewProtection,
+							experimentalStaticHeaders,
 						}),
 					);
 				} else {
@@ -299,6 +319,7 @@ export default function vercelAdapter({
 							middlewareSecret: '',
 							skewProtection,
 							buildOutput: _buildOutput,
+							experimentalStaticHeaders,
 						}),
 					);
 				}
@@ -323,6 +344,10 @@ export default function vercelAdapter({
 						]),
 				);
 				_middlewareEntryPoint = middlewareEntryPoint;
+			},
+
+			'astro:build:generated': ({ experimentalRouteToHeaders }) => {
+				_routeToHeaders = experimentalRouteToHeaders;
 			},
 			'astro:build:done': async ({ logger }: HookParameters<'astro:build:done'>) => {
 				const outDir = new URL('./.vercel/output/', _config.root);
@@ -465,7 +490,7 @@ export default function vercelAdapter({
 					}
 				}
 				const fourOhFourRoute = routes.find((route) => route.pathname === '/404');
-				const destination = new URL('./.vercel/output/config.json', _config.root);
+				const vercelConfigJson = new URL('./.vercel/output/config.json', _config.root);
 				const finalRoutes: Route[] = [
 					{
 						src: `^/${_config.build.assets}/(.*)$`,
@@ -550,12 +575,18 @@ export default function vercelAdapter({
 					);
 				}
 
+				let headers: Header[] | undefined = undefined;
+				if (_routeToHeaders && _routeToHeaders.size > 0) {
+					headers = createConfigHeaders(_routeToHeaders, _config);
+				}
+
 				// Output configuration
 				// https://vercel.com/docs/build-output-api/v3#build-output-configuration
-				await writeJson(destination, {
+				await writeJson(vercelConfigJson, {
 					version: 3,
 					routes: normalized.routes,
 					images,
+					headers,
 				});
 
 				// Remove temporary folder
@@ -707,4 +738,39 @@ function getRuntime(process: NodeJS.Process, logger: AstroIntegrationLogger): Ru
 		return `nodejs${major}.x`;
 	}
 	return 'nodejs18.x';
+}
+
+function createConfigHeaders(
+	staticHeaders: Map<IntegrationResolvedRoute, Headers>,
+	config: AstroConfig,
+): Header[] {
+	const vercelHeaders: Header[] = [];
+	for (const [route, routeHeaders] of staticHeaders.entries()) {
+		if (!route.isPrerendered) {
+			continue;
+		}
+		if (route.redirect) {
+			continue;
+		}
+
+		const definition = createHostedRouteDefinition(route, config);
+
+		if (config.experimental.csp) {
+			const csp = routeHeaders.get('Content-Security-Policy');
+
+			if (csp) {
+				vercelHeaders.push({
+					source: definition.input,
+					headers: [
+						{
+							key: 'Content-Security-Policy',
+							value: csp,
+						},
+					],
+				});
+			}
+		}
+	}
+
+	return vercelHeaders;
 }

--- a/packages/integrations/vercel/test/fixtures/static-headers/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/static-headers/astro.config.mjs
@@ -1,0 +1,12 @@
+import vercel from '@astrojs/vercel';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	output: "server",
+	adapter: vercel({
+		experimentalStaticHeaders: true,
+	}),
+	experimental: {
+		csp: true
+	},
+});

--- a/packages/integrations/vercel/test/fixtures/static-headers/package.json
+++ b/packages/integrations/vercel/test/fixtures/static-headers/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/vercel-static-headers",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/static-headers/src/components/Island.astro
+++ b/packages/integrations/vercel/test/fixtures/static-headers/src/components/Island.astro
@@ -1,0 +1,1 @@
+<p>I am a Server Island</p>

--- a/packages/integrations/vercel/test/fixtures/static-headers/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/static-headers/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Island  from "../components/Island.astro"
+export const prerender = true;
+---
+<html>
+<head><title>Index</title></head>
+<body>
+<h1>Index</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/vercel/test/static-headers.test.js
+++ b/packages/integrations/vercel/test/static-headers.test.js
@@ -1,0 +1,27 @@
+import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+describe('Static headers', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/static-headers' });
+		await fixture.build();
+	});
+
+	it('CSP headers are added when CSP is enabled', async () => {
+		const config = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
+		const headers = config.headers;
+
+		const csp = headers
+			.find((x) => x.source === '/')
+			.headers.find((x) => x.key === 'Content-Security-Policy');
+
+		assert.notEqual(csp, undefined, 'the index must have CSP headers');
+		assert.ok(
+			csp.value.includes('script-src'),
+			'must contain the script-src directive because of the server island',
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5779,6 +5779,9 @@ importers:
       '@astrojs/internal-helpers':
         specifier: workspace:*
         version: link:../../internal-helpers
+      '@astrojs/underscore-redirects':
+        specifier: workspace:*
+        version: link:../../underscore-redirects
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(react@19.1.0)(svelte@5.33.14)(vue@3.5.16(typescript@5.8.3))
@@ -5947,6 +5950,15 @@ importers:
         version: link:../../../../../astro
 
   packages/integrations/vercel/test/fixtures/static-assets:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
+  packages/integrations/vercel/test/fixtures/static-headers:
     dependencies:
       '@astrojs/vercel':
         specifier: workspace:*


### PR DESCRIPTION
## Changes

Very similar to https://github.com/withastro/astro/pull/13952, it adds support for static headers in the Vercel adapter

## Testing

Added a new test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

The changeset is a copy-past from the netlify one, updated to use the vercel adapter. 
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
