### PR TITLE
fix: toolbar image audit in content collections

### DIFF
--- a/.changeset/legal-facts-teach.md
+++ b/.changeset/legal-facts-teach.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a case where the toolbar audit would incorrectl flag images processed by Astro in content collections documents
+Fixes a case where the toolbar audit would incorrectly flag images processed by Astro in content collections documents

--- a/.changeset/legal-facts-teach.md
+++ b/.changeset/legal-facts-teach.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where the toolbar audit would incorrectl flag images processed by Astro in content collections documents

--- a/examples/blog/src/content/blog/markdown-style-guide.md
+++ b/examples/blog/src/content/blog/markdown-style-guide.md
@@ -39,7 +39,7 @@ Itatur? Quiatae cullecum rem ent aut odis in re eossequodi nonsequ idebis ne sap
 
 ### Output
 
-![blog placeholder](/blog-placeholder-about.jpg)
+![blog placeholder](../../assets/blog-placeholder-about.jpg)
 
 ## Blockquotes
 

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -700,6 +700,7 @@ async function updateImageReferencesInBody(html: string, fileName: string) {
 			...attributes,
 			src: image.src,
 			srcset: image.srcSet.attribute,
+			// This attribute is used by the toolbar audit
 			...(import.meta.env.DEV ? { 'data-image-component': 'true' } : {}),
 		})
 			.map(([key, value]) => (value ? `${key}="${escape(value)}"` : ''))

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -700,6 +700,7 @@ async function updateImageReferencesInBody(html: string, fileName: string) {
 			...attributes,
 			src: image.src,
 			srcset: image.srcSet.attribute,
+			...(import.meta.env.DEV ? { 'data-image-component': 'true' } : {}),
 		})
 			.map(([key, value]) => (value ? `${key}="${escape(value)}"` : ''))
 			.join(' ');


### PR DESCRIPTION
## Changes

- Closes #13221
- The dev toolbar relies on the `data-image-component` attribute for an audit
- In content collections md/mdx files, images are not created using the `<Image />` component so the attribute was not set in dev

## Testing

Manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
