### PR TITLE
fix(integrations): Improper code sanitization 

### DIFF
--- a/packages/integrations/mdx/src/rehype-collect-headings.ts
+++ b/packages/integrations/mdx/src/rehype-collect-headings.ts
@@ -1,11 +1,30 @@
 import type { VFile } from 'vfile';
 import { jsToTreeNode } from './utils.js';
 
+// Escape unsafe characters for safe code injection
+const charMap: Record<string, string> = {
+	'<': '\\u003C',
+	'>': '\\u003E',
+	'/': '\\u002F',
+	'\\': '\\\\',
+	'\b': '\\b',
+	'\f': '\\f',
+	'\n': '\\n',
+	'\r': '\\r',
+	'\t': '\\t',
+	'\0': '\\0',
+	'\u2028': '\\u2028',
+	'\u2029': '\\u2029'
+};
+function escapeUnsafeChars(str: string): string {
+	return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029/\\]/g, x => charMap[x] || x);
+}
+
 export function rehypeInjectHeadingsExport() {
 	return function (tree: any, file: VFile) {
 		const headings = file.data.astro?.headings ?? [];
 		tree.children.unshift(
-			jsToTreeNode(`export function getHeadings() { return ${JSON.stringify(headings)} }`),
+			jsToTreeNode(`export function getHeadings() { return ${escapeUnsafeChars(JSON.stringify(headings))} }`),
 		);
 	};
 }


### PR DESCRIPTION


fix the problem, we need to ensure that any potentially dangerous characters in the stringified headings are properly escaped before embedding them in the generated JavaScript code. The best way to do this is to escape characters such as `<`, `>`, `/`, `\`, and certain Unicode line/paragraph separators, as well as control characters, in the output of `JSON.stringify(headings)`. This can be achieved by defining an `escapeUnsafeChars` function (as in the example) and applying it to the stringified headings before constructing the export statement. The change should be made in `packages/integrations/mdx/src/rehype-collect-headings.ts`, specifically on line 8, and the function should be defined in the same file or imported if already available.