### PR TITLE
fix invalid examples in `Astro.routePattern` docstring

### DIFF
--- a/.changeset/blue-olives-itch.md
+++ b/.changeset/blue-olives-itch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix routePattern JSDoc examples to show correct return values

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -144,9 +144,9 @@ export interface AstroGlobal<
 	 * The route currently rendered. It's stripped of the `srcDir` and the `pages` folder, and it doesn't contain the extension.
 	 *
 	 * ## Example
-	 * - The value when rendering `src/pages/index.astro` will `index`.
-	 * - The value when rendering `src/pages/blog/[slug].astro` will `blog/[slug]`.
-	 * - The value when rendering `src/pages/[...path].astro` will `[...path]`.
+	 * - The value when rendering `src/pages/index.astro` will be `/`.
+	 * - The value when rendering `src/pages/blog/[slug].astro` will be `/blog/[slug]`.
+	 * - The value when rendering `src/pages/[...path].astro` will be `/[...path]`.
 	 */
 	routePattern: string;
 	/**
@@ -585,9 +585,9 @@ export interface APIContext<
 	 * The route currently rendered. It's stripped of the `srcDir` and the `pages` folder, and it doesn't contain the extension.
 	 *
 	 * ## Example
-	 * - The value when rendering `src/pages/index.astro` will `index`.
-	 * - The value when rendering `src/pages/blog/[slug].astro` will `blog/[slug]`.
-	 * - The value when rendering `src/pages/[...path].astro` will `[...path]`.
+	 * - The value when rendering `src/pages/index.astro` will be `/`.
+	 * - The value when rendering `src/pages/blog/[slug].astro` will be `/blog/[slug]`.
+	 * - The value when rendering `src/pages/[...path].astro` will be `/[...path]`.
 	 */
 	routePattern: string;
 }


### PR DESCRIPTION
## Changes
- Changes the example return values in the doc string for `Astro.routePattern` to have correct values.

## Testing
- Manually tested by creating routes in an example project with the paths specified as examples in doc string for `Astro.routePattern` and checked the return value.

## Docs
- Doesn't need changes since it is only a docstring change.
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
