### PR TITLE
Tap view transitions

### DIFF
--- a/.changeset/young-hornets-post.md
+++ b/.changeset/young-hornets-post.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the "tap" prefetch strategy worked only on the first clicked link with view transitions enabled

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -53,7 +53,8 @@ export function init(defaultOpts?: InitOptions) {
  * Prefetch links with higher priority when the user taps on them
  */
 function initTapStrategy() {
-	for (const event of ['touchstart', 'mousedown']) {
+	const events = ['touchstart', 'mousedown'];
+	for (const event of events) {
 		document.body.addEventListener(
 			event,
 			(e) => {
@@ -64,6 +65,22 @@ function initTapStrategy() {
 			{ passive: true },
 		);
 	}
+
+	onPageLoad(() => {
+		for (const anchor of document.getElementsByTagName('a')) {
+			if (listenedAnchors.has(anchor)) continue;
+			if (elMatchesStrategy(anchor, 'tap')) {
+				listenedAnchors.add(anchor);
+				for (const event of events) {
+					anchor.addEventListener(
+						event,
+						(e) => prefetch((e.target as HTMLAnchorElement).href, { ignoreSlowConnection: true }),
+						{ passive: true },
+					);
+				}
+			}
+		}
+	});
 }
 
 /**


### PR DESCRIPTION
## Changes

The "tap" prefetch strategy was the only strategy that didn't call onPageLoad to attach event listeners to new elements. This caused "tap" to only work on the first clicked link when view transitions were enabled.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This behavior isn’t explicitly tested. No new tests were added since this PR only unifies "tap" with the other strategies.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No docs added since this is a bugfix.