### PR TITLE
refactor: routes as virtual module

### DIFF
--- a/packages/astro/src/core/app/common.ts
+++ b/packages/astro/src/core/app/common.ts
@@ -2,7 +2,7 @@ import type { RoutesList } from '../../types/astro.js';
 import type { AstroConfig } from '../../types/public/index.js';
 import { decodeKey } from '../encryption.js';
 import { NOOP_MIDDLEWARE_FN } from '../middleware/noop-middleware.js';
-import { deserializeRouteData } from '../routing/manifest/serialization.js';
+import { deserializeRouteData } from './manifest.js';
 import type { RouteInfo, SerializedSSRManifest, SSRManifest } from './types.js';
 
 export function deserializeManifest(

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -1,4 +1,10 @@
 export { App } from './app.js';
 export { BaseApp, type RenderErrorOptions, type RenderOptions } from './base.js';
 export { deserializeManifest, fromRoutingStrategy, toRoutingStrategy } from './common.js';
+export {
+	deserializeRouteData,
+	deserializeRouteInfo,
+	serializeRouteData,
+	serializeRouteInfo,
+} from './manifest.js';
 export { AppPipeline } from './pipeline.js';

--- a/packages/astro/src/core/app/manifest.ts
+++ b/packages/astro/src/core/app/manifest.ts
@@ -1,6 +1,6 @@
-import type { SerializedRouteData } from '../../../types/astro.js';
-import type { AstroConfig } from '../../../types/public/config.js';
-import type { RouteData } from '../../../types/public/internal.js';
+import type { SerializedRouteData } from '../../types/astro.js';
+import type { AstroConfig, RouteData } from '../../types/public/index.js';
+import type { RouteInfo, SerializedRouteInfo } from './types.js';
 
 export function serializeRouteData(
 	routeData: RouteData,
@@ -38,5 +38,28 @@ export function deserializeRouteData(rawRouteData: SerializedRouteData): RouteDa
 		}),
 		isIndex: rawRouteData.isIndex,
 		origin: rawRouteData.origin,
+	};
+}
+
+export function serializeRouteInfo(
+	routeInfo: RouteInfo,
+	trailingSlash: AstroConfig['trailingSlash'],
+): SerializedRouteInfo {
+	return {
+		styles: routeInfo.styles,
+		file: routeInfo.file,
+		links: routeInfo.links,
+		scripts: routeInfo.scripts,
+		routeData: serializeRouteData(routeInfo.routeData, trailingSlash),
+	};
+}
+
+export function deserializeRouteInfo(rawRouteInfo: SerializedRouteInfo): RouteInfo {
+	return {
+		styles: rawRouteInfo.styles,
+		file: rawRouteInfo.file,
+		links: rawRouteInfo.links,
+		scripts: rawRouteInfo.scripts,
+		routeData: deserializeRouteData(rawRouteInfo.routeData),
 	};
 }

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -9,7 +9,7 @@ import { normalizeTheLocale } from '../../../i18n/index.js';
 import { runHookBuildSsr } from '../../../integrations/hooks.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../../vite-plugin-scripts/index.js';
 import { toFallbackType } from '../../app/common.js';
-import { toRoutingStrategy } from '../../app/index.js';
+import { serializeRouteData, toRoutingStrategy } from '../../app/index.js';
 import type {
 	SerializedRouteInfo,
 	SerializedSSRManifest,
@@ -31,7 +31,6 @@ import {
 import { encodeKey } from '../../encryption.js';
 import { fileExtension, joinPaths, prependForwardSlash } from '../../path.js';
 import { DEFAULT_COMPONENTS } from '../../routing/default.js';
-import { serializeRouteData } from '../../routing/index.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import { getOutFile, getOutFolder } from '../common.js';
 import { type BuildInternals, cssOrder, mergeInlineCss } from '../internal.js';

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -33,6 +33,7 @@ import htmlVitePlugin from '../vite-plugin-html/index.js';
 import astroIntegrationsContainerPlugin from '../vite-plugin-integrations-container/index.js';
 import astroLoadFallbackPlugin from '../vite-plugin-load-fallback/index.js';
 import markdownVitePlugin from '../vite-plugin-markdown/index.js';
+import astroPluginRoutes from '../vite-plugin-routes/index.js';
 import astroScannerPlugin from '../vite-plugin-scanner/index.js';
 import astroScriptsPlugin from '../vite-plugin-scripts/index.js';
 import astroScriptsPageSSRPlugin from '../vite-plugin-scripts/page-ssr.js';
@@ -144,6 +145,7 @@ export async function createVite(
 		},
 		plugins: [
 			await serializedManifestPlugin({ settings }),
+			await astroPluginRoutes({ settings, logger, fsMod: fs }),
 			astroVirtualManifestPlugin(),
 			configAliasVitePlugin({ settings }),
 			astroLoadFallbackPlugin({ fs, root: settings.config.root }),

--- a/packages/astro/src/core/routing/index.ts
+++ b/packages/astro/src/core/routing/index.ts
@@ -1,3 +1,2 @@
 export { createRoutesList } from './manifest/create.js';
-export { serializeRouteData } from './manifest/serialization.js';
 export { matchAllRoutes } from './match.js';

--- a/packages/astro/src/vite-plugin-astro-server/app.ts
+++ b/packages/astro/src/vite-plugin-astro-server/app.ts
@@ -57,7 +57,6 @@ export class DevApp extends BaseApp<DevPipeline> {
 		this.manifestData = manifestData;
 	}
 
-	// TODO remove routelist once it's a plugin
 	static async create(
 		routesList: RoutesList,
 		settings: AstroSettings,

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -10,6 +10,7 @@ import { normalizePath } from 'vite';
 import { toFallbackType } from '../core/app/common.js';
 import { toRoutingStrategy } from '../core/app/index.js';
 import type {
+	RouteInfo,
 	SerializedSSRManifest,
 	SSRManifest,
 	SSRManifestCSP,
@@ -33,7 +34,6 @@ import { patchOverlay } from '../core/errors/overlay.js';
 import type { Logger } from '../core/logger/core.js';
 import { NOOP_MIDDLEWARE_FN } from '../core/middleware/noop-middleware.js';
 import { createViteLoader } from '../core/module-loader/index.js';
-import { createRoutesList } from '../core/routing/index.js';
 import { getRoutePrerenderOption } from '../core/routing/manifest/prerender.js';
 import { runHookRoutesResolved } from '../integrations/hooks.js';
 import type { AstroSettings, RoutesList } from '../types/astro.js';
@@ -55,12 +55,14 @@ export default function createVitePluginAstroServer({
 	settings,
 	logger,
 	fs: fsMod,
-	routesList,
 }: AstroPluginOptions): vite.Plugin {
 	return {
 		name: 'astro:server',
 		async configureServer(viteServer) {
 			const loader = createViteLoader(viteServer);
+			const { routes } = await loader.import('astro:routes');
+			const routesList: RoutesList = { routes: routes.map((r: RouteInfo) => r.routeData) };
+
 			const app = await DevApp.create(routesList, settings, logger, loader);
 
 			const controller = createController({ loader });
@@ -88,8 +90,6 @@ export default function createVitePluginAstroServer({
 						await getRoutePrerenderOption(content, route, settings, logger);
 						await runHookRoutesResolved({ routes: routesList.routes, settings, logger });
 					} catch (_) {}
-				} else {
-					routesList = await createRoutesList({ settings, fsMod }, logger, { dev: true });
 				}
 
 				warnMissingAdapter(logger, settings);

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -1,0 +1,78 @@
+import type fsMod from 'node:fs';
+import type { Plugin } from 'vite';
+import { serializeRouteData } from '../core/app/index.js';
+import type { SerializedRouteInfo } from '../core/app/types.js';
+import type { Logger } from '../core/logger/core.js';
+import { createRoutesList } from '../core/routing/index.js';
+import type { AstroSettings } from '../types/astro.js';
+
+type Payload = {
+	settings: AstroSettings;
+	logger: Logger;
+	fsMod?: typeof fsMod;
+};
+
+const ASTRO_ROUTES_MODULE_ID = 'astro:routes';
+const ASTRO_ROUTES_MODULE_ID_RESOLVED = '\0' + ASTRO_ROUTES_MODULE_ID;
+
+export default async function astroPluginRoutes({
+	settings,
+	logger,
+	fsMod,
+}: Payload): Promise<Plugin> {
+	const routeList = await createRoutesList(
+		{
+			settings,
+			fsMod,
+		},
+		logger,
+	);
+	const serializedRouteInfo: SerializedRouteInfo[] = routeList.routes.map(
+		(r): SerializedRouteInfo => {
+			return {
+				file: '',
+				links: [],
+				scripts: [],
+				styles: [],
+				routeData: serializeRouteData(r, settings.config.trailingSlash),
+			};
+		},
+	);
+	
+	return {
+		name: 'astro:routes',
+		enforce: 'pre',
+		configureServer(server) {
+			server.watcher.on('all', (_event, relativeEntry) => {
+				const entry = new URL(relativeEntry, settings.config.root);
+				if (entry.pathname.startsWith(settings.config.srcDir.pathname)) {
+					server.restart();
+				}
+			});
+		},
+
+		applyToEnvironment(environment) {
+			return environment.name === 'ssr';
+		},
+
+		load(id) {
+			if (id === ASTRO_ROUTES_MODULE_ID_RESOLVED) {
+				const code = `
+				import { deserializeRouteInfo } from 'astro/app';
+				const serializedData = ${JSON.stringify(serializedRouteInfo)};
+				export const routes = serializedData.map(deserializeRouteInfo);
+				`;
+
+				return {
+					code,
+				};
+			}
+		},
+
+		resolveId(id) {
+			if (id === ASTRO_ROUTES_MODULE_ID) {
+				return ASTRO_ROUTES_MODULE_ID_RESOLVED;
+			}
+		},
+	};
+}

--- a/packages/astro/test/units/vite-plugin-astro-server/request.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/request.test.js
@@ -1,8 +1,9 @@
 import * as assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { serializeRouteData } from '../../../dist/core/app/index.js';
 import { createContainer } from '../../../dist/core/dev/container.js';
 import { createLoader } from '../../../dist/core/module-loader/index.js';
-import { createRoutesList, serializeRouteData } from '../../../dist/core/routing/index.js';
+import { createRoutesList } from '../../../dist/core/routing/index.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import { createController, DevApp } from '../../../dist/vite-plugin-astro-server/index.js';
 import { createDevelopmentManifest } from '../../../dist/vite-plugin-astro-server/plugin.js';


### PR DESCRIPTION
## Changes

This PR adds a new virtual module that allows to return the list of routes inside an Astro project. 

This virtual module essentially replaces the `RoutesList` type that we create when we start the dev server.

## Testing

Unit tests should pass. Integration tests pass on my machine, they will still time out here

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
