### PR TITLE
Updates image config ref docs for responsive images to match live docs

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1327,7 +1327,21 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 
 		 */
 		remotePatterns?: Partial<RemotePattern>[];
-
+		
+		/**
+		 * @docs
+		 * @name image.responsiveStyles
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 5.10.0
+		 * @description
+		 * Whether to automatically add global styles for responsive images. You should enable this option unless you are styling the images yourself.
+		 * 
+	 	 * This option is only used when `layout` is set to `constrained`, `full-width`, or `fixed` using the configuration or the `layout` prop on the image component.
+		 *
+		 * See [the images docs](https://docs.astro.build/en/guides/images/#responsive-image-styles) for more information.
+		 */
+		responsiveStyles?: boolean;
 		/**
 		 * @docs
 		 * @name image.layout
@@ -1350,7 +1364,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * @default `"cover"`
 		 * @version 5.10.0
 		 * @description
-		 * The default object-fit value for responsive images. Can be overridden by the `fit` prop on the image component.
+		 * The [`object-fit` CSS property value](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) for responsive images. Can be overridden by the `fit` prop on the image component.
 		 * Requires a value for `layout` to be set.
 		 *
 		 * See [the `fit` component property](https://docs.astro.build/en/reference/modules/astro-assets/#fit) for more details.
@@ -1363,7 +1377,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * @default `"center"`
 		 * @version 5.10.0
 		 * @description
-		 * The default object-position value for responsive images. Can be overridden by the `position` prop on the image component.
+		 * The default [`object-position` CSS property value](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) for responsive images. Can be overridden by the `position` prop on the image component.
 		 * Requires a value for `layout` to be set.
 		 *
 		 * See [the `position` component property](https://docs.astro.build/en/reference/modules/astro-assets/#position) for more details.
@@ -1381,19 +1395,6 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * the more comprehensive list is used, because only the required sizes are generated. For local services, the list is shorter to reduce the number of images generated.
 		 */
 		breakpoints?: number[];
-		/**
-		 * @docs
-		 * @name image.responsiveStyles
-		 * @type {boolean}
-		 * @default `false`
-		 * @version 5.10.0
-		 * @description
-		 * Whether to automatically add global styles for responsive images. You should enable this option unless you are styling the images yourself.
-		 * This option is only used when `layout` is set to `constrained`, `full-width`, or `fixed` using the configuration or the `layout` prop on the image component.
-		 *
-		 * See [the images docs](https://docs.astro.build/en/guides/images/#responsive-image-styles) for more information.
-		 */
-		responsiveStyles?: boolean;
 	};
 
 	/**


### PR DESCRIPTION
## Changes

Some improvements to the config reference docs for responsive images becoming stable were made in the docs PR itself. This should align the source with those docs. (Reorders entries, adds external links for CSS properties, formatting syntax - nothing fundamentally affecting documentation. Should not require a rerelease.)

## Testing

It's JSDoc for docs generation... we're just hoping it works!

## Docs

To match live docs.
