### PR TITLE
fix(cloudflare): don't warn when using in static build

### DIFF
--- a/.changeset/floppy-shoes-smell.md
+++ b/.changeset/floppy-shoes-smell.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Removes warning when using the adapter with a static build. 
+
+The Cloudflare adapter now has several uses outside of on-demand rendered pages, so this warning is misleading. Similar warnings have already been removed from other adapters.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -224,13 +224,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 			'astro:routes:resolved': ({ routes }) => {
 				_routes = routes;
 			},
-			'astro:config:done': ({ setAdapter, config, buildOutput, logger }) => {
-				if (buildOutput === 'static') {
-					logger.warn(
-						'[@astrojs/cloudflare] This adapter is intended to be used with server rendered pages, which this project does not contain any of. As such, this adapter is unnecessary.',
-					);
-				}
-
+			'astro:config:done': ({ setAdapter, config, buildOutput }) => {
 				_config = config;
 				finalBuildOutput = buildOutput;
 


### PR DESCRIPTION
## Changes

The Cloudflare adapter currently logs a warning if it is used with a static build. However there are valid reasons to use it for static builds. Similar warnings have already been removed from other adapters.

Fixes #14236

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
