### PR TITLE
fix: throw early for server islands without adapter

### DIFF
--- a/.changeset/puny-boats-call.md
+++ b/.changeset/puny-boats-call.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Throws a more helpful error in dev if trying to use a server island without an adapter

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -2,6 +2,7 @@ import MagicString from 'magic-string';
 import type { ConfigEnv, ViteDevServer, Plugin as VitePlugin } from 'vite';
 import type { AstroPluginOptions } from '../../types/astro.js';
 import type { AstroPluginMetadata } from '../../vite-plugin-astro/index.js';
+import { AstroError, AstroErrorData } from '../errors/index.js';
 
 export const VIRTUAL_ISLAND_MAP_ID = '@astro-server-islands';
 const RESOLVED_VIRTUAL_ISLAND_MAP_ID = '\0' + VIRTUAL_ISLAND_MAP_ID;
@@ -40,12 +41,8 @@ export function vitePluginServerIslands({ settings, logger }: AstroPluginOptions
 			for (const comp of astro.serverComponents) {
 				if (!settings.serverIslandNameMap.has(comp.resolvedPath)) {
 					if (!settings.adapter) {
-						logger.error(
-							'islands',
-							'You tried to render a server island without an adapter added to your project. An adapter is required to use the `server:defer` attribute on any component. Your project will fail to build unless you add an adapter or remove the attribute.',
-						);
+						throw new AstroError(AstroErrorData.NoAdapterInstalledServerIslands);
 					}
-
 					let name = comp.localName;
 					let idx = 1;
 

--- a/packages/astro/test/server-islands.test.js
+++ b/packages/astro/test/server-islands.test.js
@@ -256,7 +256,9 @@ describe('Server islands', () => {
 			});
 		});
 
-		describe('build (no adapter)', () => {
+		describe('with no adapter', () => {
+			let devServer;
+
 			it('Errors during the build', async () => {
 				try {
 					await fixture.build({
@@ -266,6 +268,18 @@ describe('Server islands', () => {
 				} catch (err) {
 					assert.equal(err.title, 'Cannot use Server Islands without an adapter.');
 				}
+			});
+
+			it('Errors during dev', async () => {
+				devServer = await fixture.startDevServer();
+				const res = await fixture.fetch('/');
+				assert.equal(res.status, 500);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+				assert.equal($('title').text(), 'NoAdapterInstalledServerIslands');
+			});
+			after(() => {
+				return devServer?.stop();
 			});
 		});
 	});


### PR DESCRIPTION
## Changes

Currently if you try to use server islands without an adapter it logs a warning in the Vite plugin, but then fails with a confusing error when it renders the route.

This PR changes it to throw an error in the plugin, catching the error early and giving a more helpful message

## Testing

Added a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
