### PR TITLE
fix(vercel): ensure srcset widths are always from configured list

### DIFF
--- a/.changeset/new-falcons-tickle.md
+++ b/.changeset/new-falcons-tickle.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fixes a bug that caused invalid image sizes to be generated when the requested widths were larger than the source image

--- a/packages/integrations/vercel/src/image/build-service.ts
+++ b/packages/integrations/vercel/src/image/build-service.ts
@@ -62,7 +62,8 @@ const service: ExternalImageService = {
 
 		return '/_vercel/image?' + searchParams;
 	},
-	// Adapted from the base service's getSrcSet, but always returning widths that are valid for Vercel
+	// Adapted from the base service's getSrcSet, but always returning widths that are valid for Vercel,
+	// meaning they're in the list of configured sizes. See sharedValidateOptions in shared.ts for more info.
 	getSrcSet(options) {
 		const { inputtedWidth, densities, widths, ...props } = options;
 

--- a/packages/integrations/vercel/src/image/build-service.ts
+++ b/packages/integrations/vercel/src/image/build-service.ts
@@ -62,6 +62,80 @@ const service: ExternalImageService = {
 
 		return '/_vercel/image?' + searchParams;
 	},
+	// Adapted from the base service's getSrcSet, but always returning widths that are valid for Vercel
+	getSrcSet(options) {
+		const { inputtedWidth, densities, widths, ...props } = options;
+
+		// If `validateOptions` returned a different width than the one of the image, use it for attributes
+		if (inputtedWidth) {
+			props.width = inputtedWidth;
+		}
+
+		let targetWidth = props.width;
+		let targetHeight = props.height;
+		if (isESMImportedImage(props.src)) {
+			const aspectRatio = props.src.width / props.src.height;
+			if (targetHeight && !targetWidth) {
+				// If we have a height but no width, use height to calculate the width
+				targetWidth = Math.round(targetHeight * aspectRatio);
+			} else if (targetWidth && !targetHeight) {
+				// If we have a width but no height, use width to calculate the height
+				targetHeight = Math.round(targetWidth / aspectRatio);
+			} else if (!targetWidth && !targetHeight) {
+				// If we have neither width or height, use the original image's dimensions
+				targetWidth = props.src.width;
+				targetHeight = props.src.height;
+			}
+		}
+
+		// Since `widths` and `densities` ultimately control the width and height of the image,
+		// we don't want the dimensions the user specified, we'll create those ourselves.
+		const {
+			width: transformWidth,
+			height: transformHeight,
+			...transformWithoutDimensions
+		} = options;
+
+		// Collect widths to generate from specified densities or widths
+		let allWidths: Array<{
+			width: number;
+			descriptor: `${number}x` | `${number}w`;
+		}> = [];
+
+		if (densities) {
+			// Densities can either be specified as numbers, or descriptors (ex: '1x'), we'll convert them all to numbers
+			const densityValues = densities.map((density) => {
+				if (typeof density === 'number') {
+					return density;
+				} else {
+					return parseFloat(density);
+				}
+			});
+
+			// Calculate the widths for each density, rounding to avoid floats.
+			const densityWidths = densityValues
+				.sort((a, b) => a - b)
+				.map((density) => Math.round(targetWidth! * density));
+
+			allWidths = densityWidths.map((width, index) => ({
+				width,
+				descriptor: `${densityValues[index]}x`,
+			}));
+		} else if (widths?.length) {
+			allWidths = widths.map((width) => ({
+				width,
+				descriptor: `${width}w`,
+			}));
+		}
+
+		return allWidths.map(({ width, descriptor }) => {
+			const transform = { ...transformWithoutDimensions, width };
+			return {
+				transform,
+				descriptor,
+			};
+		});
+	},
 };
 
 function removeLeadingForwardSlash(path: string) {

--- a/packages/integrations/vercel/test/fixtures/image/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/image/src/pages/index.astro
@@ -16,3 +16,11 @@ import bigPenguin from "../assets/penguin.jpg";
 <div id="responsive">
 	<Image src={bigPenguin} alt="Astro" layout="constrained" width="1000" />
 </div>
+
+<div id="small-source">
+	<Image
+		src={astro}
+		alt="Astro"
+		widths={[400, 800]}
+	/>
+</div>

--- a/packages/integrations/vercel/test/image.test.js
+++ b/packages/integrations/vercel/test/image.test.js
@@ -28,6 +28,22 @@ describe('Image', () => {
 		assert.equal(img.attr('width'), '225');
 	});
 
+	it('generates valid image sizes when requested width is larger than source image', async () => {
+		const html = await fixture.readFile('../.vercel/output/static/index.html');
+		const $ = cheerio.load(html);
+		const img = $('#small-source img');
+		const widths = img
+			.attr('srcset')
+			.split(', ')
+			.map((entry) => entry.split(' ')[1]);
+		assert.deepEqual(widths, ['640w'], 'uses valid widths in srcset');
+
+		const url = new URL(img.attr('src'), 'http://localhost');
+		assert.equal(url.searchParams.get('w'), '640', 'uses valid width in src');
+
+		assert.equal(img.attr('width'), '225', 'uses requested width in img attribute');
+	});
+
 	it('has proper vercel config', async () => {
 		const vercelConfig = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
 


### PR DESCRIPTION
## Changes

The Vercel image CDN requires that widths are from a configured list – requesting any other will give an error. The image service does this in most cases, except when the source image is smaller than the requested size. The default getSrcSet clamps the width, ensuring that no sizes are requested larger than the source image, instead requesting the actual image size if a larger size is requested. This is correct for most services except Vercel, which requires us to request the larger breakpoint from the allowlist, for which it will return the original size. 

This PR implements a custom getSrcSet for the Vercel image service that ensures the widths are always from the allowlist.

Fixes #14250

## Testing

Added tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
