### PR TITLE
fix(astro): prevent image service resolution on client build

### DIFF
--- a/.changeset/stale-knives-rhyme.md
+++ b/.changeset/stale-knives-rhyme.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a bug that caused some image service builds to fail

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -117,9 +117,12 @@ export default function assets({ fs, settings, sync, logger }: Options): vite.Pl
 			config(_, env) {
 				isBuild = env.command === 'build';
 			},
-			async resolveId(id) {
+			async resolveId(id, _importer, options) {
 				if (id === VIRTUAL_SERVICE_ID) {
-					return await this.resolve(settings.config.image.service.entrypoint);
+					if (options?.ssr) {
+						return await this.resolve(settings.config.image.service.entrypoint);
+					}
+					return await this.resolve('astro/assets/services/noop');
 				}
 				if (id === VIRTUAL_MODULE_ID) {
 					return resolvedVirtualModuleId;


### PR DESCRIPTION
## Changes

- Fixes a build failure that occurs when an integration enables the `imageService` option.
- Prevents the core assets Vite plugin from resolving server-only image service entrypoints during the client build.
- The plugin now checks for `options.ssr` and resolves to a `noop` service for client builds, stopping Node.js built-ins from leaking into the client pipeline.
- 
Fixes #14056. Fixes #14099.

## Testing

This change was tested locally using the reproduction repository provided in issue #14056.

1.  Linked the local, patched `astro` package to the reproduction project.
2.  Enabled `imageService: true` in the `astro.config.mjs` via the `@astrojs/vercel` adapter.
3.  Ran `pnpm build`.
4.  The build completed successfully, whereas it previously failed. All warnings related to Node.js modules being externalized for the browser were also eliminated.

No new automated tests were added as this fix corrects existing plugin behavior at the configuration level, and the impact is validated by the successful build of a previously failing project structure.

## Docs

This change does not affect user-facing behavior or public APIs; it corrects a bug in the internal build process. Therefore, no documentation updates are required.