### PR TITLE
docs: fix store.set in docs

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -553,7 +553,7 @@
 
         for (const entry of entries) {
           // Assume each entry has a 'content' field with markdown content
-          store.set(entry.id, {
+          store.set({
             id: entry.id,
             data: entry,
             rendered: await renderMarkdown(entry.content),


### PR DESCRIPTION
I was following the docs and noticed this is wrong, ``store.set`` takes a single argument.