### PR TITLE
Cf-node-import

### DIFF
--- a/.changeset/tame-cities-wear.md
+++ b/.changeset/tame-cities-wear.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a regression that broke sites that used the compile image service without nodejs_compat set

--- a/packages/integrations/cloudflare/src/entrypoints/image-endpoint.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/image-endpoint.ts
@@ -2,7 +2,7 @@
 import { imageConfig } from 'astro:assets';
 import { isRemotePath } from '@astrojs/internal-helpers/path';
 import type { APIRoute } from 'astro';
-import { isRemoteAllowed } from 'astro/assets/utils';
+import { isRemoteAllowed } from '@astrojs/internal-helpers/remote';
 
 export const prerender = false;
 

--- a/packages/integrations/cloudflare/test/fixtures/astro-env/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/astro-env/wrangler.toml
@@ -1,5 +1,4 @@
 name = "astro-env"
-compatibility_flags = ["nodejs_compat"]
 
 [vars]
 API_URL = "https://google.de"

--- a/packages/integrations/cloudflare/test/fixtures/compile-image-service/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/compile-image-service/wrangler.toml
@@ -1,1 +1,0 @@
-compatibility_flags = ["nodejs_compat"]

--- a/packages/integrations/cloudflare/test/fixtures/module-loader/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/module-loader/wrangler.toml
@@ -1,1 +1,0 @@
-compatibility_flags = ["nodejs_compat"]

--- a/packages/integrations/cloudflare/test/fixtures/with-solid-js/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/with-solid-js/wrangler.toml
@@ -1,1 +1,0 @@
-compatibility_flags = ["nodejs_compat"]

--- a/packages/integrations/cloudflare/test/fixtures/with-svelte/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/with-svelte/wrangler.toml
@@ -1,1 +1,0 @@
-compatibility_flags = ["nodejs_compat"]

--- a/packages/integrations/cloudflare/test/fixtures/with-vue/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/with-vue/wrangler.toml
@@ -1,1 +1,0 @@
-compatibility_flags = ["nodejs_compat"]

--- a/packages/integrations/cloudflare/test/fixtures/wrangler-preview-platform/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/wrangler-preview-platform/wrangler.toml
@@ -1,5 +1,4 @@
 name = "test"
-compatibility_flags = ["nodejs_compat"]
 
 [vars]
 COOL = "ME"

--- a/packages/integrations/cloudflare/test/wrangler-preview-platform.test.js
+++ b/packages/integrations/cloudflare/test/wrangler-preview-platform.test.js
@@ -19,7 +19,7 @@ describe('WranglerPreviewPlatform', () => {
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', _data.toString());
+				// console.log('[stderr]', data.toString());
 			});
 		});
 	});


### PR DESCRIPTION
## Changes

Fixes a regression that was causing node builtins to be accidentally included in Cloudlfare bundles. Reverts #14278, which was working around this.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
