### PR TITLE
fix: warn if fie loader finds duplicate IDs

### DIFF
--- a/.changeset/warm-roses-stop.md
+++ b/.changeset/warm-roses-stop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Warn if duplicate IDs are found by file loader

--- a/packages/astro/src/content/loaders/file.ts
+++ b/packages/astro/src/content/loaders/file.ts
@@ -69,12 +69,17 @@ export function file(fileName: string, options?: FileOptions): Loader {
 			}
 			logger.debug(`Found ${data.length} item array in ${fileName}`);
 			store.clear();
+			const idList = new Set();
 			for (const rawItem of data) {
 				const id = (rawItem.id ?? rawItem.slug)?.toString();
 				if (!id) {
 					logger.error(`Item in ${fileName} is missing an id or slug field.`);
 					continue;
 				}
+				if (idList.has(id)) {
+					logger.warn(`Duplicate id "${id}" found in ${fileName}. Later items with the same id will overwrite earlier ones.`);
+				}
+				idList.add(id);
 				const parsedData = await parseData({ id, data: rawItem, filePath });
 				store.set({ id, data: parsedData, filePath: normalizedFilePath });
 			}

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -414,6 +414,10 @@ describe('Content Layer', () => {
 			assert.ok(logs.find((log) => log.level === 'warn' && log.message.includes('does not exist')));
 		});
 
+		it("warns about duplicate IDs in file() loader arrays", () => {
+			assert.ok(logs.find((log) => log.level === 'warn' && log.message.includes('Duplicate id "german-shepherd" found in src/data/dogs.json')));
+		})
+
 		it("warns about missing files in glob() loader's path", async () => {
 			assert.ok(
 				logs.find((log) => log.level === 'warn' && log.message.includes('No files found matching')),

--- a/packages/astro/test/fixtures/content-layer/src/data/dogs.json
+++ b/packages/astro/test/fixtures/content-layer/src/data/dogs.json
@@ -23,6 +23,18 @@
       "Confident"
     ]
   },
+    {
+    "breed": "Alsatian",
+    "id": "german-shepherd",
+    "size": "Large",
+    "origin": "Germany",
+    "lifespan": "9-13 years",
+    "temperament": [
+      "Loyal",
+      "Intelligent",
+      "Confident"
+    ]
+  },
   {
     "breed": "Golden Retriever",
     "id": "golden-retriever",


### PR DESCRIPTION
## Changes

Generally in content loaders, writes to a particular id will overwrite any existing entry with that ID. This is expected, and meant to be managed by the laoder. Currently the file() loader allows arrays with ids in the entry, meaning there can potentially be duplicates. This PR checks for this and logs a warning.

Fixes #13948

## Testing

Adds a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
