### PR TITLE
fix i18n fallback rewrites failing in server mode

### DIFF
--- a/.changeset/rare-spies-join.md
+++ b/.changeset/rare-spies-join.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a bug where i18n fallback rewrites didn't work in server output
+Fixes a bug where i18n fallback rewrites didn't work in dynamic pages. 

--- a/.changeset/rare-spies-join.md
+++ b/.changeset/rare-spies-join.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where i18n fallback rewrites didn't work in server output

--- a/packages/astro/src/core/app/pipeline.ts
+++ b/packages/astro/src/core/app/pipeline.ts
@@ -86,7 +86,7 @@ export class AppPipeline extends Pipeline {
 			trailingSlash: this.manifest.trailingSlash,
 			buildFormat: this.manifest.buildFormat,
 			base: this.manifest.base,
-			outDir: this.manifest.outDir,
+			outDir: this.serverLike ? this.manifest.buildClientDir : this.manifest.outDir,
 		});
 
 		const componentInstance = await this.getComponentByRoute(routeData);

--- a/packages/astro/src/core/build/pipeline.ts
+++ b/packages/astro/src/core/build/pipeline.ts
@@ -273,7 +273,7 @@ export class BuildPipeline extends Pipeline {
 			trailingSlash: this.config.trailingSlash,
 			buildFormat: this.config.build.format,
 			base: this.config.base,
-			outDir: this.manifest.outDir,
+			outDir: this.serverLike ? this.manifest.buildClientDir : this.manifest.outDir,
 		});
 
 		const componentInstance = await this.getComponentByRoute(routeData);

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -317,7 +317,9 @@ export class RenderContext {
 		// This is a case where the user tries to rewrite from a SSR route to a prerendered route (SSG).
 		// This case isn't valid because when building for SSR, the prerendered route disappears from the server output because it becomes an HTML file,
 		// so Astro can't retrieve it from the emitted manifest.
-		if (this.pipeline.serverLike && !this.routeData.prerender && routeData.prerender) {
+		// Allow i18n fallback rewrites - if the target route has fallback routes, this is likely an i18n scenario
+		const isI18nFallback = routeData.fallbackRoutes && routeData.fallbackRoutes.length > 0;
+		if (this.pipeline.serverLike && !this.routeData.prerender && routeData.prerender && !isI18nFallback) {
 			throw new AstroError({
 				...ForbiddenRewrite,
 				message: ForbiddenRewrite.message(this.pathname, pathname, routeData.component),

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -22,7 +22,7 @@ type FindRouteToRewrite = {
 	trailingSlash: AstroConfig['trailingSlash'];
 	buildFormat: AstroConfig['build']['format'];
 	base: AstroConfig['base'];
-	outDir: AstroConfig['outDir'] | string;
+	outDir: AstroConfig['outDir'] | AstroConfig['build']['client'] | string;
 };
 
 interface FindRouteToRewriteResult {

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -22,7 +22,7 @@ type FindRouteToRewrite = {
 	trailingSlash: AstroConfig['trailingSlash'];
 	buildFormat: AstroConfig['build']['format'];
 	base: AstroConfig['base'];
-	outDir: AstroConfig['outDir'] | AstroConfig['build']['client'] | string;
+	outDir: URL | string;
 };
 
 interface FindRouteToRewriteResult {

--- a/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/astro.config.mjs
@@ -1,0 +1,20 @@
+import { defineConfig} from "astro/config";
+
+import node from "@astrojs/node"
+
+export default defineConfig({
+  base: "/",
+  output: "static",
+  i18n: {
+    locales: ["en", "es"],
+    defaultLocale: "en",
+    fallback: {
+      es: "en",
+    },
+    routing: {
+      fallbackType: "rewrite",
+      prefixDefaultLocale: false,
+    },
+  },
+  adapter: node({mode: 'standalone'})
+});

--- a/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/package.json
+++ b/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/i18n-routing-fallback-rewrite-hybrid",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/node": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/[slug].astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/[slug].astro
@@ -1,0 +1,13 @@
+---
+export const prerender = true
+
+export async function getStaticPaths() {
+  return [
+    { params: { slug: 'slug-1' } }, 
+    { params: { slug: 'slug-2' } }, 
+  ];
+}
+const { slug } = Astro.params;
+---
+<span id="page">{slug} - {Astro.currentLocale}</span>
+

--- a/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/about.astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/about.astro
@@ -1,0 +1,5 @@
+---
+export const prerender = false
+---
+
+<span id="page">about - {Astro.currentLocale}</span>

--- a/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/es/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/es/index.astro
@@ -1,0 +1,5 @@
+---
+export const prerender = true
+---
+
+<span id="page">ES index</span>

--- a/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid/src/pages/index.astro
@@ -1,0 +1,5 @@
+---
+export const prerender = true
+---
+
+<span id="page">locale - {Astro.currentLocale}</span>

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -2261,6 +2261,40 @@ describe('Fallback rewrite SSR', () => {
 	});
 });
 
+describe('Fallback rewrite hybrid', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let app;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/i18n-routing-fallback-rewrite-hybrid/',
+			output: 'server',
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it('should correctly prerender es index', async () => {
+		const html = await fixture.readFile('/client/es/index.html');
+		assert.match(html, /ES index/);
+	});
+
+	it('should correctly prerender fallback locale paths with path parameters', async () => {
+		const html = await fixture.readFile('/client/es/slug-1/index.html');
+		assert.match(html, /slug-1 - es/);
+	});
+
+	it('should rewrite fallback locale paths for ssr pages', async () => {
+		let request = new Request('http://example.com/es/about');
+		let response = await app.render(request);
+		assert.equal(response.status, 200);
+		const text = await response.text();
+		assert.match(text, /about - es/);
+	});
+});
+
 describe('i18n routing with server islands', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3293,6 +3293,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/i18n-routing-fallback-rewrite-hybrid:
+    dependencies:
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../../../../integrations/node
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/i18n-routing-manual:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Fixes i18n fallback rewrites in server mode: i18n fallback rewrites (e.g., /es/about → /about) now work correctly when using SSR adapters with output: "server"
- Updates route matching for server builds: Server builds place static files in a client/ subdirectory, which was causing route matching to fail. Now uses the correct output directory based on build mode
- Allows i18n fallback rewrites in ForbiddenRewrite check: The safety check that prevents rewriting from SSR routes to static routes now correctly identifies and allows i18n fallback scenarios. This was required for dev mode, where the initial matched route for i18n fallbacks is 404 page (dynamic)

**Before**: /es/about-us with i18n fallback would throw ForbiddenRewrite: You tried to rewrite the on-demand route with the static route error in server mode

**After**: /es/about-us correctly falls back to /about-us and renders the English version when no Spanish version exists

Fixes https://github.com/withastro/astro/issues/13964

## Testing

- Added new test fixture (`i18n-routing-fallback-rewrite-hybrid`)
- Verified behavior in both static and server output modes

## Docs

No docs changes needed - this fixes existing documented i18n fallback functionality that was broken in server mode. The user-facing behavior and API remain the same.