### PR TITLE
feat: experimental static import.meta.env

### DIFF
--- a/.changeset/kind-kids-listen.md
+++ b/.changeset/kind-kids-listen.md
@@ -2,35 +2,70 @@
 'astro': minor
 ---
 
-Adds an experimental flag `staticImportMetaEnv` to disable replacement of `import.meta.env` values with `process.env` calls and their coercion, and supersedes the `rawEnvValues` experimental flag
+Adds an experimental flag `staticImportMetaEnv` to disable the replacement of `import.meta.env` values with `process.env` calls and their coercion of environment variable values. This supersedes the `rawEnvValues` experimental flag which is now removed.
 
-Astro allows you to configure a [type-safe schema for your environment variables](https://docs.astro.build/en/guides/environment-variables/#type-safe-environment-variables), and converts variables imported via `astro:env` into the expected type.
+Astro allows you to configure a [type-safe schema for your environment variables](/en/guides/environment-variables/#type-safe-environment-variables), and converts variables imported via `astro:env` into the expected type. This is the recommended way to use environment variables in Astro, as it allows you to easily see and manage whether your variables are public or secret, available on the client or only on the server at build time, and the data type of your values.
 
-However, Astro by default turns non public `import.meta.env` values into `process.env` calls during the build, if the environment variable name is present in `process.env`. It also converts your environment variables used through `import.meta.env` in some cases, and this can prevent access to some values such as the strings `"true"` (which is converted to a boolean value), and `"1"` (which is converted to a number).
+However, you can still access environment variables through `process.env` and `import.meta.env` directly when needed. This was the only way to use environment variables in Astro before `astro:env` was added in Astro 5.0, and Astro's default handling of `import.meta.env` includes some logic that was only needed for earlier versions of Astro.
 
-The `experimental.staticImportMetaEnv` flag disables this behavior, ensuring that `import.meta.env` values are always inlined.
+The `experimental.staticImportMetaEnv` flag updates the behavior of `import.meta.env` to align with [Vite's handling of environment variables](https://vite.dev/guide/env-and-mode.html#env-variables) and for better ease of use with Astro's current implementations and features. **This will become the default behavior in Astro 6.0** and this early preview is introduced as an experimental feature.
 
-To enable this feature, add the experimental flag in your Astro config:
+Currently, non-public `import.meta.env` environment variables are replaced by a reference to `process.env`. Additionally, Astro may also convert the value type of your environment variables used through `import.meta.env`, which can prevent access to some values such as the strings `"true"` (which is converted to a boolean value), and `"1"` (which is converted to a number).
+
+The `experimental.staticImportMetaEnv` flag simplifies Astro's default behavior, making it easier to understand and use. Astro will no longer replace any `import.meta.env` environment variables with a `process.env` call, nor will it coerce values.
+
+To enable this feature, add the experimental flag in your Astro config and remove the now removed `rawEnvValues` if it was enabled:
 
 ```diff
+// astro.config.mjs
 import { defineConfig } from "astro/config"
 
 export default defineConfig({
 +  experimental: {
 +    staticImportMetaEnv: true,
+-    rawEnvValues: false,   
 +  }
 })
 ```
 
-This experimental flag supersedes the `experimental.rawEnvValues` flag, that you need to remove in your Astro config:
+#### Updating your project
+
+If you were relying on Astro's default coercion, you may need to update your project code to apply it manually:
 
 ```diff
-import { defineConfig } from "astro/config"
-
-export default defineConfig({
-   experimental: {
--    rawEnvValues: true,
-+    staticImportMetaEnv: true,
-   }
-})
+// src/components/MyComponent.astro
+- const enabled: boolean = import.meta.env.ENABLED
++ const enabled: boolean = import.meta.env.ENABLED === "true"
 ```
+
+If you were relying on the transformation into `process.env` calls, you may need to update your project code to apply it manually:
+
+```diff
+// src/components/MyComponent.astro
+- const enabled: boolean = import.meta.env.DB_PASSWORD
++ const enabled: boolean = process.env.DB_PASSWORD
+```
+
+You may also need to update types:
+
+```diff
+// src/env.d.ts
+interface ImportMetaEnv {
+  readonly PUBLIC_POKEAPI: string;
+-  readonly DB_PASSWORD: string;
+-  readonly ENABLED: boolean;
++  readonly ENABLED: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
++ namespace NodeJS {
++  interface ProcessEnv {
++    DB_PASSWORD: string;
++  }
++ }
+```
+
+See the [experimental static `import.meta.env` documentation](https://docs.astro.build/en/reference/experimental-flags/static-import-meta-env/) for more information about this feature. You can learn more about using environment variables in Astro, including `astro:env`, in the [environment variables documentation](/en/guides/environment-variables/).

--- a/.changeset/kind-kids-listen.md
+++ b/.changeset/kind-kids-listen.md
@@ -28,8 +28,9 @@ This experimental flag supersedes the `experimental.rawEnvValues` flag, that you
 import { defineConfig } from "astro/config"
 
 export default defineConfig({
--  experimental: {
+   experimental: {
 -    rawEnvValues: true,
--  }
++    staticImportMetaEnv: true,
+   }
 })
 ```

--- a/.changeset/kind-kids-listen.md
+++ b/.changeset/kind-kids-listen.md
@@ -14,7 +14,7 @@ Currently, non-public `import.meta.env` environment variables are replaced by a 
 
 The `experimental.staticImportMetaEnv` flag simplifies Astro's default behavior, making it easier to understand and use. Astro will no longer replace any `import.meta.env` environment variables with a `process.env` call, nor will it coerce values.
 
-To enable this feature, add the experimental flag in your Astro config and remove the now removed `rawEnvValues` if it was enabled:
+To enable this feature, add the experimental flag in your Astro config and remove `rawEnvValues` if it was enabled:
 
 ```diff
 // astro.config.mjs

--- a/.changeset/kind-kids-listen.md
+++ b/.changeset/kind-kids-listen.md
@@ -1,0 +1,35 @@
+---
+'astro': minor
+---
+
+Adds an experimental flag `staticImportMetaEnv` to disable replacement of `import.meta.env` values with `process.env` calls, and supersedes the `rawEnvValues` experimental flag
+
+Astro allows you to configure a [type-safe schema for your environment variables](https://docs.astro.build/en/guides/environment-variables/#type-safe-environment-variables), and converts variables imported via `astro:env` into the expected type.
+
+However, Astro by default turns non public `import.meta.env` values into `process.env` calls during the build, if the environment variable name is present in `process.env`.
+
+The `experimental.staticImportMetaEnv` flag disables this behavior, ensuring that `import.meta.env` values are always inlined.
+
+To enable this feature, add the experimental flag in your Astro config:
+
+```diff
+import { defineConfig } from "astro/config"
+
+export default defineConfig({
++  experimental: {
++    staticImportMetaEnv: true,
++  }
+})
+```
+
+This experimental flag supersedes the `experimental.rawEnvValues` flag, that you need to remove in your Astro config:
+
+```diff
+import { defineConfig } from "astro/config"
+
+export default defineConfig({
+-  experimental: {
+-    rawEnvValues: true,
+-  }
+})
+```

--- a/.changeset/kind-kids-listen.md
+++ b/.changeset/kind-kids-listen.md
@@ -2,13 +2,13 @@
 'astro': minor
 ---
 
-Adds an experimental flag `staticImportMetaEnv` to disable the replacement of `import.meta.env` values with `process.env` calls and their coercion of environment variable values. This supersedes the `rawEnvValues` experimental flag which is now removed.
+Adds an experimental flag `staticImportMetaEnv` to disable the replacement of `import.meta.env` values with `process.env` calls and their coercion of environment variable values. This supersedes the `rawEnvValues` experimental flag, which is now removed.
 
 Astro allows you to configure a [type-safe schema for your environment variables](https://docs.astro.build/en/guides/environment-variables/#type-safe-environment-variables), and converts variables imported via `astro:env` into the expected type. This is the recommended way to use environment variables in Astro, as it allows you to easily see and manage whether your variables are public or secret, available on the client or only on the server at build time, and the data type of your values.
 
 However, you can still access environment variables through `process.env` and `import.meta.env` directly when needed. This was the only way to use environment variables in Astro before `astro:env` was added in Astro 5.0, and Astro's default handling of `import.meta.env` includes some logic that was only needed for earlier versions of Astro.
 
-The `experimental.staticImportMetaEnv` flag updates the behavior of `import.meta.env` to align with [Vite's handling of environment variables](https://vite.dev/guide/env-and-mode.html#env-variables) and for better ease of use with Astro's current implementations and features. **This will become the default behavior in Astro 6.0** and this early preview is introduced as an experimental feature.
+The `experimental.staticImportMetaEnv` flag updates the behavior of `import.meta.env` to align with [Vite's handling of environment variables](https://vite.dev/guide/env-and-mode.html#env-variables) and for better ease of use with Astro's current implementations and features. **This will become the default behavior in Astro 6.0**, and this early preview is introduced as an experimental feature.
 
 Currently, non-public `import.meta.env` environment variables are replaced by a reference to `process.env`. Additionally, Astro may also convert the value type of your environment variables used through `import.meta.env`, which can prevent access to some values such as the strings `"true"` (which is converted to a boolean value), and `"1"` (which is converted to a number).
 
@@ -18,14 +18,14 @@ To enable this feature, add the experimental flag in your Astro config and remov
 
 ```diff
 // astro.config.mjs
-import { defineConfig } from "astro/config"
+import { defineConfig } from "astro/config";
 
 export default defineConfig({
 +  experimental: {
-+    staticImportMetaEnv: true,
--    rawEnvValues: false,   
++    staticImportMetaEnv: true
+-    rawEnvValues: false   
 +  }
-})
+});
 ```
 
 #### Updating your project
@@ -34,16 +34,16 @@ If you were relying on Astro's default coercion, you may need to update your pro
 
 ```diff
 // src/components/MyComponent.astro
-- const enabled: boolean = import.meta.env.ENABLED
-+ const enabled: boolean = import.meta.env.ENABLED === "true"
+- const enabled: boolean = import.meta.env.ENABLED;
++ const enabled: boolean = import.meta.env.ENABLED === "true";
 ```
 
 If you were relying on the transformation into `process.env` calls, you may need to update your project code to apply it manually:
 
 ```diff
 // src/components/MyComponent.astro
-- const enabled: boolean = import.meta.env.DB_PASSWORD
-+ const enabled: boolean = process.env.DB_PASSWORD
+- const enabled: boolean = import.meta.env.DB_PASSWORD;
++ const enabled: boolean = process.env.DB_PASSWORD;
 ```
 
 You may also need to update types:

--- a/.changeset/kind-kids-listen.md
+++ b/.changeset/kind-kids-listen.md
@@ -2,11 +2,11 @@
 'astro': minor
 ---
 
-Adds an experimental flag `staticImportMetaEnv` to disable replacement of `import.meta.env` values with `process.env` calls, and supersedes the `rawEnvValues` experimental flag
+Adds an experimental flag `staticImportMetaEnv` to disable replacement of `import.meta.env` values with `process.env` calls and their coercion, and supersedes the `rawEnvValues` experimental flag
 
 Astro allows you to configure a [type-safe schema for your environment variables](https://docs.astro.build/en/guides/environment-variables/#type-safe-environment-variables), and converts variables imported via `astro:env` into the expected type.
 
-However, Astro by default turns non public `import.meta.env` values into `process.env` calls during the build, if the environment variable name is present in `process.env`.
+However, Astro by default turns non public `import.meta.env` values into `process.env` calls during the build, if the environment variable name is present in `process.env`. It also converts your environment variables used through `import.meta.env` in some cases, and this can prevent access to some values such as the strings `"true"` (which is converted to a boolean value), and `"1"` (which is converted to a number).
 
 The `experimental.staticImportMetaEnv` flag disables this behavior, ensuring that `import.meta.env` values are always inlined.
 

--- a/.changeset/kind-kids-listen.md
+++ b/.changeset/kind-kids-listen.md
@@ -4,7 +4,7 @@
 
 Adds an experimental flag `staticImportMetaEnv` to disable the replacement of `import.meta.env` values with `process.env` calls and their coercion of environment variable values. This supersedes the `rawEnvValues` experimental flag which is now removed.
 
-Astro allows you to configure a [type-safe schema for your environment variables](/en/guides/environment-variables/#type-safe-environment-variables), and converts variables imported via `astro:env` into the expected type. This is the recommended way to use environment variables in Astro, as it allows you to easily see and manage whether your variables are public or secret, available on the client or only on the server at build time, and the data type of your values.
+Astro allows you to configure a [type-safe schema for your environment variables](https://docs.astro.build/en/guides/environment-variables/#type-safe-environment-variables), and converts variables imported via `astro:env` into the expected type. This is the recommended way to use environment variables in Astro, as it allows you to easily see and manage whether your variables are public or secret, available on the client or only on the server at build time, and the data type of your values.
 
 However, you can still access environment variables through `process.env` and `import.meta.env` directly when needed. This was the only way to use environment variables in Astro before `astro:env` was added in Astro 5.0, and Astro's default handling of `import.meta.env` includes some logic that was only needed for earlier versions of Astro.
 
@@ -68,4 +68,4 @@ interface ImportMeta {
 + }
 ```
 
-See the [experimental static `import.meta.env` documentation](https://docs.astro.build/en/reference/experimental-flags/static-import-meta-env/) for more information about this feature. You can learn more about using environment variables in Astro, including `astro:env`, in the [environment variables documentation](/en/guides/environment-variables/).
+See the [experimental static `import.meta.env` documentation](https://docs.astro.build/en/reference/experimental-flags/static-import-meta-env/) for more information about this feature. You can learn more about using environment variables in Astro, including `astro:env`, in the [environment variables documentation](https://docs.astro.build/en/guides/environment-variables/).

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -102,7 +102,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 		preserveScriptOrder: false,
 		liveContentCollections: false,
 		csp: false,
-		rawEnvValues: false,
+		staticImportMetaEnv: false,
 		chromeDevtoolsWorkspace: false,
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
@@ -502,7 +502,7 @@ export const AstroConfigSchema = z.object({
 				])
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.csp),
-			rawEnvValues: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.rawEnvValues),
+			staticImportMetaEnv: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.staticImportMetaEnv),
 			chromeDevtoolsWorkspace: z
 				.boolean()
 				.optional()

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -125,12 +125,11 @@ export async function createVite(
 	});
 
 	const srcDirPattern = convertPathToPattern(fileURLToPath(settings.config.srcDir));
-	// TODO: default to non coerced in Astro 7
-	const envLoader = createEnvLoader(
+	const envLoader = createEnvLoader({
 		mode,
-		settings.config,
-		settings.config.experimental.rawEnvValues,
-	);
+		config: settings.config,
+		useStatic: settings.config.experimental.staticImportMetaEnv,
+	});
 
 	// Start with the Vite configuration that Astro core needs
 	const commonConfig: vite.InlineConfig = {

--- a/packages/astro/src/env/env-loader.ts
+++ b/packages/astro/src/env/env-loader.ts
@@ -6,6 +6,10 @@ import type { AstroConfig } from '../types/public/index.js';
 // except that the first character cannot be a number.
 const isValidIdentifierRe = /^[_$a-zA-Z][\w$]*$/;
 
+/**
+ * From public env, returns private env. Each value may be stringified, transformed as `process.env`
+ * or coerced depending on options.
+ */
 function getPrivateEnv({
 	fullEnv,
 	viteConfig,

--- a/packages/astro/src/env/env-loader.ts
+++ b/packages/astro/src/env/env-loader.ts
@@ -6,12 +6,15 @@ import type { AstroConfig } from '../types/public/index.js';
 // except that the first character cannot be a number.
 const isValidIdentifierRe = /^[_$a-zA-Z][\w$]*$/;
 
-function getPrivateEnv(
-	fullEnv: Record<string, string>,
-	astroConfig: AstroConfig,
-	useRawValues: boolean,
-): Record<string, string> {
-	const viteConfig = astroConfig.vite;
+function getPrivateEnv({
+	fullEnv,
+	viteConfig,
+	useStatic,
+}: {
+	fullEnv: Record<string, string>;
+	viteConfig: AstroConfig['vite'];
+	useStatic: boolean;
+}): Record<string, string> {
 	let envPrefixes: string[] = ['PUBLIC_'];
 	if (viteConfig.envPrefix) {
 		envPrefixes = Array.isArray(viteConfig.envPrefix)
@@ -22,45 +25,51 @@ function getPrivateEnv(
 	const privateEnv: Record<string, string> = {};
 	for (const key in fullEnv) {
 		// Ignore public env var
-		if (isValidIdentifierRe.test(key) && envPrefixes.every((prefix) => !key.startsWith(prefix))) {
-			if (typeof process.env[key] !== 'undefined') {
-				let value = process.env[key];
-				// Replacements are always strings, so try to convert to strings here first
-				if (typeof value !== 'string') {
-					value = `${value}`;
-				}
-				// Boolean values should be inlined to support `export const prerender`
-				// We already know that these are NOT sensitive values, so inlining is safe
-				if (
-					!useRawValues &&
-					(value === '0' || value === '1' || value === 'true' || value === 'false')
-				) {
-					privateEnv[key] = value;
-				} else {
-					privateEnv[key] = `process.env.${key}`;
-				}
-			} else {
-				privateEnv[key] = JSON.stringify(fullEnv[key]);
+		if (!isValidIdentifierRe.test(key) || envPrefixes.some((prefix) => key.startsWith(prefix))) {
+			continue;
+		}
+		// Only replace with process.env if not static
+		// TODO: make static the default and only way to do this in Astro 6
+		if (!useStatic && typeof process.env[key] !== 'undefined') {
+			let value = process.env[key];
+			// Replacements are always strings, so try to convert to strings here first
+			if (typeof value !== 'string') {
+				value = `${value}`;
 			}
+			// Boolean values should be inlined to support `export const prerender`
+			// We already know that these are NOT sensitive values, so inlining is safe
+			if (value === '0' || value === '1' || value === 'true' || value === 'false') {
+				privateEnv[key] = value;
+			} else {
+				privateEnv[key] = `process.env.${key}`;
+			}
+		} else {
+			privateEnv[key] = JSON.stringify(fullEnv[key]);
 		}
 	}
 	return privateEnv;
 }
 
-function getEnv(mode: string, config: AstroConfig, useRawValues: boolean) {
+interface EnvLoaderOptions {
+	mode: string;
+	config: AstroConfig;
+	useStatic: boolean;
+}
+
+function getEnv({ mode, config, useStatic }: EnvLoaderOptions) {
 	const loaded = loadEnv(mode, config.vite.envDir ?? fileURLToPath(config.root), '');
-	const privateEnv = getPrivateEnv(loaded, config, useRawValues);
+	const privateEnv = getPrivateEnv({ fullEnv: loaded, viteConfig: config.vite, useStatic });
 
 	return { loaded, privateEnv };
 }
 
-export const createEnvLoader = (mode: string, config: AstroConfig, useRawValues: boolean) => {
-	let { loaded, privateEnv } = getEnv(mode, config, useRawValues);
+export const createEnvLoader = (options: EnvLoaderOptions) => {
+	let { loaded, privateEnv } = getEnv(options);
 	return {
 		get: () => {
 			// We refresh the env we have in case process.env has been updated since creating
 			// the env loader. That can happen in eg. integrations
-			({ loaded, privateEnv } = getEnv(mode, config, useRawValues));
+			({ loaded, privateEnv } = getEnv(options));
 			return loaded;
 		},
 		getPrivateEnv: () => privateEnv,

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2433,7 +2433,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * @name experimental.liveContentCollections
 		 * @type {boolean}
 		 * @default `false`
-		 * @version 5.x
+		 * @version 5.10
 		 * @description
 		 * Enables the use of live content collections.
 		 *
@@ -2441,23 +2441,22 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		liveContentCollections?: boolean;
 
 		/**
-		 * @name experimental.rawEnvValues
+		 * @name experimental.staticImportMetaEnv
 		 * @type {boolean}
 		 * @default `false`
-		 * @version 5.12
+		 * @version 5.13
 		 * @description
 		 *
-		 * Disables coercion of `import.meta.env` values that are populated from `process.env`, allowing you to use the raw value.
-		 *
-		 * By default, Astro converts your environment variables used through `import.meta.env` in some cases, and this can prevent
-		 * access to some values such as the strings `"true"` (which is converted to a boolean value), and `"1"` (which is converted
-		 * to a number).
+		 * Disables replacement of `import.meta.env` values with `process.env` calls
+		 * 
+		 * By default, Astro turns non public `import.meta.env` values into `process.env` calls during the build, if the environment
+		 * variable name is present in `process.env`.
 		 *
 		 * This flag aligns `import.meta.env`'s behavior in Astro with [Vite](https://vite.dev/guide/env-and-mode.html#env-variables).
 		 *
-		 * See the [experimental raw environment variables guide](https://docs.astro.build/en/reference/experimental-flags/raw-env-values/) for more information.
+		 * See the [experimental static `import.meta.env` docs](https://docs.astro.build/en/reference/experimental-flags/static-import-meta-env/) for more information.
 		 */
-		rawEnvValues?: boolean;
+		staticImportMetaEnv?: boolean;
 		/**
 		 * @name experimental.chromeDevtoolsWorkspace
 		 * @type {boolean}

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2447,10 +2447,12 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * @version 5.13
 		 * @description
 		 *
-		 * Disables replacement of `import.meta.env` values with `process.env` calls and disables their coercion
-		 * 
+		 * Disables replacement of `import.meta.env` values with `process.env` calls and their coercion
+		 *
 		 * By default, Astro turns non public `import.meta.env` values into `process.env` calls during the build, if the environment
-		 * variable name is present in `process.env`.
+		 * variable name is present in `process.env`. It also converts your environment variables used through `import.meta.env` in
+		 * some cases, and this can prevent access to some values such as the strings `"true"` (which is converted to a boolean value),
+		 * and `"1"` (which is converted to a number).
 		 *
 		 * This flag aligns `import.meta.env`'s behavior in Astro with [Vite](https://vite.dev/guide/env-and-mode.html#env-variables).
 		 *

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2447,7 +2447,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * @version 5.13
 		 * @description
 		 *
-		 * Disables replacement of `import.meta.env` values with `process.env` calls
+		 * Disables replacement of `import.meta.env` values with `process.env` calls and disables their coercion
 		 * 
 		 * By default, Astro turns non public `import.meta.env` values into `process.env` calls during the build, if the environment
 		 * variable name is present in `process.env`.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2449,10 +2449,9 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 *
 		 * Disables replacement of `import.meta.env` values with `process.env` calls and their coercion
 		 *
-		 * By default, Astro turns non public `import.meta.env` values into `process.env` calls during the build, if the environment
-		 * variable name is present in `process.env`. It also converts your environment variables used through `import.meta.env` in
-		 * some cases, and this can prevent access to some values such as the strings `"true"` (which is converted to a boolean value),
-		 * and `"1"` (which is converted to a number).
+		 * Currently, non-public `import.meta.env` environment variables are replaced by a reference to `process.env`. Additionally, Astro may also convert the value type of your environment variables used through `import.meta.env`, which can prevent access to some values such as the strings `"true"` (which is converted to a boolean value), and `"1"` (which is converted to a number).
+		 *
+		 * The `experimental.staticImportMetaEnv` flag simplifies Astro's default behavior, making it easier to understand and use. Astro will no longer replace any `import.meta.env` environment variables with a `process.env` call, nor will it coerce values.
 		 *
 		 * This flag aligns `import.meta.env`'s behavior in Astro with [Vite](https://vite.dev/guide/env-and-mode.html#env-variables).
 		 *

--- a/packages/astro/test/fixtures/astro-envs/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-envs/astro.config.mjs
@@ -21,6 +21,6 @@ export default defineConfig({
 		],
 	},
 	experimental: {
-		rawEnvValues: true,
+		staticImportMetaEnv: true,
 	}
 });


### PR DESCRIPTION
## Changes

- Replaces the `rawEnvValues` experimental flag by `staticImportMetaEnv`
- Instead of just disabling the coercion, this flag disables the replacement of `import.meta.env.X` by `process.env.X` if `process.env.X` is available during the build

## Testing

Added test for the `process.env` replacement

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset + https://github.com/withastro/docs/pull/12105

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
