### PR TITLE
refactor(csp): move methods inside `csp` getter

### DIFF
--- a/.changeset/brown-jokes-hug.md
+++ b/.changeset/brown-jokes-hug.md
@@ -1,0 +1,20 @@
+---
+'astro': patch
+---
+
+**BREAKING CHANGES only to the experimental CSP feature**
+
+The following runtime APIs of the `Astro` global have been renamed:
+- `Astro.insertDirective` to `Astro.csp.insertDirective`
+- `Astro.insertStyleResource` to `Astro.csp.insertStyleResource`
+- `Astro.insertStyleHash` to `Astro.csp.insertStyleHash`
+- `Astro.insertScriptResource` to `Astro.csp.insertScriptResource`
+- `Astro.insertScriptHash` to `Astro.csp.insertScriptHash`
+
+
+The following runtime APIs of the `APIContext` have been renamed:
+- `ctx.insertDirective` to `ctx.csp.insertDirective`
+- `ctx.insertStyleResource` to `ctx.csp.insertStyleResource`
+- `ctx.insertStyleHash` to `ctx.csp.insertStyleHash`
+- `ctx.insertScriptResource` to `ctx.csp.insertScriptResource`
+- `ctx.insertScriptHash` to `ctx.csp.insertScriptHash`

--- a/packages/astro/src/actions/runtime/utils.ts
+++ b/packages/astro/src/actions/runtime/utils.ts
@@ -40,11 +40,7 @@ export type ActionAPIContext = Pick<
 	| 'preferredLocaleList'
 	| 'originPathname'
 	| 'session'
-	| 'insertDirective'
-	| 'insertScriptResource'
-	| 'insertStyleResource'
-	| 'insertScriptHash'
-	| 'insertStyleHash'
+	| 'csp'
 > & {
 	// TODO: remove in Astro 6.0
 	/**

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -5,7 +5,7 @@ import {
 	computePreferredLocaleList,
 } from '../../i18n/utils.js';
 import type { MiddlewareHandler, Params, RewritePayload } from '../../types/public/common.js';
-import type { APIContext } from '../../types/public/context.js';
+import type { APIContext, AstroSharedContextCsp } from '../../types/public/context.js';
 import { ASTRO_VERSION, clientLocalsSymbol } from '../constants.js';
 import { AstroCookies } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
@@ -123,11 +123,16 @@ function createContext({
 		set locals(_) {
 			throw new AstroError(AstroErrorData.LocalsReassigned);
 		},
-		insertDirective() {},
-		insertScriptResource() {},
-		insertStyleResource() {},
-		insertScriptHash() {},
-		insertStyleHash() {},
+		get csp(): AstroSharedContextCsp {
+			return {
+				insertDirective() {},
+				insertScriptResource() {},
+				insertStyleResource() {},
+				insertScriptHash() {},
+				insertStyleHash() {},
+			}			
+		}
+
 	};
 	return Object.assign(context, {
 		getActionResult: createGetActionResult(context.locals),

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -12,7 +12,12 @@ import { renderEndpoint } from '../runtime/server/endpoint.js';
 import { renderPage } from '../runtime/server/index.js';
 import type { ComponentInstance } from '../types/astro.js';
 import type { MiddlewareHandler, Props, RewritePayload } from '../types/public/common.js';
-import type { APIContext, AstroGlobal, AstroGlobalPartial } from '../types/public/context.js';
+import type {
+	APIContext,
+	AstroGlobal,
+	AstroGlobalPartial,
+	AstroSharedContextCsp,
+} from '../types/public/context.js';
 import type { RouteData, SSRResult } from '../types/public/internal.js';
 import type { SSRActions } from './app/types.js';
 import {
@@ -430,37 +435,41 @@ export class RenderContext {
 				}
 				return renderContext.session;
 			},
-			insertDirective(payload) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.directives.push(payload);
-			},
+			get csp(): AstroSharedContextCsp {
+				return {
+					insertDirective(payload) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.directives.push(payload);
+					},
 
-			insertScriptResource(resource) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.scriptResources.push(resource);
-			},
-			insertStyleResource(resource) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
+					insertScriptResource(resource) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.scriptResources.push(resource);
+					},
+					insertStyleResource(resource) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
 
-				renderContext.result?.styleResources.push(resource);
-			},
-			insertStyleHash(hash) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.styleHashes.push(hash);
-			},
-			insertScriptHash(hash) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.scriptHashes.push(hash);
+						renderContext.result?.styleResources.push(resource);
+					},
+					insertStyleHash(hash) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.styleHashes.push(hash);
+					},
+					insertScriptHash(hash) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.scriptHashes.push(hash);
+					},
+				};
 			},
 		};
 	}
@@ -695,37 +704,41 @@ export class RenderContext {
 			get originPathname() {
 				return getOriginPathname(renderContext.request);
 			},
-			insertDirective(payload) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.directives.push(payload);
-			},
+			get csp(): AstroSharedContextCsp {
+				return {
+					insertDirective(payload) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.directives.push(payload);
+					},
 
-			insertScriptResource(resource) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.scriptResources.push(resource);
-			},
-			insertStyleResource(resource) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
+					insertScriptResource(resource) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.scriptResources.push(resource);
+					},
+					insertStyleResource(resource) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
 
-				renderContext.result?.styleResources.push(resource);
-			},
-			insertStyleHash(hash) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.styleHashes.push(hash);
-			},
-			insertScriptHash(hash) {
-				if (!pipeline.manifest.csp) {
-					throw new AstroError(CspNotEnabled);
-				}
-				renderContext.result?.scriptHashes.push(hash);
+						renderContext.result?.styleResources.push(resource);
+					},
+					insertStyleHash(hash) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.styleHashes.push(hash);
+					},
+					insertScriptHash(hash) {
+						if (!pipeline.manifest.csp) {
+							throw new AstroError(CspNotEnabled);
+						}
+						renderContext.result?.scriptHashes.push(hash);
+					},
+				};
 			},
 		};
 	}

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -357,6 +357,13 @@ export interface AstroSharedContext<
 	isPrerendered: boolean;
 
 	/**
+	 * It exposes utilities to control CSP headers
+	 */
+	csp: AstroSharedContextCsp;
+}
+
+export type AstroSharedContextCsp = {
+	/**
 	 * It adds a specific CSP directive to the route being rendered.
 	 *
 	 * ## Example
@@ -410,7 +417,7 @@ export interface AstroSharedContext<
 	 * ```
 	 */
 	insertScriptHash: (hash: CspHash) => void;
-}
+};
 
 /**
  * The `APIContext` is the object made available to endpoints and middleware.

--- a/packages/astro/test/fixtures/csp-adapter/src/pages/scripts.astro
+++ b/packages/astro/test/fixtures/csp-adapter/src/pages/scripts.astro
@@ -1,7 +1,7 @@
 ---
-Astro.insertScriptResource("https://scripts.cdn.example.com");
-Astro.insertScriptHash('sha256-customHash');
-Astro.insertDirective("default-src 'self'");
+Astro.csp.insertScriptResource("https://scripts.cdn.example.com");
+Astro.csp.insertScriptHash('sha256-customHash');
+Astro.csp.insertDirective("default-src 'self'");
 ---
 
 <html lang="en">

--- a/packages/astro/test/fixtures/csp-adapter/src/pages/ssr.astro
+++ b/packages/astro/test/fixtures/csp-adapter/src/pages/ssr.astro
@@ -1,9 +1,9 @@
 ---
 export const prerender = false;
 
-Astro.insertStyleResource("https://styles.cdn.example.com");
-Astro.insertStyleHash('sha256-customHash');
-Astro.insertDirective("default-src 'self'");
+Astro.csp.insertStyleResource("https://styles.cdn.example.com");
+Astro.csp.insertStyleHash('sha256-customHash');
+Astro.csp.insertDirective("default-src 'self'");
 ---
 
 <html lang="en">

--- a/packages/astro/test/fixtures/csp/src/pages/scripts.astro
+++ b/packages/astro/test/fixtures/csp/src/pages/scripts.astro
@@ -1,7 +1,7 @@
 ---
-Astro.insertScriptResource("https://scripts.cdn.example.com");
-Astro.insertScriptHash('sha256-customHash');
-Astro.insertDirective("default-src 'self'");
+Astro.csp.insertScriptResource("https://scripts.cdn.example.com");
+Astro.csp.insertScriptHash('sha256-customHash');
+Astro.csp.insertDirective("default-src 'self'");
 ---
 
 <html lang="en">

--- a/packages/astro/test/fixtures/csp/src/pages/styles.astro
+++ b/packages/astro/test/fixtures/csp/src/pages/styles.astro
@@ -1,7 +1,7 @@
 ---
-Astro.insertStyleResource("https://styles.cdn.example.com");
-Astro.insertStyleHash('sha256-customHash');
-Astro.insertDirective("default-src 'self'");
+Astro.csp.insertStyleResource("https://styles.cdn.example.com");
+Astro.csp.insertStyleHash('sha256-customHash');
+Astro.csp.insertDirective("default-src 'self'");
 ---
 
 <html lang="en">


### PR DESCRIPTION
## Changes

This PR changes the runtime APIs added for CSP to be available from the getter `Astro.csp`/`ctx.csp`

## Testing

Updated the tests. CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/12241

 I'll update the RFC once this lands.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
