### PR TITLE
fix: adds mock feature flags to the Netlify dev context object

### DIFF
--- a/.changeset/some-results-move.md
+++ b/.changeset/some-results-move.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Adds mock feature flags in dev

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -539,8 +539,10 @@ export default function netlifyIntegration(
 			get cookies(): never {
 				throw new Error('Please use Astro.cookies instead.');
 			},
-			// @ts-expect-error This is not currently included in the public Netlify types
-			flags: undefined,
+			flags: {
+					get: () => undefined,
+					evaluations: new Set<string>(),
+			} as unknown as Context['flags'],
 			json: (input) => Response.json(input),
 			log: console.info,
 			next: () => {


### PR DESCRIPTION
## Changes

The Netlify types expect Context to have a flags object, so this PR adds a mock/stub one. This is mostly to satisfy TypeScript.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
