### PR TITLE
fix(cli): Update incorrect CSS import path in Tailwind setup

### DIFF
--- a/.changeset/loose-worlds-stop.md
+++ b/.changeset/loose-worlds-stop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the incorrect CSS import path shown in the terminal message during Tailwind integration setup.

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -364,7 +364,7 @@ export async function add(names: string[], { flags }: AddOptions) {
 			);
 			if (integrations.find((integration) => integration.integrationName === 'tailwind')) {
 				const code = boxen(
-					getDiffContent('---\n---', "---\nimport './src/styles/global.css'\n---")!,
+					getDiffContent('---\n---', "---\nimport '../styles/global.css'\n---")!,
 					{
 						margin: 0.5,
 						padding: 0.5,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10949,7 +10949,6 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
## Changes

Fixes the incorrect CSS import path shown in the terminal message during Tailwind integration setup.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

should pass

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

N/A
