### PR TITLE
fix(astro): action named apply

### DIFF
--- a/.changeset/wild-jeans-smash.md
+++ b/.changeset/wild-jeans-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where actions named 'apply' do not work due to being a function prototype method.

--- a/packages/astro/e2e/actions-blog.test.js
+++ b/packages/astro/e2e/actions-blog.test.js
@@ -165,4 +165,25 @@ test.describe('Astro Actions - Blog', () => {
 		const p = page.locator('p').nth(0);
 		await expect(p).toContainText('Form result: {"data":3}');
 	});
+
+	test('Apply action - success', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/apply'));
+
+		const form = page.getByTestId('apply-form');
+		const nameInput = form.locator('input[name="name"]');
+		const emailInput = form.locator('input[name="email"]');
+
+		// Fill out the form
+		await nameInput.fill('John Doe');
+		await emailInput.fill('john.doe@example.com');
+
+		const submitButton = form.getByRole('button');
+		await submitButton.click();
+
+		// Check that the form was submitted successfully
+		const result = page.getByTestId('result');
+		await expect(result).toBeVisible();
+		await expect(result).toContainText('John Doe');
+		await expect(result).toContainText('john.doe@example.com');
+	});
 });

--- a/packages/astro/e2e/fixtures/actions-blog/src/actions/index.ts
+++ b/packages/astro/e2e/fixtures/actions-blog/src/actions/index.ts
@@ -56,6 +56,17 @@ export const server = {
 			},
 		}),
 
+		apply: defineAction({
+			accept: 'form',
+			input: z.object({
+				name: z.string().min(2),
+				email: z.string().email(),
+			}),
+			handler: async ({ name, email }) => {
+				return { name, email, submitted: true };
+			},
+		}),
+
 		lotsOfStuff: defineAction({
 			accept: 'form',
 			input: z.object({

--- a/packages/astro/e2e/fixtures/actions-blog/src/components/ApplyForm.tsx
+++ b/packages/astro/e2e/fixtures/actions-blog/src/components/ApplyForm.tsx
@@ -1,0 +1,41 @@
+import { actions, isInputError } from 'astro:actions';
+import { useState } from 'react';
+
+export function ApplyForm() {
+	const [result, setResult] = useState<any>(null);
+
+	return (
+		<form
+			method="POST"
+			data-testid="apply-form"
+			action={actions.blog.apply.toString()}
+			onSubmit={async (e) => {
+				e.preventDefault();
+				const form = e.target as HTMLFormElement;
+				const formData = new FormData(form);
+				const { data, error } = await actions.blog.apply(formData);
+
+				if (error) {
+					console.error('Error:', error);
+				} else {
+					setResult(data);
+					form.reset();
+				}
+			}}
+		>
+			<label htmlFor="name">Name</label>
+			<input id="name" type="text" name="name" placeholder="Your name" />
+
+			<label htmlFor="email">Email</label>
+			<input id="email" type="email" name="email" placeholder="your.email@example.com" />
+
+			<button type="submit">Submit</button>
+
+			{result && (
+				<div data-testid="result">
+					<p>Submitted: {result.name} ({result.email})</p>
+				</div>
+			)}
+		</form>
+	);
+}

--- a/packages/astro/e2e/fixtures/actions-blog/src/pages/apply.astro
+++ b/packages/astro/e2e/fixtures/actions-blog/src/pages/apply.astro
@@ -1,0 +1,13 @@
+---
+import { ApplyForm } from '../components/ApplyForm';
+---
+
+<html>
+	<head>
+		<title>Apply</title>
+	</head>
+	<body>
+		<h1>Apply</h1>
+		<ApplyForm client:load />
+	</body>
+</html>

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -26,7 +26,8 @@ function toActionProxy(actionCallback = {}, aggregatedPath = '') {
 			Object.assign(action, {
 				queryString: getActionQueryString(path),
 				toString: () => action.queryString,
-				// define valueOf as the object's own property, not the prototype's
+				// redefine prototype methods as the object's own property, not the prototype's
+				bind: action.bind,
 				valueOf: () => action.valueOf,
 				// Progressive enhancement info for React.
 				$$FORM_ACTION: function () {

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -13,7 +13,7 @@ const ENCODED_DOT = '%2E';
 function toActionProxy(actionCallback = {}, aggregatedPath = '') {
 	return new Proxy(actionCallback, {
 		get(target, objKey) {
-			if (objKey in target || typeof objKey === 'symbol') {
+			if (target.hasOwnProperty(objKey) || typeof objKey === 'symbol') {
 				return target[objKey];
 			}
 			// Add the key, encoding dots so they're not interpreted as nested properties.

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -26,6 +26,8 @@ function toActionProxy(actionCallback = {}, aggregatedPath = '') {
 			Object.assign(action, {
 				queryString: getActionQueryString(path),
 				toString: () => action.queryString,
+				// define valueOf as the object's own property, not the prototype's
+				valueOf: () => action.valueOf,
 				// Progressive enhancement info for React.
 				$$FORM_ACTION: function () {
 					const searchParams = new URLSearchParams(action.toString());


### PR DESCRIPTION
Addresses https://github.com/withastro/astro/issues/13528
Closes https://github.com/withastro/astro/issues/13528

## Changes

- Fixes an issue where user actions could not be named apply (and, by extension, other function prototype names like call).
- Root cause: the proxy previously used objKey in target, which would return true even for properties on the function prototype chain.
  - This meant that an action named apply conflicted with the function prototype’s .apply method and couldn’t be used.
- Updated the check to target.hasOwnProperty(objKey).
  - Now only explicitly defined action properties are returned.
  - Result: user actions can now safely be named apply.
- This change hid Function.prototype.valueOf, which Astro’s runtime internally relies on when invoking actions in progressive enhancement fallback paths.
  - Fix: explicitly define valueOf as an own property on the action object.
  - Astro does not depend on .apply, .call, or .bind, so only .valueOf was patched.

⚠️ Trade‑off: 
- After this change, you can define an action named apply. 
- However, you cannot directly call .apply, .call, or any other prototype method on an action function.
- If this trade‑off isn’t desirable, an alternative would be to keep the original behavior and document that action names like apply, call, or bind are restricted.

## Testing

- Verified with an action named apply, matching the original bug report.
- Confirmed that progressive fallback (actions-blog.test.js) works correctly with the valueOf patch.

## Docs

This is a user-facing behavior change:
- Actions can now safely be named apply or call, but not bind.
- Function prototype methods (.apply, .call) are no longer usable on action functions.

/cc @withastro/maintainers-docs for input.
