### PR TITLE
Add lastModified field to live collection cache hints

### DIFF
--- a/.changeset/olive-lines-cough.md
+++ b/.changeset/olive-lines-cough.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Adds `lastModified` field to experimental live collection cache hints
+
+Live loaders can now set a `lastModified` field in the cache hints for entries and collections to indicate when the data was last modified. This is then available in the `cacheHint` field returned by `getCollection` and `getEntry`.

--- a/packages/astro/src/types/public/content.ts
+++ b/packages/astro/src/types/public/content.ts
@@ -131,6 +131,8 @@ export interface CacheHint {
 	tags?: Array<string>;
 	/** Maximum age of the response in seconds */
 	maxAge?: number;
+	/** Last modified time of the content */
+	lastModified?: Date;
 }
 
 export interface LiveDataEntry<TData extends Record<string, any> = Record<string, unknown>> {

--- a/packages/astro/test/fixtures/live-loaders/src/live.config.ts
+++ b/packages/astro/test/fixtures/live-loaders/src/live.config.ts
@@ -52,6 +52,7 @@ const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 			cacheHint: {
 				tags: [`page:${filter.id}`],
 				maxAge: 60,
+				lastModified: new Date('2025-01-01T00:00:00.000Z'),
 			},
 		};
 	},
@@ -69,6 +70,7 @@ const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 			cacheHint: {
 				tags: ['page'],
 				maxAge: 60,
+				lastModified: new Date('2025-01-02T00:00:00.000Z'),
 			},
 		};
 	},

--- a/packages/astro/test/live-loaders.test.js
+++ b/packages/astro/test/live-loaders.test.js
@@ -47,11 +47,13 @@ describe('Live content collections', () => {
 					cacheHint: {
 						tags: [`page:123`],
 						maxAge: 60,
+						lastModified: '2025-01-01T00:00:00.000Z',
 					},
 				},
 				cacheHint: {
 					tags: [`page:123`],
 					maxAge: 60,
+					lastModified: '2025-01-01T00:00:00.000Z',
 				},
 			});
 			assert.deepEqual(data.entryByObject, {
@@ -61,11 +63,13 @@ describe('Live content collections', () => {
 					cacheHint: {
 						tags: [`page:456`],
 						maxAge: 60,
+						lastModified: '2025-01-01T00:00:00.000Z',
 					},
 				},
 				cacheHint: {
 					tags: [`page:456`],
 					maxAge: 60,
+					lastModified: '2025-01-01T00:00:00.000Z',
 				},
 			});
 			assert.deepEqual(data.collection, {
@@ -86,6 +90,7 @@ describe('Live content collections', () => {
 				cacheHint: {
 					tags: ['page'],
 					maxAge: 60,
+					lastModified: '2025-01-02T00:00:00.000Z',
 				},
 			});
 		});
@@ -101,11 +106,13 @@ describe('Live content collections', () => {
 						id: '456',
 						data: { title: 'Page 456', age: 25 },
 						cacheHint: {
+							lastModified: '2025-01-01T00:00:00.000Z',
 							tags: [`page:456`],
 							maxAge: 60,
 						},
 					},
 					cacheHint: {
+						lastModified: '2025-01-01T00:00:00.000Z',
 						tags: [`page:456`],
 						maxAge: 60,
 					},
@@ -167,11 +174,13 @@ describe('Live content collections', () => {
 					id: '123',
 					data: { title: 'Page 123', age: 10 },
 					cacheHint: {
+						lastModified: '2025-01-01T00:00:00.000Z',
 						tags: [`page:123`],
 						maxAge: 60,
 					},
 				},
 				cacheHint: {
+					lastModified: '2025-01-01T00:00:00.000Z',
 					tags: [`page:123`],
 					maxAge: 60,
 				},
@@ -190,11 +199,13 @@ describe('Live content collections', () => {
 						id: '456',
 						data: { title: 'Page 456', age: 25 },
 						cacheHint: {
+							lastModified: '2025-01-01T00:00:00.000Z',
 							tags: [`page:456`],
 							maxAge: 60,
 						},
 					},
 					cacheHint: {
+						lastModified: '2025-01-01T00:00:00.000Z',
 						tags: [`page:456`],
 						maxAge: 60,
 					},


### PR DESCRIPTION
## Changes

This is a suggested change to the API

Introduce a `lastModified` field in the cache hints for live collections, allowing loaders to specify when data was last modified.

## Testing

Updated tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I've [commented](https://github.com/withastro/roadmap/pull/1164#issuecomment-2994133264) on the RFC to propose this. If this is merged I'll update the experimental docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
