### PR TITLE
feat: support remove of sections from template readmes

### DIFF
--- a/.changeset/cold-queens-thank.md
+++ b/.changeset/cold-queens-thank.md
@@ -1,0 +1,11 @@
+---
+'create-astro': minor
+---
+
+Removes "Open in x" badges from templates when they are used
+
+Adds support for magic comments in template READMEs that wrap sections to remove when the template is used. This allows us to have content that is visible when the template is viewed in the repo, but not when the template is used.
+
+Supported magic comments are:
+
+`<!-- ASTRO:REMOVE:START -->` and `<!-- ASTRO:REMOVE:END -->`

--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -4,13 +4,21 @@
 npm create astro@latest -- --template basics
 ```
 
+<!-- ASTRO:REMOVE:START -->
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
 
+<!-- ASTRO:REMOVE:END -->
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
+<!-- ASTRO:REMOVE:START -->
+
 ![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
+
+<!-- ASTRO:REMOVE:END -->
 
 ## 🚀 Project Structure
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -4,13 +4,21 @@
 npm create astro@latest -- --template blog
 ```
 
+<!-- ASTRO:REMOVE:START -->
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/blog)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/blog)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/blog/devcontainer.json)
 
+<!-- ASTRO:REMOVE:END -->
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
+<!-- ASTRO:REMOVE:START -->
+
 ![blog](https://github.com/withastro/astro/assets/2244813/ff10799f-a816-4703-b967-c78997e8323d)
+
+<!-- ASTRO:REMOVE:END -->
 
 Features:
 

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -4,9 +4,13 @@
 npm create astro@latest -- --template minimal
 ```
 
+<!-- ASTRO:REMOVE:START -->
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
+
+<!-- ASTRO:REMOVE:END -->
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -5,6 +5,45 @@ import { downloadTemplate } from '@bluwy/giget-core';
 import { error, info, title } from '../messages.js';
 import type { Context } from './context.js';
 
+/**
+ * Removes sections from README content that are marked with HTML template markers.
+ * 
+ * Template marker format:
+ * <!-- ASTRO:REMOVE:START -->
+ * Content to remove
+ * <!-- ASTRO:REMOVE:END -->
+ */
+export function removeTemplateMarkerSections(content: string): string {
+	// Pattern to match HTML template marker sections
+	const pattern = /<!--\s*ASTRO:REMOVE:START\s*-->[\s\S]*?<!--\s*ASTRO:REMOVE:END\s*-->/gi;
+
+	let result = content.replace(pattern, '');
+
+	// Clean up extra whitespace that might be left behind
+	// Replace multiple consecutive newlines with at most 2 newlines
+	result = result.replace(/\n{3,}/g, '\n\n');
+
+	return result;
+}
+
+/**
+ * Processes a template README file by removing template marker sections and
+ * replacing package manager references.
+ */
+export function processTemplateReadme(content: string, packageManager: string): string {
+	// Remove sections marked with template markers
+	let processed = removeTemplateMarkerSections(content);
+
+	// Replace package manager references if not npm
+	if (packageManager !== 'npm') {
+		processed = processed
+			.replace(/\bnpm run\b/g, packageManager)
+			.replace(/\bnpm\b/g, packageManager);
+	}
+
+	return processed;
+}
+
 export async function template(
 	ctx: Pick<Context, 'template' | 'prompt' | 'yes' | 'dryRun' | 'exit' | 'tasks'>,
 ) {
@@ -104,17 +143,12 @@ async function copyTemplate(tmpl: string, ctx: Context) {
 				dir: '.',
 			});
 
-			// Modify the README file to reflect the correct package manager
-			if (ctx.packageManager !== 'npm') {
-				const readmePath = path.resolve(ctx.cwd, 'README.md');
+			// Process the README file to remove marked sections and update package manager
+			const readmePath = path.resolve(ctx.cwd, 'README.md');
+			if (fs.existsSync(readmePath)) {
 				const readme = fs.readFileSync(readmePath, 'utf8');
-
-				// `run` is removed since it's optional in other package managers
-				const updatedReadme = readme
-					.replace(/\bnpm run\b/g, ctx.packageManager)
-					.replace(/\bnpm\b/g, ctx.packageManager);
-
-				fs.writeFileSync(readmePath, updatedReadme);
+				const processedReadme = processTemplateReadme(readme, ctx.packageManager);
+				fs.writeFileSync(readmePath, processedReadme);
 			}
 		} catch (err: any) {
 			// Only remove the directory if it's most likely created by us.

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -8,7 +8,9 @@ import { next } from './actions/next-steps.js';
 import { projectName } from './actions/project-name.js';
 import { template } from './actions/template.js';
 import { verify } from './actions/verify.js';
-import { setStdout } from './messages.js';
+
+export { setStdout } from './messages.js';
+export { removeTemplateMarkerSections, processTemplateReadme } from './actions/template.js';
 
 const exit = () => process.exit(0);
 process.on('SIGINT', exit);
@@ -58,4 +60,4 @@ export async function main() {
 	process.exit(0);
 }
 
-export { dependencies, getContext, git, intro, next, projectName, setStdout, template, verify };
+export { dependencies, getContext, git, intro, next, projectName, template, verify };

--- a/packages/create-astro/test/template-processing.test.js
+++ b/packages/create-astro/test/template-processing.test.js
@@ -1,0 +1,357 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { removeTemplateMarkerSections, processTemplateReadme } from '../dist/index.js';
+
+describe('removeTemplateMarkerSections', async () => {
+	it('removes HTML template marker sections', async () => {
+		const content = `# Title
+
+Keep this content.
+
+<!-- ASTRO:REMOVE:START -->
+Remove this section.
+It spans multiple lines.
+<!-- ASTRO:REMOVE:END -->
+
+Keep this too.`;
+
+		const expected = `# Title
+
+Keep this content.
+
+Keep this too.`;
+
+		const result = removeTemplateMarkerSections(content);
+		assert.equal(result.trim(), expected.trim());
+	});
+
+	it('removes multiple HTML template marker sections', async () => {
+		const content = `# Title
+
+<!-- ASTRO:REMOVE:START -->
+First section to remove.
+<!-- ASTRO:REMOVE:END -->
+
+Keep this content.
+
+<!-- ASTRO:REMOVE:START -->
+Second section to remove.
+<!-- ASTRO:REMOVE:END -->
+
+Final content.`;
+
+		const expected = `# Title
+
+Keep this content.
+
+Final content.`;
+
+		const result = removeTemplateMarkerSections(content);
+		assert.equal(result.trim(), expected.trim());
+	});
+
+
+	it('handles whitespace in template marker tags', async () => {
+		const content = `# Title
+
+<!--   ASTRO:REMOVE:START   -->
+Remove this content.
+<!--   ASTRO:REMOVE:END   -->
+
+Keep this.`;
+
+		const expected = `# Title
+
+Keep this.`;
+
+		const result = removeTemplateMarkerSections(content);
+		assert.equal(result.trim(), expected.trim());
+	});
+
+	it('is case insensitive', async () => {
+		const content = `# Title
+
+<!-- astro:remove:start -->
+Remove this content.
+<!-- ASTRO:REMOVE:END -->
+
+Keep this.`;
+
+		const expected = `# Title
+
+Keep this.`;
+
+		const result = removeTemplateMarkerSections(content);
+		assert.equal(result.trim(), expected.trim());
+	});
+
+	it('does not modify content without template markers', async () => {
+		const content = `# Title
+
+Regular content here.
+
+<!-- Regular HTML comment -->
+More content.
+
+// Regular line comment
+Final content.`;
+
+		const result = removeTemplateMarkerSections(content);
+		assert.equal(result, content);
+	});
+
+	it('handles empty content', async () => {
+		const result = removeTemplateMarkerSections('');
+		assert.equal(result, '');
+	});
+
+	it('handles content with only template markers', async () => {
+		const content = `<!-- ASTRO:REMOVE:START -->
+Everything should be removed.
+<!-- ASTRO:REMOVE:END -->`;
+
+		const result = removeTemplateMarkerSections(content);
+		assert.equal(result.trim(), '');
+	});
+
+	it('cleans up excessive whitespace', async () => {
+		const content = `# Title
+
+
+<!-- ASTRO:REMOVE:START -->
+Remove this section.
+<!-- ASTRO:REMOVE:END -->
+
+
+
+Keep this content.`;
+
+		const expected = `# Title
+
+Keep this content.`;
+
+		const result = removeTemplateMarkerSections(content);
+		assert.equal(result.trim(), expected.trim());
+	});
+
+
+	it('handles malformed template markers gracefully', async () => {
+		const content = `# Title
+
+<!-- ASTRO:REMOVE:START -->
+Missing end comment - should not break anything.
+
+Keep this content.
+
+<!-- ASTRO:REMOVE:START -->
+Nested start comment.
+<!-- ASTRO:REMOVE:END -->
+
+Keep this too.`;
+
+		const result = removeTemplateMarkerSections(content);
+		// Should still process the properly formed section
+		assert.ok(!result.includes('Nested start comment'));
+		assert.ok(result.includes('Keep this too'));
+	});
+
+	it('preserves content structure and formatting', async () => {
+		const content = `# My Project
+
+## Features
+
+- Feature 1
+- Feature 2
+
+<!-- ASTRO:REMOVE:START -->
+## Development Only
+
+This section is for developers.
+
+### Debug Info
+- Debug feature 1
+- Debug feature 2
+<!-- ASTRO:REMOVE:END -->
+
+## Installation
+
+\`\`\`bash
+npm install
+\`\`\`
+
+## Usage
+
+Regular usage instructions.`;
+
+		const result = removeTemplateMarkerSections(content);
+		
+		// Should preserve main structure
+		assert.ok(result.includes('# My Project'));
+		assert.ok(result.includes('## Features'));
+		assert.ok(result.includes('## Installation'));
+		assert.ok(result.includes('## Usage'));
+		
+		// Should remove development section
+		assert.ok(!result.includes('## Development Only'));
+		assert.ok(!result.includes('Debug Info'));
+		assert.ok(!result.includes('Debug feature'));
+	});
+});
+
+describe('processTemplateReadme', async () => {
+	it('processes README with template markers and npm package manager', async () => {
+		const content = `# Test Project
+
+<!-- ASTRO:REMOVE:START -->
+Development section
+<!-- ASTRO:REMOVE:END -->
+
+## Commands
+
+| Command | Action |
+|---------|--------|
+| \`npm install\` | Install dependencies |
+| \`npm run dev\` | Start dev server |
+| \`npm run build\` | Build project |`;
+
+		const result = processTemplateReadme(content, 'npm');
+
+		// Should remove template markers but keep npm commands unchanged
+		assert.ok(!result.includes('Development section'));
+		assert.ok(result.includes('npm install'));
+		assert.ok(result.includes('npm run dev'));
+		assert.ok(result.includes('npm run build'));
+	});
+
+	it('processes README with template markers and yarn package manager', async () => {
+		const content = `# Test Project
+
+<!-- ASTRO:REMOVE:START -->
+Development section
+<!-- ASTRO:REMOVE:END -->
+
+## Commands
+
+| Command | Action |
+|---------|--------|
+| \`npm install\` | Install dependencies |
+| \`npm run dev\` | Start dev server |
+| \`npm run build\` | Build project |`;
+
+		const result = processTemplateReadme(content, 'yarn');
+
+		// Should remove template markers and replace npm with yarn
+		assert.ok(!result.includes('Development section'));
+		assert.ok(result.includes('yarn install'));
+		assert.ok(result.includes('yarn dev'));
+		assert.ok(result.includes('yarn build'));
+		assert.ok(!result.includes('npm'));
+	});
+
+	it('processes README with template markers and pnpm package manager', async () => {
+		const content = `# Test Project
+
+<!-- ASTRO:REMOVE:START -->
+Development section
+<!-- ASTRO:REMOVE:END -->
+
+## Commands
+
+| Command | Action |
+|---------|--------|
+| \`npm install\` | Install dependencies |
+| \`npm run dev\` | Start dev server |`;
+
+		const result = processTemplateReadme(content, 'pnpm');
+
+		// Should remove template markers and replace npm with pnpm
+		assert.ok(!result.includes('Development section'));
+		assert.ok(result.includes('pnpm install'));
+		assert.ok(result.includes('pnpm dev'));
+		assert.ok(!result.includes('`npm '));
+		assert.ok(!result.includes('npm run'));
+	});
+
+	it('handles README with no template markers and different package manager', async () => {
+		const content = `# Test Project
+
+## Commands
+
+Run \`npm install\` and then \`npm run dev\` to start.`;
+
+		const result = processTemplateReadme(content, 'bun');
+
+		// Should only replace package manager
+		assert.equal(result, `# Test Project
+
+## Commands
+
+Run \`bun install\` and then \`bun dev\` to start.`);
+	});
+
+	it('handles README with only template markers and npm', async () => {
+		const content = `<!-- ASTRO:REMOVE:START -->
+Everything should be removed.
+<!-- ASTRO:REMOVE:END -->`;
+
+		const result = processTemplateReadme(content, 'npm');
+
+		// Should remove all content
+		assert.equal(result.trim(), '');
+	});
+
+	it('preserves complex README structure during processing', async () => {
+		const content = `# My Astro Project
+
+[![CI](https://example.com/badge.svg)](https://example.com)
+
+<!-- ASTRO:REMOVE:START -->
+[![Open in StackBlitz](https://example.com/stackblitz.svg)](https://stackblitz.com/example)
+
+> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+<!-- ASTRO:REMOVE:END -->
+
+## Features
+
+- ✅ Feature 1
+- ✅ Feature 2
+
+## Commands
+
+All commands are run from the root of the project:
+
+| Command | Action |
+| :-- | :-- |
+| \`npm install\` | Installs dependencies |
+| \`npm run dev\` | Starts local dev server |
+| \`npm run build\` | Build your production site |
+
+## Learn More
+
+Check out the [documentation](https://docs.astro.build).`;
+
+		const result = processTemplateReadme(content, 'pnpm');
+
+		// Should preserve main structure
+		assert.ok(result.includes('# My Astro Project'));
+		assert.ok(result.includes('[![CI]'));
+		assert.ok(result.includes('## Features'));
+		assert.ok(result.includes('## Commands'));
+		assert.ok(result.includes('## Learn More'));
+
+		// Should remove development section
+		assert.ok(!result.includes('Open in StackBlitz'));
+		assert.ok(!result.includes('Seasoned astronaut'));
+
+		// Should replace package manager
+		assert.ok(result.includes('pnpm install'));
+		assert.ok(result.includes('pnpm dev'));
+		assert.ok(result.includes('pnpm build'));
+		assert.ok(!result.includes('`npm '));
+		assert.ok(!result.includes('npm run'));
+
+		// Should preserve formatting and structure
+		assert.ok(result.includes('| Command | Action |'));
+		assert.ok(result.includes('- ✅ Feature 1'));
+	});
+});


### PR DESCRIPTION
## Changes

Currently all template README files include badges to open them in StackBlitz etc. This is confusing when a site is deployed.

This PR adds support for magic comments that wrap sections to remove from templates when used:

`<!-- ASTRO:REMOVE:START -->` and `<!-- ASTRO:REMOVE:END -->`

## Testing

Added tests for this and for the existing README processing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I couldn't find any docs on how to create templates, so I don't think anything needs updating

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
