### PR TITLE
fix(astro): add support for 'avis' brand in HEIF

### DIFF
--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -2,4 +2,5 @@
 'astro': patch
 ---
 
-Add support for `avis` brand (avif-sequence)
+Add support for `avis` brand (avif-sequence) in HEIF images.
+This extends image import capabilities in the `/src` directory by recognizing AVIF sequences embedded within HEIF containers.

--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Add support for 'avis' brand (avif-sequence)
+Add support for `avis` brand (avif-sequence)

--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add support for 'avis' brand (avif-sequence)

--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -2,4 +2,5 @@
 'astro': patch
 ---
 
-Fixes a problem where using animated `.avif` file returns a `NoImageMetadata` error.
+Fixes a problem where importing animated `.avif` files would return a `NoImageMetadata` error.
+

--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -2,5 +2,5 @@
 'astro': patch
 ---
 
-Add support for `avis` brand (avif-sequence) in HEIF images.
-This extends image import capabilities in the `/src` directory by recognizing AVIF sequences embedded within HEIF containers.
+Add support for the `avis` brand (AVIF sequence) in HEIF images.
+This expands image import capabilities in the `/src` directory by recognizing AVIF sequences (.avif) embedded within HEIF containers. Users can now use animated `.avif` images without encountering a `NoImageMetadataError`.

--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -2,5 +2,4 @@
 'astro': patch
 ---
 
-Add support for the `avis` brand (AVIF sequence) in HEIF images.
-This expands image import capabilities in the `/src` directory by recognizing AVIF sequences (.avif) embedded within HEIF containers. Users can now use animated `.avif` images without encountering a `NoImageMetadata` error.
+Fixes a problem where using animated `.avif` file returns a `NoImageMetadata` error.

--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -3,4 +3,4 @@
 ---
 
 Add support for the `avis` brand (AVIF sequence) in HEIF images.
-This expands image import capabilities in the `/src` directory by recognizing AVIF sequences (.avif) embedded within HEIF containers. Users can now use animated `.avif` images without encountering a `NoImageMetadataError`.
+This expands image import capabilities in the `/src` directory by recognizing AVIF sequences (.avif) embedded within HEIF containers. Users can now use animated `.avif` images without encountering a `NoImageMetadata` error.

--- a/.changeset/great-pugs-find.md
+++ b/.changeset/great-pugs-find.md
@@ -2,5 +2,5 @@
 'astro': patch
 ---
 
-Fixes a problem where importing animated `.avif` files would return a `NoImageMetadata` error.
+Fixes a problem where importing animated `.avif` files returns a `NoImageMetadata` error.
 

--- a/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
@@ -5,7 +5,7 @@ const brandMap = {
   avif: 'avif',
   avis: 'avif', // avif-sequence
   mif1: 'heif',
-  msf1: 'heif', // hief-sequence
+  msf1: 'heif', // heif-sequence
   heic: 'heic',
   heix: 'heic',
   hevc: 'heic', // heic-sequence

--- a/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
@@ -3,7 +3,7 @@ import { findBox, readUInt32BE, toUTF8String } from './utils.js'
 
 const brandMap = {
   avif: 'avif',
-	avis: 'avif', // avif-sequence
+  avis: 'avif', // avif-sequence
   mif1: 'heif',
   msf1: 'heif', // hief-sequence
   heic: 'heic',
@@ -22,7 +22,7 @@ function detectBrands(buffer: Uint8Array, start: number, end: number) {
 	}
 
 	// Determine the most relevant type based on detected brands
-	if ('avif' in brandsDetected) {
+	if ('avif' in brandsDetected || 'avis' in brandsDetected) {
 			return 'avif';
 	} else if ('heic' in brandsDetected || 'heix' in brandsDetected || 'hevc' in brandsDetected || 'hevx' in brandsDetected) {
 			return 'heic';

--- a/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
@@ -3,6 +3,7 @@ import { findBox, readUInt32BE, toUTF8String } from './utils.js'
 
 const brandMap = {
   avif: 'avif',
+	avis: 'avif', // avif-sequence
   mif1: 'heif',
   msf1: 'heif', // hief-sequence
   heic: 'heic',


### PR DESCRIPTION
## Changes

- add `avis` brand for animated avif file

## Testing

Manually tested using animated avif file

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
