### PR TITLE
Fix `file()` loader JSON schema

### DIFF
--- a/.changeset/tender-cameras-follow.md
+++ b/.changeset/tender-cameras-follow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes JSON schema output for content collections using the `file()` loader

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -643,11 +643,25 @@ async function generateJSONSchema(
 		zodSchemaForJson = await getContentLayerSchema(collectionConfig, collectionKey);
 	}
 
+	// The `file()` loader uses a schema which applies to every item in the file rather than a schema
+	// for the whole file. We special case this to provide the correct JSON schema to users.
+	// TODO: it would be nice if loaders could indicate this behavior so it wasn’t unique to the built-in loader.
+	if (
+		collectionConfig.type === CONTENT_LAYER_TYPE &&
+		collectionConfig.loader.name === 'file-loader'
+	) {
+		// `file()` supports arrays of items, but you can’t set `$schema` when using a top-level array,
+		// so we’re only handling the object case.
+		// We use `z.object()` instead of `z.record()` for compatibility with the next `if` statement.
+		zodSchemaForJson = z.object({}).catchall(zodSchemaForJson);
+	}
+
 	if (zodSchemaForJson instanceof z.ZodObject) {
 		zodSchemaForJson = zodSchemaForJson.extend({
 			$schema: z.string().optional(),
 		});
 	}
+
 	try {
 		await fsMod.promises.writeFile(
 			new URL(`./${collectionKey.replace(/"/g, '')}.schema.json`, collectionSchemasDir),

--- a/packages/astro/test/content-intellisense.test.js
+++ b/packages/astro/test/content-intellisense.test.js
@@ -21,11 +21,11 @@ describe('Content Intellisense', () => {
 	});
 
 	it('generate JSON schemas for content collections', async () => {
-		assert.deepEqual(collectionsDir.includes('blog-cc.schema.json'), true);
+		assert.equal(collectionsDir.includes('blog-cc.schema.json'), true);
 	});
 
 	it('generate JSON schemas for content layer', async () => {
-		assert.deepEqual(collectionsDir.includes('blog-cl.schema.json'), true);
+		assert.equal(collectionsDir.includes('blog-cl.schema.json'), true);
 	});
 
 	it('manifest exists', async () => {

--- a/packages/astro/test/content-intellisense.test.js
+++ b/packages/astro/test/content-intellisense.test.js
@@ -28,6 +28,20 @@ describe('Content Intellisense', () => {
 		assert.equal(collectionsDir.includes('blog-cl.schema.json'), true);
 	});
 
+	it('generate JSON schemas for file loader', async () => {
+		assert.equal(collectionsDir.includes('data-cl.schema.json'), true);
+	});
+
+	it('generates a record JSON schema for the file loader', async () => {
+		const schema = JSON.parse(await fixture.readFile('../.astro/collections/data-cl.schema.json'));
+		assert.equal(schema.definitions['data-cl'].type, 'object');
+		assert.equal(schema.definitions['data-cl'].additionalProperties.type, 'object');
+		assert.deepEqual(schema.definitions['data-cl'].additionalProperties.properties, {
+			name: { type: 'string' },
+			color: { type: 'string' },
+		});
+	});
+
 	it('manifest exists', async () => {
 		assert.notEqual(manifest, undefined);
 	});

--- a/packages/astro/test/fixtures/content-intellisense/src/content.config.ts
+++ b/packages/astro/test/fixtures/content-intellisense/src/content.config.ts
@@ -1,4 +1,4 @@
-import { glob } from 'astro/loaders';
+import { glob, file } from 'astro/loaders';
 import { defineCollection, z } from 'astro:content';
 
 const blogCC = defineCollection({
@@ -18,7 +18,13 @@ const blogCL = defineCollection({
   }),
 });
 
+const dataCL = defineCollection({
+	loader: file('src/data-cl.yml'),
+	schema: z.object({ name: z.string(), color: z.string() }),
+})
+
 export const collections = {
 	"blog-cc": blogCC,
 	"blog-cl": blogCL,
+	"data-cl": dataCL,
 };

--- a/packages/astro/test/fixtures/content-intellisense/src/data-cl.yml
+++ b/packages/astro/test/fixtures/content-intellisense/src/data-cl.yml
@@ -1,0 +1,4 @@
+- name: Starlight
+  color: golden
+- name: Astro flame
+  color: red


### PR DESCRIPTION
## Changes

- Closes #13536 
- Fixes JSON schema output for content collections using the `file()` loader

## Testing

Added a new test in the `content-intellisense` fixture which checks that the schema produced for the file loader looks correct.

## Docs

N/A — just a bug fix