### PR TITLE
feat(db): add support for non-node libsql client

### DIFF
--- a/.changeset/full-dingos-repeat.md
+++ b/.changeset/full-dingos-repeat.md
@@ -1,0 +1,17 @@
+---
+'@astrojs/db': minor
+---
+
+Adds support for environments such as Cloudflare or Deno that require a non-node based libsql client.
+
+To utilize this new feature, you must add the following to your Astro Db config. This will enable the usage of the alterative LibSQL web driver. In most cases this should only be needed on Cloudflare or Deno type environments, and using the default mode `node` will be enough for normal usage.
+
+```ts
+import db from '@astrojs/db';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [db({ mode: 'web' })],
+});
+```

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -51,6 +51,7 @@ type VitePluginDBParams =
 			root: URL;
 			output: AstroConfig['output'];
 			seedHandler: SeedHandler;
+			mode: 'node' | 'web';
 	  };
 
 export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
@@ -77,6 +78,7 @@ export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 					tables: params.tables.get(),
 					isBuild: command === 'build',
 					output: params.output,
+					mode: params.mode,
 				});
 			}
 
@@ -137,11 +139,13 @@ export function getRemoteVirtualModContents({
 	appToken,
 	isBuild,
 	output,
+	mode
 }: {
 	tables: DBTables;
 	appToken: string;
 	isBuild: boolean;
 	output: AstroConfig['output'];
+	mode: 'node' | 'web';
 }) {
 	const dbInfo = getRemoteDatabaseInfo();
 
@@ -176,6 +180,7 @@ import {asDrizzleTable, createRemoteDatabaseClient} from ${RUNTIME_IMPORT};
 export const db = await createRemoteDatabaseClient({
   url: ${dbUrlArg()},
   token: ${appTokenArg()},
+  mode: ${JSON.stringify(mode)},
 });
 
 export * from ${RUNTIME_VIRTUAL_IMPORT};


### PR DESCRIPTION
## Changes

- Closes #13152

This PR solves the outstanding issue that was being caused by the usage of the `@libsql/client`'s default export of their node client, by introducing a new option to switch from the node client to the web client. Allowing users on platforms like Cloudflare to finally be able to use Astro DB since the Studio sunset.

## Testing

There is currently no tests testing external server connections. And im not sure how possible it would be to spin up a libsql server locally in CI for tests.

## Docs

CC @sarah11918 at your request i'm tagging you!