### PR TITLE
fix: make SVG ImageMetadata serializable

### DIFF
--- a/.changeset/floppy-shrimps-smile.md
+++ b/.changeset/floppy-shrimps-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that meant that SVG components could no longer be serialized with `JSON.stringify`

--- a/packages/astro/src/assets/runtime.ts
+++ b/packages/astro/src/assets/runtime.ts
@@ -29,6 +29,11 @@ export function createSvgComponent({ meta, attributes, children }: SvgComponentP
 		});
 	}
 
+	Object.defineProperty(Component, 'toJSON', {
+		value: () => meta,
+		enumerable: false,
+	});
+
 	// Attaching the metadata to the component to maintain current functionality
 	return Object.assign(Component, meta);
 }

--- a/packages/astro/test/core-image-svg.test.js
+++ b/packages/astro/test/core-image-svg.test.js
@@ -138,5 +138,16 @@ describe('astro:assets - SVG Components', () => {
 				assert.equal($svg.attr('aria-description'), 'Some description');
 			});
 		});
+
+		describe('metadata', () => {
+			it('returns a serializable metadata object', async () => {
+				let res = await fixture.fetch('/serialize.json');
+				let json = await res.json();
+				assert.equal(json.image.format, 'svg');
+				assert.equal(json.image.width, 85);
+				assert.equal(json.image.height, 107);
+				assert.ok(json.image.src.startsWith("/"));
+			});
+		});
 	});
 });

--- a/packages/astro/test/fixtures/core-image-svg/src/pages/serialize.json.ts
+++ b/packages/astro/test/fixtures/core-image-svg/src/pages/serialize.json.ts
@@ -1,0 +1,7 @@
+import type { APIRoute } from 'astro';
+import image from '../assets/astro.svg';
+
+export const GET: APIRoute = async ({ session, request }) =>
+	Response.json({
+		image,
+	});


### PR DESCRIPTION
## Changes

When SVG components were introduced, the metadata was attached to the component so that they were backwards-compatible with former usage. However because they are now component factories they're not serializable with JSON.stringify anymore. This is a particular issue when they are attached to content entries, which may be returned by an endpoint.

This PR adds a `toJSON` method to the component that returns just the metadata. This makes it serialisable again.

Fixes #13979

## Testing

Added a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
