### PR TITLE
fix: don't return metadata for SVGs outside Astro components

### DIFF
--- a/packages/astro/test/core-image-svg.test.js
+++ b/packages/astro/test/core-image-svg.test.js
@@ -149,5 +149,15 @@ describe('astro:assets - SVG Components', () => {
 				assert.ok(json.image.src.startsWith('/'));
 			});
 		});
+
+		describe('frameworks', () => {
+			it('does not process SVGs in framework components', async () => {
+				let res = await fixture.fetch('/framework');
+				let html = await res.text();
+				const $ = cheerio.load(html);
+				const $img = $('img');
+				assert.ok($img.attr('src').startsWith('data:image/svg+xml'));
+			});
+		});
 	});
 });

--- a/packages/astro/test/fixtures/core-image-svg/astro.config.mjs
+++ b/packages/astro/test/fixtures/core-image-svg/astro.config.mjs
@@ -1,6 +1,8 @@
 import mdx from '@astrojs/mdx';
 import { defineConfig } from 'astro/config';
 
+import preact from '@astrojs/preact';
+
 export default defineConfig({
-  integrations: [mdx()],
+  integrations: [mdx(), preact()],
 });

--- a/packages/astro/test/fixtures/core-image-svg/package.json
+++ b/packages/astro/test/fixtures/core-image-svg/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@astrojs/mdx": "workspace:*",
+    "@astrojs/preact": "^4.1.0",
     "astro": "workspace:*",
-    "@astrojs/mdx": "workspace:*"
+    "preact": "^10.27.0"
   },
   "scripts": {
     "dev": "astro dev"

--- a/packages/astro/test/fixtures/core-image-svg/src/components/PreactComponent.tsx
+++ b/packages/astro/test/fixtures/core-image-svg/src/components/PreactComponent.tsx
@@ -1,0 +1,13 @@
+/** @jsxImportSource preact */
+
+import plus from '../assets/plus.svg';
+
+/** A counter written with Preact */
+export function PreactCounter() {
+	console.log({plus})
+	return (
+		<div class="counter">
+			<img src={plus as unknown as string} />
+		</div>
+	);
+}

--- a/packages/astro/test/fixtures/core-image-svg/src/pages/framework.astro
+++ b/packages/astro/test/fixtures/core-image-svg/src/pages/framework.astro
@@ -1,0 +1,13 @@
+---
+import { PreactCounter } from "../components/PreactComponent.tsx"
+---
+<html>
+<head>
+
+</head>
+<body>
+	<div id="default">
+		<PreactCounter />
+	</div>
+</body>
+</html>

--- a/packages/astro/test/fixtures/core-image-svg/tsconfig.json
+++ b/packages/astro/test/fixtures/core-image-svg/tsconfig.json
@@ -7,5 +7,7 @@
         "src/assets/*"
       ]
     },
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2828,9 +2828,15 @@ importers:
       '@astrojs/mdx':
         specifier: workspace:*
         version: link:../../../../integrations/mdx
+      '@astrojs/preact':
+        specifier: ^4.1.0
+        version: link:../../../../integrations/preact
       astro:
         specifier: workspace:*
         version: link:../../..
+      preact:
+        specifier: ^10.27.0
+        version: 10.27.0
 
   packages/astro/test/fixtures/core-image-unconventional-settings:
     dependencies:
@@ -11382,6 +11388,7 @@ packages:
 
   libsql@0.5.4:
     resolution: {integrity: sha512-GEFeWca4SDAQFxjHWJBE6GK52LEtSskiujbG3rqmmeTO9t4sfSBKIURNLLpKDDF7fb7jmTuuRkDAn9BZGITQNw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
