### PR TITLE
refactor(dev): use entry point to bootstrap the app

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -151,7 +151,7 @@ export async function createVite(
 			astroScriptsPlugin({ settings }),
 			// The server plugin is for dev only and having it run during the build causes
 			// the build to run very slow as the filewatcher is triggered often.
-			command === 'dev' && vitePluginAstroServer({ settings, logger, fs }), // manifest is only required in dev mode, where it gets created before a Vite instance is created, and get passed to this function
+			command === 'dev' && vitePluginAstroServer({ settings, logger }),
 			importMetaEnv({ envLoader }),
 			astroEnv({ settings, sync, envLoader }),
 			markdownVitePlugin({ settings, logger }),

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -1,6 +1,19 @@
 import type { Plugin } from 'vite';
+import { toFallbackType } from '../core/app/common.js';
+import { toRoutingStrategy } from '../core/app/index.js';
+import type { SerializedSSRManifest, SSRManifestCSP, SSRManifestI18n } from '../core/app/types.js';
+import {
+	getAlgorithm,
+	getDirectives,
+	getScriptHashes,
+	getScriptResources,
+	getStrictDynamic,
+	getStyleHashes,
+	getStyleResources,
+	shouldTrackCspHashes,
+} from '../core/csp/common.js';
+import { createKey, encodeKey, getEnvironmentKey, hasEnvironmentKey } from '../core/encryption.js';
 import type { AstroSettings } from '../types/astro.js';
-import { createSerializedManifest } from '../vite-plugin-astro-server/plugin.js';
 
 export const SERIALIZED_MANIFEST_ID = 'astro:serialized-manifest';
 const SERIALIZED_MANIFEST_RESOLVED_ID = '\0' + SERIALIZED_MANIFEST_ID;
@@ -30,5 +43,69 @@ export async function serializedManifestPlugin({
 				return { code };
 			}
 		},
+	};
+}
+
+export async function createSerializedManifest(
+	settings: AstroSettings,
+): Promise<SerializedSSRManifest> {
+	let i18nManifest: SSRManifestI18n | undefined;
+	let csp: SSRManifestCSP | undefined;
+	if (settings.config.i18n) {
+		i18nManifest = {
+			fallback: settings.config.i18n.fallback,
+			strategy: toRoutingStrategy(settings.config.i18n.routing, settings.config.i18n.domains),
+			defaultLocale: settings.config.i18n.defaultLocale,
+			locales: settings.config.i18n.locales,
+			domainLookupTable: {},
+			fallbackType: toFallbackType(settings.config.i18n.routing),
+		};
+	}
+
+	if (shouldTrackCspHashes(settings.config.experimental.csp)) {
+		csp = {
+			cspDestination: settings.adapter?.adapterFeatures?.experimentalStaticHeaders
+				? 'adapter'
+				: undefined,
+			scriptHashes: getScriptHashes(settings.config.experimental.csp),
+			scriptResources: getScriptResources(settings.config.experimental.csp),
+			styleHashes: getStyleHashes(settings.config.experimental.csp),
+			styleResources: getStyleResources(settings.config.experimental.csp),
+			algorithm: getAlgorithm(settings.config.experimental.csp),
+			directives: getDirectives(settings),
+			isStrictDynamic: getStrictDynamic(settings.config.experimental.csp),
+		};
+	}
+
+	return {
+		hrefRoot: settings.config.root.toString(),
+		srcDir: settings.config.srcDir,
+		cacheDir: settings.config.cacheDir,
+		outDir: settings.config.outDir,
+		buildServerDir: settings.config.build.server,
+		buildClientDir: settings.config.build.client,
+		publicDir: settings.config.publicDir,
+		trailingSlash: settings.config.trailingSlash,
+		buildFormat: settings.config.build.format,
+		compressHTML: settings.config.compressHTML,
+		assets: [],
+		entryModules: {},
+		routes: [],
+		adapterName: settings?.adapter?.name ?? '',
+		clientDirectives: Array.from(settings.clientDirectives.entries()),
+		renderers: [],
+		base: settings.config.base,
+		userAssetsBase: settings.config?.vite?.base,
+		assetsPrefix: settings.config.build.assetsPrefix,
+		site: settings.config.site,
+		componentMetadata: [],
+		inlinedScripts: [],
+		i18n: i18nManifest,
+		checkOrigin:
+			(settings.config.security?.checkOrigin && settings.buildOutput === 'server') ?? false,
+		key: await encodeKey(hasEnvironmentKey() ? await getEnvironmentKey() : await createKey()),
+		sessionConfig: settings.config.session,
+		csp,
+		serverIslandNameMap: [],
 	};
 }

--- a/packages/astro/src/vite-plugin-astro-server/entrypoint.ts
+++ b/packages/astro/src/vite-plugin-astro-server/entrypoint.ts
@@ -1,0 +1,36 @@
+// @ts-expect-error
+import { routes } from 'astro:routes';
+// @ts-expect-error
+import { manifest } from 'astro:serialized-manifest';
+import type http from 'node:http';
+import type { RouteInfo } from '../core/app/types.js';
+import { Logger } from '../core/logger/core.js';
+import { nodeLogDestination } from '../core/logger/node.js';
+import type { ModuleLoader } from '../core/module-loader/index.js';
+import type { AstroSettings, RoutesList } from '../types/astro.js';
+import { DevApp } from './app.js';
+import type { DevServerController } from './controller.js';
+
+export default async function createExports(
+	settings: AstroSettings,
+	controller: DevServerController,
+	loader: ModuleLoader,
+) {
+	const logger = new Logger({
+		dest: nodeLogDestination,
+		level: 'info',
+	});
+	const routesList: RoutesList = { routes: routes.map((r: RouteInfo) => r.routeData) };
+	const app = await DevApp.create(manifest, routesList, settings, logger, loader);
+
+	return {
+		handler(incomingRequest: http.IncomingMessage, incomingResponse: http.ServerResponse) {
+			app.handleRequest({
+				controller,
+				incomingRequest,
+				incomingResponse,
+				isHttps: loader.isHttps(),
+			});
+		},
+	};
+}


### PR DESCRIPTION
## Changes

This refactors the dev server to use an entrypoint to load the application.

## Testing

The minimal example works, the react example works.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
