### PR TITLE
chore(assets): compose source URL later

### DIFF
--- a/packages/astro/src/assets/endpoint/generic.ts
+++ b/packages/astro/src/assets/endpoint/generic.ts
@@ -50,7 +50,7 @@ export const GET: APIRoute = async ({ request }) => {
 			return new Response('Forbidden', { status: 403 });
 		}
 		
-		const sourceUrl = isRemoteImage && URL.canParse(transform.src) ? new URL(transform.src) : new URL(transform.src, url.origin);
+		const sourceUrl = new URL(transform.src, url.origin);
 		inputBuffer = await loadRemoteImage(sourceUrl, isRemoteImage ? new Headers() : request.headers);
 
 		if (!inputBuffer) {


### PR DESCRIPTION
## Changes

This PR fixes a failure in our tests:
- moves the creation of `sourceUrl` after we check if `transform.src` is a remote image and allowed
- we check if `transform.src` is a valid `URL`

## Testing

The failures should pass now.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
