### PR TITLE
fix: ensure the index route matches with base and no trailing slash

### DIFF
--- a/.changeset/full-cloths-sleep.md
+++ b/.changeset/full-cloths-sleep.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused index pages to not be found when a base was set with trailingSlash: never

--- a/packages/astro/src/core/routing/manifest/pattern.ts
+++ b/packages/astro/src/core/routing/manifest/pattern.ts
@@ -38,7 +38,7 @@ export function getPattern(
 	const trailing =
 		addTrailingSlash && segments.length ? getTrailingSlashPattern(addTrailingSlash) : '$';
 	let initial = '\\/';
-	if (addTrailingSlash === 'never' && base !== '/') {
+	if (addTrailingSlash === 'never' && base !== '/' && pathname !== '') {
 		initial = '';
 	}
 	return new RegExp(`^${pathname || initial}${trailing}`);

--- a/packages/astro/test/ssr-trailing-slash.test.js
+++ b/packages/astro/test/ssr-trailing-slash.test.js
@@ -255,9 +255,7 @@ describe('Redirecting trailing slashes in SSR', () => {
 			const app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/mybase');
 			const response = await app.render(request);
-			// Should not redirect, but will 404 since we don't have an index page
-			assert.notEqual(response.status, 301);
-			assert.notEqual(response.status, 308);
+			assert.equal(response.status, 200);
 		});
 
 		it('Redirects to remove trailing slash on sub-paths with base', async () => {


### PR DESCRIPTION
## Changes

The handling of base paths with trailingSlash never was causing an empty pattern to be generated for the root index. This PR ensures that it will always match `/`

Fixes #14245

## Testing

Fixed a test that was missing this

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
