### PR TITLE
fix(db): update types for AstroDB to align with new drizzle-orm types

### DIFF
--- a/.changeset/wicked-animals-flow.md
+++ b/.changeset/wicked-animals-flow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Fix: Update types for AstroDB to drizzle table conversion to properly align with new drizzle-orm types.

--- a/packages/db/src/runtime/types.ts
+++ b/packages/db/src/runtime/types.ts
@@ -4,7 +4,7 @@ import type { ColumnsConfig, DBColumn, OutputColumnsConfig } from '../core/types
 
 type GeneratedConfig<T extends ColumnDataType = ColumnDataType> = Pick<
 	ColumnBaseConfig<T, string>,
-	'name' | 'tableName' | 'notNull' | 'hasDefault'
+	'name' | 'tableName' | 'notNull' | 'hasDefault' | 'hasRuntimeDefault' | 'isPrimaryKey'
 >;
 
 type AstroText<T extends GeneratedConfig<'string'>> = SQLiteColumn<
@@ -15,9 +15,9 @@ type AstroText<T extends GeneratedConfig<'string'>> = SQLiteColumn<
 		driverParam: string;
 		enumValues: never;
 		baseColumn: never;
-		isPrimaryKey: boolean;
 		isAutoincrement: boolean;
-		hasRuntimeDefault: boolean;
+        identity: undefined;
+        generated: undefined;
 	}
 >;
 
@@ -29,9 +29,9 @@ type AstroDate<T extends GeneratedConfig<'custom'>> = SQLiteColumn<
 		driverParam: string;
 		enumValues: never;
 		baseColumn: never;
-		isPrimaryKey: boolean;
 		isAutoincrement: boolean;
-		hasRuntimeDefault: boolean;
+        identity: undefined;
+        generated: undefined;
 	}
 >;
 
@@ -43,9 +43,9 @@ type AstroBoolean<T extends GeneratedConfig<'boolean'>> = SQLiteColumn<
 		driverParam: number;
 		enumValues: never;
 		baseColumn: never;
-		isPrimaryKey: boolean;
 		isAutoincrement: boolean;
-		hasRuntimeDefault: boolean;
+        identity: undefined;
+        generated: undefined;
 	}
 >;
 
@@ -57,9 +57,9 @@ type AstroNumber<T extends GeneratedConfig<'number'>> = SQLiteColumn<
 		driverParam: number;
 		enumValues: never;
 		baseColumn: never;
-		isPrimaryKey: boolean;
 		isAutoincrement: boolean;
-		hasRuntimeDefault: boolean;
+        identity: undefined;
+        generated: undefined;
 	}
 >;
 
@@ -71,9 +71,9 @@ type AstroJson<T extends GeneratedConfig<'custom'>> = SQLiteColumn<
 		driverParam: string;
 		enumValues: never;
 		baseColumn: never;
-		isPrimaryKey: boolean;
 		isAutoincrement: boolean;
-		hasRuntimeDefault: boolean;
+        identity: undefined;
+        generated: undefined;
 	}
 >;
 
@@ -102,11 +102,17 @@ export type Table<
 			{
 				tableName: TTableName;
 				name: K;
+				isPrimaryKey: TColumns[K]['schema'] extends { primaryKey: true }
+					? true
+					: false;
 				hasDefault: TColumns[K]['schema'] extends { default: NonNullable<unknown> }
 					? true
 					: TColumns[K]['schema'] extends { primaryKey: true }
 						? true
 						: false;
+				hasRuntimeDefault: TColumns[K]['schema'] extends { default: NonNullable<unknown> }
+					? true
+					: false;
 				notNull: TColumns[K]['schema']['optional'] extends true ? false : true;
 			}
 		>;

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -8,7 +8,7 @@ export function asDrizzleTable<
 	TableName extends string = string,
 	TColumns extends ColumnsConfig = ColumnsConfig,
 >(name: TableName, tableConfig: TableConfig<TColumns>) {
-	return internal_asDrizzleTable(name, tableSchema.parse(tableConfig)) as unknown as Table<
+	return internal_asDrizzleTable(name, tableSchema.parse(tableConfig)) as Table<
 		TableName,
 		TColumns
 	>;


### PR DESCRIPTION
## Changes

Fix AstroDB `asDrizzleTable` and schema conversion to correctly align table types with `drizzle-orm` to prevent loss of variables during type inference.

- Closes #13886

Before:
<img width="852" height="590" alt="image" src="https://github.com/user-attachments/assets/c09f7b3e-d42c-47fd-9ad0-b64981c2dfde" />

After: 
<img width="852" height="590" alt="image" src="https://github.com/user-attachments/assets/2c74612f-94b5-4dc9-9a7e-eb2ec6c0aabe" />

## Testing

No tests added, this is a type only change to correct previously broken types.

## Docs

This fixes previously broken types.  No doc changes needed.
