### PR TITLE
Allow undefined domains

### DIFF
--- a/.changeset/clear-showers-stop.md
+++ b/.changeset/clear-showers-stop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Allow setting `domains` to `undefined` in `imagesConfig` so that `remotePatterns` can be better utilized for images from a variety of domains.

--- a/packages/integrations/vercel/src/image/shared.ts
+++ b/packages/integrations/vercel/src/image/shared.ts
@@ -28,9 +28,9 @@ export type VercelImageConfig = {
 	 */
 	sizes: number[];
 	/**
-	 * Allowed external domains that can use Image Optimization. Leave empty for only allowing the deployment domain to use Image Optimization.
+	 * Allowed external domains that can use Image Optimization. Set to `[]` to only allow the deployment domain to use Image Optimization.
 	 */
-	domains: string[];
+	domains?: string[];
 	/**
 	 * Allowed external patterns that can use Image Optimization. Similar to `domains` but provides more control with RegExp.
 	 */

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -550,7 +550,10 @@ export default function vercelAdapter({
 					if (imagesConfig) {
 						images = {
 							...imagesConfig,
-							domains: [...imagesConfig.domains, ..._config.image.domains],
+							  domains:
+    imagesConfig.domains || _config.image.domains
+      ? [...(imagesConfig.domains ?? []), ...(_config.image.domains ?? [])]
+      : undefined,
 							remotePatterns: [...(imagesConfig.remotePatterns ?? [])],
 						};
 						const remotePatterns = _config.image.remotePatterns;


### PR DESCRIPTION
## Changes

The allows `domains` in `imagesConfig` to be `undefined`. Previously, if it was not defined, you would get an error that it is not iterable. Leaving it undefined allows for using `remotePatterns` to create patterns to essentially optimize any image from any website.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
