### PR TITLE
docs: update name of automated changeset release PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,7 +335,7 @@ By default, `create-astro` and [astro.new](https://astro.new) point to this bran
 
 The repo is set up with automatic releases, using the changeset GitHub action & bot.
 
-To release a new version of Astro, find the `Version Packages` PR, read it over, and merge it.
+To release a new version of Astro, find the `[ci] release` PR, read it over, and merge it.
 
 ### Releasing PR preview snapshots
 


### PR DESCRIPTION
## Changes

Update small outdated info in `CONTRIBUTING.md`: `Version Packages` -> `[ci] release`
You can see that the title of the PR is not the default `Version Packages`, but `[ci] release` in the workflow:
https://github.com/withastro/astro/blob/02366e9ce38df8e7362817c095ff05ae61dc7b56/.github/workflows/release.yml#L55
(First contributions start small 🙌)

## Testing

We don't need tests for md files.

## Docs

We don't need docs for md files (intentionally not saying "We don't need docs for docs", because we have docs for docs 😅)
