### PR TITLE
Fix broken documentation link

### DIFF
--- a/packages/astro/src/template/4xx.ts
+++ b/packages/astro/src/template/4xx.ts
@@ -144,7 +144,7 @@ export function trailingSlashMismatchTemplate(
 		title: 'Not found',
 		tabTitle: '404: Not Found',
 		body: `<p>Your site is configured with <code>trailingSlash</code> set to <code>${trailingSlash}</code>. Do you want to go to <a href="${corrected}">${corrected}</a> instead?</p>
-<p>See <a href=https://docs.astro.build/en/reference/configuration-reference/#trailingslash">the documentation for <code>trailingSlash</code></a> if you need help.</p>`,
+<p>See <a href="https://docs.astro.build/en/reference/configuration-reference/#trailingslash">the documentation for <code>trailingSlash</code></a> if you need help.</p>`,
 	});
 }
 


### PR DESCRIPTION
## Changes

Previously, it led to https://docs.astro.build/en/reference/configuration-reference/#trailingslash%22 (see the double quuote at the end of the URL)

## Docs

The 404 page template was fixed, there is no reason to touch the documentation.
