### PR TITLE
fix: add stub for getLiveCollection in non-live contexts

### DIFF
--- a/.changeset/major-games-thank.md
+++ b/.changeset/major-games-thank.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Throw a more helpful error if defineLiveCollection is used outside of a live.config file

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -974,3 +974,12 @@ export function defineCollection(config: any) {
 	}
 	return defineCollectionOrig(config);
 }
+
+export function defineLiveCollection() {
+	throw new AstroError({
+		...AstroErrorData.LiveContentConfigError,
+		message: AstroErrorData.LiveContentConfigError.message(
+			'Live collections must be defined in a `src/live.config.ts` file.',
+		),
+	});
+}

--- a/packages/astro/templates/content/module.mjs
+++ b/packages/astro/templates/content/module.mjs
@@ -11,7 +11,7 @@ import {
 	createReference,
 } from 'astro/content/runtime';
 
-export { defineCollection, renderEntry as render } from 'astro/content/runtime';
+export { defineCollection, defineLiveCollection, renderEntry as render } from 'astro/content/runtime';
 export { z } from 'astro/zod';
 
 /* @@LIVE_CONTENT_CONFIG@@ */


### PR DESCRIPTION
## Changes

Since #14092, defineCollection and defineLiveCollection are only available in the appropriate files. While the live config file imports a module with stubs that throw helpful errors, currently the content.config file does not, meaning that if a user tries to use `defineLiveCollection` they get a confusing error: `(0 , __vite_ssr_import_0__.defineLiveCollection) is not a function`

This PR adds a stub implementation that throws a more helpful error.

## Testing

Tested manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This uses an existing error for this scenario.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
