### PR TITLE
fix: exit with non-zero code for Zod errors

### DIFF
--- a/.changeset/few-rules-lose.md
+++ b/.changeset/few-rules-lose.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Exits with non-zero exit code when config has an error

--- a/packages/astro/src/cli/throw-and-exit.ts
+++ b/packages/astro/src/cli/throw-and-exit.ts
@@ -8,7 +8,9 @@ import { eventError, telemetry } from '../events/index.js';
 /** Display error and exit */
 export async function throwAndExit(cmd: string, err: unknown) {
 	// Suppress ZodErrors from AstroConfig as the pre-logged error is sufficient
-	if (isAstroConfigZodError(err)) return;
+	if (isAstroConfigZodError(err)) {
+		process.exit(1);
+	}
 
 	let telemetryPromise: Promise<any>;
 	let errorMessage: string;


### PR DESCRIPTION
## Changes

Currently we skip the exit error handling for config Zod errors, because it has already logged an error message. However it also skips the exit code handling, meaning it will appear to scripts that the command has succeeded.

This PR still skips the error logging and telemetry, but does `process.exit(1)` so that the command exits as an error

Fixes #13994

## Testing
Tested manually
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
