### PR TITLE
Make "type" optional when defining live collections

### DIFF
--- a/.changeset/petite-turtles-leave.md
+++ b/.changeset/petite-turtles-leave.md
@@ -2,4 +2,25 @@
 'astro': patch
 ---
 
-Live content collections no longer require "type: 'live'" to be set
+Removes the requirement to set `type: 'live'` when defining experimental live content collections
+
+Previously, live collections required a `type` and `loader` configured. Now, Astro can determine that your collection is a `live` collection without defining it explicitly.
+
+This means it is now safe to remove `type: 'live'` from your collections defined in `src/live.config.ts`:
+
+```diff
+import { defineLiveCollection } from 'astro:content';
+import { storeLoader } from '@mystore/astro-loader';
+
+const products = defineLiveCollection({
+-  type: 'live',
+  loader: storeLoader({
+    apiKey: process.env.STORE_API_KEY,
+    endpoint: 'https://api.mystore.com/v1',
+  }),
+});
+
+export const collections = { products };
+```
+
+This is not a breaking change: your existing live collections will continue to work even if you still include `type: 'live'`. However, we suggest removing this line at your earliest convenience for future compatibility when the feature becomes stable and this config option may be removed entirely.

--- a/.changeset/petite-turtles-leave.md
+++ b/.changeset/petite-turtles-leave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Live content collections no longer require "type: 'live'" to be set

--- a/packages/astro/src/content/config.ts
+++ b/packages/astro/src/content/config.ts
@@ -149,7 +149,7 @@ export function defineLiveCollection<
 		throw new AstroError({
 			...AstroErrorData.LiveContentConfigError,
 			message: AstroErrorData.LiveContentConfigError.message(
-				'Live collection loaders must have `loadCollection` and `loadEntry` methods. Are you using a build-time loader instead?',
+				'Live collection loaders must have `loadCollection()` and `loadEntry()` methods. Please check that you are not using a loader intended for build-time collections',
 				importerFilename,
 			),
 		});

--- a/packages/astro/src/content/config.ts
+++ b/packages/astro/src/content/config.ts
@@ -98,7 +98,7 @@ export type LiveCollectionConfig<
 	L extends LiveLoader,
 	S extends BaseSchema | undefined = undefined,
 > = {
-	type: 'live';
+	type?: 'live';
 	schema?: S;
 	loader: L;
 };
@@ -122,6 +122,9 @@ export function defineLiveCollection<
 			),
 		});
 	}
+	// Default to live content type if not specified
+	config.type ??= LIVE_CONTENT_TYPE;
+
 	if (config.type !== LIVE_CONTENT_TYPE) {
 		throw new AstroError({
 			...AstroErrorData.LiveContentConfigError,
@@ -141,6 +144,17 @@ export function defineLiveCollection<
 			),
 		});
 	}
+
+	if(!config.loader.loadCollection || !config.loader.loadEntry) {
+		throw new AstroError({
+			...AstroErrorData.LiveContentConfigError,
+			message: AstroErrorData.LiveContentConfigError.message(
+				'Live collection loaders must have `loadCollection` and `loadEntry` methods. Are you using a build-time loader instead?',
+				importerFilename,
+			),
+		});
+	}
+
 	if (typeof config.schema === 'function') {
 		throw new AstroError({
 			...AstroErrorData.LiveContentConfigError,
@@ -172,6 +186,11 @@ export function defineCollection<S extends BaseSchema>(
 		if (config.type && config.type !== CONTENT_LAYER_TYPE) {
 			throw new AstroUserError(
 				`Collections that use the Content Layer API must have a \`loader\` defined and no \`type\` set. Check your collection definitions in ${importerFilename ?? 'your content config file'}.`,
+			);
+		}
+		if (typeof config.loader === 'object' && typeof config.loader.load !== 'function' && ('loadEntry' in config.loader || 'loadCollection' in config.loader)) {
+			throw new AstroUserError(
+				`Live content collections must be defined in "src/live.config.ts" file. Check your collection definitions in "${importerFilename ?? 'your content config file'}" to ensure you are not using a live loader.`,
 			);
 		}
 		config.type = CONTENT_LAYER_TYPE;

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -106,7 +106,7 @@ const collectionConfigParser = z.union([
 		_legacy: z.boolean().optional(),
 	}),
 	z.object({
-		type: z.literal(LIVE_CONTENT_TYPE),
+		type: z.literal(LIVE_CONTENT_TYPE).optional().default(LIVE_CONTENT_TYPE),
 		schema: z.any().optional(),
 		loader: z.function(),
 	}),

--- a/packages/astro/test/fixtures/live-loaders/src/live.config.ts
+++ b/packages/astro/test/fixtures/live-loaders/src/live.config.ts
@@ -30,7 +30,7 @@ class CustomError extends Error {
 	}
 }
 
-const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
+export const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 	name: 'test-loader',
 	loadEntry: async ({ filter }) => {
 		const entry = entries[filter.id];
@@ -77,7 +77,6 @@ const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 };
 
 const liveStuff = defineLiveCollection({
-	type: 'live',
 	loader,
 	schema: z.object({
 		title: z.string(),

--- a/packages/astro/test/fixtures/live-loaders/src/live.config.ts
+++ b/packages/astro/test/fixtures/live-loaders/src/live.config.ts
@@ -30,7 +30,7 @@ class CustomError extends Error {
 	}
 }
 
-export const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
+const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 	name: 'test-loader',
 	loadEntry: async ({ filter }) => {
 		const entry = entries[filter.id];


### PR DESCRIPTION
## Changes

Now that live content collections are defined using a different function we can remove the requirement for type: 'live' to be set. Instead I have added error checks to ensure the wrong loader type isn't used.

## Testing

Updated fixture.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I will do a docs PR

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
