### PR TITLE
fix: log errors for invalid content config

### DIFF
--- a/.changeset/kind-snakes-grow.md
+++ b/.changeset/kind-snakes-grow.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Logs helpful errors if content is invalid
+Improves error reporting for content collections by adding logging for configuration errors that had previously been silently ignored. Also adds a new error that is thrown if a live collection is used in `content.config.ts` rather than `live.config.ts`.

--- a/.changeset/kind-snakes-grow.md
+++ b/.changeset/kind-snakes-grow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Logs helpful errors if content is invalid

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseFrontmatter } from '@astrojs/markdown-remark';
 import { slug as githubSlug } from 'github-slugger';
-import { green } from 'kleur/colors';
+import { green, red } from 'kleur/colors';
 import type { PluginContext } from 'rollup';
 import type { ViteDevServer } from 'vite';
 import xxhash from 'xxhash-wasm';
@@ -536,6 +536,26 @@ async function loadContentConfig({
 		const digest = await hasher.h64ToString(await fs.promises.readFile(configPathname, 'utf-8'));
 		return { ...config.data, digest };
 	} else {
+		const message = config.error.issues
+			.map((issue) => `  → ${green(issue.path.join('.'))}: ${red(issue.message)}`)
+			.join('\n');
+		console.error(
+			`${green('[content]')} There was a problem with your content config:\n\n${message}\n`,
+		);
+		if (settings.config.experimental.liveContentCollections) {
+			const liveCollections = Object.entries(unparsedConfig.collections ?? {}).filter(
+				([, collection]: [string, any]) => collection?.type === LIVE_CONTENT_TYPE,
+			);
+			if (liveCollections.length > 0) {
+				throw new AstroError({
+					...AstroErrorData.LiveContentConfigError,
+					message: AstroErrorData.LiveContentConfigError.message(
+						'Live collections must be defined in a `src/live.config.ts` file.',
+						path.relative(fileURLToPath(settings.config.root), configPathname),
+					),
+				});
+			}
+		}
 		return undefined;
 	}
 }


### PR DESCRIPTION
## Changes

When looking at ways to catch misuse of live collections I realised that currently we're silently ignoring errors when parsing content config. This PR changes it to log errors in these cases. Because these aren't currently fatal errors, throwing would be a breaking change, so I'm just logging for now.

Additionally, if live collections are enabled then it checks if it failed because`createLiveCollection` has been used in `content.config.ts` and if so it *does* throw an error (which was I was originally trying to do).

<img width="1248" height="221" alt="image" src="https://github.com/user-attachments/assets/c0798270-0cb6-4cab-8e93-384ab0dab7ec" />


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
