### PR TITLE
fix: move priority prop to shared image props

### DIFF
--- a/.changeset/fluffy-seas-shine.md
+++ b/.changeset/fluffy-seas-shine.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Correct types to allow `priority` on all images

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -157,6 +157,17 @@ type ImageSharedProps<T> = T & {
 	 * ```
 	 */
 	quality?: ImageQuality;
+
+	/**
+	 * If true, the image will be loaded with a higher priority. This can be useful for images that are visible above the fold. There should usually be only one image with `priority` set to `true` per page.
+	 * All other images will be lazy-loaded according to when they are in the viewport.
+	 * **Example**:
+	 * ```astro
+	 * <Image src={...} priority alt="..." />
+	 * ```
+	 */
+	priority?: boolean;
+
 } & (
 		| {
 				/**
@@ -201,15 +212,6 @@ type ImageSharedProps<T> = T & {
 				 */
 
 				position?: string;
-				/**
-				 * If true, the image will be loaded with a higher priority. This can be useful for images that are visible above the fold. There should usually be only one image with `priority` set to `true` per page.
-				 * All other images will be lazy-loaded according to when they are in the viewport.
-				 * **Example**:
-				 * ```astro
-				 * <Image src={...} priority alt="..." />
-				 * ```
-				 */
-				priority?: boolean;
 
 				/**
 				 * A list of widths to generate images for. The value of this property will be used to assign the `srcset` property on the final `img` element.

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -114,6 +114,13 @@ describe('astro:image', () => {
 				assert.equal(res.headers.get('content-type'), 'image/webp');
 			});
 
+			it('includes priority loading attributes', () => {
+				let $img = $('#priority img');
+				assert.equal($img.attr('loading'), 'eager');
+				assert.equal($img.attr('decoding'), 'sync');
+				assert.equal($img.attr('fetchpriority'), 'high');
+			});
+
 			it('properly skip processing SVGs, but does not error', async () => {
 				let res = await fixture.fetch('/svgSupport');
 				let html = await res.text();

--- a/packages/astro/test/fixtures/core-image-ssg/src/pages/index.astro
+++ b/packages/astro/test/fixtures/core-image-ssg/src/pages/index.astro
@@ -18,5 +18,9 @@ import myImage from "../assets/penguin1.jpg";
 	<div id="encoded-chars">
 		<Image src="https://avatars.githubusercontent.com/u%2f622227?s=64" alt="fred2" width="48" height="48" />
 	</div>
+
+		<div id="priority">
+		<Image src={myImage} alt="a penguin" priority densities={[1,2]}/>
+	</div>
 </body>
 </html>

--- a/packages/astro/test/fixtures/core-image/src/pages/index.astro
+++ b/packages/astro/test/fixtures/core-image/src/pages/index.astro
@@ -11,6 +11,10 @@ import myImage from "../assets/penguin1.jpg";
 		<Image src={myImage} alt="a penguin" />
 	</div>
 
+	<div id="priority">
+		<Image src={myImage} alt="a penguin" priority densities={[1,2]}/>
+	</div>
+
 	<div id="local-width">
 		<Image src={myImage} alt="a penguin" width={350} />
 	</div>


### PR DESCRIPTION
## Changes

The `priority` prop used to be only available for responsive images, but since they moved to stable we allow it for any image. However the types were not updated, meaning there would be errors if you tried to use the prop with non-responsive props such as `densities`.

This PR moves `priority` to shared props

Fixes #14086

## Testing

Added test cases

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
