### PR TITLE
fix: session options type fix

### DIFF
--- a/.changeset/fuzzy-laws-feel.md
+++ b/.changeset/fuzzy-laws-feel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused a type error when defining session options without a driver

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -163,11 +163,15 @@ interface TestSessionConfig extends CommonSessionConfig {
 }
 
 export type SessionConfig<TDriver extends SessionDriverName> =
-	TDriver extends keyof BuiltinDriverOptions
-		? BuiltinSessionConfig<TDriver>
-		: TDriver extends 'test'
-			? TestSessionConfig
-			: CustomSessionConfig;
+	// Distributive conditional tuple trick
+	// https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
+	[TDriver] extends [never]
+		? CustomSessionConfig
+		: TDriver extends keyof BuiltinDriverOptions
+			? BuiltinSessionConfig<TDriver>
+			: TDriver extends 'test'
+				? TestSessionConfig
+				: CustomSessionConfig;
 
 export type ResolvedSessionConfig<TDriver extends SessionDriverName> = SessionConfig<TDriver> & {
 	driverModule?: () => Promise<{ default: () => Driver }>;


### PR DESCRIPTION
## Changes

This fixes a bug that caused a type error when trying to define session options without a named driver (e.g. if there's a default added by an adapter). The fix was a weird (but documented) TS fix, which involved wrapping the conditionals in tuples. See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types

Closes #14090

## Testing
Manually tested
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
Bug fix
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
