### PR TITLE
fix: get id from cookie when destroying an unloaded session

### DIFF
--- a/.changeset/soft-rabbits-yell.md
+++ b/.changeset/soft-rabbits-yell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that prevented destroyed sessions from being deleted from storage unless the session had been loaded


### PR DESCRIPTION
## Changes

Ensures that underlying session data is deleted when calling `session.destroy()`, even if the session hasn't been loaded. Previously it would skip deletion if no session ID was set. This meant that if the session hadn't been accessed in some way (which would call `#ensureSessionID` internally), the session ID would be unset and nothing deleted, even if the ID was set in the cookie. 

## Testing
Added test
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
