### PR TITLE
fix: sanitize generated image filenames

### DIFF
--- a/.changeset/purple-peaches-allow.md
+++ b/.changeset/purple-peaches-allow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that meant some remote image URLs could cause invalid filenames to be used for processed images

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -5,6 +5,10 @@ import { shorthash } from '../../runtime/server/shorthash.js';
 import type { ImageTransform } from '../types.js';
 import { isESMImportedImage } from './imageKind.js';
 
+// Taken from https://github.com/rollup/rollup/blob/a8647dac0fe46c86183be8596ef7de25bc5b4e4b/src/utils/sanitizeFileName.ts
+// eslint-disable-next-line no-control-regex
+const INVALID_CHAR_REGEX = /[\u0000-\u001F"#$%&*+,:;<=>?[\]^`{|}\u007F]/g;
+
 /**
  * Converts a file path and transformation properties of the transformation image service, into a formatted filename.
  *
@@ -33,12 +37,12 @@ export function propsToFilename(filePath: string, transform: ImageTransform, has
 	if (filePath.startsWith('data:')) {
 		filename = shorthash(filePath);
 	} else {
-		filename = basename(filename, ext);
+		filename = basename(filename, ext).replace(INVALID_CHAR_REGEX, '_');
 	}
 	const prefixDirname = isESMImportedImage(transform.src) ? dirname(filePath) : '';
 
 	let outputExt = transform.format ? `.${transform.format}` : ext;
-	return decodeURIComponent(`${prefixDirname}/${filename}_${hash}${outputExt}`);
+	return `${prefixDirname}/${filename}_${hash}${outputExt}`;
 }
 
 /**

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -904,7 +904,7 @@ describe('astro:image', () => {
 				root: './fixtures/core-image-ssg/',
 				image: {
 					service: testImageService(),
-					domains: ['astro.build', 'avatars.githubusercontent.com'],
+					domains: ['astro.build', 'avatars.githubusercontent.com', 'server-islands.com'],
 				},
 			});
 			// Remove cache directory
@@ -951,6 +951,18 @@ describe('astro:image', () => {
 			const src = $img.attr('src');
 			const data = await fixture.readFile(src, null);
 			assert.equal(data instanceof Buffer, true);
+		});
+
+		it('handles remote images with special characters', async () => {
+			const html = await fixture.readFile('/special-chars/index.html');
+			const $ = cheerio.load(html);
+			const $img = $('img');
+			assert.equal($img.length, 1);
+			const src = $img.attr('src');
+			// The filename should be encoded and sanitized
+			assert.ok(src.startsWith('/_astro/c_23'));
+			const data = await fixture.readFile(src, null);
+			assert.ok(data instanceof Buffer);
 		});
 
 		it('Picture component images are written', async () => {

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -904,7 +904,7 @@ describe('astro:image', () => {
 				root: './fixtures/core-image-ssg/',
 				image: {
 					service: testImageService(),
-					domains: ['astro.build', 'avatars.githubusercontent.com', 'server-islands.com'],
+					domains: ['astro.build', 'avatars.githubusercontent.com', 'kaleidoscopic-biscotti-6fe98c.netlify.app'],
 				},
 			});
 			// Remove cache directory

--- a/packages/astro/test/fixtures/core-image-ssg/src/pages/special-chars.astro
+++ b/packages/astro/test/fixtures/core-image-ssg/src/pages/special-chars.astro
@@ -7,5 +7,5 @@ import { Image } from 'astro:assets';
 	<title>Special Characters in Image Paths</title>
 </head>
 <body>
-	<Image src="https://server-islands.com/c%2523.png" alt="C#" inferSize={true} />
+	<Image src="https://kaleidoscopic-biscotti-6fe98c.netlify.app/c%2523.png" alt="C#" width={100} height={100} />
 </html>

--- a/packages/astro/test/fixtures/core-image-ssg/src/pages/special-chars.astro
+++ b/packages/astro/test/fixtures/core-image-ssg/src/pages/special-chars.astro
@@ -7,5 +7,5 @@ import { Image } from 'astro:assets';
 	<title>Special Characters in Image Paths</title>
 </head>
 <body>
-	<Image src="https://kaleidoscopic-biscotti-6fe98c.netlify.app/c%2523.png" alt="C#" width={100} height={100} />
+	<Image src="https://kaleidoscopic-biscotti-6fe98c.netlify.app/c%2523.png" alt="C#" inferSize />
 </html>

--- a/packages/astro/test/fixtures/core-image-ssg/src/pages/special-chars.astro
+++ b/packages/astro/test/fixtures/core-image-ssg/src/pages/special-chars.astro
@@ -1,0 +1,11 @@
+---
+import { Image } from 'astro:assets';
+---
+<html>
+<head>
+	<meta charset="UTF-8" />
+	<title>Special Characters in Image Paths</title>
+</head>
+<body>
+	<Image src="https://server-islands.com/c%2523.png" alt="C#" inferSize={true} />
+</html>


### PR DESCRIPTION
## Changes

The filenames for transformed images is based on the source image filename and a hash of the transform. For local files this is fine, because rollup sanitises the filename when emitting the generated file. However for remote images, this is based on the remote image URL, which we are decoding, meaning any characters could be present. This caused #14026 because that used inferSize, but if it didn't it would've succeeded in the build but generated an image filename that could not be deployed to some platforms such as Netlify, which forbids `#` in deployed filenames.

This PR sanitizes the filename using the same regex as rollup, replacing special characters with undersocres. It also doesn't double-decode the URLs.

Fixes #14026 

## Testing

Added tests, including uploading a test image to server-islands.com so we have one in a domain we control!

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
