### PR TITLE
fix(vercel): preserve leading slash in image optimization URLs for ESM imports

### DIFF
--- a/.changeset/wide-forks-wave.md
+++ b/.changeset/wide-forks-wave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix Vercel Image Optimization dropping leading slash in URL param for ESM imported images. Resolves issue where ESM imported images generated malformed URLs missing the leading slash, while string paths worked correctly.

--- a/.changeset/wide-forks-wave.md
+++ b/.changeset/wide-forks-wave.md
@@ -2,4 +2,4 @@
 '@astrojs/vercel': patch
 ---
 
-Fix Vercel Image Optimization dropping leading slash in URL param for ESM imported images. Resolves issue where ESM imported images generated malformed URLs missing the leading slash, while string paths worked correctly.
+Fix Vercel Image Optimization dropping leading slash in URL param for ESM imported images (#14250). Resolves issue where ESM imported images generated malformed URLs missing the leading slash, while string paths worked correctly.

--- a/packages/integrations/vercel/src/image/build-service.ts
+++ b/packages/integrations/vercel/src/image/build-service.ts
@@ -51,7 +51,7 @@ const service: ExternalImageService = {
 
 		// For non-SVG files, continue with the Vercel image processing
 		const fileSrc = isESMImportedImage(options.src)
-			? removeLeadingForwardSlash(options.src.src)
+			? options.src.src
 			: options.src;
 
 		const searchParams = new URLSearchParams();
@@ -63,9 +63,5 @@ const service: ExternalImageService = {
 		return '/_vercel/image?' + searchParams;
 	},
 };
-
-function removeLeadingForwardSlash(path: string) {
-	return path.startsWith('/') ? path.substring(1) : path;
-}
 
 export default service;

--- a/packages/integrations/vercel/test/image.test.js
+++ b/packages/integrations/vercel/test/image.test.js
@@ -23,7 +23,7 @@ describe('Image', () => {
 		const $ = cheerio.load(html);
 		const img = $('#basic-image img');
 
-		assert.equal(img.attr('src').startsWith('/_vercel/image?url=_astr'), true);
+		assert.equal(img.attr('src').startsWith('/_vercel/image?url=%2F_astr'), true);
 		assert.equal(img.attr('loading'), 'lazy');
 		assert.equal(img.attr('width'), '225');
 	});


### PR DESCRIPTION
## Changes

Fixes Vercel Image Optimization dropping leading slash in URL param for ESM imported images (#14250)

### What changed?
- Removed `removeLeadingForwardSlash()` call for ESM imported images in `@astrojs/vercel` build service
- Updated test expectations to verify correct URL format with preserved leading slash
- Removed unused `removeLeadingForwardSlash()` helper function

### Why?
ESM imported images (e.g., `import img from './image.jpg'`) were generating malformed `/_vercel/image` URLs missing the leading slash (`url=_astro%2F...` instead of `url=%2F_astro%2F...`), while string paths worked correctly. This caused the Vercel Image Optimization API to return `INVALID_IMAGE_OPTIMIZE_REQUEST` errors.

### Testing
-  All existing image tests pass 
-  Updated test now correctly expects URLs with leading slash preserved
-  Both ESM and string images now generate consistent, valid URLs

### Result
Before: `/_vercel/image?url=_astro%2Fimage.hash.jpg`  
After: `/_vercel/image?url=%2F_astro%2Fimage.hash.jpg` 

Fixes #14250