### PR TITLE
fix punctuation in an error message

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1805,7 +1805,7 @@ export const ContentCollectionTypeMismatchError = {
  * @docs
  * @message `COLLECTION_ENTRY_NAME` failed to parse.
  * @description
- * Collection entries of `type: 'data'` must return an object with valid JSON (for `.json` entries), YAML (for `.yaml` entries) or TOML (for `.toml` entries).'
+ * Collection entries of `type: 'data'` must return an object with valid JSON (for `.json` entries), YAML (for `.yaml` entries) or TOML (for `.toml` entries).
  */
 export const DataCollectionEntryParseError = {
 	name: 'DataCollectionEntryParseError',


### PR DESCRIPTION
## Changes

Removes errant punctuation from an error message

## Testing

Not tested

## Docs

All docs, only affects error message in docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
