### PR TITLE
Suppress deprecation warnings for create-astro

### DIFF
--- a/packages/create-astro/create-astro.mjs
+++ b/packages/create-astro/create-astro.mjs
@@ -12,4 +12,6 @@ if (requiredMajorVersion < minimumMajorVersion) {
 	process.exit(1);
 }
 
+process.removeAllListeners('warning');
+
 import('./dist/index.js').then(({ main }) => main());

--- a/packages/create-astro/create-astro.mjs
+++ b/packages/create-astro/create-astro.mjs
@@ -12,6 +12,6 @@ if (requiredMajorVersion < minimumMajorVersion) {
 	process.exit(1);
 }
 
-process.removeAllListeners('warning');
+process.noDeprecation = true
 
 import('./dist/index.js').then(({ main }) => main());


### PR DESCRIPTION
## Changes

- Suppresses node deprecation warnings when running `npm create astro`
- We'll probably need to revisit our `fs` usage, but this is a quick fix for v24.5+

## Testing

N/A

## Docs

N/A