### PR TITLE
fix: fix HMR for styles

### DIFF
--- a/.changeset/rare-suns-read.md
+++ b/.changeset/rare-suns-read.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that prevented HMR from working with inline styles

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -18,10 +18,22 @@ export default function hmrReload(): Plugin {
 
 				const invalidatedModules = new Set<EnvironmentModuleNode>();
 				for (const mod of modules) {
-					if (mod.id == null) continue;
-					const clientModule = server.environments.client.moduleGraph.getModuleById(mod.id);
-					if (clientModule != null) continue;
-
+					if (!mod.id) {
+						continue;
+					}
+					let clientModule = server.environments.client.moduleGraph.getModuleById(mod.id);
+					if (clientModule) {
+						continue;
+					}
+					if (mod.id.includes('?inline')) {
+						clientModule = server.environments.client.moduleGraph.getModuleById(
+							// check if the module is included without the ?inline flag
+							mod.id.replace('?inline&', '?').replace(/\?inline$/, ''),
+						);
+						if (clientModule) {
+							continue;
+						}
+					}
 					this.environment.moduleGraph.invalidateModule(mod, invalidatedModules, timestamp, true);
 					hasSsrOnlyModules = true;
 				}


### PR DESCRIPTION
## Changes

When deciding whether a module update needs a full reload, we check if the module is present in the client module graph. If it isn't, then it's SSR-only and needs a full reload. Inline styles are in the client module graph, but they weren't triggering HMR because the invalidated module includes an `?inline` flag, whereas the module in the client graph doesn't, so it wasn't found. This PR does a naive fix of also checking with the flag removed, but it feels like there should be a better approach. This doesn't work for external stylesheets, and it does raise the question of *why* it's not in the client graph with the correct id. Keeping this draft until a get some feedback on whether this approach is reasonable. 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
