### PR TITLE
fix: use hasOwnProperty to check for adapter start export

### DIFF
--- a/.changeset/sad-mails-play.md
+++ b/.changeset/sad-mails-play.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused an error "serverEntrypointModule[_start] is not a function" in some adapters

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -197,7 +197,7 @@ function generateSSRCode(adapter: AstroAdapter, middlewareId: string) {
 		// They are NOT equivalent! Some bundlers will throw if `start` is not exported, but we
 		// only want to silently ignore it... hence the dynamic, obfuscated weirdness.
 		`const _start = 'start';
-if (_start in serverEntrypointModule) {
+if (Object.prototype.hasOwnProperty.call(serverEntrypointModule, _start)) {
 	serverEntrypointModule[_start](_manifest, _args);
 }`,
 	];


### PR DESCRIPTION
## Changes

This fixes a regression that seems to be a rollup bug. We currently test if an adapter entrypoint exports a "start" function by using a dynamic check like this:

```js
const _start = 'start';
if (_start in serverEntrypointModule) {
    serverEntrypointModule[_start](_manifest, _args);
}
```

However since last week, this is being optimised to:

```js
const _start = 'start';
{
        serverEntrypointModule[_start](_manifest, _args);
}
```
This causes runtime errors on Netlify, and probably elsewhere. This PR changes the check to:

```js
const _start = 'start';
if (Object.prototype.hasOwnProperty.call(serverEntrypointModule, _start)) {
	serverEntrypointModule[_start](_manifest, _args);
}
```

...which rollup leaves alone.

Fixes #14152

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
