### PR TITLE
fix: regressions in Netlify adapter

### DIFF
--- a/.changeset/easy-animals-glow.md
+++ b/.changeset/easy-animals-glow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes a bug that caused remote images to sometimes not display correctly when using the Netlify Image CDN in local dev

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -1,0 +1,30 @@
+---
+'@astrojs/netlify': patch
+---
+
+Defaults to not injecting environment variables from Netlify
+
+`@astrojs/netlify@6.5.0` introduced a potentially breaking change that enabled injecting Netlify environment variables in `astro dev` by default. This could lead to unexpected behavior in Astro projects that do not expect these variables to be present. This now defaults to disabled, and users can enable it by setting the `devFeatures.environmentVariables` option in their Astro config. 
+
+```js
+import { defineConfig } from 'astro/config';
+import netlify from '@astrojs/netlify';
+
+export default defineConfig({
+  integrations: [netlify()],
+  devFeatures: {
+    environmentVariables: true,
+  },
+});
+```
+
+You can also set `devFeatures` to `true` to enable or disable all dev features, including environment variables and images:
+
+```js
+import { defineConfig } from 'astro/config';
+import netlify from '@astrojs/netlify';
+export default defineConfig({
+  integrations: [netlify()],
+  devFeatures: true,
+});
+```

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -6,7 +6,7 @@ Adds a new `devFeatures` configuration option to control some of the behaviors i
 
 You can now individually configure whether or not to populate your environment with the variables from your linked Netlify site (now disabled by default), and using a local version of the Netlify Image CDN for images (still enabled by default) when running `astro dev`.
 
-Additionally, no longer injects environment variables from Netlify by default when running `astro dev`.
+Additionally, the adapter no longer injects environment variables from Netlify by default when running `astro dev`.
 
 `@astrojs/netlify@6.5.0` introduced a potentially breaking change that enabled injecting Netlify environment variables in `astro dev` by default. This could lead to unexpected behavior in Astro projects that do not expect these variables to be present. This now defaults to disabled, and users can enable it by setting the `devFeatures.environmentVariables` option in their Astro config. Similarly, you can use `devFeatures.images` to disable using the Netlify Image CDN locally if needed:
 

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -2,7 +2,9 @@
 '@astrojs/netlify': patch
 ---
 
-Defaults to not injecting environment variables from Netlify
+Adds a new `devFeatures` configuration option to control the behavior introduced in `@astrojs/netlify@6.5.0` which introduced Netlify production features into the dev environment.
+
+Additionally, no longer injects environment variables from Netlify by default when running `astro dev`.
 
 `@astrojs/netlify@6.5.0` introduced a potentially breaking change that enabled injecting Netlify environment variables in `astro dev` by default. This could lead to unexpected behavior in Astro projects that do not expect these variables to be present. This now defaults to disabled, and users can enable it by setting the `devFeatures.environmentVariables` option in their Astro config.
 

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -4,17 +4,18 @@
 
 Defaults to not injecting environment variables from Netlify
 
-`@astrojs/netlify@6.5.0` introduced a potentially breaking change that enabled injecting Netlify environment variables in `astro dev` by default. This could lead to unexpected behavior in Astro projects that do not expect these variables to be present. This now defaults to disabled, and users can enable it by setting the `devFeatures.environmentVariables` option in their Astro config. 
+`@astrojs/netlify@6.5.0` introduced a potentially breaking change that enabled injecting Netlify environment variables in `astro dev` by default. This could lead to unexpected behavior in Astro projects that do not expect these variables to be present. This now defaults to disabled, and users can enable it by setting the `devFeatures.environmentVariables` option in their Astro config.
 
 ```js
 import { defineConfig } from 'astro/config';
 import netlify from '@astrojs/netlify';
 
 export default defineConfig({
-  integrations: [netlify()],
-  devFeatures: {
-    environmentVariables: true,
-  },
+  adapter: netlify({
+    devFeatures: {
+      environmentVariables: true,
+    },
+  }),
 });
 ```
 
@@ -24,7 +25,8 @@ You can also set `devFeatures` to `true` to enable or disable all dev features, 
 import { defineConfig } from 'astro/config';
 import netlify from '@astrojs/netlify';
 export default defineConfig({
-  integrations: [netlify()],
-  devFeatures: true,
+  adapter: netlify({
+    devFeatures: true,
+  }),
 });
 ```

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -2,11 +2,13 @@
 '@astrojs/netlify': patch
 ---
 
-Adds a new `devFeatures` configuration option to control the behavior introduced in `@astrojs/netlify@6.5.0` which introduced Netlify production features into the dev environment.
+Adds a new `devFeatures` configuration option to control some of the behaviors introduced in `@astrojs/netlify@6.5.0` which introduced Netlify production features into the dev environment.
+
+You can now individually configure whether or not to populate your environment with the variables from your linked Netlify site (now disabled by default), and using a local version of the Netlify Image CDN for images (still enabled by default) when running `astro dev`.
 
 Additionally, no longer injects environment variables from Netlify by default when running `astro dev`.
 
-`@astrojs/netlify@6.5.0` introduced a potentially breaking change that enabled injecting Netlify environment variables in `astro dev` by default. This could lead to unexpected behavior in Astro projects that do not expect these variables to be present. This now defaults to disabled, and users can enable it by setting the `devFeatures.environmentVariables` option in their Astro config.
+`@astrojs/netlify@6.5.0` introduced a potentially breaking change that enabled injecting Netlify environment variables in `astro dev` by default. This could lead to unexpected behavior in Astro projects that do not expect these variables to be present. This now defaults to disabled, and users can enable it by setting the `devFeatures.environmentVariables` option in their Astro config. Similarly, you can use `devFeatures.images` to disable using the Netlify Image CDN locally if needed:
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -22,7 +24,7 @@ export default defineConfig({
 });
 ```
 
-You can also set `devFeatures` to `true` to enable or disable all dev features, including environment variables and images:
+You can also set `devFeatures` to `true` or `false` to enable or disable all configurable dev features:
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -2,7 +2,7 @@
 '@astrojs/netlify': patch
 ---
 
-Adds a new `devFeatures` configuration option to control some of the behaviors introduced in `@astrojs/netlify@6.5.0` which introduced Netlify production features into the dev environment.
+Adds a new `devFeatures` configuration option to control some of the behaviors introduced in `@astrojs/netlify@6.5.0`, which introduced Netlify production features into the dev environment.
 
 You can now individually configure whether or not to populate your environment with the variables from your linked Netlify site (now disabled by default), and use a local version of the Netlify Image CDN for images (still enabled by default) when running `astro dev`.
 

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -16,6 +16,7 @@ export default defineConfig({
   adapter: netlify({
     devFeatures: {
       environmentVariables: true,
+      images: false
     },
   }),
 });

--- a/.changeset/fifty-pets-knock.md
+++ b/.changeset/fifty-pets-knock.md
@@ -4,7 +4,7 @@
 
 Adds a new `devFeatures` configuration option to control some of the behaviors introduced in `@astrojs/netlify@6.5.0` which introduced Netlify production features into the dev environment.
 
-You can now individually configure whether or not to populate your environment with the variables from your linked Netlify site (now disabled by default), and using a local version of the Netlify Image CDN for images (still enabled by default) when running `astro dev`.
+You can now individually configure whether or not to populate your environment with the variables from your linked Netlify site (now disabled by default), and use a local version of the Netlify Image CDN for images (still enabled by default) when running `astro dev`.
 
 Additionally, the adapter no longer injects environment variables from Netlify by default when running `astro dev`.
 

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -42,7 +42,7 @@
     "@astrojs/underscore-redirects": "workspace:*",
     "@netlify/blobs": "^10.0.4",
     "@netlify/functions": "^4.1.10",
-    "@netlify/vite-plugin": "^2.3.7",
+    "@netlify/vite-plugin": "^2.3.10",
     "@vercel/nft": "^0.29.2",
     "esbuild": "^0.25.0",
     "tinyglobby": "^0.2.13",

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -34,6 +34,7 @@
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "pnpm run test-fn && pnpm run test-static",
     "test-fn": "astro-scripts test \"test/functions/*.test.js\"",
+    "test:dev": "astro-scripts test \"test/development/*.test.js\"",
     "test-static": "astro-scripts test \"test/static/*.test.js\"",
     "test:hosted": "astro-scripts test \"test/hosted/*.test.js\""
   },

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -32,7 +32,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
-    "test": "pnpm run test-fn && pnpm run test-static",
+    "test": "pnpm run test-fn && pnpm run test-static && pnpm run test:dev",
     "test-fn": "astro-scripts test \"test/functions/*.test.js\"",
     "test:dev": "astro-scripts test \"test/development/*.test.js\"",
     "test-static": "astro-scripts test \"test/static/*.test.js\"",

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -40,9 +40,9 @@
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/underscore-redirects": "workspace:*",
-    "@netlify/blobs": "^10.0.4",
-    "@netlify/functions": "^4.1.10",
-    "@netlify/vite-plugin": "^2.3.10",
+    "@netlify/blobs": "^10.0.5",
+    "@netlify/functions": "^4.1.11",
+    "@netlify/vite-plugin": "^2.4.1",
     "@vercel/nft": "^0.29.2",
     "esbuild": "^0.25.0",
     "tinyglobby": "^0.2.13",

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -587,8 +587,8 @@ export default function netlifyIntegration(
 					images: {
 						// We don't need to disable the feature, because if the user disables it
 						// we'll disable the whole image service.
-						// @ts-expect-error: not yet public API
-						remoteImages: remoteImagesFromAstroConfig(config, logger),
+						// @ts-expect-error: as yet unreleased API
+						remoteURLPatterns: remoteImagesFromAstroConfig(config, logger),
 					},
 					environmentVariables: {
 						// If features is an object, use the `environmentVariables` property

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -587,7 +587,6 @@ export default function netlifyIntegration(
 					images: {
 						// We don't need to disable the feature, because if the user disables it
 						// we'll disable the whole image service.
-						// @ts-expect-error: as yet unreleased API
 						remoteURLPatterns: remoteImagesFromAstroConfig(config, logger),
 					},
 					environmentVariables: {

--- a/packages/integrations/netlify/test/development/fixtures/primitives/astro.config.mjs
+++ b/packages/integrations/netlify/test/development/fixtures/primitives/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
       hostname: '*.example.org',
       pathname: '/images/*',
     }],
-    domains: ['example.net', 'secret.example.edu'],
+    domains: ['example.net', 'secret.example.edu', 'images.unsplash.com'],
   },
   site: `http://example.com`
 });

--- a/packages/integrations/netlify/test/development/fixtures/primitives/src/pages/astronaut.astro
+++ b/packages/integrations/netlify/test/development/fixtures/primitives/src/pages/astronaut.astro
@@ -7,3 +7,9 @@ export const prerender = true;
 
 <Image src={astronautImage} alt="an astronaut floating in space" />
 
+<Image 
+	src="https://images.unsplash.com/photo-1658397966058-d1d252892754?q=80&w=928&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" 
+	width={300} 
+	height={400} 
+	alt="an astronaut falling over" 
+/>

--- a/packages/integrations/netlify/test/development/fixtures/primitives/src/pages/astronaut.astro
+++ b/packages/integrations/netlify/test/development/fixtures/primitives/src/pages/astronaut.astro
@@ -5,6 +5,8 @@ import astronautImage from "../astronaut.jpg"
 export const prerender = true;
 ---
 
+<h1>Hello, Astronaut</h1>
+
 <Image src={astronautImage} alt="an astronaut floating in space" />
 
 <Image 

--- a/packages/integrations/netlify/test/development/primitives.test.js
+++ b/packages/integrations/netlify/test/development/primitives.test.js
@@ -36,7 +36,9 @@ describe('Netlify primitives', () => {
 			const imgResponse = await fixture.fetch('/astronaut');
 			const $img = cheerio.load(await imgResponse.text());
 
-			assert($img('img').attr('src').startsWith('/_image?href='));
+			assert.equal($img('h1').text(), 'Hello, Astronaut');
+
+			// assert($img('img').attr('src').startsWith('/_image?href='));
 		});
 
 		it('loads function routes', async () => {
@@ -58,6 +60,22 @@ describe('Netlify primitives', () => {
 			const $root = cheerio.load(await efResponse.text());
 
 			assert.equal($root('h1').text(), 'HELLO THERE, ASTRONAUT.');
+		});
+
+		it('loads images in development', async () => {
+			const imgResponse = await fixture.fetch('/astronaut');
+			const $img = cheerio.load(await imgResponse.text());
+			const images = $img('img').map((_i, el) => {
+				return $img(el).attr('src');
+			});
+
+			for (const imgSrc of images) {
+				assert(imgSrc.startsWith('/.netlify/images'));
+				const imageResponse = await fixture.fetch(imgSrc);
+				assert.equal(imageResponse.status, 200);
+				// Images are JPEG by default in development
+				assert.equal(imageResponse.headers.get('content-type'), 'image/jpeg');
+			}
 		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,7 +621,7 @@ importers:
         version: 5.0.0
       unstorage:
         specifier: ^1.15.0
-        version: 1.15.0(@netlify/blobs@10.0.4)
+        version: 1.15.0(@netlify/blobs@10.0.5)
       vfile:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5330,14 +5330,14 @@ importers:
         specifier: workspace:*
         version: link:../../underscore-redirects
       '@netlify/blobs':
-        specifier: ^10.0.4
-        version: 10.0.4
+        specifier: ^10.0.5
+        version: 10.0.5
       '@netlify/functions':
-        specifier: ^4.1.10
-        version: 4.1.10(rollup@4.40.2)
+        specifier: ^4.1.11
+        version: 4.1.11(rollup@4.40.2)
       '@netlify/vite-plugin':
-        specifier: ^2.3.10
-        version: 2.3.10(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))
+        specifier: ^2.4.1
+        version: 2.4.1(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))
       '@vercel/nft':
         specifier: ^0.29.2
         version: 0.29.2(rollup@4.40.2)
@@ -8016,12 +8016,12 @@ packages:
   '@netlify/binary-info@1.0.0':
     resolution: {integrity: sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==}
 
-  '@netlify/blobs@10.0.4':
-    resolution: {integrity: sha512-eQghoBRI11PxlwtoEhCUS1+BZTLClX/SyxzgAWjTIKSv+qYSdT0T9p4EktbspSEqhZCDROtlRPY5mszuTeSvYw==}
+  '@netlify/blobs@10.0.5':
+    resolution: {integrity: sha512-igbARa6gUII83lZdloe0zQzf2YLqJOZ3/3k2GMkEFFNxfLptAjvnh1z6WtFVV6bbO2IR2qOeuS2uaWRXeTNtlw==}
     engines: {node: ^14.16.0 || >=16.0.0}
 
-  '@netlify/cache@3.0.5':
-    resolution: {integrity: sha512-59GNOCVfQlOfvNPCQ3SF014NRBweVhP5eDrqSzfzVAGANmEcrRKcU59fTCZx6SUtuuLy6ndewGC/oWX0rfFZ6w==}
+  '@netlify/cache@3.0.6':
+    resolution: {integrity: sha512-nDnLz+XrovhF/raTSHJc7xRv6F+wSk5uVVvwAs1lA0uxXitM+yHM8q9orKH2iNJEUZkAk0T3TZ5tK6zsma0INw==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/config@23.0.11':
@@ -8029,12 +8029,12 @@ packages:
     engines: {node: '>=18.14.0'}
     hasBin: true
 
-  '@netlify/dev-utils@3.2.2':
-    resolution: {integrity: sha512-ECz/xEaqhAPUoFkeC2Ofpky1HBEKwPCsAL66iK/dLFHUFs39SC3y6Bn5QY76DzONmt+RjWmoYkSIEhJ1xAWHfA==}
+  '@netlify/dev-utils@3.3.0':
+    resolution: {integrity: sha512-bW8akt30XHUY3Yh4x7pB/Yis5yCafQxbfAGAAZgHlOYfG1WqlazFsTd9OvW5d8C3g3Y2H/JA2Oy03pTBFPtSkg==}
     engines: {node: ^18.14.0 || >=20}
 
-  '@netlify/dev@4.4.0':
-    resolution: {integrity: sha512-B3WHvO2HIgISplheoYDP3mR4G/NSBKRjFbmtsEtS9U9D9RHXAQiVCY0aAnlc/h1VGmBAVscjfOkkz7guOybSFA==}
+  '@netlify/dev@4.4.1':
+    resolution: {integrity: sha512-SOX85hrIcOl3VsugNeMMUB2hSh3vCsmZO0014R/3vZhKinP29Fk7oGWhVgFmJWJWPHDKeDuGRO2egRlcwoDKhg==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/edge-bundler@14.0.6':
@@ -8044,24 +8044,24 @@ packages:
   '@netlify/edge-functions-bootstrap@2.14.0':
     resolution: {integrity: sha512-Fs1cQ+XKfKr2OxrAvmX+S46CJmrysxBdCUCTk/wwcCZikrDvsYUFG7FTquUl4JfAf9taYYyW/tPv35gKOKS8BQ==}
 
-  '@netlify/edge-functions@2.15.6':
-    resolution: {integrity: sha512-lVPi0ZUNLEMo4Q/EbWWsa+1Q3EAEzaZ0F1oGtw3k5tctGZ13kJ0go/zs98reErCFNec/0lC8dqcbZn4WDAqzNg==}
+  '@netlify/edge-functions@2.15.7':
+    resolution: {integrity: sha512-VVKxtocaRYBcs/+7ugvtAyTb0V5/qcBrQjWWxEPcotJC2xYat8b63M/+VTayDhbEqmKmGXj6FwSWG96xtODrbQ==}
     engines: {node: '>=18.0.0'}
 
-  '@netlify/functions@4.1.10':
-    resolution: {integrity: sha512-qAu2rTtVROK46NOHULIMTJRuAy38ezJIjgN1Qanr6Rrp/tHAg/q//OZdOzN/x2wyYO8WzQiHKwU9SjgEjbot6w==}
+  '@netlify/functions@4.1.11':
+    resolution: {integrity: sha512-fa0R9lGvFDVQHcYPb5flWJea/X/umH0xXjB61lYiuDiYlPP0TDr6fIfIupr8JOWePjNod7tXQmIiu5vnHVk0cg==}
     engines: {node: '>=18.0.0'}
 
   '@netlify/headers-parser@9.0.1':
     resolution: {integrity: sha512-KHKNVNtzWUkUQhttHsLA217xIjUQxBOY5RCMRkR77G5pH1Sca9gqGhnMvk3KfRol/OZK2/1k83ZpYuvMswsK/w==}
     engines: {node: '>=18.14.0'}
 
-  '@netlify/headers@2.0.4':
-    resolution: {integrity: sha512-ImcYYPtZ0kUM3p+ySYr+8u5Pz+j2oso5v/u55EzWi48XicbTmjsmMpDZ9uOzN2FDFwlKdpWbRGifefp3h3hIpw==}
+  '@netlify/headers@2.0.5':
+    resolution: {integrity: sha512-m8JJipKr1Z42qyroL2VhnyFIxvE9tBDpoiswfpOcl128aV8U4R+qrzGZFm4b0eqnH5fGi+rGR/3/+62xsgvkBw==}
     engines: {node: '>=20.6.1'}
 
-  '@netlify/images@1.2.0':
-    resolution: {integrity: sha512-GPTM5atcvaZXMA404hKsnHYnU7zvpem0rC7gar9pkBDAgkXlYndfrW2j4SzgB9ICbJ0Ho4K1eIJYxREPQhoStg==}
+  '@netlify/images@1.2.1':
+    resolution: {integrity: sha512-vjjIMBM1FJVDuwMl6+wNMO3dFHbm6OFKc0cxHEZjdfHiOmf1HOq8VoQ9GdRy+ae/LmE5uQ5rQQ7Mn1s8eFkcEg==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/open-api@2.37.0':
@@ -8072,32 +8072,32 @@ packages:
     resolution: {integrity: sha512-zS6qBHpmU7IpHGzrHNPqu+Tjvh1cAJuVEoFUvCp0lRUeNcTdIq9VZM7/34vtIN6MD/OMFg3uv80yefSqInV2nA==}
     engines: {node: '>=18.14.0'}
 
-  '@netlify/redirects@3.0.4':
-    resolution: {integrity: sha512-RS7P6tWKr/T03S2IwB4XcskhPNBX66bRbuFl6UNUNuE/aV/yYcI4uiH3x+0HUpVuI2rbMx4U0wAAM7aPQaiLTA==}
+  '@netlify/redirects@3.0.5':
+    resolution: {integrity: sha512-/M04DYmJ4O+iiPgo1u8FcPVECEJZ0riX5Ft2LqMV4FJCpEQU0jgRZNB0ql40w3uLGdwHb/qj4xbHKPIBa+OEag==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/runtime-utils@2.1.0':
     resolution: {integrity: sha512-z1h+wjB7IVYUsFZsuIYyNxiw5WWuylseY+eXaUDHBxNeLTlqziy+lz03QkR67CUR4Y790xGIhaHV00aOR2KAtw==}
     engines: {node: ^18.14.0 || >=20}
 
-  '@netlify/runtime@4.0.8':
-    resolution: {integrity: sha512-9Rg+7/dMDAve+S9CSx55afu0k/N2/9P5c9wB3ZZ0LbUwvwTLthmY5jktGu93gglHLmBIPzd29752azjxqWMAIg==}
+  '@netlify/runtime@4.0.9':
+    resolution: {integrity: sha512-qv4qbw7V1+lxW/naSmbUvr9Zw1+5OsjyxrJlGRDMbZACrDqs4wxGZ3C6ETgDATXg4is+8XWAotTUdtwq3EKD1w==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/serverless-functions-api@2.1.3':
     resolution: {integrity: sha512-bNlN/hpND8xFQzpjyKxm6vJayD+bPBlOvs4lWihE7WULrphuH1UuFsoVE5386bNNGH8Rs1IH01AFsl7ALQgOlQ==}
     engines: {node: '>=18.0.0'}
 
-  '@netlify/static@3.0.4':
-    resolution: {integrity: sha512-eI86xTZHyjwkpqTlLi+9GHtvc4xkFao4OquHZGI4CsJ5HhjVxkA9G6hu/Otzod/SDW4JJlBEO0CnK9wI9cZPHA==}
+  '@netlify/static@3.0.5':
+    resolution: {integrity: sha512-6gY/kXjBICtbnc8X9CJNWClGoT1esI64E/WhRzwHuRMZ2NbzGY0nsoE6RB3DGRhXXirB70m0E2uk2/FvD7+WiA==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/types@2.0.2':
     resolution: {integrity: sha512-6899BAqehToSAd3hoevqGaIkG0M9epPMLTi6byynNVIzqv2x+b9OtRXqK67G/gCX7XkrtLQ9Xm3QNJmaFNrSXA==}
     engines: {node: ^18.14.0 || >=20}
 
-  '@netlify/vite-plugin@2.3.10':
-    resolution: {integrity: sha512-9NmJ7XBhPoiOPz0RXwSLXLBmOHznZP6hN0TP1LLcIc1uqVXjUMnft+WqNYIrSY4iA8pdSqozfglzqhX7y4CIxw==}
+  '@netlify/vite-plugin@2.4.1':
+    resolution: {integrity: sha512-jU6nmWUOHS9YuQXVCS5voyTG+xlwOkhkVuUrcFdc6nxmndPCgJPVYSIVwHhSiB1yogrHxic5bqwvY6O3RPss/g==}
     engines: {node: ^20.6.1 || >=22}
     peerDependencies:
       vite: ^5 || ^6 || ^7
@@ -15290,12 +15290,12 @@ snapshots:
 
   '@netlify/binary-info@1.0.0': {}
 
-  '@netlify/blobs@10.0.4':
+  '@netlify/blobs@10.0.5':
     dependencies:
-      '@netlify/dev-utils': 3.2.2
+      '@netlify/dev-utils': 3.3.0
       '@netlify/runtime-utils': 2.1.0
 
-  '@netlify/cache@3.0.5':
+  '@netlify/cache@3.0.6':
     dependencies:
       '@netlify/runtime-utils': 2.1.0
 
@@ -15325,7 +15325,7 @@ snapshots:
       yaml: 2.8.0
       yargs: 17.7.2
 
-  '@netlify/dev-utils@3.2.2':
+  '@netlify/dev-utils@3.3.0':
     dependencies:
       '@whatwg-node/server': 0.10.10
       ansis: 4.1.0
@@ -15343,18 +15343,18 @@ snapshots:
       uuid: 11.1.0
       write-file-atomic: 5.0.1
 
-  '@netlify/dev@4.4.0(rollup@4.40.2)':
+  '@netlify/dev@4.4.1(rollup@4.40.2)':
     dependencies:
-      '@netlify/blobs': 10.0.4
+      '@netlify/blobs': 10.0.5
       '@netlify/config': 23.0.11
-      '@netlify/dev-utils': 3.2.2
-      '@netlify/edge-functions': 2.15.6
-      '@netlify/functions': 4.1.10(rollup@4.40.2)
-      '@netlify/headers': 2.0.4
-      '@netlify/images': 1.2.0(@netlify/blobs@10.0.4)
-      '@netlify/redirects': 3.0.4
-      '@netlify/runtime': 4.0.8
-      '@netlify/static': 3.0.4
+      '@netlify/dev-utils': 3.3.0
+      '@netlify/edge-functions': 2.15.7
+      '@netlify/functions': 4.1.11(rollup@4.40.2)
+      '@netlify/headers': 2.0.5
+      '@netlify/images': 1.2.1(@netlify/blobs@10.0.5)
+      '@netlify/redirects': 3.0.5
+      '@netlify/runtime': 4.0.9
+      '@netlify/static': 3.0.5
       ulid: 3.0.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15404,19 +15404,19 @@ snapshots:
 
   '@netlify/edge-functions-bootstrap@2.14.0': {}
 
-  '@netlify/edge-functions@2.15.6':
+  '@netlify/edge-functions@2.15.7':
     dependencies:
-      '@netlify/dev-utils': 3.2.2
+      '@netlify/dev-utils': 3.3.0
       '@netlify/edge-bundler': 14.0.6
       '@netlify/edge-functions-bootstrap': 2.14.0
       '@netlify/runtime-utils': 2.1.0
       '@netlify/types': 2.0.2
       get-port: 7.1.0
 
-  '@netlify/functions@4.1.10(rollup@4.40.2)':
+  '@netlify/functions@4.1.11(rollup@4.40.2)':
     dependencies:
-      '@netlify/blobs': 10.0.4
-      '@netlify/dev-utils': 3.2.2
+      '@netlify/blobs': 10.0.5
+      '@netlify/dev-utils': 3.3.0
       '@netlify/serverless-functions-api': 2.1.3
       '@netlify/zip-it-and-ship-it': 12.2.0(rollup@4.40.2)
       cron-parser: 4.9.0
@@ -15441,13 +15441,13 @@ snapshots:
       map-obj: 5.0.2
       path-exists: 5.0.0
 
-  '@netlify/headers@2.0.4':
+  '@netlify/headers@2.0.5':
     dependencies:
       '@netlify/headers-parser': 9.0.1
 
-  '@netlify/images@1.2.0(@netlify/blobs@10.0.4)':
+  '@netlify/images@1.2.1(@netlify/blobs@10.0.5)':
     dependencies:
-      ipx: 3.0.3(@netlify/blobs@10.0.4)
+      ipx: 3.0.3(@netlify/blobs@10.0.5)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15478,7 +15478,7 @@ snapshots:
       is-plain-obj: 4.1.0
       path-exists: 5.0.0
 
-  '@netlify/redirects@3.0.4':
+  '@netlify/redirects@3.0.5':
     dependencies:
       '@netlify/redirect-parser': 15.0.2
       cookie: 1.0.2
@@ -15487,25 +15487,25 @@ snapshots:
 
   '@netlify/runtime-utils@2.1.0': {}
 
-  '@netlify/runtime@4.0.8':
+  '@netlify/runtime@4.0.9':
     dependencies:
-      '@netlify/blobs': 10.0.4
-      '@netlify/cache': 3.0.5
+      '@netlify/blobs': 10.0.5
+      '@netlify/cache': 3.0.6
       '@netlify/runtime-utils': 2.1.0
       '@netlify/types': 2.0.2
 
   '@netlify/serverless-functions-api@2.1.3': {}
 
-  '@netlify/static@3.0.4':
+  '@netlify/static@3.0.5':
     dependencies:
       mime-types: 3.0.1
 
   '@netlify/types@2.0.2': {}
 
-  '@netlify/vite-plugin@2.3.10(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))':
+  '@netlify/vite-plugin@2.4.1(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))':
     dependencies:
-      '@netlify/dev': 4.4.0(rollup@4.40.2)
-      '@netlify/dev-utils': 3.2.2
+      '@netlify/dev': 4.4.1(rollup@4.40.2)
+      '@netlify/dev-utils': 3.3.0
       chalk: 5.4.1
       vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0)
     transitivePeerDependencies:
@@ -18375,7 +18375,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipx@3.0.3(@netlify/blobs@10.0.4):
+  ipx@3.0.3(@netlify/blobs@10.0.5):
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       citty: 0.1.6
@@ -18391,7 +18391,7 @@ snapshots:
       sharp: 0.33.5
       svgo: 3.3.2
       ufo: 1.5.4
-      unstorage: 1.15.0(@netlify/blobs@10.0.4)
+      unstorage: 1.15.0(@netlify/blobs@10.0.5)
       xss: 1.0.15
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -21367,7 +21367,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unstorage@1.15.0(@netlify/blobs@10.0.4):
+  unstorage@1.15.0(@netlify/blobs@10.0.5):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -21378,7 +21378,7 @@ snapshots:
       ofetch: 1.4.1
       ufo: 1.5.4
     optionalDependencies:
-      '@netlify/blobs': 10.0.4
+      '@netlify/blobs': 10.0.5
 
   untun@0.1.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5336,8 +5336,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(rollup@4.40.2)
       '@netlify/vite-plugin':
-        specifier: ^2.3.7
-        version: 2.3.7(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))
+        specifier: ^2.3.10
+        version: 2.3.10(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))
       '@vercel/nft':
         specifier: ^0.29.2
         version: 0.29.2(rollup@4.40.2)
@@ -8033,8 +8033,8 @@ packages:
     resolution: {integrity: sha512-ECz/xEaqhAPUoFkeC2Ofpky1HBEKwPCsAL66iK/dLFHUFs39SC3y6Bn5QY76DzONmt+RjWmoYkSIEhJ1xAWHfA==}
     engines: {node: ^18.14.0 || >=20}
 
-  '@netlify/dev@4.3.7':
-    resolution: {integrity: sha512-9NYcDTmnvDkPmjX2b58WhOdsd/CrOL1AO8C7ljv45wgdzuXHjpo41+TxM01i48HMscRIfEbnhJfCPxSVV9+J+g==}
+  '@netlify/dev@4.4.0':
+    resolution: {integrity: sha512-B3WHvO2HIgISplheoYDP3mR4G/NSBKRjFbmtsEtS9U9D9RHXAQiVCY0aAnlc/h1VGmBAVscjfOkkz7guOybSFA==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/edge-bundler@14.0.6':
@@ -8060,8 +8060,8 @@ packages:
     resolution: {integrity: sha512-ImcYYPtZ0kUM3p+ySYr+8u5Pz+j2oso5v/u55EzWi48XicbTmjsmMpDZ9uOzN2FDFwlKdpWbRGifefp3h3hIpw==}
     engines: {node: '>=20.6.1'}
 
-  '@netlify/images@1.1.2':
-    resolution: {integrity: sha512-xhjv74xQT3rbQM195zV5wEWYGASasGSHnuK9rCDjuoOiZpxzD3ua8s+A0y2TWTa3yRVj3dqbBPDICM/yxEq/vA==}
+  '@netlify/images@1.2.0':
+    resolution: {integrity: sha512-GPTM5atcvaZXMA404hKsnHYnU7zvpem0rC7gar9pkBDAgkXlYndfrW2j4SzgB9ICbJ0Ho4K1eIJYxREPQhoStg==}
     engines: {node: '>=20.6.1'}
 
   '@netlify/open-api@2.37.0':
@@ -8096,11 +8096,11 @@ packages:
     resolution: {integrity: sha512-6899BAqehToSAd3hoevqGaIkG0M9epPMLTi6byynNVIzqv2x+b9OtRXqK67G/gCX7XkrtLQ9Xm3QNJmaFNrSXA==}
     engines: {node: ^18.14.0 || >=20}
 
-  '@netlify/vite-plugin@2.3.7':
-    resolution: {integrity: sha512-1qZSDdl2Jg+a6CRhu4WKtXULmKPnrbnuUfKzaRe+f+fiWr0fp7I+k7vmAYUi0kib3BrKTcJcZJ5ebDWj47jd+w==}
+  '@netlify/vite-plugin@2.3.10':
+    resolution: {integrity: sha512-9NmJ7XBhPoiOPz0RXwSLXLBmOHznZP6hN0TP1LLcIc1uqVXjUMnft+WqNYIrSY4iA8pdSqozfglzqhX7y4CIxw==}
     engines: {node: ^20.6.1 || >=22}
     peerDependencies:
-      vite: ^5 || ^6
+      vite: ^5 || ^6 || ^7
 
   '@netlify/zip-it-and-ship-it@12.2.0':
     resolution: {integrity: sha512-64tKrE4bGGh/uChrCKQ1g6rDmY+Jl95bh+GGeP1mzIOcXmZHFja8sWMyaKv8iOxIiPdaJCQuhadSmE4ATUDVFg==}
@@ -15343,7 +15343,7 @@ snapshots:
       uuid: 11.1.0
       write-file-atomic: 5.0.1
 
-  '@netlify/dev@4.3.7(rollup@4.40.2)':
+  '@netlify/dev@4.4.0(rollup@4.40.2)':
     dependencies:
       '@netlify/blobs': 10.0.4
       '@netlify/config': 23.0.11
@@ -15351,7 +15351,7 @@ snapshots:
       '@netlify/edge-functions': 2.15.6
       '@netlify/functions': 4.1.10(rollup@4.40.2)
       '@netlify/headers': 2.0.4
-      '@netlify/images': 1.1.2(@netlify/blobs@10.0.4)
+      '@netlify/images': 1.2.0(@netlify/blobs@10.0.4)
       '@netlify/redirects': 3.0.4
       '@netlify/runtime': 4.0.8
       '@netlify/static': 3.0.4
@@ -15445,7 +15445,7 @@ snapshots:
     dependencies:
       '@netlify/headers-parser': 9.0.1
 
-  '@netlify/images@1.1.2(@netlify/blobs@10.0.4)':
+  '@netlify/images@1.2.0(@netlify/blobs@10.0.4)':
     dependencies:
       ipx: 3.0.3(@netlify/blobs@10.0.4)
     transitivePeerDependencies:
@@ -15502,9 +15502,9 @@ snapshots:
 
   '@netlify/types@2.0.2': {}
 
-  '@netlify/vite-plugin@2.3.7(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))':
+  '@netlify/vite-plugin@2.3.10(rollup@4.40.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0))':
     dependencies:
-      '@netlify/dev': 4.3.7(rollup@4.40.2)
+      '@netlify/dev': 4.4.0(rollup@4.40.2)
       '@netlify/dev-utils': 3.2.2
       chalk: 5.4.1
       vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.86.3)(yaml@2.8.0)


### PR DESCRIPTION
## Changes

This PR tackles a couple of issues that came up with the Netlify adapter's Vite plugin dev mode features.

First, the Vite plugin was injecting env vars from linked Netlify sites. This is nice DX, but is a change that could surprise peopel - suddenly their dev environment had variables they weren't expecting, which could mess with their local setup.

Second, remote images were broken in the image CDN. The local image server didn't take account of the permitted remote image domains injected by Astro during the build, meaning all remote images were shown as forbidden. 

The fixes:
- Added a new `devFeatures` option to the adapter config to allow enabling or disabling features
- Environment variables now default to disabled - You need to explicitly opt in with `devFeatures: { environmentVariables: true }` or `devFeatures: true`. We can change the default in a major in future
- Netlify is releasing an update to their Vite plugin that allows us to inject the allowed domains for remote images, which this now implements

## Testing

Adds new tests (and runs the dev tests in CI, which they weren't before)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
https://github.com/withastro/docs/pull/12030

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
