### PR TITLE
Do not define domains when remotePatterns is present

### DIFF
--- a/.changeset/twelve-cups-grin.md
+++ b/.changeset/twelve-cups-grin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': major
+---
+
+Make domains and remotePatterns mutually exclusive

--- a/packages/integrations/vercel/src/image/shared.ts
+++ b/packages/integrations/vercel/src/image/shared.ts
@@ -5,7 +5,7 @@ export function getDefaultImageConfig(astroImageConfig: AstroConfig['image']): V
 	const defaultSizes = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 	const defaultImageConfig = {
 		sizes: astroImageConfig.sizes ?? defaultSizes,
-	} as AstroConfig['image'];
+	} as AstroConfig['image'] & { sizes: VercelImageConfig['sizes'] };
 
 	if (astroImageConfig.remotePatterns) {
 		// Cast is necessary here because Vercel's types are slightly different from ours regarding allowed protocols. Behavior should be the same, however.

--- a/packages/integrations/vercel/src/image/shared.ts
+++ b/packages/integrations/vercel/src/image/shared.ts
@@ -2,10 +2,9 @@ import type { AstroConfig, ImageQualityPreset, ImageTransform } from 'astro';
 import { isESMImportedImage } from 'astro/assets/utils';
 
 export function getDefaultImageConfig(astroImageConfig: AstroConfig['image']): VercelImageConfig {
-	const defaultSizes = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 	const defaultImageConfig = {
-		sizes: astroImageConfig.sizes ?? defaultSizes,
-	} as AstroConfig['image'] & { sizes: VercelImageConfig['sizes'] };
+		sizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+	} as VercelImageConfig;
 
 	if (astroImageConfig.remotePatterns) {
 		// Cast is necessary here because Vercel's types are slightly different from ours regarding allowed protocols. Behavior should be the same, however.

--- a/packages/integrations/vercel/src/image/shared.ts
+++ b/packages/integrations/vercel/src/image/shared.ts
@@ -2,12 +2,19 @@ import type { AstroConfig, ImageQualityPreset, ImageTransform } from 'astro';
 import { isESMImportedImage } from 'astro/assets/utils';
 
 export function getDefaultImageConfig(astroImageConfig: AstroConfig['image']): VercelImageConfig {
-	return {
-		sizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-		domains: astroImageConfig.domains ?? [],
-		// Cast is necessary here because Vercel's types are slightly different from ours regarding allowed protocols. Behavior should be the same, however.
-		remotePatterns: (astroImageConfig.remotePatterns as VercelImageConfig['remotePatterns']) ?? [],
+	const defaultSizes = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
+	const defaultImageConfig = {
+	  sizes: astroImageConfig.sizes ?? defaultSizes,
 	};
+
+	if (astroImageConfig.remotePatterns) {
+		// Cast is necessary here because Vercel's types are slightly different from ours regarding allowed protocols. Behavior should be the same, however.
+		defaultImageConfig.remotePatterns = astroImageConfig.remotePatterns as VercelImageConfig['remotePatterns'];
+	} else {
+		defaultImageConfig.domains = astroImageConfig.domains ?? [];
+	}
+	
+	return defaultImageConfig;
 }
 
 export type DevImageService = 'sharp' | (string & {});
@@ -30,7 +37,7 @@ export type VercelImageConfig = {
 	/**
 	 * Allowed external domains that can use Image Optimization. Leave empty for only allowing the deployment domain to use Image Optimization.
 	 */
-	domains: string[];
+	domains?: string[];
 	/**
 	 * Allowed external patterns that can use Image Optimization. Similar to `domains` but provides more control with RegExp.
 	 */

--- a/packages/integrations/vercel/src/image/shared.ts
+++ b/packages/integrations/vercel/src/image/shared.ts
@@ -4,16 +4,17 @@ import { isESMImportedImage } from 'astro/assets/utils';
 export function getDefaultImageConfig(astroImageConfig: AstroConfig['image']): VercelImageConfig {
 	const defaultSizes = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 	const defaultImageConfig = {
-	  sizes: astroImageConfig.sizes ?? defaultSizes,
-	};
+		sizes: astroImageConfig.sizes ?? defaultSizes,
+	} as AstroConfig['image'];
 
 	if (astroImageConfig.remotePatterns) {
 		// Cast is necessary here because Vercel's types are slightly different from ours regarding allowed protocols. Behavior should be the same, however.
-		defaultImageConfig.remotePatterns = astroImageConfig.remotePatterns as VercelImageConfig['remotePatterns'];
+		defaultImageConfig.remotePatterns =
+			astroImageConfig.remotePatterns as VercelImageConfig['remotePatterns'];
 	} else {
 		defaultImageConfig.domains = astroImageConfig.domains ?? [];
 	}
-	
+
 	return defaultImageConfig;
 }
 

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -548,11 +548,18 @@ export default function vercelAdapter({
 				let images: VercelImageConfig | undefined;
 				if (imageService || imagesConfig) {
 					if (imagesConfig) {
-						images = {
-							...imagesConfig,
-							domains: [...imagesConfig.domains, ..._config.image.domains],
-							remotePatterns: [...(imagesConfig.remotePatterns ?? [])],
-						};
+						if (imagesConfig.remotePatterns) {
+							images = {
+								...imagesConfig,
+								remotePatterns: [...imagesConfig.remotePatterns],
+							};
+							delete images.domains;
+						} else {
+							images = {
+								...imagesConfig,
+								domains: [...(imagesConfig.domains ?? []), ...(_config.image.domains ?? [])],
+							};
+						}
 						const remotePatterns = _config.image.remotePatterns;
 						for (const pattern of remotePatterns) {
 							if (isAcceptedPattern(pattern)) {

--- a/packages/integrations/vercel/test/image.test.js
+++ b/packages/integrations/vercel/test/image.test.js
@@ -33,7 +33,6 @@ describe('Image', () => {
 
 		assert.deepEqual(vercelConfig.images, {
 			sizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-			domains: ['astro.build'],
 			remotePatterns: [
 				{
 					protocol: 'https',


### PR DESCRIPTION
## Changes

- Makes `domains` and `remotePatterns` mutually exclusive
- Fixes an issue where we would always define domains as an empty array, which would essentially disable all remote images in vercel.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I updated the existing test, but I am not super sure how the vercel config is built for them. We may want to add more test cases.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
