### PR TITLE
refactor(dev): expose dev app and entrypoint

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -50,6 +50,7 @@
     "./container": "./dist/container/index.js",
     "./app": "./dist/core/app/index.js",
     "./app/node": "./dist/core/app/node.js",
+    "./app/dev": "./dist/core/app/dev/index.js",
     "./client/*": "./dist/runtime/client/*",
     "./components": "./components/index.ts",
     "./components/*": "./components/*",

--- a/packages/astro/src/core/app/dev/index.ts
+++ b/packages/astro/src/core/app/dev/index.ts
@@ -1,15 +1,17 @@
-// @ts-expect-error
+// @ts-expect-error This is a virtual module
 import { routes } from 'astro:routes';
-// @ts-expect-error
+// @ts-expect-error This is a virtual module
 import { manifest } from 'astro:serialized-manifest';
 import type http from 'node:http';
-import type { RouteInfo } from '../core/app/types.js';
-import { Logger } from '../core/logger/core.js';
-import { nodeLogDestination } from '../core/logger/node.js';
-import type { ModuleLoader } from '../core/module-loader/index.js';
-import type { AstroSettings, RoutesList } from '../types/astro.js';
+import type { AstroSettings, RoutesList } from '../../../types/astro.js';
+import type { DevServerController } from '../../../vite-plugin-astro-server/controller.js';
+import { Logger } from '../../logger/core.js';
+import { nodeLogDestination } from '../../logger/node.js';
+import type { ModuleLoader } from '../../module-loader/index.js';
+import type { RouteInfo } from '../types.js';
 import { DevApp } from './app.js';
-import type { DevServerController } from './controller.js';
+
+export { DevApp };
 
 export default async function createExports(
 	settings: AstroSettings,

--- a/packages/astro/src/core/app/dev/pipeline.ts
+++ b/packages/astro/src/core/app/dev/pipeline.ts
@@ -1,30 +1,30 @@
 import { fileURLToPath } from 'node:url';
-import { getInfoOutput } from '../cli/info/index.js';
-import type { HeadElements, TryRewriteResult } from '../core/base-pipeline.js';
-import { ASTRO_VERSION } from '../core/constants.js';
-import { enhanceViteSSRError } from '../core/errors/dev/index.js';
-import { AggregateError, CSSError, MarkdownError } from '../core/errors/index.js';
-import type { Logger } from '../core/logger/core.js';
-import type { ModuleLoader } from '../core/module-loader/index.js';
-import { RedirectComponentInstance, routeIsRedirect } from '../core/redirects/index.js';
-import { loadRenderer, Pipeline } from '../core/render/index.js';
-import { createDefaultRoutes } from '../core/routing/default.js';
-import { findRouteToRewrite } from '../core/routing/rewrite.js';
-import { isPage, viteID } from '../core/util.js';
-import { resolveIdToUrl } from '../core/viteUtils.js';
-import type { AstroSettings, ComponentInstance, RoutesList } from '../types/astro.js';
-import type { RewritePayload } from '../types/public/common.js';
+import { getInfoOutput } from '../../../cli/info/index.js';
+import type { AstroSettings, ComponentInstance, RoutesList } from '../../../types/astro.js';
 import type {
+	DevToolbarMetadata,
+	RewritePayload,
 	RouteData,
 	SSRElement,
 	SSRLoadedRenderer,
 	SSRManifest,
-} from '../types/public/internal.js';
-import type { DevToolbarMetadata } from '../types/public/toolbar.js';
-import { PAGE_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
-import { getStylesForURL } from './css.js';
-import { getComponentMetadata } from './metadata.js';
-import { createResolve } from './resolve.js';
+} from '../../../types/public/index.js';
+import { getStylesForURL } from '../../../vite-plugin-astro-server/css.js';
+import { getComponentMetadata } from '../../../vite-plugin-astro-server/metadata.js';
+import { createResolve } from '../../../vite-plugin-astro-server/resolve.js';
+import { PAGE_SCRIPT_ID } from '../../../vite-plugin-scripts/index.js';
+import { type HeadElements, Pipeline, type TryRewriteResult } from '../../base-pipeline.js';
+import { ASTRO_VERSION } from '../../constants.js';
+import { enhanceViteSSRError } from '../../errors/dev/index.js';
+import { AggregateError, CSSError, MarkdownError } from '../../errors/index.js';
+import type { Logger } from '../../logger/core.js';
+import type { ModuleLoader } from '../../module-loader/index.js';
+import { RedirectComponentInstance, routeIsRedirect } from '../../redirects/index.js';
+import { loadRenderer } from '../../render/index.js';
+import { createDefaultRoutes } from '../../routing/default.js';
+import { findRouteToRewrite } from '../../routing/rewrite.js';
+import { isPage, viteID } from '../../util.js';
+import { resolveIdToUrl } from '../../viteUtils.js';
 
 export class DevPipeline extends Pipeline {
 	// renderers are loaded on every request,

--- a/packages/astro/src/prerender/routing.ts
+++ b/packages/astro/src/prerender/routing.ts
@@ -1,8 +1,8 @@
+import type { DevPipeline } from '../core/app/dev/pipeline.js';
 import { routeIsRedirect } from '../core/redirects/index.js';
 import { routeComparator } from '../core/routing/priority.js';
 import type { AstroSettings } from '../types/astro.js';
 import type { RouteData } from '../types/public/internal.js';
-import type { DevPipeline } from '../vite-plugin-astro-server/pipeline.js';
 import { getPrerenderStatus } from './metadata.js';
 
 type GetSortedPreloadedMatchesParams = {

--- a/packages/astro/src/types/public/integrations.ts
+++ b/packages/astro/src/types/public/integrations.ts
@@ -106,6 +106,7 @@ export interface AstroAdapter {
 	name: string;
 	serverEntrypoint?: string | URL;
 	previewEntrypoint?: string | URL;
+	devEntrypoint?: string | URL;
 	exports?: string[];
 	args?: any;
 	adapterFeatures?: AstroAdapterFeatures;

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -1,3 +1,2 @@
-export { DevApp } from './app.js';
 export { createController, runWithErrorHandling } from './controller.js';
 export { default as vitePluginAstroServer } from './plugin.js';

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { IncomingMessage } from 'node:http';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import type * as vite from 'vite';
 import { toFallbackType } from '../core/app/common.js';
 import { toRoutingStrategy } from '../core/app/index.js';
@@ -25,7 +25,6 @@ import { patchOverlay } from '../core/errors/overlay.js';
 import type { Logger } from '../core/logger/core.js';
 import { NOOP_MIDDLEWARE_FN } from '../core/middleware/noop-middleware.js';
 import { createViteLoader } from '../core/module-loader/index.js';
-import { viteID } from '../core/util.js';
 import type { AstroSettings } from '../types/astro.js';
 import { baseMiddleware } from './base.js';
 import { createController } from './controller.js';
@@ -46,10 +45,8 @@ export default function createVitePluginAstroServer({
 		name: 'astro:server',
 		async configureServer(viteServer) {
 			const loader = createViteLoader(viteServer);
-			// NOTE: this is temporary, we will use the configuration and proper loading later
-			// @ts-expect-error
-			const url = pathToFileURL(import.meta.dirname + '/entrypoint.js');
-			const createExports = await loader.import(viteID(url));
+			const entrypoint = settings.adapter?.devEntrypoint ?? 'astro/app/dev';
+			const createExports = await loader.import(entrypoint.toString());
 			const controller = createController({ loader });
 			const { handler } = await createExports.default(settings, controller, loader);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,7 +351,7 @@ importers:
   examples/minimal:
     dependencies:
       astro:
-        specifier: workspace:*
+        specifier: ^5.13.5
         version: link:../../packages/astro
 
   examples/portfolio:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,7 +351,7 @@ importers:
   examples/minimal:
     dependencies:
       astro:
-        specifier: ^5.13.5
+        specifier: workspace:*
         version: link:../../packages/astro
 
   examples/portfolio:
@@ -11365,7 +11365,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.30.1:


### PR DESCRIPTION
## Changes

This PR does the following:

- adds a new specifier to Astro named `astro/app/dev`. This new specifier exposes two bindings: a `default`, which is `createExports`, and `DevApp` if users need to use it 
- adds a `devEntrypoint` to the adapters, which is used inside the Astro dev server plugin. If it is absent, the plugin uses `astro/app/dev` as a fallback

This should get us closer to use the cloudflare plugin

## Testing

Minimal and React examples still work 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
