### PR TITLE
chore: add link to changeset style guide in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,8 @@
 - What does this change?
 - Be short and concise. Bullet points can help!
 - Before/after screenshots can help as well.
-- Don't forget a changeset! `pnpm exec changeset`
+- Don't forget a changeset! Run `pnpm changeset`.
+- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.
 
 ## Testing
 


### PR DESCRIPTION
## Changes

We have [great docs on writing changesets](https://contribute.docs.astro.build/docs-for-code-changes/changesets/) but most people don't know that. This adds a link to the PR template. The ideal would be if we could link from the bot comment, but it doesn't seem to be customisable

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
