### PR TITLE
fix(astro): add module declaration for `?no-inline` asset imports

### DIFF
--- a/.changeset/giant-adults-fry.md
+++ b/.changeset/giant-adults-fry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add module declaration for `?no-inline` asset imports

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -536,6 +536,11 @@ declare module '*?inline' {
 	export default src;
 }
 
+declare module '*?no-inline' {
+	const src: string;
+	export default src;
+}
+
 declare module '*?url&inline' {
 	const src: string;
 	export default src;


### PR DESCRIPTION
## Changes

Added a simple `declare module` definition to get rid of TypeScript errors for Vite's `'...?no-inline'` import feature.
The typing is currently only defined for `'...?url&no-inline'` imports, but not for `'...?no-inline'` imports, for some reason.

### Before
![Screenshot of an IDE with an import error](https://github.com/user-attachments/assets/b6211411-84f2-4f1b-9657-d66ac7ed004e)

### After
![Screenshot of an IDE with no errors](https://github.com/user-attachments/assets/03befd68-7186-4225-a710-455be5a2aab8)

> Note: The two errors reported on `client.d.ts` are from lines 182 and 189 - pretty unrelated to my change.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Manually modified the minimal example from `/examples/minimal` to import the SVG favicon with `'...?no-inline'`. Then checked the output of `astro check` before and after my change.

No unit tests or other forms of scripted tests were added, since I didn't find any for the already existing module declarations. Let me know in case I should add tests and how.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Since the current module declarations don't have specific docs either, except for maybe references to [Vite's docs](https://vite.dev/guide/assets.html#explicit-inline-handling), I don't think we need to add any.
