### PR TITLE
fix: update spawn command to concatenate command and flags

### DIFF
--- a/.changeset/stupid-ways-tie.md
+++ b/.changeset/stupid-ways-tie.md
@@ -1,8 +1,6 @@
 ---
-'create-astro': major
-'@astrojs/upgrade': major
+'create-astro': patch
+'@astrojs/upgrade': patch
 ---
 
-Update to the new way the spawn command must be used, after the use of arrays was deprecated in Node.js 24 when the shell option is enabled, 
-
-ref: https://nodejs.org/api/deprecations.html#DEP0190, https://github.com/nodejs/node/pull/57199 https://github.com/nodejs/help/issues/5063#issuecomment-3132899776
+Prevents deprecation warnings in Node 24

--- a/.changeset/stupid-ways-tie.md
+++ b/.changeset/stupid-ways-tie.md
@@ -1,0 +1,8 @@
+---
+'create-astro': major
+'@astrojs/upgrade': major
+---
+
+Update to the new way the spawn command must be used, after the use of arrays was deprecated in Node.js 24 when the shell option is enabled, 
+
+ref: https://nodejs.org/api/deprecations.html#DEP0190, https://github.com/nodejs/node/pull/57199 https://github.com/nodejs/help/issues/5063#issuecomment-3132899776

--- a/packages/create-astro/src/shell.ts
+++ b/packages/create-astro/src/shell.ts
@@ -27,7 +27,7 @@ export async function shell(
 	let stdout = '';
 	let stderr = '';
 	try {
-		child = spawn(command, flags, {
+		child = spawn(`${command} ${flags.join(' ')}`, {
 			cwd: opts.cwd,
 			shell: true,
 			stdio: opts.stdio,

--- a/packages/upgrade/src/shell.ts
+++ b/packages/upgrade/src/shell.ts
@@ -35,7 +35,7 @@ export async function shell(
 		signal = controller.signal;
 	}
 	try {
-		child = spawn(command, flags, {
+		child = spawn(`${command} ${flags.join(' ')}`, {
 			cwd: opts.cwd,
 			shell: true,
 			stdio: opts.stdio,


### PR DESCRIPTION
## Changes

Update to the new way the spawn command must be used, after the use of arrays was deprecated in Node.js 24 when the shell option is enabled, 

ref: https://nodejs.org/api/deprecations.html#DEP0190, https://github.com/nodejs/node/pull/57199 https://github.com/nodejs/help/issues/5063#issuecomment-3132899776

closes: #14139

## Testing
Before:
<img width="1358" height="155" alt="imagen" src="https://github.com/user-attachments/assets/54232e8c-212c-4829-a885-bc98cebe5e0f" />

After:
<img width="719" height="173" alt="imagen" src="https://github.com/user-attachments/assets/a0425f87-d37f-4146-91f1-da85bad98eb9" />

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No changes to the documentation are needed, it's just a minor change.
