### PR TITLE
fix(astro): refresh loaded env

### DIFF
--- a/.changeset/major-ideas-exist.md
+++ b/.changeset/major-ideas-exist.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where `astro:env` would not load the right environments variables in dev

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -125,10 +125,8 @@ export async function createVite(
 	});
 
 	const srcDirPattern = convertPathToPattern(fileURLToPath(settings.config.srcDir));
-	// TODO: use a single non coerced env loader in Astro 7
-	// Coercion is managed by astro:env directly
-	const astroEnvLoader = createEnvLoader(mode, settings.config, false);
-	const importMetaEnvLoader = createEnvLoader(
+	// TODO: default to non coerced in Astro 7
+	const envLoader = createEnvLoader(
 		mode,
 		settings.config,
 		settings.config.experimental.rawEnvValues,
@@ -157,8 +155,8 @@ export async function createVite(
 			// The server plugin is for dev only and having it run during the build causes
 			// the build to run very slow as the filewatcher is triggered often.
 			command === 'dev' && vitePluginAstroServer({ settings, logger, fs, routesList, manifest }), // manifest is only required in dev mode, where it gets created before a Vite instance is created, and get passed to this function
-			importMetaEnv({ envLoader: importMetaEnvLoader }),
-			astroEnv({ settings, sync, envLoader: astroEnvLoader }),
+			importMetaEnv({ envLoader }),
+			astroEnv({ settings, sync, envLoader }),
 			markdownVitePlugin({ settings, logger }),
 			htmlVitePlugin(),
 			astroPostprocessVitePlugin(),

--- a/packages/integrations/cloudflare/test/astro-env.test.js
+++ b/packages/integrations/cloudflare/test/astro-env.test.js
@@ -7,66 +7,126 @@ import { astroCli, wranglerCli } from './_test-utils.js';
 const root = new URL('./fixtures/astro-env/', import.meta.url);
 
 describe('astro:env', () => {
-	let wrangler;
+	describe('ssr', () => {
+		let wrangler;
 
-	before(async () => {
-		process.env.API_URL = 'https://google.de';
-		process.env.PORT = '4322';
-		await astroCli(fileURLToPath(root), 'build');
+		before(async () => {
+			process.env.API_URL = 'https://google.de';
+			process.env.PORT = '4322';
+			await astroCli(fileURLToPath(root), 'build');
 
-		wrangler = wranglerCli(fileURLToPath(root));
-		await new Promise((resolve) => {
-			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
-				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
+			wrangler = wranglerCli(fileURLToPath(root));
+			await new Promise((resolve) => {
+				wrangler.stdout.on('data', (data) => {
+					// console.log('[stdout]', data.toString());
+					if (data.toString().includes('http://127.0.0.1:8788')) resolve();
+				});
+				wrangler.stderr.on('data', (_data) => {
+					// console.log('[stderr]', data.toString());
+				});
 			});
-			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', data.toString());
-			});
+		});
+
+		after(() => {
+			wrangler.kill();
+		});
+
+		it('runtime', async () => {
+			const res = await fetch('http://127.0.0.1:8788/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal(
+				$('#runtime').text().includes('https://google.de') &&
+					$('#runtime').text().includes('4322') &&
+					$('#runtime').text().includes('123456789'),
+				true,
+			);
+		});
+
+		it('client', async () => {
+			const res = await fetch('http://127.0.0.1:8788/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#client').text().includes('https://google.de'), true);
+		});
+
+		it('server', async () => {
+			const res = await fetch('http://127.0.0.1:8788/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#server').text().includes('4322'), true);
+		});
+
+		it('secret', async () => {
+			const res = await fetch('http://127.0.0.1:8788/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#secret').text().includes('123456789'), true);
+		});
+
+		it('action secret', async () => {
+			const res = await fetch('http://127.0.0.1:8788/test');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#secret').text().includes('123456789'), true);
 		});
 	});
 
-	after(() => {
-		wrangler.kill();
-	});
+	describe('dev', () => {
+		let cli;
+		before(async () => {
+			cli = astroCli(fileURLToPath(root), 'dev', '--host', '127.0.0.1');
+			await new Promise((resolve) => {
+				cli.stdout.on('data', (data) => {
+					if (data.includes('http://127.0.0.1:4321/')) {
+						resolve();
+					}
+				});
+			});
+		});
 
-	it('runtime', async () => {
-		const res = await fetch('http://127.0.0.1:8788/');
-		const html = await res.text();
-		const $ = cheerio.load(html);
-		assert.equal(
-			$('#runtime').text().includes('https://google.de') &&
-				$('#runtime').text().includes('4322') &&
-				$('#runtime').text().includes('123456789'),
-			true,
-		);
-	});
+		after((_done) => {
+			cli.kill();
+		});
 
-	it('client', async () => {
-		const res = await fetch('http://127.0.0.1:8788/');
-		const html = await res.text();
-		const $ = cheerio.load(html);
-		assert.equal($('#client').text().includes('https://google.de'), true);
-	});
+		it('runtime', async () => {
+			const res = await fetch('http://127.0.0.1:4321/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal(
+				$('#runtime').text().includes('https://google.de') &&
+					$('#runtime').text().includes('4322') &&
+					$('#runtime').text().includes('123456789'),
+				true,
+			);
+		});
 
-	it('server', async () => {
-		const res = await fetch('http://127.0.0.1:8788/');
-		const html = await res.text();
-		const $ = cheerio.load(html);
-		assert.equal($('#server').text().includes('4322'), true);
-	});
+		it('client', async () => {
+			const res = await fetch('http://127.0.0.1:4321/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#client').text().includes('https://google.de'), true);
+		});
 
-	it('secret', async () => {
-		const res = await fetch('http://127.0.0.1:8788/');
-		const html = await res.text();
-		const $ = cheerio.load(html);
-		assert.equal($('#secret').text().includes('123456789'), true);
-	});
+		it('server', async () => {
+			const res = await fetch('http://127.0.0.1:4321/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#server').text().includes('4322'), true);
+		});
 
-	it('action secret', async () => {
-		const res = await fetch('http://127.0.0.1:8788/test');
-		const html = await res.text();
-		const $ = cheerio.load(html);
-		assert.equal($('#secret').text().includes('123456789'), true);
+		it('secret', async () => {
+			const res = await fetch('http://127.0.0.1:4321/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#secret').text().includes('123456789'), true);
+		});
+
+		it('action secret', async () => {
+			const res = await fetch('http://127.0.0.1:4321/test');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#secret').text().includes('123456789'), true);
+		});
 	});
 });


### PR DESCRIPTION
## Changes

- Closes #14036
- First of all, the PR that introduced `experimental.rawEnvValues` was probably breaking env in some rare cases because the env loader system relies on the fact that it loads env in the `astro:env` virtual module, and then is consumed in the `import.meta.env` virtual module
- About the fix for the linked issue:
	- We load env when we created the env loader. That's to allow using it quite early, eg. in the content config (see #12977)
	- But integrations may set `process.env` values so they can be consumed by `astro:env` later (eg. cloudflare's platform proxy is started in `astro:server:setup`). So calling `envLoader.get()` would get the previous version of `process.env`
	- This PR updates the behavior of `envLoader.get()` so it gets a new version of the loaded env

## Testing

Added dev tests for cloudflare and confirmed they were failing without the changes of this PR

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
