### PR TITLE
fix: set key argument as prop in JSX transform

### DIFF
--- a/.changeset/cruel-pandas-wonder.md
+++ b/.changeset/cruel-pandas-wonder.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that prevented "key" from being used as a prop for Astro components in MDX

--- a/packages/astro/src/jsx-runtime/index.ts
+++ b/packages/astro/src/jsx-runtime/index.ts
@@ -72,12 +72,15 @@ function transformSetDirectives(vnode: AstroVNode) {
 	}
 }
 
-function createVNode(type: any, props: Record<string, any>) {
+function createVNode(type: any, props: Record<string, any> = {}, key?: string | number): AstroVNode {
+	if (key) {
+		props.key = key;
+	}
 	const vnode: AstroVNode = {
 		[Renderer]: 'astro:jsx',
 		[AstroJSX]: true,
 		type,
-		props: props ?? {},
+		props,
 	};
 	transformSetDirectives(vnode);
 	transformSlots(vnode);

--- a/packages/integrations/mdx/test/fixtures/mdx-page/src/components/KeyTest.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-page/src/components/KeyTest.astro
@@ -1,0 +1,10 @@
+---
+export interface Props {
+  key: string;
+}
+
+const { key } = Astro.props
+
+---
+
+<p id="key-test">{key}</p>

--- a/packages/integrations/mdx/test/fixtures/mdx-page/src/pages/index.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-page/src/pages/index.mdx
@@ -1,3 +1,6 @@
 import '../styles.css'
+import KeyTest from '../components/KeyTest.astro'
 
 # Hello page!
+
+<KeyTest key="oranges"  />

--- a/packages/integrations/mdx/test/mdx-page.test.js
+++ b/packages/integrations/mdx/test/mdx-page.test.js
@@ -54,6 +54,14 @@ describe('MDX Page', () => {
 			const html = await fixture.readFile('/chinese-encoding-layout-manual/index.html');
 			assert.doesNotMatch(html, /<meta charset="utf-8"/);
 		});
+
+		it('renders MDX with key prop', async () => {
+			const html = await fixture.readFile('/index.html');
+			const { document } = parseHTML(html);
+
+			const keyTest = document.querySelector('#key-test');
+			assert.equal(keyTest.textContent, 'oranges');
+		});
 	});
 
 	describe('dev', () => {


### PR DESCRIPTION
## Changes

The "key" prop is special in JSX, so when MDX compiles to JSX transforms it passes the key prop as the third argument for the JSX transform, rather than in the props record. This is expected when using React, because for React it *is* special. However with Astro it's a regular prop, and so was getting lost. This PR updates the Astro JSX transform to accept the key argument, and to add it to the props record.

Fixes #14010

## Testing

Added a test to the MDX integration, though the fix is in the astro package.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
The current magicness of `key` is undocumented, so this just makes it behave as expected.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
