### PR TITLE
ci: move from windows-2025 to windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        # windows-latest is still windows-2022 for some reason, even though the windows-2025 image is GA
-        OS: [ubuntu-latest, windows-2025]
+        OS: [ubuntu-latest, windows-latest]
         NODE_VERSION: [22]
       fail-fast: true
     steps:
@@ -114,7 +113,7 @@ jobs:
         include:
           - os: macos-14
             NODE_VERSION: 22
-          - os: windows-2025
+          - os: windows-latest
             NODE_VERSION: 22
       fail-fast: false
     env:
@@ -151,7 +150,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        OS: [ubuntu-latest, windows-2025]
+        OS: [ubuntu-latest, windows-latest]
         NODE_VERSION: [22]
       fail-fast: false
     env:
@@ -188,7 +187,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        OS: [ubuntu-latest, windows-2025]
+        OS: [ubuntu-latest, windows-latest]
         NODE_VERSION: [22]
     env:
       NODE_VERSION: ${{ matrix.NODE_VERSION }}


### PR DESCRIPTION

## Changes

The Windows image label is changed, as that label is currently being migrated to windows-2025 (https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
