### PR TITLE
fix: don't externalize Zod

### DIFF
--- a/.changeset/chubby-pets-switch.md
+++ b/.changeset/chubby-pets-switch.md
@@ -1,0 +1,10 @@
+---
+'astro': patch
+---
+
+Fixes a bug that prevented Zod 4 from being installed in an Astro site
+
+You can now install and use your own version of Zod 4 in an Astro site, and Astro will continue to use its own version of Zod for its own APIs. This is particularly useful where you have dependencies that require Zod 4.
+
+> [!NOTE]
+> You should not attempt to use Zod 4 for for Astro APIs such as content collections or actions. You should use the `astro/zod`, `astro:content`, or `astro:schema` imports instead, which will always use the version of Zod that Astro is using. 

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -73,6 +73,8 @@ const ALWAYS_NOEXTERNAL = [
 	'@nanostores/preact',
 	// fontsource packages are CSS that need to be processed
 	'@fontsource/*',
+	// Without this the user can't install newer versions of Zod in their project
+	'zod',
 ];
 
 // These specifiers are usually dependencies written in CJS, but loaded through Vite's transform

--- a/packages/astro/test/fixtures/zod-versions/package.json
+++ b/packages/astro/test/fixtures/zod-versions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/zod-versions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "zod": "^4.0.0"
+  }
+}

--- a/packages/astro/test/fixtures/zod-versions/src/pages/astro-zod.json.ts
+++ b/packages/astro/test/fixtures/zod-versions/src/pages/astro-zod.json.ts
@@ -1,0 +1,14 @@
+import { z as astroZod } from "astro/zod";
+import { z as zodContent} from "astro:content";
+import { z } from "zod";
+
+export const prerender = false;
+
+export async function GET() {
+  return Response.json({
+		astroZodIsZod4: "toJSONSchema" in astroZod,
+		astroContentZodIsZod4: "toJSONSchema" in zodContent,
+		astroZodAndZodContentAreSame: astroZod === zodContent,
+		zodIsZod4: "toJSONSchema" in z,
+	});
+}

--- a/packages/astro/test/fixtures/zod-versions/src/pages/not-prerendered.json.ts
+++ b/packages/astro/test/fixtures/zod-versions/src/pages/not-prerendered.json.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const prerender = false;
+
+export async function GET() {
+  const schema = z.object({
+    name: z.string(),
+    age: z.number(),
+  });
+  const json = z.toJSONSchema(schema);
+  return Response.json(json);
+}

--- a/packages/astro/test/fixtures/zod-versions/src/pages/prerendered.json.ts
+++ b/packages/astro/test/fixtures/zod-versions/src/pages/prerendered.json.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const prerender = true;
+
+export async function GET() {
+  const schema = z.object({
+    name: z.string(),
+    age: z.number(),
+  });
+  const json = z.toJSONSchema(schema);
+  return Response.json(json);
+}

--- a/packages/astro/test/zod-versions.test.js
+++ b/packages/astro/test/zod-versions.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
+
+describe('Zod versions', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	/** @type {import('./test-utils').App} */
+	let app;
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/zod-versions/',
+			output: 'server',
+			outDir: './dist/normal',
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it("uses the site's Zod version in SSR page", async () => {
+		const request = new Request('http://example.com/not-prerendered.json');
+		const response = await app.render(request);
+		const json = await response.json();
+		// This uses the topJSONSchema function that's only available in Zod v4+
+		assert.equal(json['$schema'], 'https://json-schema.org/draft/2020-12/schema');
+	});
+
+	it("uses the site's Zod version in prerendered page", async () => {
+		const data = await fixture.readFile('client/prerendered.json');
+		const json = JSON.parse(data);
+		assert.equal(json['$schema'], 'https://json-schema.org/draft/2020-12/schema');
+	});
+
+	it("can access Astro's Zod version via Astro's virtual modules", async () => {
+		const request = new Request('http://example.com/astro-zod.json');
+		const response = await app.render(request);
+		const json = await response.json();
+		assert.equal(json.astroContentZodIsZod4, false);
+		assert.equal(json.astroZodIsZod4, false);
+		assert.equal(json.zodIsZod4, true);
+		assert.equal(json.astroZodAndZodContentAreSame, true);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4396,6 +4396,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/zod-versions:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+      zod:
+        specifier: ^4.0.0
+        version: 4.0.10
+
   packages/astro/test/units/_temp-fixtures:
     dependencies:
       '@astrojs/mdx':
@@ -11197,7 +11206,6 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:
@@ -14006,6 +14014,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.0.10:
+    resolution: {integrity: sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -22411,5 +22422,7 @@ snapshots:
   zod@3.22.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.0.10: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Changes

Adds `zod` to the list of deps that are never externalised, allowing users to install different versions in their own sites.

 Fixes #14117

## Testing

Added tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
Not sure if this needs to be documented

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
