### PR TITLE
fix: retry upgrade with `--legacy-peer-deps` if npm has peer dep error

### DIFF
--- a/.changeset/dirty-gifts-march.md
+++ b/.changeset/dirty-gifts-march.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/upgrade': patch
+---
+
+Retry installation with `--legacy-peer-deps` if npm has peer dep error

--- a/packages/upgrade/src/actions/install.ts
+++ b/packages/upgrade/src/actions/install.ts
@@ -28,6 +28,7 @@ export async function install(
 		Context,
 		'version' | 'packages' | 'packageManager' | 'prompt' | 'dryRun' | 'exit' | 'cwd'
 	>,
+	shellFn: typeof shell = shell,
 ) {
 	await banner();
 	newline();
@@ -80,7 +81,7 @@ export async function install(
 	if (ctx.dryRun) {
 		await info('--dry-run', `Skipping dependency installation`);
 	} else {
-		await runInstallCommand(ctx, dependencies, devDependencies);
+		await runInstallCommand(ctx, dependencies, devDependencies, shellFn);
 	}
 }
 
@@ -119,6 +120,7 @@ async function runInstallCommand(
 	ctx: Pick<Context, 'cwd' | 'packageManager' | 'exit'>,
 	dependencies: PackageInfo[],
 	devDependencies: PackageInfo[],
+	shellFn: typeof shell = shell,
 ) {
 	const cwd = fileURLToPath(ctx.cwd);
 	if (ctx.packageManager.name === 'yarn') await ensureYarnLock({ cwd });
@@ -133,7 +135,7 @@ async function runInstallCommand(
 	const doInstall = async (legacyPeerDeps = false) => {
 		try {
 			if (dependencies.length > 0) {
-				await shell(
+				await shellFn(
 					installCommand.command,
 					[
 						...installCommand.args,
@@ -146,7 +148,7 @@ async function runInstallCommand(
 				);
 			}
 			if (devDependencies.length > 0) {
-				await shell(
+				await shellFn(
 					installCommand.command,
 					[
 						...installCommand.args,


### PR DESCRIPTION
## Changes

npm is very fussy with peer dependencies, and can easily end up with false positives in its checks when upgrading Astro packages. This is particularly likely when upgrading Astro alongside another package that has a peer dependency on it.

This PR checks to see if installs failed because of a peer dependency issue, and if so retries with the `--legacy-peer-deps` flag

Fixes #13884

## Testing

Added test, and tested manually with the repro from #13884.

To create the test I needed to add support for mocking the shell function. Module mocking isn't supported in Node < 24, so I did it by allowing an optional shell funciton arg to be passed to the install command.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
