### PR TITLE
feat(db): Adds enum support to text column

### DIFF
--- a/.changeset/little-apples-serve.md
+++ b/.changeset/little-apples-serve.md
@@ -1,5 +1,25 @@
 ---
-'@astrojs/db': patch
+'@astrojs/db': minor
 ---
 
 Adds support for enum support for text columns in Astro DB tables.
+
+```ts
+import { column, defineTable } from 'astro:db';
+
+// Table definition
+const UserTable = defineTable({
+	columns: {
+		id: column.number({ primaryKey: true }),
+		name: column.text(),
+        rank: column.text({ enum: ['user', 'mod', 'admin'] }),
+	},
+});
+
+// Type definition
+type UserTableInferInsert = {
+    id: string;
+    name: string;
+    rank: "user" | "mod" | "admin";
+}
+```

--- a/.changeset/little-apples-serve.md
+++ b/.changeset/little-apples-serve.md
@@ -16,7 +16,7 @@ const UserTable = defineTable({
 	},
 });
 
-// Type definition
+// Resulting type definition
 type UserTableInferInsert = {
     id: string;
     name: string;

--- a/.changeset/little-apples-serve.md
+++ b/.changeset/little-apples-serve.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Adds support for enums on column.text() to table types

--- a/.changeset/little-apples-serve.md
+++ b/.changeset/little-apples-serve.md
@@ -2,4 +2,4 @@
 '@astrojs/db': patch
 ---
 
-Adds support for enums on column.text() to table types
+Adds support for enum support for text columns in Astro DB tables.

--- a/packages/db/src/core/schemas.ts
+++ b/packages/db/src/core/schemas.ts
@@ -84,6 +84,7 @@ const textColumnBaseSchema = baseColumnSchema
 	.extend({
 		default: z.union([z.string(), sqlSchema]).optional(),
 		multiline: z.boolean().optional(),
+		enum: z.tuple([z.string()]).rest(z.string()).optional(), // At least one value required,
 	})
 	.and(
 		z.union([

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -94,7 +94,7 @@ function columnMapper(columnName: string, column: DBColumn) {
 
 	switch (column.type) {
 		case 'text': {
-			c = text(columnName);
+			c = text(columnName, { enum: column.schema.enum });
 			// Duplicate default logic across cases to preserve type inference.
 			// No clean generic for every column builder.
 			if (column.schema.default !== undefined)

--- a/packages/db/src/runtime/types.ts
+++ b/packages/db/src/runtime/types.ts
@@ -82,18 +82,18 @@ type AstroJson<T extends GeneratedConfig<'custom'>> = SQLiteColumn<
 
 type Column<
 	T extends DBColumn['type'],
-	S extends [string, ...string[]] | never,
-	G extends GeneratedConfig,
+	E extends [string, ...string[]] | never,
+	S extends GeneratedConfig,
 > = T extends 'boolean'
-	? AstroBoolean<G>
+	? AstroBoolean<S>
 	: T extends 'number'
-		? AstroNumber<G>
+		? AstroNumber<S>
 		: T extends 'text'
-			? AstroText<G, S extends infer S ? (S extends [string, ...string[]] ? S : never) : never>
+			? AstroText<S, E extends infer F ? (F extends [string, ...string[]] ? F : never) : never>
 			: T extends 'date'
-				? AstroDate<G>
+				? AstroDate<S>
 				: T extends 'json'
-					? AstroJson<G>
+					? AstroJson<S>
 					: never;
 
 export type Table<

--- a/packages/db/src/runtime/types.ts
+++ b/packages/db/src/runtime/types.ts
@@ -4,12 +4,7 @@ import type { ColumnsConfig, DBColumn, OutputColumnsConfig } from '../core/types
 
 type GeneratedConfig<T extends ColumnDataType = ColumnDataType> = Pick<
 	ColumnBaseConfig<T, string>,
-	| 'name'
-	| 'tableName'
-	| 'notNull'
-	| 'hasDefault'
-	| 'hasRuntimeDefault'
-	| 'isPrimaryKey'
+	'name' | 'tableName' | 'notNull' | 'hasDefault' | 'hasRuntimeDefault' | 'isPrimaryKey'
 >;
 
 type AstroText<
@@ -17,9 +12,7 @@ type AstroText<
 	D extends [string, ...string[]] | never,
 > = SQLiteColumn<
 	T & {
-		data: D extends [string, ...string[]]
-			? D[number] // Convert tuple to union
-			: string;
+		data: D extends [string, ...string[]] ? D[number] : string;
 		dataType: 'string';
 		columnType: 'SQLiteText';
 		driverParam: string;
@@ -113,7 +106,9 @@ export type Table<
 	columns: {
 		[K in Extract<keyof TColumns, string>]: Column<
 			TColumns[K]['type'],
-			TColumns[K]['schema'] extends { enum: [string, ...string[]] } ? TColumns[K]['schema']['enum'] : never,
+			TColumns[K]['schema'] extends { enum: [string, ...string[]] }
+				? TColumns[K]['schema']['enum']
+				: never,
 			{
 				tableName: TTableName;
 				name: K;

--- a/packages/db/src/runtime/types.ts
+++ b/packages/db/src/runtime/types.ts
@@ -4,16 +4,21 @@ import type { ColumnsConfig, DBColumn, OutputColumnsConfig } from '../core/types
 
 type GeneratedConfig<T extends ColumnDataType = ColumnDataType> = Pick<
 	ColumnBaseConfig<T, string>,
-	'name' | 'tableName' | 'notNull' | 'hasDefault' | 'hasRuntimeDefault' | 'isPrimaryKey'
+	| 'name'
+	| 'tableName'
+	| 'notNull'
+	| 'hasDefault'
+	| 'hasRuntimeDefault'
+	| 'isPrimaryKey'
+	| 'enumValues'
+	| 'data'
 >;
 
 type AstroText<T extends GeneratedConfig<'string'>> = SQLiteColumn<
 	T & {
-		data: string;
 		dataType: 'string';
 		columnType: 'SQLiteText';
 		driverParam: string;
-		enumValues: never;
 		baseColumn: never;
 		isAutoincrement: boolean;
 		identity: undefined;
@@ -23,11 +28,9 @@ type AstroText<T extends GeneratedConfig<'string'>> = SQLiteColumn<
 
 type AstroDate<T extends GeneratedConfig<'custom'>> = SQLiteColumn<
 	T & {
-		data: Date;
 		dataType: 'custom';
 		columnType: 'SQLiteCustomColumn';
 		driverParam: string;
-		enumValues: never;
 		baseColumn: never;
 		isAutoincrement: boolean;
 		identity: undefined;
@@ -37,11 +40,9 @@ type AstroDate<T extends GeneratedConfig<'custom'>> = SQLiteColumn<
 
 type AstroBoolean<T extends GeneratedConfig<'boolean'>> = SQLiteColumn<
 	T & {
-		data: boolean;
 		dataType: 'boolean';
 		columnType: 'SQLiteBoolean';
 		driverParam: number;
-		enumValues: never;
 		baseColumn: never;
 		isAutoincrement: boolean;
 		identity: undefined;
@@ -51,11 +52,9 @@ type AstroBoolean<T extends GeneratedConfig<'boolean'>> = SQLiteColumn<
 
 type AstroNumber<T extends GeneratedConfig<'number'>> = SQLiteColumn<
 	T & {
-		data: number;
 		dataType: 'number';
 		columnType: 'SQLiteInteger';
 		driverParam: number;
-		enumValues: never;
 		baseColumn: never;
 		isAutoincrement: boolean;
 		identity: undefined;
@@ -65,11 +64,9 @@ type AstroNumber<T extends GeneratedConfig<'number'>> = SQLiteColumn<
 
 type AstroJson<T extends GeneratedConfig<'custom'>> = SQLiteColumn<
 	T & {
-		data: unknown;
 		dataType: 'custom';
 		columnType: 'SQLiteCustomColumn';
 		driverParam: string;
-		enumValues: never;
 		baseColumn: never;
 		isAutoincrement: boolean;
 		identity: undefined;
@@ -112,6 +109,26 @@ export type Table<
 					? true
 					: false;
 				notNull: TColumns[K]['schema']['optional'] extends true ? false : true;
+				enumValues: TColumns[K]['schema'] extends { enum: infer E }
+					? E extends [string, ...string[]]
+						? E
+						: never
+					: never;
+				data: TColumns[K]['type'] extends 'boolean'
+					? boolean
+					: TColumns[K]['type'] extends 'number'
+						? number
+						: TColumns[K]['type'] extends 'text'
+							? TColumns[K]['schema'] extends { enum: infer E }
+								? E extends [string, ...string[]]
+									? E[number] // Convert tuple to union
+									: string
+								: string
+							: TColumns[K]['type'] extends 'date'
+								? Date
+								: TColumns[K]['type'] extends 'json'
+									? unknown
+									: never;
 			}
 		>;
 	};

--- a/packages/db/src/runtime/types.ts
+++ b/packages/db/src/runtime/types.ts
@@ -9,14 +9,18 @@ type GeneratedConfig<T extends ColumnDataType = ColumnDataType> = Pick<
 
 type AstroText<
 	T extends GeneratedConfig<'string'>,
-	D extends [string, ...string[]] | never,
+	E extends [string, ...string[]] | never,
 > = SQLiteColumn<
 	T & {
-		data: D extends [string, ...string[]] ? D[number] : string;
+		data: E extends infer EnumValues
+			? EnumValues extends [string, ...string[]]
+				? EnumValues[number]
+				: never
+			: string;
 		dataType: 'string';
 		columnType: 'SQLiteText';
 		driverParam: string;
-		enumValues: D extends [string, ...string[]] ? D : never;
+		enumValues: E extends [string, ...string[]] ? E : never;
 		baseColumn: never;
 		isAutoincrement: boolean;
 		identity: undefined;
@@ -89,7 +93,7 @@ type Column<
 	: T extends 'number'
 		? AstroNumber<S>
 		: T extends 'text'
-			? AstroText<S, E extends infer F ? (F extends [string, ...string[]] ? F : never) : never>
+			? AstroText<S, E>
 			: T extends 'date'
 				? AstroDate<S>
 				: T extends 'json'


### PR DESCRIPTION
## Changes

Adds support for enums on the text column for AstroDB

## Testing

Not sure if there is a good way to test this, as per the [drizzle docs](https://orm.drizzle.team/docs/column-types/sqlite#text):

> You can define { enum: ["value1", "value2"] } config to infer insert and select types, it **won’t check runtime values**.

So i would assume it would need type testing similar to the [last PR](https://github.com/withastro/astro/pull/14186) I opened for db.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Currently there is no docs to specific features/options of the different columns, only ["shared options"](https://docs.astro.build/en/guides/integrations-guide/db/#columns)

If docs are required we should also be sure to document any other missing items from our schema.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
