### PR TITLE
fix(node): emit set-cookie header from middlewares for not-found routes (#14136)

### DIFF
--- a/.changeset/upset-pianos-sink.md
+++ b/.changeset/upset-pianos-sink.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+fix(node): emit set-cookie header from middlewares for not-found routes (#14136)

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -45,7 +45,7 @@ export function createAppHandler(app: NodeApp): RequestHandler {
 		} else if (next) {
 			return next();
 		} else {
-			const response = await app.render(req);
+			const response = await app.render(req, { addCookieHeader: true });
 			await NodeApp.writeResponse(response, res);
 		}
 	};


### PR DESCRIPTION
## Changes

Fixes #14136. A `set-cookie` header is now emitted when set by middleware (e.g. through `context.cookies` or implicitly by `context.session`) on routes that are not found.

## Testing

Unfortunately, I wasn't able to get `pnpm run test` to work locally (same issue on my home and work computers and in and outside a devcontainer, some "cannot find module" thing). So, no new test, even though I'd like to add one.
Instead, I tested this by making this same change in a sample project's `node_modules`.

## Docs

## Notes

I'm not familiar enough with Astro's internals, so a question: Why is `app.render()` called with `req` in the 404 case and `request` in the happy case? Also, I wonder if `locals` should be passed in addition to `addCookieHeader`.