### PR TITLE
feat(sitemap): add namespaces configuration option

### DIFF
--- a/.changeset/rich-insects-scream.md
+++ b/.changeset/rich-insects-scream.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/sitemap': minor
+---
+
+Add configurable XML namespaces support to sitemap generation
+
+- Add `namespaces` option to control which XML namespaces are included
+- Support for news, xhtml, image, and video namespaces
+- All namespaces enabled by default for backward compatibility

--- a/packages/integrations/sitemap/src/config-defaults.ts
+++ b/packages/integrations/sitemap/src/config-defaults.ts
@@ -3,4 +3,10 @@ import type { SitemapOptions } from './index.js';
 export const SITEMAP_CONFIG_DEFAULTS = {
 	filenameBase: 'sitemap',
 	entryLimit: 45000,
+	namespaces: {
+		news: true,
+		xhtml: true, 
+		image: true,
+		video: true,
+	},
 } satisfies SitemapOptions;

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -39,6 +39,14 @@ export type SitemapOptions =
 			serialize?(item: SitemapItem): SitemapItem | Promise<SitemapItem | undefined> | undefined;
 
 			xslURL?: string;
+			
+		// namespace configuration
+			namespaces?: {
+				news?: boolean;
+				xhtml?: boolean;
+				image?: boolean;
+				video?: boolean;
+			};
 	  }
 	| undefined;
 
@@ -180,6 +188,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							customSitemaps,
 							xslURL: xslURL,
 							lastmod,
+							namespaces: opts.namespaces,
 						},
 						config,
 					);

--- a/packages/integrations/sitemap/src/schema.ts
+++ b/packages/integrations/sitemap/src/schema.ts
@@ -37,6 +37,16 @@ export const SitemapOptionsSchema = z
 		changefreq: z.nativeEnum(ChangeFreq).optional(),
 		lastmod: z.date().optional(),
 		priority: z.number().min(0).max(1).optional(),
+
+		namespaces: z
+			.object({
+					news: z.boolean().optional(),
+					xhtml: z.boolean().optional(),
+					image: z.boolean().optional(),
+					video: z.boolean().optional(),
+			})
+			.optional()
+			.default(SITEMAP_CONFIG_DEFAULTS.namespaces),
 	})
 	.strict()
 	.default(SITEMAP_CONFIG_DEFAULTS);

--- a/packages/integrations/sitemap/src/write-sitemap.ts
+++ b/packages/integrations/sitemap/src/write-sitemap.ts
@@ -19,6 +19,12 @@ type WriteSitemapConfig = {
 	limit?: number;
 	xslURL?: string;
 	lastmod?: string;
+	namespaces?: {
+		news?: boolean;
+		xhtml?: boolean;
+		image?: boolean;
+		video?: boolean;
+	};
 };
 
 // adapted from sitemap.js/sitemap-simple
@@ -34,6 +40,7 @@ export async function writeSitemap(
 		publicBasePath = './',
 		xslURL: xslUrl,
 		lastmod,
+		namespaces = { news: true, xhtml: true, image: true, video: true },
 	}: WriteSitemapConfig,
 	astroConfig: AstroConfig,
 ) {
@@ -46,6 +53,13 @@ export async function writeSitemap(
 			const sitemapStream = new SitemapStream({
 				hostname,
 				xslUrl,
+				// Custom namespace handling
+				xmlns: {
+					news: namespaces?.news !== false,
+					xhtml: namespaces?.xhtml !== false,
+					image: namespaces?.image !== false,
+					video: namespaces?.video !== false,
+				},
 			});
 			const path = `./${filenameBase}-${i}.xml`;
 			const writePath = resolve(destinationDir, path);

--- a/packages/integrations/sitemap/test/namespaces.test.js
+++ b/packages/integrations/sitemap/test/namespaces.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { sitemap } from './fixtures/static/deps.mjs';
+import { loadFixture, readXML } from './test-utils.js';
+
+describe('Namespaces Configuration', () => {
+    let fixture;
+
+    describe('Default namespaces', () => {
+        before(async () => {
+            fixture = await loadFixture({
+                root: './fixtures/static/',
+                integrations: [sitemap()],
+            });
+            await fixture.build();
+        });
+
+        it('includes all default namespaces', async () => {
+            const xml = await fixture.readFile('/sitemap-0.xml');
+            assert.ok(xml.includes('xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"'));
+            assert.ok(xml.includes('xmlns:xhtml="http://www.w3.org/1999/xhtml"'));
+            assert.ok(xml.includes('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"'));
+            assert.ok(xml.includes('xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"'));
+        });
+    });
+
+    describe('Excluding news namespace', () => {
+        before(async () => {
+            fixture = await loadFixture({
+                root: './fixtures/static/',
+                integrations: [
+                    sitemap({
+                        namespaces: {
+                            news: false,
+                        },
+                    }),
+                ],
+            });
+            await fixture.build();
+        });
+
+        it('excludes news namespace but includes others', async () => {
+            const xml = await fixture.readFile('/sitemap-0.xml');
+            assert.ok(!xml.includes('xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"'));
+            assert.ok(xml.includes('xmlns:xhtml="http://www.w3.org/1999/xhtml"'));
+            assert.ok(xml.includes('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"'));
+            assert.ok(xml.includes('xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"'));
+        });
+    });
+
+    describe('Minimal namespaces', () => {
+        before(async () => {
+            fixture = await loadFixture({
+                root: './fixtures/static/',
+                integrations: [
+                    sitemap({
+                        namespaces: {
+                            news: false,
+                            xhtml: false,
+                            image: false,
+                            video: false,
+                        },
+                    }),
+                ],
+            });
+            await fixture.build();
+        });
+
+        it('excludes all optional namespaces', async () => {
+            const xml = await fixture.readFile('/sitemap-0.xml');
+            assert.ok(!xml.includes('xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"'));
+            assert.ok(!xml.includes('xmlns:xhtml="http://www.w3.org/1999/xhtml"'));
+            assert.ok(!xml.includes('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"'));
+            assert.ok(!xml.includes('xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"'));
+            // Still includes the main sitemap namespace
+            assert.ok(xml.includes('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'));
+        });
+    });
+});

--- a/packages/integrations/sitemap/test/namespaces.test.js
+++ b/packages/integrations/sitemap/test/namespaces.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import { sitemap } from './fixtures/static/deps.mjs';
-import { loadFixture, readXML } from './test-utils.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Namespaces Configuration', () => {
     let fixture;


### PR DESCRIPTION
Add support for customizing XML namespaces in generated sitemaps through a new namespaces configuration option. This allows users to exclude unused namespaces like xmlns:news for cleaner sitemap files.

- Add namespaces option to SitemapOptions type
- Update schema validation for namespaces configuration
- Implement namespace filtering in writeSitemap function
- Add comprehensive tests for namespace configuration
- Maintain backward compatibility with all namespaces enabled by default

## Changes

- Introduces a new namespaces option in the sitemap integration config.
- Users can now selectively enable/disable XML namespaces (news, xhtml, image, video) in generated sitemaps.
- Schema validation updated to support the new option.
- The sitemap XML output now reflects the selected namespaces.
- Adds tests to verify correct namespace inclusion/exclusion.
- Default behavior remains unchanged (all namespaces included).

## Testing

- Added unit and integration tests for all namespace configuration scenarios.
- Verified that disabling specific namespaces removes them from the output XML.
- Ensured backward compatibility by testing default config.

## Docs

- This change adds a new config option for users. Documentation should be updated to describe the namespaces option and provide usage examples.
- /cc @withastro/maintainers-docs for feedback!
