### PR TITLE
chore: Add support for allowQuery and passQuery in Vercel ISR config

### DIFF
--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -175,6 +175,8 @@ interface VercelISRConfig {
 	 * @default `[]`
 	 */
 	exclude?: (string | RegExp)[];
+	allowQuery?: string[];
+	passQuery?: boolean;
 }
 
 export default function vercelAdapter({
@@ -670,8 +672,8 @@ class VercelBuilder {
 		await writeJson(prerenderConfig, {
 			expiration: isr.expiration ?? false,
 			bypassToken: isr.bypassToken,
-			allowQuery: [ASTRO_PATH_PARAM],
-			passQuery: true,
+			allowQuery:  isr.allowQuery,
+			passQuery: isr.passQuery,
 		});
 	}
 


### PR DESCRIPTION
## Changes

- Adds support for Vercel’s `allowQuery` and `passQuery` options in @astrojs/vercel ISR configuration.
- These allow query parameters to be preserved during ISR revalidation and background regeneration.
- Enables support for authenticated preview/draft routes that rely on query string context.
- Passed directly to `.prerender-config.json` as part of the build output.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- This unlocks a Vercel-documented feature that has been inaccessible from Astro until now
- Useful for any Astro + headless CMS setups that rely on preview modes
- /cc @withastro/maintainers-docs to consider mentioning this in the adapter’s ISR section


<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
