### PR TITLE
fix(db): Fix type casting for text column and enum handling

### DIFF
--- a/.changeset/eight-teeth-sniff.md
+++ b/.changeset/eight-teeth-sniff.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Fixes type casting for Astro DB tables.

--- a/.changeset/eight-teeth-sniff.md
+++ b/.changeset/eight-teeth-sniff.md
@@ -2,4 +2,4 @@
 '@astrojs/db': patch
 ---
 
-Fixes type casting for Astro DB tables.
+Fixes inferred types for Astro DB tables using `column.text` fields.

--- a/knip.js
+++ b/knip.js
@@ -39,6 +39,9 @@ export default {
 				'remark-code-titles',
 			],
 		},
+		'packages/db': {
+			entry: [testEntry, 'test/types/**/*'],
+		},
 		'packages/integrations/*': {
 			entry: [testEntry],
 		},

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -66,7 +66,9 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc && pnpm types:virtual",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.js\""
+    "test": "pnpm run test:integration && pnpm run test:types",
+    "test:integration": "astro-scripts test \"test/**/*.test.js\"",
+    "test:types": "tsc --project test/types/tsconfig.json"
   },
   "dependencies": {
     "@libsql/client": "^0.15.2",
@@ -85,6 +87,7 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.0.0",
+    "expect-type": "^1.2.0",
     "typescript": "^5.8.3",
     "vite": "^6.3.4"
   }

--- a/packages/db/src/runtime/types.ts
+++ b/packages/db/src/runtime/types.ts
@@ -9,14 +9,10 @@ type GeneratedConfig<T extends ColumnDataType = ColumnDataType> = Pick<
 
 type AstroText<
 	T extends GeneratedConfig<'string'>,
-	E extends [string, ...string[]] | never,
+	E extends readonly [string, ...string[]] | string,
 > = SQLiteColumn<
 	T & {
-		data: E extends infer EnumValues
-			? EnumValues extends [string, ...string[]]
-				? EnumValues[number]
-				: never
-			: string;
+		data: E extends readonly (infer U)[] ? U : string;
 		dataType: 'string';
 		columnType: 'SQLiteText';
 		driverParam: string;
@@ -86,7 +82,7 @@ type AstroJson<T extends GeneratedConfig<'custom'>> = SQLiteColumn<
 
 type Column<
 	T extends DBColumn['type'],
-	E extends [string, ...string[]] | never,
+	E extends readonly [string, ...string[]] | string,
 	S extends GeneratedConfig,
 > = T extends 'boolean'
 	? AstroBoolean<S>
@@ -110,9 +106,11 @@ export type Table<
 	columns: {
 		[K in Extract<keyof TColumns, string>]: Column<
 			TColumns[K]['type'],
-			TColumns[K]['schema'] extends { enum: [string, ...string[]] }
-				? TColumns[K]['schema']['enum']
-				: never,
+			TColumns[K]['schema'] extends { enum: infer E }
+				? E extends readonly [string, ...string[]]
+					? E
+					: string
+				: string,
 			{
 				tableName: TTableName;
 				name: K;

--- a/packages/db/src/runtime/virtual.ts
+++ b/packages/db/src/runtime/virtual.ts
@@ -27,7 +27,7 @@ export const column = {
 	boolean: <T extends BooleanColumnInput['schema']>(opts: T = {} as T) => {
 		return createColumn('boolean', opts) satisfies { type: 'boolean' };
 	},
-	text: <T extends TextColumnOpts, const E extends T['enum'] extends readonly [string, ...string[]] ? T['enum'] : never>(opts: T & { enum?: E } = {} as T & { enum?: E }) => {
+	text: <T extends TextColumnOpts, const E extends T['enum'] extends readonly [string, ...string[]] ? Omit<T, 'enum'> & T['enum'] : T>(opts: E = {} as E) => {
 		return createColumn('text', opts) satisfies { type: 'text' };
 	},
 	date<T extends DateColumnInput['schema']>(opts: T = {} as T) {

--- a/packages/db/src/runtime/virtual.ts
+++ b/packages/db/src/runtime/virtual.ts
@@ -27,7 +27,7 @@ export const column = {
 	boolean: <T extends BooleanColumnInput['schema']>(opts: T = {} as T) => {
 		return createColumn('boolean', opts) satisfies { type: 'boolean' };
 	},
-	text: <T extends TextColumnOpts>(opts: T = {} as T) => {
+	text: <T extends TextColumnOpts, const E extends T['enum'] extends readonly [string, ...string[]] ? T['enum'] : never>(opts: T & { enum?: E } = {} as T & { enum?: E }) => {
 		return createColumn('text', opts) satisfies { type: 'text' };
 	},
 	date<T extends DateColumnInput['schema']>(opts: T = {} as T) {

--- a/packages/db/test/types/table.ts
+++ b/packages/db/test/types/table.ts
@@ -1,0 +1,124 @@
+import { describe, it } from 'node:test';
+import { expectTypeOf } from 'expect-type';
+import type {
+	column as TColumn,
+	defineTable as TDefineTable,
+} from '../../dist/_internal/runtime/virtual.d.ts';
+import { column as _column, defineTable as _defineTable } from '../../dist/runtime/virtual.js';
+import { asDrizzleTable } from '../../dist/utils.js';
+
+// Ensure the correct types are being used for tests...
+// This is a workaround due to the types being exported under /_internal/ path
+// and not under /runtime/ path.
+const column: typeof TColumn = _column;
+const defineTable: typeof TDefineTable = _defineTable;
+
+describe('Table Type Tests', () => {
+	it('basic table', async () => {
+		const testTable = defineTable({
+			columns: {
+				id: column.number({ primaryKey: true }),
+				name: column.text(),
+				createdAt: column.date(),
+			},
+		});
+
+		const tsTestTable = asDrizzleTable('testTable', testTable);
+
+		const inferInsert = tsTestTable.$inferInsert;
+		const inferSelect = tsTestTable.$inferSelect;
+
+		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+			name: string;
+			createdAt: Date;
+			id?: number | undefined;
+		}>();
+
+		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+			id: number;
+			name: string;
+			createdAt: Date;
+		}>();
+	});
+
+	it('table with optional column', async () => {
+		const optionalTable = defineTable({
+			columns: {
+				id: column.number({ primaryKey: true }),
+				name: column.text(),
+				description: column.text({ optional: true }),
+			},
+		});
+
+		const tsOptionalTable = asDrizzleTable('optionalTable', optionalTable);
+
+		const inferInsert = tsOptionalTable.$inferInsert;
+		const inferSelect = tsOptionalTable.$inferSelect;
+
+		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+			name: string;
+			id?: number | undefined;
+			description?: string | null | undefined;
+		}>();
+
+		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+			id: number;
+			name: string;
+			description: string | null;
+		}>();
+	});
+
+	it('table with enum column', async () => {
+		const enumTable = defineTable({
+			columns: {
+				id: column.number({ primaryKey: true }),
+				name: column.text(),
+				status: column.text({ enum: ['active', 'inactive'] }),
+			},
+		});
+
+		const tsEnumTable = asDrizzleTable('enumTable', enumTable);
+
+		const inferInsert = tsEnumTable.$inferInsert;
+		const inferSelect = tsEnumTable.$inferSelect;
+
+		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+			name: string;
+			id?: number | undefined;
+			status: 'active' | 'inactive';
+		}>();
+
+		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+			id: number;
+			name: string;
+			status: 'active' | 'inactive';
+		}>();
+	});
+
+	it('table with optional enum column', async () => {
+		const enumTable = defineTable({
+			columns: {
+				id: column.number({ primaryKey: true }),
+				name: column.text(),
+				status: column.text({ enum: ['active', 'inactive'], optional: true }),
+			},
+		});
+
+		const tsEnumTable = asDrizzleTable('enumTable', enumTable);
+
+		const inferInsert = tsEnumTable.$inferInsert;
+		const inferSelect = tsEnumTable.$inferSelect;
+
+		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+			name: string;
+			id?: number | undefined;
+			status?: 'active' | 'inactive' | null | undefined;
+		}>();
+
+		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+			id: number;
+			name: string;
+			status: 'active' | 'inactive' | null;
+		}>();
+	});
+});

--- a/packages/db/test/types/table.ts
+++ b/packages/db/test/types/table.ts
@@ -25,16 +25,13 @@ describe('Table Type Tests', () => {
 
 		const tsTestTable = asDrizzleTable('testTable', testTable);
 
-		type inferInsert = typeof tsTestTable.$inferInsert;
-		type inferSelect = typeof tsTestTable.$inferSelect;
-
-		expectTypeOf<inferInsert>().toEqualTypeOf<{
+		expectTypeOf(tsTestTable.$inferInsert).toEqualTypeOf<{
 			name: string;
 			createdAt: Date;
 			id?: number | undefined;
 		}>();
 
-		expectTypeOf<inferSelect>().toEqualTypeOf<{
+		expectTypeOf(tsTestTable.$inferSelect).toEqualTypeOf<{
 			id: number;
 			name: string;
 			createdAt: Date;
@@ -52,16 +49,13 @@ describe('Table Type Tests', () => {
 
 		const tsOptionalTable = asDrizzleTable('optionalTable', optionalTable);
 
-		type inferInsert = typeof tsOptionalTable.$inferInsert;
-		type inferSelect = typeof tsOptionalTable.$inferSelect;
-
-		expectTypeOf<inferInsert>().toEqualTypeOf<{
+		expectTypeOf(tsOptionalTable.$inferInsert).toEqualTypeOf<{
 			name: string;
 			id?: number | undefined;
 			description?: string | null | undefined;
 		}>();
 
-		expectTypeOf<inferSelect>().toEqualTypeOf<{
+		expectTypeOf(tsOptionalTable.$inferSelect).toEqualTypeOf<{
 			id: number;
 			name: string;
 			description: string | null;
@@ -79,16 +73,13 @@ describe('Table Type Tests', () => {
 
 		const tsEnumTable = asDrizzleTable('enumTable', enumTable);
 
-		type inferInsert = typeof tsEnumTable.$inferInsert;
-		type inferSelect = typeof tsEnumTable.$inferSelect;
-
-		expectTypeOf<inferInsert>().toEqualTypeOf<{
+		expectTypeOf(tsEnumTable.$inferInsert).toEqualTypeOf<{
 			name: string;
 			id?: number | undefined;
 			status: 'active' | 'inactive';
 		}>();
 
-		expectTypeOf<inferSelect>().toEqualTypeOf<{
+		expectTypeOf(tsEnumTable.$inferSelect).toEqualTypeOf<{
 			id: number;
 			name: string;
 			status: 'active' | 'inactive';
@@ -106,16 +97,13 @@ describe('Table Type Tests', () => {
 
 		const tsEnumTable = asDrizzleTable('enumTable', enumTable);
 
-		type inferInsert = typeof tsEnumTable.$inferInsert;
-		type inferSelect = typeof tsEnumTable.$inferSelect;
-
-		expectTypeOf<inferInsert>().toEqualTypeOf<{
+		expectTypeOf(tsEnumTable.$inferInsert).toEqualTypeOf<{
 			name: string;
 			id?: number | undefined;
 			status?: 'active' | 'inactive' | null | undefined;
 		}>();
 
-		expectTypeOf<inferSelect>().toEqualTypeOf<{
+		expectTypeOf(tsEnumTable.$inferSelect).toEqualTypeOf<{
 			id: number;
 			name: string;
 			status: 'active' | 'inactive' | null;

--- a/packages/db/test/types/table.ts
+++ b/packages/db/test/types/table.ts
@@ -25,16 +25,16 @@ describe('Table Type Tests', () => {
 
 		const tsTestTable = asDrizzleTable('testTable', testTable);
 
-		const inferInsert = tsTestTable.$inferInsert;
-		const inferSelect = tsTestTable.$inferSelect;
+		type inferInsert = typeof tsTestTable.$inferInsert;
+		type inferSelect = typeof tsTestTable.$inferSelect;
 
-		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+		expectTypeOf<inferInsert>().toEqualTypeOf<{
 			name: string;
 			createdAt: Date;
 			id?: number | undefined;
 		}>();
 
-		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+		expectTypeOf<inferSelect>().toEqualTypeOf<{
 			id: number;
 			name: string;
 			createdAt: Date;
@@ -52,16 +52,16 @@ describe('Table Type Tests', () => {
 
 		const tsOptionalTable = asDrizzleTable('optionalTable', optionalTable);
 
-		const inferInsert = tsOptionalTable.$inferInsert;
-		const inferSelect = tsOptionalTable.$inferSelect;
+		type inferInsert = typeof tsOptionalTable.$inferInsert;
+		type inferSelect = typeof tsOptionalTable.$inferSelect;
 
-		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+		expectTypeOf<inferInsert>().toEqualTypeOf<{
 			name: string;
 			id?: number | undefined;
 			description?: string | null | undefined;
 		}>();
 
-		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+		expectTypeOf<inferSelect>().toEqualTypeOf<{
 			id: number;
 			name: string;
 			description: string | null;
@@ -79,16 +79,16 @@ describe('Table Type Tests', () => {
 
 		const tsEnumTable = asDrizzleTable('enumTable', enumTable);
 
-		const inferInsert = tsEnumTable.$inferInsert;
-		const inferSelect = tsEnumTable.$inferSelect;
+		type inferInsert = typeof tsEnumTable.$inferInsert;
+		type inferSelect = typeof tsEnumTable.$inferSelect;
 
-		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+		expectTypeOf<inferInsert>().toEqualTypeOf<{
 			name: string;
 			id?: number | undefined;
 			status: 'active' | 'inactive';
 		}>();
 
-		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+		expectTypeOf<inferSelect>().toEqualTypeOf<{
 			id: number;
 			name: string;
 			status: 'active' | 'inactive';
@@ -106,16 +106,16 @@ describe('Table Type Tests', () => {
 
 		const tsEnumTable = asDrizzleTable('enumTable', enumTable);
 
-		const inferInsert = tsEnumTable.$inferInsert;
-		const inferSelect = tsEnumTable.$inferSelect;
+		type inferInsert = typeof tsEnumTable.$inferInsert;
+		type inferSelect = typeof tsEnumTable.$inferSelect;
 
-		expectTypeOf<typeof inferInsert>().toEqualTypeOf<{
+		expectTypeOf<inferInsert>().toEqualTypeOf<{
 			name: string;
 			id?: number | undefined;
 			status?: 'active' | 'inactive' | null | undefined;
 		}>();
 
-		expectTypeOf<typeof inferSelect>().toEqualTypeOf<{
+		expectTypeOf<inferSelect>().toEqualTypeOf<{
 			id: number;
 			name: string;
 			status: 'active' | 'inactive' | null;

--- a/packages/db/test/types/tsconfig.json
+++ b/packages/db/test/types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "emitDeclarationOnly": false,
+    "noEmit": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4492,6 +4492,9 @@ importers:
       cheerio:
         specifier: 1.0.0
         version: 1.0.0
+      expect-type:
+        specifier: ^1.2.0
+        version: 1.2.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3


### PR DESCRIPTION
## Changes

Fixes type casting for text column and enum inference.

- Test Schema
<img width="494" height="205" alt="image" src="https://github.com/user-attachments/assets/188ba806-6822-4b70-a07d-5105cc4d6156" />

- Before
<img width="494" height="120" alt="image" src="https://github.com/user-attachments/assets/458d1b18-6b4e-4618-ab6a-6fd2593cff9e" />

- After
<img width="494" height="120" alt="image" src="https://github.com/user-attachments/assets/a60b5577-d4df-4f18-8149-b585f9cf1aa1" />


## Testing

Implement type testing for tables

## Docs

This fixes previously working behavior.