### PR TITLE
fix: don't try to create hydration entrypoints for Astro components

### DIFF
--- a/.changeset/common-chicken-agree.md
+++ b/.changeset/common-chicken-agree.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused builds to fail with an unhelpful error message if a client directive was mistakenly added to an Astro component

--- a/packages/astro/test/astro-directives.test.js
+++ b/packages/astro/test/astro-directives.test.js
@@ -100,4 +100,19 @@ describe('Directives', async () => {
 		assert.equal($('#true').length, 1);
 		assert.equal($('#true').text(), 'true');
 	});
+
+	it('ignores client directives on Astro components', async () => {
+		const html = await fixture.readFile('/client/index.html');
+		const $ = cheerio.load(html);
+
+		const hello = $('h1.hello');
+		assert.equal(hello.text(), "Hello");
+
+		// Astro components should not have client directives
+		assert.equal(hello.attr('client:load'), undefined);
+
+		// Should not create Astro islands
+		assert.equal($('astro-island').length, 0);
+
+	});
 });

--- a/packages/astro/test/fixtures/astro-directives/src/components/Hello.astro
+++ b/packages/astro/test/fixtures/astro-directives/src/components/Hello.astro
@@ -1,0 +1,1 @@
+<h1 class="hello">Hello</h1>

--- a/packages/astro/test/fixtures/astro-directives/src/pages/client.astro
+++ b/packages/astro/test/fixtures/astro-directives/src/pages/client.astro
@@ -1,0 +1,14 @@
+---
+import Hello from '../components/Hello.astro';
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Document</title>
+</head>
+<body>
+	<Hello client:idle/>
+</body>
+</html>


### PR DESCRIPTION
## Changes

If a user mistakenly includes a client directive on an Astro component we currently warn in dev, but in builds we fail with a confusing error. This is not a deliberate fail: it's because it fails when we try to compile it.

This PR removes Astro components form the list of hydrated or client components, allowing the build to complete and the warnings to be logged.

## Testing

Added a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
