### PR TITLE
test: enable test for style preprocess error line highlighting

### DIFF
--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -81,8 +81,7 @@ test.describe('Error display', () => {
 		expect(fileLocation).toMatch(/^vue\/VueRuntimeError.vue/);
 	});
 
-	// TODO: unskip when upgrading to Vite 6.0.0-beta.7 or above
-	test.skip('shows correct line when a style preprocess has an error', async ({ page, astro }) => {
+	test('shows correct line when a style preprocess has an error', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/astro-sass-error'), { waitUntil: 'networkidle' });
 
 		const { fileLocation, absoluteFileLocation } = await getErrorOverlayContent(page);


### PR DESCRIPTION
## Changes

Now a newer version of Vite is being used, and the test works correctly locally, so I want to see if it passes in CI to determine if it’s safe to re-enable it

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
