### PR TITLE
fix: don't lose cookies in middleware sequences

### DIFF
--- a/.changeset/open-cities-make.md
+++ b/.changeset/open-cities-make.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused cookies to not be correctly set when using middleware sequences

--- a/packages/astro/src/core/middleware/sequence.ts
+++ b/packages/astro/src/core/middleware/sequence.ts
@@ -1,6 +1,5 @@
 import type { MiddlewareHandler, RewritePayload } from '../../types/public/common.js';
 import type { APIContext } from '../../types/public/context.js';
-import { AstroCookies } from '../cookies/cookies.js';
 import { ForbiddenRewrite } from '../errors/errors-data.js';
 import { AstroError } from '../errors/index.js';
 import { getParams, type Pipeline } from '../render/index.js';
@@ -78,7 +77,6 @@ export function sequence(...handlers: MiddlewareHandler[]): MiddlewareHandler {
 						carriedPayload = payload;
 						handleContext.request = newRequest;
 						handleContext.url = new URL(newRequest.url);
-						handleContext.cookies = new AstroCookies(newRequest);
 						handleContext.params = getParams(routeData, pathname);
 						handleContext.routePattern = routeData.route;
 						setOriginPathname(

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
@@ -2,12 +2,14 @@ import { sequence, defineMiddleware } from 'astro/middleware';
 
 const middleware1 = defineMiddleware((_, next) => next('/'));
 
-const middleware2 = defineMiddleware(async ({ request }, next) => {
+const middleware2 = defineMiddleware(async ({ request, cookies }, next) => {
+	cookies.set('cookie1', 'Cookie from middleware 1');
 	console.log(await request.clone().text());
 	return next();
 });
 
-const middleware3 = defineMiddleware(async ({ request }, next) => {
+const middleware3 = defineMiddleware(async ({ request, cookies }, next) => {
+	cookies.set('cookie2', 'Cookie from middleware 2');
 	await request.clone();
 	return next();
 });

--- a/packages/astro/test/fixtures/middleware-sequence-rewrite/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-sequence-rewrite/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	vite: {
+		plugins: [],
+	}
+});

--- a/packages/astro/test/fixtures/middleware-sequence-rewrite/package.json
+++ b/packages/astro/test/fixtures/middleware-sequence-rewrite/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/middleware-sequence-rewrite",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/middleware-sequence-rewrite/src/middleware.ts
+++ b/packages/astro/test/fixtures/middleware-sequence-rewrite/src/middleware.ts
@@ -1,0 +1,19 @@
+import type { MiddlewareHandler } from 'astro';
+import { sequence } from 'astro:middleware';
+
+export const mid1: MiddlewareHandler = async ({ cookies, url, rewrite, request }, next) => {
+	cookies.set('cookie1', 'Cookie from middleware 1');
+	if (url.pathname === '/') {
+		console.log('Rewriting');
+		return rewrite('/another');
+	}
+	return next();
+};
+
+export const mid2: MiddlewareHandler = async ({ cookies, url }, next) => {
+	cookies.set('cookie2', 'Cookie from middleware 2');
+	const res = next();
+	return res;
+};
+
+export const onRequest: MiddlewareHandler = sequence(mid1, mid2);

--- a/packages/astro/test/fixtures/middleware-sequence-rewrite/src/pages/another.astro
+++ b/packages/astro/test/fixtures/middleware-sequence-rewrite/src/pages/another.astro
@@ -1,0 +1,1 @@
+<h1>Hello Another</h1>

--- a/packages/astro/test/fixtures/middleware-sequence-rewrite/src/pages/index.astro
+++ b/packages/astro/test/fixtures/middleware-sequence-rewrite/src/pages/index.astro
@@ -1,0 +1,1 @@
+<h1>Hello Sequence</h1>

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -413,4 +413,35 @@ describe('Middleware should support clone request', () => {
 		const html = await res.text();
 		assert.equal(html.includes('Hello Sequence and Request Clone'), true);
 	});
+
+	it('should preserve cookies set in sequence', async () => {
+		const res = await fixture.fetch('/');
+		assert.ok(res.headers.get('set-cookie').includes('cookie1=Cookie%20from%20middleware%201'));
+		assert.ok(res.headers.get('set-cookie').includes('cookie2=Cookie%20from%20middleware%202'));
+	});
+});
+
+describe('Middleware sequence rewrites', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/middleware-sequence-rewrite/',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('should preserve cookies set in sequence', async () => {
+		const res = await fixture.fetch('/');
+		const html = await res.text();
+		assert.ok(html.includes('Hello Another'));
+		assert.ok(res.headers.get('set-cookie').includes('cookie1=Cookie%20from%20middleware%201'));
+		assert.ok(res.headers.get('set-cookie').includes('cookie2=Cookie%20from%20middleware%202'));
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3528,6 +3528,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/middleware-sequence-rewrite:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/middleware-ssg:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Currently if middleware includes rewrites, only the first middleware in a sequence that sets cookies is returned to the browser, and any cookies set in subsequent middleware is lost. This PR fixes that.

Fixes #14262

## Testing

Added tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
