### PR TITLE
fix(render): server islands in fragments

### DIFF
--- a/.changeset/great-sloths-rule.md
+++ b/.changeset/great-sloths-rule.md
@@ -2,9 +2,9 @@
 'astro': patch
 ---
 
-Fixes a bug where server islands wouldn't be correctly rendered when they rendered inside fragments.
+Fixes a bug where server islands wouldn't be correctly rendered when they are rendered inside fragments.
 
-Now the following example works as expected:
+Now the following examples work as expected:
 
 ```astro
 ---

--- a/.changeset/great-sloths-rule.md
+++ b/.changeset/great-sloths-rule.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where Server Island wouldn't work when rendered inside a Fragment component.

--- a/.changeset/great-sloths-rule.md
+++ b/.changeset/great-sloths-rule.md
@@ -2,4 +2,27 @@
 'astro': patch
 ---
 
-Fixes a bug where Server Island wouldn't work when rendered inside a Fragment component.
+Fixes a bug where server islands wouldn't be correctly rendered when they rendered inside fragments.
+
+Now the following example works as expected:
+
+```astro
+---
+import { Cart } from "../components/Cart.astro";
+---
+
+<>
+  <Cart server:defer />
+</>
+
+<Fragment>
+
+<Fragment slot="rest">
+  <Cart server:defer>
+    <div slot="fallback">
+      Not working
+    </div>
+  </Cart>
+</Fragment>
+
+```

--- a/.changeset/great-sloths-rule.md
+++ b/.changeset/great-sloths-rule.md
@@ -15,7 +15,6 @@ import { Cart } from "../components/Cart.astro";
   <Cart server:defer />
 </>
 
-<Fragment>
 
 <Fragment slot="rest">
   <Cart server:defer>

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -55,6 +55,9 @@ export class ServerIslandComponent {
 	displayName: string;
 	hostId: string | undefined;
 	islandContent: string | undefined;
+	componentPath: string | undefined;
+	componentExport: string | undefined;
+	componentId: string | undefined;
 	constructor(
 		result: SSRResult,
 		props: Record<string | number, any>,
@@ -68,8 +71,72 @@ export class ServerIslandComponent {
 	}
 
 	async init(): Promise<ThinHead> {
+		const content = await this.getIslandContent();
+
+		if (this.result.cspDestination) {
+			this.result._metadata.extraScriptHashes.push(
+				await generateCspDigest(SERVER_ISLAND_REPLACER, this.result.cspAlgorithm),
+			);
+			const contentDigest = await generateCspDigest(content, this.result.cspAlgorithm);
+			this.result._metadata.extraScriptHashes.push(contentDigest);
+		}
+
+		return createThinHead();
+	}
+	async render(destination: RenderDestination) {
+		const hostId = await this.getHostId();
+		const islandContent = await this.getIslandContent();
+		destination.write(createRenderInstruction({ type: 'server-island-runtime' }));
+		destination.write('<!--[if astro]>server-island-start<![endif]-->');
+		// Render the slots
+		for (const name in this.slots) {
+			if (name === 'fallback') {
+				await renderChild(destination, this.slots.fallback(this.result));
+			}
+		}
+		destination.write(
+			`<script type="module" data-astro-rerun data-island-id="${hostId}">${islandContent}</script>`,
+		);
+	}
+
+	getComponentPath(): string {
+		if (this.componentPath) {
+			return this.componentPath;
+		}
 		const componentPath = this.props['server:component-path'];
+		if (!componentPath) {
+			throw new Error(`Could not find server component path`);
+		}
+		this.componentPath = componentPath;
+		return componentPath;
+	}
+
+	getComponentExport(): string {
+		if (this.componentExport) {
+			return this.componentExport;
+		}
 		const componentExport = this.props['server:component-export'];
+		if (!componentExport) {
+			throw new Error(`Could not find server component export`);
+		}
+		this.componentExport = componentExport;
+		return componentExport;
+	}
+
+	async getHostId() {
+		if (!this.hostId) {
+			this.hostId = await crypto.randomUUID();
+		}
+		return this.hostId;
+	}
+
+	async getIslandContent() {
+		if (this.islandContent) {
+			return this.islandContent;
+		}
+
+		const componentPath = this.getComponentPath();
+		const componentExport = this.getComponentExport();
 		const componentId = this.result.serverIslandNameMap.get(componentPath);
 
 		if (!componentId) {
@@ -98,8 +165,7 @@ export class ServerIslandComponent {
 				? ''
 				: await encryptString(key, JSON.stringify(this.props));
 
-		const hostId = crypto.randomUUID();
-
+		const hostId = await this.getHostId();
 		const slash = this.result.base.endsWith('/') ? '' : '/';
 		let serverIslandUrl = `${this.result.base}${slash}_server-islands/${componentId}${this.result.trailingSlash === 'always' ? '/' : ''}`;
 
@@ -134,32 +200,8 @@ let response = await fetch('${serverIslandUrl}', {
 	body: JSON.stringify(data),
 });`;
 
-		const content = `${method}replaceServerIsland('${hostId}', response);`;
-
-		if (this.result.cspDestination) {
-			this.result._metadata.extraScriptHashes.push(
-				await generateCspDigest(SERVER_ISLAND_REPLACER, this.result.cspAlgorithm),
-			);
-			const contentDigest = await generateCspDigest(content, this.result.cspAlgorithm);
-			this.result._metadata.extraScriptHashes.push(contentDigest);
-		}
-		this.islandContent = content;
-		this.hostId = hostId;
-
-		return createThinHead();
-	}
-	async render(destination: RenderDestination) {
-		destination.write(createRenderInstruction({ type: 'server-island-runtime' }));
-		destination.write('<!--[if astro]>server-island-start<![endif]-->');
-		// Render the slots
-		for (const name in this.slots) {
-			if (name === 'fallback') {
-				await renderChild(destination, this.slots.fallback(this.result));
-			}
-		}
-		destination.write(
-			`<script type="module" data-astro-rerun data-island-id="${this.hostId}">${this.islandContent}</script>`,
-		);
+		this.islandContent = `${method}replaceServerIsland('${hostId}', response);`;
+		return this.islandContent;
 	}
 }
 

--- a/packages/astro/test/fixtures/server-islands/ssr/src/pages/fragment.astro
+++ b/packages/astro/test/fixtures/server-islands/ssr/src/pages/fragment.astro
@@ -1,7 +1,6 @@
 ---
 import Island from '../components/Island.astro';
 
-const xssMe ="</script><script>alert('xss')</script><!--"
 ---
 <html>
 <head>

--- a/packages/astro/test/fixtures/server-islands/ssr/src/pages/fragment.astro
+++ b/packages/astro/test/fixtures/server-islands/ssr/src/pages/fragment.astro
@@ -1,0 +1,20 @@
+---
+import Island from '../components/Island.astro';
+
+const xssMe ="</script><script>alert('xss')</script><!--"
+---
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+<h1>Testing</h1>
+	<Fragment>
+		<Island server:defer>
+			<div slot="fallback">
+				Not working
+			</div>
+		</Island>
+	</Fragment>
+</body>
+</html>

--- a/packages/astro/test/fixtures/server-islands/ssr/src/pages/named-fragment.astro
+++ b/packages/astro/test/fixtures/server-islands/ssr/src/pages/named-fragment.astro
@@ -1,7 +1,6 @@
 ---
 import Island from '../components/Island.astro';
 
-const xssMe ="</script><script>alert('xss')</script><!--"
 ---
 <html>
 <head>

--- a/packages/astro/test/fixtures/server-islands/ssr/src/pages/named-fragment.astro
+++ b/packages/astro/test/fixtures/server-islands/ssr/src/pages/named-fragment.astro
@@ -1,0 +1,20 @@
+---
+import Island from '../components/Island.astro';
+
+const xssMe ="</script><script>alert('xss')</script><!--"
+---
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+<h1>Testing</h1>
+	<Fragment slot="rest">
+		<Island server:defer>
+			<div slot="fallback">
+				Not working
+			</div>
+		</Island>
+	</Fragment>
+</body>
+</html>

--- a/packages/astro/test/server-islands.test.js
+++ b/packages/astro/test/server-islands.test.js
@@ -106,6 +106,24 @@ describe('Server islands', () => {
 				assert.equal(fetchMatch.length, 2, 'should include props in the query	string');
 				assert.equal(fetchMatch[1], '', 'should not include encrypted empty props');
 			});
+
+			it('supports fragments', async () => {
+				const res = await fixture.fetch('/fragment');
+				assert.equal(res.status, 200);
+				const html = await res.text();
+				const fetchMatch = html.match(/fetch\('\/_server-islands\/Island\?[^']*p=([^&']*)/);
+				assert.equal(fetchMatch.length, 2, 'should include props in the query	string');
+				assert.equal(fetchMatch[1], '', 'should not include encrypted empty props');
+			});
+
+			it('supports fragments with named slots', async () => {
+				const res = await fixture.fetch('/fragment');
+				assert.equal(res.status, 200);
+				const html = await res.text();
+				const fetchMatch = html.match(/fetch\('\/_server-islands\/Island\?[^']*p=([^&']*)/);
+				assert.equal(fetchMatch.length, 2, 'should include props in the query	string');
+				assert.equal(fetchMatch[1], '', 'should not include encrypted empty props');
+			});
 		});
 
 		describe('prod', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10758,7 +10758,6 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/13969

This is a "weird" fix. When rendering the server island inside a fragment, the `init` function (where we calculate content and hostId, the undefined info of the issue)  is called after the `render` function. So put the generation of `hostId` and `islandContent` inside a shared function, and saved it inside the class.

Here's the weird part: when calling `render`, the `props` are correctly present and evaluated. However, and `init` is called, the props aren't there anymore. I'm not sure if this is a bug coming from somewhere else, or that's the expected behaviour.

As a workaround, I created two new functions where we save these props inside the class. Doing so fixes the bug and the rest of the tests keep passing. Still, it's weird


## Testing

Added two new tests:
- simple fragment
- fragment with slots

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
