### PR TITLE
fix: add info message in dev

### DIFF
--- a/.changeset/small-knives-feel.md
+++ b/.changeset/small-knives-feel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds an informative message in dev mode when the CSP feature is enabled.

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -1,23 +1,19 @@
-import type nodeFs from "node:fs";
-import { fileURLToPath } from "node:url";
-import * as vite from "vite";
-import { globalContentLayer } from "../../content/content-layer.js";
-import { attachContentServerListeners } from "../../content/server-listeners.js";
-import { eventCliSession, telemetry } from "../../events/index.js";
-import { SETTINGS_FILE } from "../../preferences/constants.js";
-import type { AstroSettings } from "../../types/astro.js";
-import type { AstroInlineConfig } from "../../types/public/config.js";
-import {
-	createNodeLogger,
-	createSettings,
-	resolveConfig,
-} from "../config/index.js";
-import { collectErrorMetadata } from "../errors/dev/utils.js";
-import { isAstroConfigZodError } from "../errors/errors.js";
-import { createSafeError } from "../errors/index.js";
-import { formatErrorMessage } from "../messages.js";
-import type { Container } from "./container.js";
-import { createContainer, startContainer } from "./container.js";
+import type nodeFs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as vite from 'vite';
+import { globalContentLayer } from '../../content/content-layer.js';
+import { attachContentServerListeners } from '../../content/server-listeners.js';
+import { eventCliSession, telemetry } from '../../events/index.js';
+import { SETTINGS_FILE } from '../../preferences/constants.js';
+import type { AstroSettings } from '../../types/astro.js';
+import type { AstroInlineConfig } from '../../types/public/config.js';
+import { createNodeLogger, createSettings, resolveConfig } from '../config/index.js';
+import { collectErrorMetadata } from '../errors/dev/utils.js';
+import { isAstroConfigZodError } from '../errors/errors.js';
+import { createSafeError } from '../errors/index.js';
+import { formatErrorMessage } from '../messages.js';
+import type { Container } from './container.js';
+import { createContainer, startContainer } from './container.js';
 
 async function createRestartedContainer(
 	container: Container,
@@ -50,8 +46,7 @@ function shouldRestartContainer(
 
 	// If the config file changed, reload the config and restart the server.
 	if (inlineConfig.configFile) {
-		shouldRestart =
-			vite.normalizePath(inlineConfig.configFile) === normalizedChangedFile;
+		shouldRestart = vite.normalizePath(inlineConfig.configFile) === normalizedChangedFile;
 	}
 	// Otherwise, watch for any astro.config.* file changes in project root
 	else {
@@ -60,9 +55,7 @@ function shouldRestartContainer(
 			fileURLToPath(new URL(SETTINGS_FILE, settings.dotAstroDir)),
 		);
 		if (settingsPath.endsWith(normalizedChangedFile)) {
-			shouldRestart = settings.preferences.ignoreNextPreferenceReload
-				? false
-				: true;
+			shouldRestart = settings.preferences.ignoreNextPreferenceReload ? false : true;
 
 			settings.preferences.ignoreNextPreferenceReload = false;
 		}
@@ -78,28 +71,19 @@ function shouldRestartContainer(
 	return shouldRestart;
 }
 
-async function restartContainer(
-	container: Container,
-): Promise<Container | Error> {
+async function restartContainer(container: Container): Promise<Container | Error> {
 	const { logger, close, settings: existingSettings } = container;
 	container.restartInFlight = true;
 
 	try {
-		const { astroConfig } = await resolveConfig(
-			container.inlineConfig,
-			"dev",
-			container.fs,
-		);
+		const { astroConfig } = await resolveConfig(container.inlineConfig, 'dev', container.fs);
 		if (astroConfig.experimental.csp) {
 			logger.info(
-				"config",
+				'config',
 				"Be aware that due to the nature of the development server, CSP won't work as expected. To see the final results, you have to build the project and run the preview server.",
 			);
 		}
-		const settings = await createSettings(
-			astroConfig,
-			fileURLToPath(existingSettings.config.root),
-		);
+		const settings = await createSettings(astroConfig, fileURLToPath(existingSettings.config.root));
 		await close();
 		return await createRestartedContainer(container, settings);
 	} catch (_err) {
@@ -107,23 +91,20 @@ async function restartContainer(
 		// Print all error messages except ZodErrors from AstroConfig as the pre-logged error is sufficient
 		if (!isAstroConfigZodError(_err)) {
 			logger.error(
-				"config",
-				formatErrorMessage(
-					collectErrorMetadata(error),
-					logger.level() === "debug",
-				) + "\n",
+				'config',
+				formatErrorMessage(collectErrorMetadata(error), logger.level() === 'debug') + '\n',
 			);
 		}
 		// Inform connected clients of the config error
 		container.viteServer.hot.send({
-			type: "error",
+			type: 'error',
 			err: {
 				message: error.message,
-				stack: error.stack || "",
+				stack: error.stack || '',
 			},
 		});
 		container.restartInFlight = false;
-		logger.error(null, "Continuing with previous valid configuration\n");
+		logger.error(null, 'Continuing with previous valid configuration\n');
 		return error;
 	}
 }
@@ -143,23 +124,16 @@ export async function createContainerWithAutomaticRestart({
 	fs,
 }: CreateContainerWithAutomaticRestart): Promise<Restart> {
 	const logger = createNodeLogger(inlineConfig ?? {});
-	const { userConfig, astroConfig } = await resolveConfig(
-		inlineConfig ?? {},
-		"dev",
-		fs,
-	);
+	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'dev', fs);
 	if (astroConfig.experimental.csp) {
 		logger.info(
-			"config",
+			'config',
 			"Be aware that due to the nature of the development server, CSP won't work as expected. To see the final results, you have to build the project and run the preview server.",
 		);
 	}
-	telemetry.record(eventCliSession("dev", userConfig));
+	telemetry.record(eventCliSession('dev', userConfig));
 
-	const settings = await createSettings(
-		astroConfig,
-		fileURLToPath(astroConfig.root),
-	);
+	const settings = await createSettings(astroConfig, fileURLToPath(astroConfig.root));
 
 	const initialContainer = await createContainer({
 		settings,
@@ -180,8 +154,8 @@ export async function createContainerWithAutomaticRestart({
 		},
 	};
 
-	async function handleServerRestart(logMsg = "", server?: vite.ViteDevServer) {
-		logger.info(null, (logMsg + " Restarting...").trim());
+	async function handleServerRestart(logMsg = '', server?: vite.ViteDevServer) {
+		logger.info(null, (logMsg + ' Restarting...').trim());
 		const container = restart.container;
 		const result = await restartContainer(container);
 		if (result instanceof Error) {
@@ -216,15 +190,15 @@ export async function createContainerWithAutomaticRestart({
 	// Set up watchers, vite restart API, and shortcuts
 	function setupContainer() {
 		const watcher = restart.container.viteServer.watcher;
-		watcher.on("change", handleChangeRestart("Configuration file updated."));
-		watcher.on("unlink", handleChangeRestart("Configuration file removed."));
-		watcher.on("add", handleChangeRestart("Configuration file added."));
+		watcher.on('change', handleChangeRestart('Configuration file updated.'));
+		watcher.on('unlink', handleChangeRestart('Configuration file removed.'));
+		watcher.on('add', handleChangeRestart('Configuration file added.'));
 
 		// Restart the Astro dev server instead of Vite's when the API is called by plugins.
 		// Ignore the `forceOptimize` parameter for now.
 		restart.container.viteServer.restart = async () => {
 			if (!restart.container.restartInFlight) {
-				await handleServerRestart("", restart.container.viteServer);
+				await handleServerRestart('', restart.container.viteServer);
 			}
 		};
 
@@ -232,14 +206,14 @@ export async function createContainerWithAutomaticRestart({
 
 		const customShortcuts: Array<vite.CLIShortcut> = [
 			// Disable default Vite shortcuts that don't work well with Astro
-			{ key: "r", description: "" },
-			{ key: "u", description: "" },
-			{ key: "c", description: "" },
+			{ key: 'r', description: '' },
+			{ key: 'u', description: '' },
+			{ key: 'c', description: '' },
 		];
 
 		customShortcuts.push({
-			key: "s",
-			description: "sync content layer",
+			key: 's',
+			description: 'sync content layer',
 			action: () => {
 				globalContentLayer.get()?.sync();
 			},

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -80,7 +80,7 @@ async function restartContainer(container: Container): Promise<Container | Error
 		if (astroConfig.experimental.csp) {
 			logger.info(
 				'config',
-				"Be aware that due to the nature of the development server, CSP won't work as expected. To see the final results, you have to build the project and run the preview server.",
+				"Astro's Content Security Policy (CSP) does not work in development mode. To verify your CSP implementation, build the project and run the preview server.",
 			);
 		}
 		const settings = await createSettings(astroConfig, fileURLToPath(existingSettings.config.root));

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -78,7 +78,7 @@ async function restartContainer(container: Container): Promise<Container | Error
 	try {
 		const { astroConfig } = await resolveConfig(container.inlineConfig, 'dev', container.fs);
 		if (astroConfig.experimental.csp) {
-			logger.info(
+			logger.warn(
 				'config',
 				"Astro's Content Security Policy (CSP) does not work in development mode. To verify your CSP implementation, build the project and run the preview server.",
 			);
@@ -126,9 +126,9 @@ export async function createContainerWithAutomaticRestart({
 	const logger = createNodeLogger(inlineConfig ?? {});
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'dev', fs);
 	if (astroConfig.experimental.csp) {
-		logger.info(
+		logger.warn(
 			'config',
-			"Be aware that due to the nature of the development server, CSP won't work as expected. To see the final results, you have to build the project and run the preview server.",
+			"Astro's Content Security Policy (CSP) does not work in development mode. To verify your CSP implementation, build the project and run the preview server.",
 		);
 	}
 	telemetry.record(eventCliSession('dev', userConfig));


### PR DESCRIPTION
## Changes

This PR adds a small message that is shown in dev mode when users use CSP.

## Testing



<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 

I would appreciate some feedback around the nature of the message. I decided to use info severity. Should we use warning?

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
