### PR TITLE
fix: run fallback view transition for old page only after dispatching `astro:before-swap` event

### DIFF
--- a/.changeset/smart-mirrors-eat.md
+++ b/.changeset/smart-mirrors-eat.md
@@ -2,22 +2,7 @@
 'astro': patch
 ---
 
-Fixed a bug where fallback view transitions for page exit could not be skipped with `ClientRouter`.
-
-In browsers that do not support the View Transition API, fallback animations are used by default.
-Due to a bug, when navigating with `ClientRouter` in these browsers,
-calling `event.skipTransition()` on the `astro:before-swap` event
-would skip the _enter_ transition of the new page,
-but not the _exit_ transition of the current page,
-even though both should be skipped
-(as they are in browsers that support the View Transition API).
-
-The behaviour is now consistent across browsers, regardless of View Transition API support.
-For example, the following code will skip both the exit transition of the current page
-and the enter transition of the new page for self links:
-
-```javascript
-document.addEventListener('astro:before-swap', (e) => {
-  if (e.from.href === e.to.href) e.viewTransition?.skipTransition();
-});
-```
+Fixes a `<ClientRouter />` bug where the fallback view transition animations when exiting a page
+ran too early for browsers that do not support the View Transition API.
+This bug prevented `event.viewTransition?.skipTransition()` from skipping the page exit animation
+when used in an `astro:before-swap` event hook.

--- a/.changeset/smart-mirrors-eat.md
+++ b/.changeset/smart-mirrors-eat.md
@@ -1,0 +1,23 @@
+---
+'astro': patch
+---
+
+Fixed a bug where fallback view transitions for page exit could not be skipped with `ClientRouter`.
+
+In browsers that do not support the View Transition API, fallback animations are used by default.
+Due to a bug, when navigating with `ClientRouter` in these browsers,
+calling `event.skipTransition()` on the `astro:before-swap` event
+would skip the _enter_ transition of the new page,
+but not the _exit_ transition of the current page,
+even though both should be skipped
+(as they are in browsers that support the View Transition API).
+
+Now, the following code will skip both the exit transition of the current page
+and the enter transition of the new page, regardless of View Transition API support,
+so that the behaviour is consistent across browsers:
+
+```javascript
+document.addEventListener('astro:before-swap', (e) => {
+  e.viewTransition?.skipTransition();
+});
+```

--- a/.changeset/smart-mirrors-eat.md
+++ b/.changeset/smart-mirrors-eat.md
@@ -12,12 +12,12 @@ but not the _exit_ transition of the current page,
 even though both should be skipped
 (as they are in browsers that support the View Transition API).
 
-Now, the following code will skip both the exit transition of the current page
-and the enter transition of the new page, regardless of View Transition API support,
-so that the behaviour is consistent across browsers:
+The behaviour is now consistent across browsers, regardless of View Transition API support.
+For example, the following code will skip both the exit transition of the current page
+and the enter transition of the new page for self links:
 
 ```javascript
 document.addEventListener('astro:before-swap', (e) => {
-  e.viewTransition?.skipTransition();
+  if (e.from.href === e.to.href) e.viewTransition?.skipTransition();
 });
 ```

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/skip.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/skip.astro
@@ -1,0 +1,28 @@
+---
+import Layout from '../components/Layout.astro';
+---
+<Layout>
+	<p id="skip">Skip</p>
+	<a id="a1" href="/skip">go to page w/o param</a>
+	<a id="a2" href="/skip?param=true">go to page with param</a>
+</Layout>
+<script>
+	const observer = new MutationObserver((mutations) => {
+		for (const mutation of mutations) {
+			if (mutation.type === 'attributes') {
+					console.log('[test]', mutation.attributeName, 
+						(mutation.target as HTMLElement).getAttribute(mutation.attributeName!));
+			}
+		}
+	});		
+	observer.observe(document.documentElement, {
+		attributes: true,
+		attributeFilter: ["data-astro-transition-fallback"]
+	});
+
+	document.addEventListener('astro:before-swap', (e) => {
+    if (e.from.href === e.to.href) {
+      e.viewTransition?.skipTransition()
+    }
+  });
+</script>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1657,4 +1657,18 @@ test.describe('View Transitions', () => {
 			'inline module, page-load',
 		);
 	});
+
+	test('fallback skipTransition() skips transition', async ({ page, astro, browserName }) => {
+
+		test.skip(browserName !== 'firefox', 'Only makes sense for browser that uses fallback');
+		let lines = [];
+		page.on('console', (msg) => {
+			msg.text().startsWith('[test]') && lines.push(msg.text().slice('[test]'.length + 1));
+		});
+		await page.goto(astro.resolveUrl('/skip'));
+		await expect(page).toHaveTitle('Testing');
+		await page.click('#a1');
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+		expect(lines.join('')).toBe("");
+	});
 });

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1668,7 +1668,7 @@ test.describe('View Transitions', () => {
 		await expect(page).toHaveTitle('Testing');
 		await page.click('#a2');
 		await new Promise((resolve) => setTimeout(resolve, 1000));
-		expect(lines.join(' | ')).toBe("data-astro-transition-fallback old | data-astro-transition-fallback new | data-astro-transition-fallback new | data-astro-transition-fallback new | data-astro-transition-fallback null");
+		expect(lines.join(' | ')).toBe("data-astro-transition-fallback old | data-astro-transition-fallback old | data-astro-transition-fallback old | data-astro-transition-fallback new | data-astro-transition-fallback null");
 	});
 	
 	test('fallback skipTransition() skips transition', async ({ page, astro, browserName }) => {

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1658,8 +1658,20 @@ test.describe('View Transitions', () => {
 		);
 	});
 
+	test('fallback triggers animation if not skipped', async ({ page, astro, browserName }) => {
+		test.skip(browserName !== 'firefox', 'Only makes sense for browser that uses fallback');
+		let lines = [];
+		page.on('console', (msg) => {
+			msg.text().startsWith('[test]') && lines.push(msg.text().slice('[test]'.length + 1));
+		});
+		await page.goto(astro.resolveUrl('/skip'));
+		await expect(page).toHaveTitle('Testing');
+		await page.click('#a2');
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+		expect(lines.join(' | ')).toBe("data-astro-transition-fallback old | data-astro-transition-fallback new | data-astro-transition-fallback new | data-astro-transition-fallback new | data-astro-transition-fallback null");
+	});
+	
 	test('fallback skipTransition() skips transition', async ({ page, astro, browserName }) => {
-
 		test.skip(browserName !== 'firefox', 'Only makes sense for browser that uses fallback');
 		let lines = [];
 		page.on('console', (msg) => {

--- a/packages/astro/src/transitions/events.ts
+++ b/packages/astro/src/transitions/events.ts
@@ -178,9 +178,16 @@ export async function doPreparation(
 	return event;
 }
 
-export function doSwap(afterPreparation: BeforeEvent, viewTransition: ViewTransition) {
+export async function doSwap(
+	afterPreparation: BeforeEvent,
+	viewTransition: ViewTransition,
+	afterDispatch?: () => Promise<void>,
+) {
 	const event = new TransitionBeforeSwapEvent(afterPreparation, viewTransition);
 	document.dispatchEvent(event);
+	if (afterDispatch) {
+		await afterDispatch();
+	}
 	event.swap();
 	return event;
 }

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -301,21 +301,27 @@ async function updateDOM(
 		return Promise.allSettled(newAnimations.map((a) => a.finished));
 	}
 
-	if (
-		fallback === 'animate' &&
-		!currentTransition.transitionSkipped &&
-		!preparationEvent.signal.aborted
-	) {
-		try {
-			await animate('old');
-		} catch {
-			// animate might reject as a consequence of a call to skipTransition()
-			// ignored on purpose
+	const animateFallbackOld = async () => {
+		if (
+			fallback === 'animate' &&
+			!currentTransition.transitionSkipped &&
+			!preparationEvent.signal.aborted
+		) {
+			try {
+				await animate('old');
+			} catch {
+				// animate might reject as a consequence of a call to skipTransition()
+				// ignored on purpose
+			}
 		}
-	}
+	};
 
 	const pageTitleForBrowserHistory = document.title; // document.title will be overridden by swap()
-	const swapEvent = doSwap(preparationEvent, currentTransition.viewTransition!);
+	const swapEvent = await doSwap(
+		preparationEvent,
+		currentTransition.viewTransition!,
+		animateFallbackOld,
+	);
 	moveToLocation(swapEvent.to, swapEvent.from, options, pageTitleForBrowserHistory, historyState);
 	triggerEvent(TRANSITION_AFTER_SWAP);
 


### PR DESCRIPTION
## Changes

Fallback view transition animations for browsers that do not support the View Transition API were running too early when using  `ClientRouter`. Specifically, the exit animation for the current page during navigation would run before the `astro:before-swap` event, even though it should run after it (but before the actual swap).

This bug only affects browsers that do *not* support the View Transition API and was first discovered in #14034 (the original issue was about navigating to self, but discussion led to finding this bug). The consequence of the bug is that calling `.skipTransition()` in the `astro:before-swap` event would only skip the *enter* animation of the new page, but not the *exit* animation of the current page — this is inconsistent with browsers that *do* support native view transitions, where both animations would be skipped. E.g.:

```javascript
document.addEventListener("astro:before-swap", (e) => {
  e.viewTransition?.skipTransition();
});
```

The fix is quite simple: we just need to move the code for the fallback exit animation so that it's after dispatch of the `astro:before-swap` event (so that hooks can run), but before the actual swap occurs.

Closes #14034.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
2 E2E tests added by @martrapp (thanks!):
- `skipTransition()` should skip transition animations when called in `astro:before-swap` event hook (Firefox only)
- Transition animations should run when *not* skipped (Firefox only)

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
I don't think this requires changes to the documentation since it's just a bug fix.
