### PR TITLE
don't coerce environment variable values when populating import.meta.env

### DIFF
--- a/.changeset/hungry-trains-sip.md
+++ b/.changeset/hungry-trains-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+don't coerce environment variable values when populating import.meta.env

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -125,7 +125,8 @@ export async function createVite(
 	});
 
 	const srcDirPattern = convertPathToPattern(fileURLToPath(settings.config.srcDir));
-	const envLoader = createEnvLoader(mode, settings.config);
+	const astroEnvLoader = createEnvLoader(mode, settings.config, true);
+	const importMetaEnvLoader = createEnvLoader(mode, settings.config, false);
 
 	// Start with the Vite configuration that Astro core needs
 	const commonConfig: vite.InlineConfig = {
@@ -150,8 +151,8 @@ export async function createVite(
 			// The server plugin is for dev only and having it run during the build causes
 			// the build to run very slow as the filewatcher is triggered often.
 			command === 'dev' && vitePluginAstroServer({ settings, logger, fs, routesList, manifest }), // manifest is only required in dev mode, where it gets created before a Vite instance is created, and get passed to this function
-			importMetaEnv({ envLoader }),
-			astroEnv({ settings, sync, envLoader }),
+			importMetaEnv({ envLoader: importMetaEnvLoader }),
+			astroEnv({ settings, sync, envLoader: astroEnvLoader }),
 			markdownVitePlugin({ settings, logger }),
 			htmlVitePlugin(),
 			astroPostprocessVitePlugin(),

--- a/packages/astro/src/env/env-loader.ts
+++ b/packages/astro/src/env/env-loader.ts
@@ -9,6 +9,7 @@ const isValidIdentifierRe = /^[_$a-zA-Z][\w$]*$/;
 function getPrivateEnv(
 	fullEnv: Record<string, string>,
 	astroConfig: AstroConfig,
+	coerceValues: boolean
 ): Record<string, string> {
 	const viteConfig = astroConfig.vite;
 	let envPrefixes: string[] = ['PUBLIC_'];
@@ -30,7 +31,7 @@ function getPrivateEnv(
 				}
 				// Boolean values should be inlined to support `export const prerender`
 				// We already know that these are NOT sensitive values, so inlining is safe
-				if (value === '0' || value === '1' || value === 'true' || value === 'false') {
+				if (coerceValues && (value === '0' || value === '1' || value === 'true' || value === 'false')) {
 					privateEnv[key] = value;
 				} else {
 					privateEnv[key] = `process.env.${key}`;
@@ -43,9 +44,9 @@ function getPrivateEnv(
 	return privateEnv;
 }
 
-export const createEnvLoader = (mode: string, config: AstroConfig) => {
+export const createEnvLoader = (mode: string, config: AstroConfig, coerceValues: boolean) => {
 	const loaded = loadEnv(mode, config.vite.envDir ?? fileURLToPath(config.root), '');
-	const privateEnv = getPrivateEnv(loaded, config);
+	const privateEnv = getPrivateEnv(loaded, config, coerceValues);
 	return {
 		get: () => loaded,
 		getPrivateEnv: () => privateEnv,


### PR DESCRIPTION
## Changes

See #13967 

Just to go over my thought process:

- The `env-loader` logic is used for both populating the `astro:env` virtual modules and `import.meta.env`.
- We want variables imported via `astro:env` to still be converted into the expected type.
- We want variables on `import.meta.env` to *not* be converted and should be set as-is (i.e. a `string`).
- `astro:env` is entirely set up in `vite-plugin-env.ts` (?)
- `import.meta.env` is entirely set up in `vite-plugin-import-meta-env.ts` (?)

I added a `coerceValues` argument to `createEnvLoader` and `getPrivateEnv`.

Then, in `packages/astro/src/core/create-vite.ts`, we create two separate `envLoader`s, one more `astro:env` and one for `import.meta.env`, where the the `importMetaEnv` plugin is passed an `envLoader` with `coerceValues = false`.

### Alternate Solution

This solution requires making two `envLoader`s.

As an alternative, we could attached a property to the object returned by `createEnvLoader` called something like `getRawPrivateEnv` which contains the original string values. We would use one `envLoader` and then in `vite-plugin-import-meta-env.ts` we use`getRawPrivateEnv` instead of `getPrivateEnv`. 

## Testing

I tested with the `examples/minimal` project:

- Add the following to `index.astro`:
  	```astro
	import { MY_VAR } from 'astro:env/client';
	console.log(`typeof: ${typeof import.meta.env.MY_VAR}`);
	console.log(`typeof: ${typeof MY_VAR}`);
	```
- Set up the `astro.config`:
	```ts
	export default defineConfig({env: {
		schema: {
			MY_VAR: {
				access: "public",
				context: "client",
				type: "boolean",
				
			}
		}
	}});
	```
- Run `MY_VAR=true pnpm --filter @example/minimal run build`:
	```
    typeof: string // from import.meta.env
	typeof: boolean // from astro:env
	```

## Docs

/cc @withastro/maintainers-docs for feedback!