### PR TITLE
fix(csp): hashes for head elements

### DIFF
--- a/.changeset/smooth-baboons-move.md
+++ b/.changeset/smooth-baboons-move.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where inline styles and scripts didn't work when CSP was enabled. Now when adding `<styles>` elements inside an Astro component, their hashes care correctly computed.

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -35,6 +35,7 @@ import { type Pipeline, Slots, getParams, getProps } from './render/index.js';
 import { isRoute404or500, isRouteExternalRedirect, isRouteServerIsland } from './routing/match.js';
 import { copyRequest, getOriginPathname, setOriginPathname } from './routing/rewrite.js';
 import { AstroSession } from './session.js';
+import { generateCspDigest } from './encryption.js';
 
 export const apiContextRoutesSymbol = Symbol.for('context.routes');
 /**
@@ -435,6 +436,21 @@ export class RenderContext {
 		const { clientDirectives, inlinedScripts, compressHTML, manifest, renderers, resolve } =
 			pipeline;
 		const { links, scripts, styles } = await pipeline.headElements(routeData);
+
+		const extraStyleHashes = [];
+		const extraScriptHashes = [];
+		const shouldInjectCspMetaTags = !!manifest.csp;
+		const cspAlgorithm = manifest.csp?.algorithm ?? 'SHA-256';
+		if (shouldInjectCspMetaTags) {
+			for (const style of styles) {
+				extraStyleHashes.push(await generateCspDigest(style.children, cspAlgorithm));
+			}
+
+			for (const script of scripts) {
+				extraScriptHashes.push(await generateCspDigest(script.children, cspAlgorithm));
+			}
+		}
+
 		const componentMetadata =
 			(await pipeline.componentMetadata(routeData)) ?? manifest.componentMetadata;
 		const headers = new Headers({ 'Content-Type': 'text/html' });
@@ -492,13 +508,13 @@ export class RenderContext {
 				hasRenderedServerIslandRuntime: false,
 				headInTree: false,
 				extraHead: [],
-				extraStyleHashes: [],
-				extraScriptHashes: [],
+				extraStyleHashes,
+				extraScriptHashes,
 				propagators: new Set(),
 			},
 			cspDestination: manifest.csp?.cspDestination ?? (routeData.prerender ? 'meta' : 'header'),
-			shouldInjectCspMetaTags: !!manifest.csp,
-			cspAlgorithm: manifest.csp?.algorithm ?? 'SHA-256',
+			shouldInjectCspMetaTags,
+			cspAlgorithm,
 			// The following arrays must be cloned, otherwise they become mutable across routes.
 			scriptHashes: manifest.csp?.scriptHashes ? [...manifest.csp.scriptHashes] : [],
 			scriptResources: manifest.csp?.scriptResources ? [...manifest.csp.scriptResources] : [],

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -286,6 +286,24 @@ describe('CSP', () => {
 		assert.equal(meta.attr('content'), undefined, 'meta tag should not be present');
 	});
 
+	it('should generate hashes for inline styles', async () => {
+		fixture = await loadFixture({
+			root: './fixtures/csp/',
+		});
+		await fixture.build();
+		const html = await fixture.readFile('/inline/index.html');
+		const $ = cheerio.load(html);
+
+		const meta = $('meta[http-equiv="Content-Security-Policy"]');
+		// hash of the <style> content
+		assert.ok(
+			meta
+				.attr('content')
+				.toString()
+				.includes("'sha256-fP5hIETY85LoQH4mfn28a0KQgRZ3ZBI/WJOYJRKChes='"),
+		);
+	});
+
 	it('should return CSP header inside a hook', async () => {
 		let routeToHeaders;
 		fixture = await loadFixture({

--- a/packages/astro/test/fixtures/csp/src/components/InlineStuff.astro
+++ b/packages/astro/test/fixtures/csp/src/components/InlineStuff.astro
@@ -1,0 +1,8 @@
+<style>
+	.text {
+		color: red;
+		text-transform: uppercase;
+	}
+</style>
+<p class="text">Powered By</p>
+

--- a/packages/astro/test/fixtures/csp/src/pages/inline.astro
+++ b/packages/astro/test/fixtures/csp/src/pages/inline.astro
@@ -1,0 +1,5 @@
+---
+import InlineStuff from "../components/InlineStuff.astro";
+---
+
+<InlineStuff />


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/13986

Turns out there's a whole new world inside `pipeline.headElements`, which I forgot about it.

This PR loops over `scripts` and `styles` emitted by the pipeline method, and generate the hashes if CSP is enabled. 

## Testing

I added a new test, and tested the reproduction

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
