### PR TITLE
fix(routing): static redirect with prerendered route

### DIFF
--- a/.changeset/rude-sites-heal.md
+++ b/.changeset/rude-sites-heal.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where static redirects couldn't correctly generate a redirect when the destination is a prerendered route, and the `output` is set to `"server"`.

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -509,10 +509,20 @@ export async function createRoutesList(
 	for (const route of routes) {
 		promises.push(
 			limit(async () => {
-				if (route.type !== 'page' && route.type !== 'endpoint') return;
+				if (route.type !== 'page' && route.type !== 'endpoint' && route.type !== 'redirect') return;
+				// External redirects aren't taken into account
+				if (route.type === 'redirect' && !route.redirectRoute) return;
 				const localFs = params.fsMod ?? nodeFs;
 				const content = await localFs.promises.readFile(
-					fileURLToPath(new URL(route.component, settings.config.root)),
+					fileURLToPath(
+						new URL(
+							// The destination redirect might be a prerendered
+							route.type === 'redirect' && route.redirectRoute
+								? route.redirectRoute.component
+								: route.component,
+							settings.config.root,
+						),
+					),
 					'utf-8',
 				);
 

--- a/packages/astro/src/core/routing/manifest/prerender.ts
+++ b/packages/astro/src/core/routing/manifest/prerender.ts
@@ -16,6 +16,9 @@ export async function getRoutePrerenderOption(
 	const match = PRERENDER_REGEX.exec(content);
 	if (match) {
 		route.prerender = match[1] === 'true';
+		if (route.redirectRoute) {
+			route.redirectRoute.prerender = match[1] === 'true';
+		}
 	}
 
 	await runHookRouteSetup({ route, settings, logger });

--- a/packages/astro/test/fixtures/redirects/src/pages/more/[dynamic]/[prerender].astro
+++ b/packages/astro/test/fixtures/redirects/src/pages/more/[dynamic]/[prerender].astro
@@ -1,0 +1,10 @@
+---
+export const prerender = true;
+
+export function getStaticPaths() {
+  return [{ params: { dynamic:'hello', prerender:'world' } }]
+}
+---
+{JSON.stringify(Astro.params)}
+
+<a href="/">home</a>

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -21,6 +21,8 @@ describe('Astro.redirect', () => {
 					'/source/[dynamic]': '/not-verbatim/target1/[dynamic]',
 					// may be called src/pages/not-verbatim/target2/[abc]/[xyz].astro
 					'/source/[dynamic]/[route]': '/not-verbatim/target2/[dynamic]/[route]',
+					// check for prerendered routes
+					'/source/[dynamic]/[prerender]': '/not-verbatim/target2/[dynamic]/[prerender]',
 					// may be called src/pages/not-verbatim/target3/[...rest].astro
 					'/source/[...spread]': '/not-verbatim/target3/[...spread]',
 				},


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/astro/issues/14054

The issue was caused by the fact that when we generate the static redirect, the `prerender` flag was set to `false` for all redirect routes, when a server adapter is used. 

This PR now changes the logic that is used to check the presence of `export const pretender = true`. If the route has a `redirectRoute`, also that route has its `prerender` flag updated.

This is a safe assumption because before calling `getRoutePrerenderOption`, we provide the content of the destination route (AKA `route.redirectRoute`)

## Testing

Added a new test case. Manually tested against the reproduction provided

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
