### PR TITLE
feat: add automatic chrome workspace handling

### DIFF
--- a/.changeset/plain-dragons-bow.md
+++ b/.changeset/plain-dragons-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Adds experimental support for Chrome devtools workspace folders

--- a/.changeset/plain-dragons-bow.md
+++ b/.changeset/plain-dragons-bow.md
@@ -4,9 +4,14 @@
 
 Adds experimental support for automatic [Chrome DevTools workspace folders](https://developer.chrome.com/docs/devtools/workspaces)
 
-This adds a new experimental flag `chromeDevtoolsWorkspace`. When enabled, the dev server will automatically configure a Chrome DevTools workspace for your project, allowing you to edit files directly in the browser and have those changes reflected in your local file system.
+This feature allows you to edit files directly in the browser and have those changes reflected in your local file system via a connected workspace folder. This allows you to apply edits such as CSS tweaks without leaving your browser tab!
+
+With this feature enabled, the Astro dev server will automatically configure a Chrome DevTools workspace for your project. Your project will then appear as a workspace source, ready to connect. Then, changes that you make in the "Sources" panel are automatically saved to your project source code.
+
+To enable this feature, add the experimental flag `chromeDevtoolsWorkspace` to your Astro config:
 
 ```js
+// astro.config.mjs
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
@@ -16,4 +21,4 @@ export default defineConfig({
 });
 ```
 
-See the [Chrome DevTools workspace documentation](https://developer.chrome.com/docs/devtools/workspaces) for more information.
+See the [experimental Chrome DevTools workspace feature documentation](https://docs.astro.build/en/reference/experimental-flags/chrome-devtools-workspace/) for more information.

--- a/.changeset/plain-dragons-bow.md
+++ b/.changeset/plain-dragons-bow.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-Adds experimental support for Chrome devtools workspace folders
+Adds experimental support for automatic [Chrome DevTools workspace folders](https://developer.chrome.com/docs/devtools/workspaces)

--- a/.changeset/plain-dragons-bow.md
+++ b/.changeset/plain-dragons-bow.md
@@ -3,3 +3,17 @@
 ---
 
 Adds experimental support for automatic [Chrome DevTools workspace folders](https://developer.chrome.com/docs/devtools/workspaces)
+
+This adds a new experimental flag `chromeDevtoolsWorkspace`. When enabled, the dev server will automatically configure a Chrome DevTools workspace for your project, allowing you to edit files directly in the browser and have those changes reflected in your local file system.
+
+```js
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  experimental: {
+    chromeDevtoolsWorkspace: true,
+  },
+});
+```
+
+See the [Chrome DevTools workspace documentation](https://developer.chrome.com/docs/devtools/workspaces) for more information.

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -103,6 +103,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 		liveContentCollections: false,
 		csp: false,
 		rawEnvValues: false,
+		chromeDevtoolsWorkspace: false,
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -502,6 +503,10 @@ export const AstroConfigSchema = z.object({
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.csp),
 			rawEnvValues: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.rawEnvValues),
+			chromeDevtoolsWorkspace: z
+				.boolean()
+				.optional()
+				.default(ASTRO_CONFIG_DEFAULTS.experimental.chromeDevtoolsWorkspace),
 		})
 		.strict(
 			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/experimental-flags/ for a list of all current experiments.`,

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2458,6 +2458,31 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * See the [experimental raw environment variables guide](https://docs.astro.build/en/reference/experimental-flags/raw-env-values/) for more information.
 		 */
 		rawEnvValues?: boolean;
+		/**
+		 * @name experimental.chromeDevtoolsWorkspace
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 5.13
+		 * @description
+		 *
+		 * Enables Chrome DevTools workspace integration for the Astro dev server.
+		 *
+		 * When enabled, the dev server will automatically configure a Chrome DevTools workspace for your project,
+		 * allowing you to edit files directly in the browser and have those changes reflected in your local file system.
+		 *
+		 * ```js
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
+		 *   experimental: {
+		 *     chromeDevtoolsWorkspace: true,
+		 *   },
+		 * });
+		 * ```
+		 *
+		 * See the [Chrome DevTools workspace documentation](https://developer.chrome.com/docs/devtools/workspaces) for more information.
+		 */
+		chromeDevtoolsWorkspace?: boolean;
 	};
 }
 

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2467,7 +2467,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 *
 		 * Enables Chrome DevTools workspace integration for the Astro dev server.
 		 *
-		 * When enabled, the dev server will automatically configure a Chrome DevTools workspace for your project,
+		 * When enabled, the dev server will automatically configure a [Chrome DevTools workspace](https://developer.chrome.com/docs/devtools/workspaces) for your project,
 		 * allowing you to edit files directly in the browser and have those changes reflected in your local file system.
 		 *
 		 * ```js
@@ -2480,7 +2480,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * });
 		 * ```
 		 *
-		 * See the [Chrome DevTools workspace documentation](https://developer.chrome.com/docs/devtools/workspaces) for more information.
+		 * See the [experimental Chrome DevTools workspace feature documentation](https://docs.astro.build/en/reference/experimental-flags/chrome-devtools-workspace/) for more information.
 		 */
 		chromeDevtoolsWorkspace?: boolean;
 	};

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -160,15 +160,16 @@ export default function createVitePluginAstroServer({
 						await mkdir(cacheDir, { recursive: true });
 					}
 
-					let config = {
-						version: '1.0',
-						projectId: randomUUID(),
-						workspaceRoot: fileURLToPath(settings.config.root),
-					};
+					let config;
 					try {
 						config = JSON.parse(await readFile(configPath, 'utf-8'));
 					} catch {
-						await writeFile(configPath, JSON.stringify(config, null, 2));
+						config = {
+							version: '1.0',
+							projectId: randomUUID(),
+							workspaceRoot: fileURLToPath(settings.config.root),
+						};
+						await writeFile(configPath, JSON.stringify(config));
 					}
 
 					response.setHeader('Content-Type', 'application/json');

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -153,8 +153,8 @@ export default function createVitePluginAstroServer({
 						return;
 					}
 
-					const cacheDir = fileURLToPath(settings.config.cacheDir);
-					const configPath = join(cacheDir, 'chrome-workspace.json');
+					const cacheDir = settings.config.cacheDir;
+					const configPath = new URL('./chrome-workspace.json', cacheDir);
 
 					if (!existsSync(cacheDir)) {
 						await mkdir(cacheDir, { recursive: true });

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -4,7 +4,6 @@ import type fs from 'node:fs';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { IncomingMessage } from 'node:http';
-import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type * as vite from 'vite';
 import { normalizePath } from 'vite';

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -161,25 +161,18 @@ export default function createVitePluginAstroServer({
 					}
 
 					let config = {
-						version: 1,
+						version: '1.0',
 						projectId: randomUUID(),
 						workspaceRoot: fileURLToPath(settings.config.root),
 					};
-					if (existsSync(configPath)) {
-						try {
-							config = JSON.parse(await readFile(configPath, 'utf-8'));
-						} catch {}
+					try {
+						config = JSON.parse(await readFile(configPath, 'utf-8'));
+					} catch {
+						await writeFile(configPath, JSON.stringify(config, null, 2));
 					}
-					await writeFile(configPath, JSON.stringify(config, null, 2));
 
 					response.setHeader('Content-Type', 'application/json');
-					response.end(
-						JSON.stringify({
-							version: '1.0',
-							projectId: config.projectId,
-							workspaceRoot: config.workspaceRoot,
-						}),
-					);
+					response.end(JSON.stringify(config));
 					return;
 				});
 

--- a/packages/astro/test/chrome-devtools-workspace.test.js
+++ b/packages/astro/test/chrome-devtools-workspace.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+describe('Chrome DevTools workspace', () => {
+	describe('with experimental flag enabled', () => {
+		let fixture;
+		let devServer;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-dev-headers/',
+				experimental: {
+					chromeDevtoolsWorkspace: true,
+				},
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('serves Chrome DevTools workspace endpoint', async () => {
+			const result = await fixture.fetch('/.well-known/appspecific/com.chrome.devtools.json');
+			assert.equal(result.status, 200);
+			assert.equal(result.headers.get('content-type'), 'application/json');
+
+			const data = await result.json();
+			assert.equal(data.version, '1.0');
+			assert.equal(typeof data.projectId, 'string');
+			assert.equal(data.projectId.length, 36); // UUID length
+			assert.equal(typeof data.workspaceRoot, 'string');
+			assert.ok(data.workspaceRoot.includes('astro-dev-headers'));
+		});
+	});
+
+	describe('with experimental flag disabled', () => {
+		let fixture;
+		let devServer;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-dev-headers/',
+				experimental: {
+					chromeDevtoolsWorkspace: false,
+				},
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('returns 404 for Chrome DevTools workspace endpoint', async () => {
+			const result = await fixture.fetch('/.well-known/appspecific/com.chrome.devtools.json');
+			assert.equal(result.status, 404);
+		});
+	});
+});


### PR DESCRIPTION
## Changes

Adds experimental support for auto-configuring [Chrome Devtools Workspaces](https://developer.chrome.com/docs/devtools/workspaces). 

When devtools are open, Chrome automatically requests `/.well-known/appspecific/com.chrome.devtools.json` to see if it can setup workspace config. This is a feature to make it easy to configure workspaces, that let users edit files directly in the browser and save them back to disk. See [this doc](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md#solution) for more info. Unfortunately this leads to lots of annoying console spam, so people tend to open issues against frameworks. Some (e.g. Nuxt) have implemented experimental features like this. Others (like SvelteKit) special-case the path to quietly return a 404. This PR does both: it adds an experimental flag to auto-generate the workspace config. It also quietly returns a 404 if the flag is disabled to prevent the console spam.

Fixes #13789

## Testing
Added tests
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Documented JSDoc. Experimental flags docs: https://github.com/withastro/docs/pull/12108

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
