### PR TITLE
refactor: skip check inside `createRoutesList`

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -143,7 +143,7 @@ export async function createVite(
 		},
 		plugins: [
 			await serializedManifestPlugin({ settings }),
-			await astroPluginRoutes({ settings, logger, fsMod: fs }),
+			await astroPluginRoutes({ settings, logger, fsMod: fs, command }),
 			astroVirtualManifestPlugin(),
 			configAliasVitePlugin({ settings }),
 			astroLoadFallbackPlugin({ fs, root: settings.config.root }),

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -465,7 +465,17 @@ function detectRouteCollision(a: RouteData, b: RouteData, _config: AstroConfig, 
 export async function createRoutesList(
 	params: CreateRouteManifestParams,
 	logger: Logger,
-	{ dev = false }: { dev?: boolean } = {},
+	{
+		dev = false,
+		skipBuildOutputAssignment = false,
+	}: {
+		dev?: boolean;
+		/**
+		 * When `true`, the assignment of `settings.buildOutput` is skipped.
+		 * Usually, that's needed when this function has already been called.
+		 */
+		skipBuildOutputAssignment?: boolean;
+	} = {},
 ): Promise<RoutesList> {
 	const { settings } = params;
 	const { config } = settings;
@@ -494,7 +504,9 @@ export async function createRoutesList(
 		...[...filteredFiledBasedRoutes, ...injectedRoutes, ...redirectRoutes].sort(routeComparator),
 	];
 
-	settings.buildOutput = getPrerenderDefault(config) ? 'static' : 'server';
+	if (!skipBuildOutputAssignment) {
+		settings.buildOutput = getPrerenderDefault(config) ? 'static' : 'server';
+	}
 
 	// Check the prerender option for each route
 	const limit = pLimit(10);

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -19,6 +19,7 @@ type Payload = {
 	settings: AstroSettings;
 	logger: Logger;
 	fsMod?: typeof fsMod;
+	command: 'dev' | 'build';
 };
 
 const ASTRO_ROUTES_MODULE_ID = 'astro:routes';
@@ -30,6 +31,7 @@ export default async function astroPluginRoutes({
 	settings,
 	logger,
 	fsMod,
+	command,
 }: Payload): Promise<Plugin> {
 	logger.debug('update', 'Re-calculate routes');
 	let routeList = await createRoutesList(
@@ -39,7 +41,7 @@ export default async function astroPluginRoutes({
 		},
 		logger,
 		// TODO: the caller should handle this
-		{ dev: true },
+		{ dev: true, skipBuildOutputAssignment: command === 'build' },
 	);
 
 	let serializedRouteInfo: SerializedRouteInfo[] = routeList.routes.map(


### PR DESCRIPTION
## Changes

This PR fixes a regression where `createRoutesList` is called twice: once when creating the build runner, once inside the plugin.

This unfortunately calls `createRoutesList` twice. I will fix this problem in a later PR

## Testing

New tests are now passing 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
