### PR TITLE
feat(csp): add collapseHeaders option to experimental CSP

### DIFF
--- a/.changeset/fresh-eyes-drive.md
+++ b/.changeset/fresh-eyes-drive.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Adds `collapseHeaders` option to `experimental.csp` that consolidates all CSP headers into a single catch-all route, preventing build errors and reducing route processing overhead for large sites with many routes.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -635,7 +635,17 @@ async function generatePath(
 		pipeline.settings.adapter?.adapterFeatures?.experimentalStaticHeaders &&
 		pipeline.settings.config.experimental?.csp
 	) {
-		routeToHeaders.set(pathname, { headers: responseHeaders, route: integrationRoute });
+		const cspConfig = pipeline.settings.config.experimental.csp;
+		const shouldCollapseHeaders =
+			typeof cspConfig === 'object' && cspConfig.collapseHeaders === true;
+
+		if (shouldCollapseHeaders) {
+			// For collapsed headers, use a catch-all route pattern
+			routeToHeaders.set('/(.*)', { headers: responseHeaders, route: integrationRoute });
+		} else {
+			// Default behavior: per-route headers
+			routeToHeaders.set(pathname, { headers: responseHeaders, route: integrationRoute });
+		}
 	}
 
 	await fs.promises.mkdir(outFolder, { recursive: true });

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -498,6 +498,7 @@ export const AstroConfigSchema = z.object({
 								strictDynamic: z.boolean().optional(),
 							})
 							.optional(),
+						collapseHeaders: z.boolean().optional().default(false),
 					}),
 				])
 				.optional()

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2385,6 +2385,36 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 					 *
 					 */
 					directives?: CspDirective[];
+
+					/**
+					 * @name experimental.csp.collapseHeaders
+					 * @type {boolean}
+					 * @default `false`
+					 * @version 5.14.0
+					 * @description
+					 *
+					 * When enabled and using adapters that support static headers, collapses all CSP headers
+					 * to a single catch-all route instead of creating individual route entries per page.
+					 * This significantly reduces configuration file size for large sites and prevents
+					 * deployment payload limit errors.
+					 *
+					 * ```js
+					 * import { defineConfig } from 'astro/config';
+					 *
+					 * export default defineConfig({
+					 *   experimental: {
+					 *     csp: {
+					 *       collapseHeaders: true
+					 *     }
+					 *   }
+					 * });
+					 * ```
+					 *
+					 * This option only affects adapters that support `experimentalStaticHeaders`.
+					 * When no adapter is used or the adapter doesn't support static headers,
+					 * this option is safely ignored and CSP continues to work via meta tags.
+					 */
+					collapseHeaders?: boolean;
 			  };
 
 		/**

--- a/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/astro.config.mjs
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/astro.config.mjs
@@ -1,0 +1,14 @@
+import netlify from '@astrojs/netlify';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	output: "server",
+	adapter: netlify({
+		experimentalStaticHeaders: true,
+	}),
+	experimental: {
+		csp: {
+			collapseHeaders: true
+		}
+	},
+});

--- a/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/src/components/Island.astro
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/src/components/Island.astro
@@ -1,0 +1,1 @@
+<p>I am a Server Island</p>

--- a/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/src/pages/about.astro
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/src/pages/about.astro
@@ -1,0 +1,11 @@
+---
+import Island  from "../components/Island.astro"
+export const prerender = true;
+---
+<html>
+<head><title>About</title></head>
+<body>
+<h1>About</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/src/pages/index.astro
+++ b/packages/integrations/netlify/test/static/fixtures/static-headers-collapsed/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Island  from "../components/Island.astro"
+export const prerender = true;
+---
+<html>
+<head><title>Index</title></head>
+<body>
+<h1>Index</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/netlify/test/static/static-headers.test.js
+++ b/packages/integrations/netlify/test/static/static-headers.test.js
@@ -27,3 +27,36 @@ describe('Static headers', () => {
 		);
 	});
 });
+
+describe('Static headers - collapsed CSP', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/static-headers-collapsed/', import.meta.url),
+		});
+		await fixture.build();
+	});
+
+	it('CSP headers are collapsed to single catch-all route when collapseHeaders is enabled', async () => {
+		const config = await fixture.readFile('../.netlify/v1/config.json');
+		const headers = JSON.parse(config).headers;
+		const globalCspHeader = headers.find(
+			(x) => x.for === '/(.*)' && x.values['Content-Security-Policy'],
+		);
+
+		assert.notEqual(globalCspHeader, undefined, 'should have global CSP header');
+		assert.ok(
+			typeof globalCspHeader.values['Content-Security-Policy'] === 'string',
+			'should have CSP header string',
+		);
+	});
+
+	it('CSP headers create exactly one entry when collapsed', async () => {
+		const config = await fixture.readFile('../.netlify/v1/config.json');
+		const headers = JSON.parse(config).headers;
+		const cspHeaders = headers.filter((x) => x.values['Content-Security-Policy']);
+
+		assert.equal(cspHeaders.length, 1, 'should have exactly one CSP header entry');
+	});
+});

--- a/packages/integrations/node/test/fixtures/static-headers-collapsed/astro.config.mjs
+++ b/packages/integrations/node/test/fixtures/static-headers-collapsed/astro.config.mjs
@@ -1,0 +1,15 @@
+import nodejs from '@astrojs/node';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	output: "server",
+	adapter: nodejs({
+		mode: 'standalone',
+		experimentalStaticHeaders: true,
+	}),
+	experimental: {
+		csp: {
+			collapseHeaders: true
+		}
+	},
+});

--- a/packages/integrations/node/test/fixtures/static-headers-collapsed/src/components/Island.astro
+++ b/packages/integrations/node/test/fixtures/static-headers-collapsed/src/components/Island.astro
@@ -1,0 +1,1 @@
+<p>I am a Server Island</p>

--- a/packages/integrations/node/test/fixtures/static-headers-collapsed/src/pages/about.astro
+++ b/packages/integrations/node/test/fixtures/static-headers-collapsed/src/pages/about.astro
@@ -1,0 +1,11 @@
+---
+import Island  from "../components/Island.astro"
+export const prerender = true;
+---
+<html>
+<head><title>About</title></head>
+<body>
+<h1>About</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/node/test/fixtures/static-headers-collapsed/src/pages/index.astro
+++ b/packages/integrations/node/test/fixtures/static-headers-collapsed/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Island  from "../components/Island.astro"
+export const prerender = true;
+---
+<html>
+<head><title>Index</title></head>
+<body>
+<h1>Index</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/node/test/static-headers.test.js
+++ b/packages/integrations/node/test/static-headers.test.js
@@ -69,3 +69,32 @@ describe('Static headers', () => {
 		);
 	});
 });
+
+describe('Static headers - collapsed CSP', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/static-headers-collapsed' });
+		await fixture.build();
+	});
+
+	it('CSP headers are collapsed to single catch-all route when collapseHeaders is enabled', async () => {
+		const headers = JSON.parse(await fixture.readFile('../dist/_experimentalHeaders.json'));
+		const globalCspHeader = headers.find((x) => x.pathname === '/(.*)');
+
+		assert.notEqual(globalCspHeader, undefined, 'should have global CSP header entry');
+
+		const csp = globalCspHeader.headers.find((x) => x.key === 'Content-Security-Policy');
+		assert.notEqual(csp, undefined, 'should have CSP header');
+		assert.ok(typeof csp.value === 'string', 'should have CSP header string');
+	});
+
+	it('CSP headers create exactly one entry when collapsed', async () => {
+		const headers = JSON.parse(await fixture.readFile('../dist/_experimentalHeaders.json'));
+		const cspHeaders = headers.filter((x) =>
+			x.headers.some((h) => h.key === 'Content-Security-Policy'),
+		);
+
+		assert.equal(cspHeaders.length, 1, 'should have exactly one CSP header entry');
+	});
+});

--- a/packages/integrations/vercel/test/fixtures/static-headers-collapsed/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/static-headers-collapsed/astro.config.mjs
@@ -1,0 +1,14 @@
+import vercel from '@astrojs/vercel';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	output: "server",
+	adapter: vercel({
+		experimentalStaticHeaders: true,
+	}),
+	experimental: {
+		csp: {
+			collapseHeaders: true
+		}
+	},
+});

--- a/packages/integrations/vercel/test/fixtures/static-headers-collapsed/src/components/Island.astro
+++ b/packages/integrations/vercel/test/fixtures/static-headers-collapsed/src/components/Island.astro
@@ -1,0 +1,1 @@
+<p>I am a Server Island</p>

--- a/packages/integrations/vercel/test/fixtures/static-headers-collapsed/src/pages/about.astro
+++ b/packages/integrations/vercel/test/fixtures/static-headers-collapsed/src/pages/about.astro
@@ -1,0 +1,11 @@
+---
+import Island  from "../components/Island.astro"
+export const prerender = true;
+---
+<html>
+<head><title>About</title></head>
+<body>
+<h1>About</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/static-headers-collapsed/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/static-headers-collapsed/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Island  from "../components/Island.astro"
+export const prerender = true;
+---
+<html>
+<head><title>Index</title></head>
+<body>
+<h1>Index</h1>
+<Island server:defer />
+</body>
+</html>

--- a/packages/integrations/vercel/test/static-headers.test.js
+++ b/packages/integrations/vercel/test/static-headers.test.js
@@ -25,3 +25,36 @@ describe('Static headers', () => {
 		);
 	});
 });
+
+describe('Static headers - collapsed CSP', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/static-headers-collapsed',
+		});
+		await fixture.build();
+	});
+
+	it('CSP headers are collapsed to single catch-all route when collapseHeaders is enabled', async () => {
+		const config = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
+		const globalCspRoute = config.routes.find(
+			(r) => r.src === '/(.*)' && r.headers && r.headers['content-security-policy'],
+		);
+
+		assert.ok(globalCspRoute, 'should have global CSP route');
+		assert.ok(
+			typeof globalCspRoute.headers['content-security-policy'] === 'string',
+			'should have CSP header string',
+		);
+	});
+
+	it('CSP headers create exactly one entry when collapsed', async () => {
+		const config = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
+		const cspRoutes = config.routes.filter(
+			(r) => r.headers && r.headers['content-security-policy'],
+		);
+
+		assert.equal(cspRoutes.length, 1, 'should have exactly one CSP route entry');
+	});
+});


### PR DESCRIPTION
## Changes

- Adds `collapseHeaders` option to `experimental.csp` configuration
- When used with adapters supporting `experimentalStaticHeaders`, consolidates all CSP headers into a single catch-all route
- Prevents build errors for large sites with many routes / large CSP config
- Reduces configuration file size from MB to KB for large sites (especially with i18n)
- Maintains full backward compatibility with existing CSP usage
- Benefits all adapters that support `experimentalStaticHeaders` automatically (Vercel, Netlify, Node)

**Before:** 15k+ individual CSP route entries → 9MB config file → Build failures  
**After:** 1 global CSP route entry → 10KB config file → Successful builds

**Usage:**
```js
// Default behavior (unchanged)
experimental: {
  csp: true
}

// New option
experimental: {
  csp: {
    collapseHeaders: true
  }
}
```

## Testing

- Added tests for all (3) adapters that support `experimentalStaticHeaders` using existing `static-headers.test.js` files for Vercel, Netlify, and Node adapters.
- Created test fixtures with `collapseHeaders: true` configuration for each adapter
- Verified collapsed headers create single catch-all route entries across all platforms
- Confirmed backward compatibility with existing CSP configurations
- All tests passing

## Docs

This is a core CSP feature that works universally with all adapters supporting `experimentalStaticHeaders` which affects behavior for large sites experiencing build size limits with CSP enabled.

Documentation updates needed for:

- New `collapseHeaders` option in experimental CSP configuration
- When to use collapsed vs per-route CSP headers
- Usage examples with different adapters
- Build / performance implications and best practices

/cc @withastro/maintainers-docs for feedback!

<!-- https://github.com/withastro/docs -->
