### PR TITLE
fix: actions typegen path

### DIFF
--- a/.changeset/stale-donkeys-bake.md
+++ b/.changeset/stale-donkeys-bake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where Astro Actions types would be broken when using a `tsconfig.json` with `"moduleResolution": "nodenext"`

--- a/packages/astro/src/actions/integration.ts
+++ b/packages/astro/src/actions/integration.ts
@@ -11,8 +11,10 @@ import { ACTIONS_TYPES_FILE, ACTION_RPC_ROUTE_PATTERN, VIRTUAL_MODULE_ID } from 
  */
 export default function astroIntegrationActionsRouteHandler({
 	settings,
+	filename,
 }: {
 	settings: AstroSettings;
+	filename: string;
 }): AstroIntegration {
 	return {
 		name: VIRTUAL_MODULE_ID,
@@ -33,7 +35,7 @@ export default function astroIntegrationActionsRouteHandler({
 				}
 
 				const stringifiedActionsImport = JSON.stringify(
-					viteID(new URL('./actions', params.config.srcDir)),
+					viteID(new URL(`./${filename}`, params.config.srcDir)),
 				);
 				settings.injectedTypes.push({
 					filename: ACTIONS_TYPES_FILE,

--- a/packages/astro/src/actions/utils.ts
+++ b/packages/astro/src/actions/utils.ts
@@ -41,7 +41,7 @@ export async function isActionsFilePresent(fs: typeof fsMod, srcDir: URL) {
 
 	let contents: string;
 	try {
-		contents = fs.readFileSync(actionsFile, 'utf-8');
+		contents = fs.readFileSync(actionsFile.url, 'utf-8');
 	} catch {
 		return false;
 	}
@@ -50,17 +50,17 @@ export async function isActionsFilePresent(fs: typeof fsMod, srcDir: URL) {
 	// If not, the user may have an empty `actions` file,
 	// or may be using the `actions` file for another purpose
 	// (possible since actions are non-breaking for v4.X).
-	const [, exports] = eslexer.parse(contents, actionsFile.pathname);
+	const [, exports] = eslexer.parse(contents, actionsFile.url.pathname);
 	for (const exp of exports) {
 		if (exp.n === 'server') {
-			return true;
+			return actionsFile.filename;
 		}
 	}
 	return false;
 }
 
 function search(fs: typeof fsMod, srcDir: URL) {
-	const paths = [
+	const filenames = [
 		'actions.mjs',
 		'actions.js',
 		'actions.mts',
@@ -69,10 +69,11 @@ function search(fs: typeof fsMod, srcDir: URL) {
 		'actions/index.js',
 		'actions/index.mts',
 		'actions/index.ts',
-	].map((p) => new URL(p, srcDir));
-	for (const file of paths) {
-		if (fs.existsSync(file)) {
-			return file;
+	];
+	for (const filename of filenames) {
+		const url = new URL(filename, srcDir);
+		if (fs.existsSync(url)) {
+			return { filename, url };
 		}
 	}
 	return undefined;

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -182,8 +182,11 @@ export async function runHookConfigSetup({
 	if (settings.config.adapter) {
 		settings.config.integrations.unshift(settings.config.adapter);
 	}
-	if (await isActionsFilePresent(fs, settings.config.srcDir)) {
-		settings.config.integrations.push(astroIntegrationActionsRouteHandler({ settings }));
+	const actionsFilename = await isActionsFilePresent(fs, settings.config.srcDir)
+	if (actionsFilename) {
+		settings.config.integrations.push(
+			astroIntegrationActionsRouteHandler({ settings, filename: actionsFilename }),
+		);
 	}
 
 	let updatedConfig: AstroConfig = { ...settings.config };


### PR DESCRIPTION
## Changes

- Closes #13903
- Instead of hardcoding what path to use, we grab the matched action filename and use directly

## Testing

Manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
