### PR TITLE
fix: show 500.astro if error occurs in middleware

### DIFF
--- a/.changeset/five-forks-guess.md
+++ b/.changeset/five-forks-guess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where an error occurring in a middleware would show the dev overlay instead of the custom `500.astro` page

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -229,6 +229,16 @@ export async function handleRoute({
 			statusCode = 500;
 			return _response;
 		} catch (_err) {
+			// We always throw for errors related to middleware calling
+			if (
+				isAstroError(_err) &&
+				[
+					AstroErrorData.MiddlewareNoDataOrNextCalled.name,
+					AstroErrorData.MiddlewareNotAResponse.name,
+				].includes(_err.name)
+			) {
+				throw _err;
+			}
 			if (skipMiddleware === false) {
 				return renderError(_err, true);
 			}

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -202,6 +202,41 @@ export async function handleRoute({
 	let statusCode = 200;
 	let isReroute = false;
 	let isRewrite = false;
+
+	async function renderError(err: any, skipMiddleware: boolean) {
+		const custom500 = getCustom500Route(routesList);
+		// Show dev overlay
+		if (!custom500) {
+			throw err;
+		}
+		try {
+			const filePath500 = new URL(`./${custom500.component}`, config.root);
+			const preloaded500Component = await pipeline.preload(custom500, filePath500);
+			renderContext = await RenderContext.create({
+				locals,
+				pipeline,
+				pathname,
+				middleware: skipMiddleware ? undefined : middleware,
+				request,
+				routeData: route,
+				clientAddress: incomingRequest.socket.remoteAddress,
+				actions,
+			});
+			renderContext.props.error = err;
+			const _response = await renderContext.render(preloaded500Component);
+			// Log useful information that the custom 500 page may not display unlike the default error overlay
+			logger.error('router', err.stack || err.message);
+			statusCode = 500;
+			return _response;
+		} catch (_err) {
+			if (skipMiddleware === false) {
+				return renderError(_err, true);
+			}
+			// If even skipping the middleware isn't enough to prevent the error, show the dev overlay
+			throw _err;
+		}
+	}
+
 	try {
 		response = await renderContext.render(mod);
 		isReroute = response.headers.has(REROUTE_DIRECTIVE_HEADER);
@@ -216,17 +251,7 @@ export async function handleRoute({
 				? response.status
 				: (statusCodedMatched ?? response.status);
 	} catch (err: any) {
-		const custom500 = getCustom500Route(routesList);
-		if (!custom500) {
-			throw err;
-		}
-		// Log useful information that the custom 500 page may not display unlike the default error overlay
-		logger.error('router', err.stack || err.message);
-		const filePath500 = new URL(`./${custom500.component}`, config.root);
-		const preloaded500Component = await pipeline.preload(custom500, filePath500);
-		renderContext.props.error = err;
-		response = await renderContext.render(preloaded500Component);
-		statusCode = 500;
+		response = await renderError(err, false);
 	} finally {
 		renderContext.session?.[PERSIST_SYMBOL]();
 	}

--- a/packages/astro/test/custom-500.test.js
+++ b/packages/astro/test/custom-500.test.js
@@ -61,6 +61,24 @@ describe('Custom 500', () => {
 			assert.equal($('p').text(), 'some error');
 		});
 
+		it('renders custom 500 even if error occurs in the middleware', async () => {
+			fixture = await loadFixture({
+				root: './fixtures/custom-500-middleware/',
+				output: 'server',
+				adapter: testAdapter(),
+			});
+			devServer = await fixture.startDevServer();
+
+			const response = await fixture.fetch('/');
+			assert.equal(response.status, 500);
+
+			const html = await response.text();
+			const $ = cheerio.load(html);
+
+			assert.equal($('h1').text(), 'Server error');
+			assert.equal($('p').text(), 'an error');
+		});
+
 		it('renders default error overlay if custom 500 throws', async () => {
 			fixture = await loadFixture({
 				root: './fixtures/custom-500-failing/',

--- a/packages/astro/test/fixtures/custom-500-middleware/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-500-middleware/astro.config.mjs
@@ -1,0 +1,4 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({});

--- a/packages/astro/test/fixtures/custom-500-middleware/package.json
+++ b/packages/astro/test/fixtures/custom-500-middleware/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/custom-500-middleware",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/custom-500-middleware/src/middleware.js
+++ b/packages/astro/test/fixtures/custom-500-middleware/src/middleware.js
@@ -1,0 +1,4 @@
+export function onRequest(_context, next) {
+    throw 'an error'
+    return next()
+}

--- a/packages/astro/test/fixtures/custom-500-middleware/src/pages/500.astro
+++ b/packages/astro/test/fixtures/custom-500-middleware/src/pages/500.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+  error: unknown
+}
+
+const { error } = Astro.props
+---
+
+<html lang="en">
+<head>
+  <title>Server error - Custom 500</title>
+</head>
+<body>
+  <h1>Server error</h1>
+	<p>{error}</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/custom-500-middleware/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-500-middleware/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+---
+
+<html lang="en">
+<head>
+  <title>Custom 500</title>
+</head>
+<body>
+  <h1>Home</h1>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3044,6 +3044,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/custom-500-middleware:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/custom-assets-name:
     dependencies:
       '@astrojs/node':


### PR DESCRIPTION
## Changes

- Closes #13546
- Matches the behavior of `NodeApp#renderError`: if rendering `500.astro` fails, we try another time while disabling middleware in case the error is in the middleware
- We still log the error in the terminal anyways

## Testing

Manually + fixture

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
