### PR TITLE
Fix automatic Chrome DevTools workspace feature

### DIFF
--- a/.changeset/wet-brooms-take.md
+++ b/.changeset/wet-brooms-take.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the `experimental.chromeDevtoolsWorkspace` feature.

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -164,9 +164,11 @@ export default function createVitePluginAstroServer({
 						config = JSON.parse(await readFile(configPath, 'utf-8'));
 					} catch {
 						config = {
-							version: '1.0',
-							projectId: randomUUID(),
-							workspaceRoot: fileURLToPath(settings.config.root),
+							workspace: {
+								version: '1.1',
+								uuid: randomUUID(),
+								root: fileURLToPath(settings.config.root),
+							},
 						};
 						await writeFile(configPath, JSON.stringify(config));
 					}

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -152,6 +152,7 @@ export default function createVitePluginAstroServer({
 						return;
 					}
 
+					const pluginVersion = '1.1';
 					const cacheDir = settings.config.cacheDir;
 					const configPath = new URL('./chrome-workspace.json', cacheDir);
 
@@ -162,10 +163,11 @@ export default function createVitePluginAstroServer({
 					let config;
 					try {
 						config = JSON.parse(await readFile(configPath, 'utf-8'));
+						if (config.version !== pluginVersion) throw new Error('Found outdated config.');
 					} catch {
 						config = {
 							workspace: {
-								version: '1.1',
+								version: pluginVersion,
 								uuid: randomUUID(),
 								root: fileURLToPath(settings.config.root),
 							},

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -163,7 +163,9 @@ export default function createVitePluginAstroServer({
 					let config;
 					try {
 						config = JSON.parse(await readFile(configPath, 'utf-8'));
-						if (config.version !== pluginVersion) throw new Error('Found outdated config.');
+						// If the cached workspace config was created with a previous version of this plugin,
+						// we throw an error so it gets recreated in the `catch` block below.
+						if (config.version !== pluginVersion) throw new Error('Cached config is outdated.');
 					} catch {
 						config = {
 							workspace: {

--- a/packages/astro/test/chrome-devtools-workspace.test.js
+++ b/packages/astro/test/chrome-devtools-workspace.test.js
@@ -27,11 +27,11 @@ describe('Chrome DevTools workspace', () => {
 			assert.equal(result.headers.get('content-type'), 'application/json');
 
 			const data = await result.json();
-			assert.equal(data.version, '1.0');
-			assert.equal(typeof data.projectId, 'string');
-			assert.equal(data.projectId.length, 36); // UUID length
-			assert.equal(typeof data.workspaceRoot, 'string');
-			assert.ok(data.workspaceRoot.includes('astro-dev-headers'));
+			assert.equal(data.workspace.version, '1.1');
+			assert.equal(typeof data.workspace.uuid, 'string');
+			assert.equal(data.workspace.uuid.length, 36); // UUID length
+			assert.equal(typeof data.workspace.root, 'string');
+			assert.ok(data.workspace.root.includes('astro-dev-headers'));
 		});
 	});
 


### PR DESCRIPTION
## Changes

- Fixes the experimental automatic Chrome DevTools workspace folders support added in Astro 5.13.0
- #14122 added this but for some reason used a data format that did not match what Chrome is actually looking for.
- Chrome [documents their `com.chrome.devtools.json` format](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md#solution) like this:
   ```json
   {
     "workspace": {
       "root": "/Users/foobar/Projects/my-awesome-web-project",
       "uuid": "53b029bb-c989-4dca-969b-835fecec3717"
     }
   }
   ```
- Before this PR our endpoint was responding with:
   ```json
   {
     "version": "1.0",
     "projectId": "53b029bb-c989-4dca-969b-835fecec3717"
     "workspaceRoot": "/Users/foobar/Projects/my-awesome-web-project",
   }
   ```
- These do not match 😁 
- This PR makes Astro return what Chrome wants when the experimental feature is enabled. (I also added logic to invalidate old dev tools configs as we currently cache these, so the invalid ones would hang around otherwise for anyone who has been trying out the feature.)

## Testing

Tested a local dev project to ensure Chrome actually detected the workspace with the changed output in this PR.

## Docs

N/A — bug fix