### PR TITLE
Add support for Cloudflare images binding in environment API

### DIFF
--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -23,6 +23,7 @@
     "./entrypoints/middleware.js": "./dist/entrypoints/middleware.js",
     "./image-service": "./dist/entrypoints/image-service.js",
     "./image-endpoint": "./dist/entrypoints/image-endpoint.js",
+    "./image-transform-endpoint": "./dist/entrypoints/image-transform-endpoint.js",
     "./handler": "./dist/utils/handler.js",
     "./package.json": "./package.json"
   },

--- a/packages/integrations/cloudflare/src/entrypoints/image-transform-endpoint.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/image-transform-endpoint.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from 'astro';
+import { transform } from '../utils/image-binding-transform.js';
+
+export const prerender = false;
+
+// @ts-expect-error The Header types between libdom and @cloudflare/workers-types are causing issues
+export const GET: APIRoute = async (ctx) => {
+	// @ts-expect-error The runtime locals types are not populated here
+	return transform(ctx.request.url, ctx.locals.runtime.env.IMAGES, ctx.locals.runtime.env.ASSETS);
+};

--- a/packages/integrations/cloudflare/src/utils/handler.ts
+++ b/packages/integrations/cloudflare/src/utils/handler.ts
@@ -30,6 +30,10 @@ declare global {
 	// This is not a real global, but is injected using Vite define to allow us to specify the session binding name in the config.
 	var __ASTRO_SESSION_BINDING_NAME: string;
 
+	// This is not a real global, but is injected using Vite define to allow us to specify the Images binding name in the config.
+	// eslint-disable-next-line no-var
+	var __ASTRO_IMAGES_BINDING_NAME: string;
+
 	// Just used to pass the KV binding to unstorage.
 	var __env__: Partial<Env>;
 }

--- a/packages/integrations/cloudflare/src/utils/image-binding-transform.ts
+++ b/packages/integrations/cloudflare/src/utils/image-binding-transform.ts
@@ -1,0 +1,46 @@
+// @ts-expect-error Not sure how to make this typecheck properly
+import { imageConfig } from 'astro:assets';
+import { isRemotePath } from '@astrojs/internal-helpers/path';
+import { isRemoteAllowed } from '@astrojs/internal-helpers/remote';
+
+import type {
+	Fetcher,
+	ImagesBinding,
+	ImageTransform,
+	ReadableStream,
+} from '@cloudflare/workers-types';
+
+export async function transform(rawUrl: string, images: ImagesBinding, assets: Fetcher) {
+	const url = new URL(rawUrl);
+
+	const href = url.searchParams.get('href');
+
+	if (!href || (isRemotePath(href) && !isRemoteAllowed(href, imageConfig))) {
+		return new Response('Forbidden', { status: 403 });
+	}
+
+	const imageSrc = new URL(href, url.origin);
+	const content = await (isRemotePath(href) ? fetch(imageSrc) : assets.fetch(imageSrc));
+	if (!content.body) {
+		return new Response(null, { status: 404 });
+	}
+	const input = images.input(content.body as ReadableStream);
+
+	const format = url.searchParams.get('f');
+
+	if (!format || !['avif', 'webp', 'jpeg'].includes(format)) {
+		return new Response(`The "${format}" format is not supported`, { status: 400 });
+	}
+
+	return (
+		await input
+			.transform({
+				width: url.searchParams.has('w') ? parseInt(url.searchParams.get('w')!) : undefined,
+				height: url.searchParams.has('h') ? parseInt(url.searchParams.get('h')!) : undefined,
+				// `quality` is documented, but doesn't appear to work in manual testing...
+				// quality: url.searchParams.get('q'),
+				fit: url.searchParams.get('fit') as ImageTransform['fit'],
+			})
+			.output({ format: `image/${format as 'webp' | 'avif' | 'jpeg'}` })
+	).response();
+}

--- a/packages/integrations/cloudflare/src/utils/image-config.ts
+++ b/packages/integrations/cloudflare/src/utils/image-config.ts
@@ -1,7 +1,12 @@
 import type { AstroConfig, AstroIntegrationLogger, HookParameters } from 'astro';
 import { passthroughImageService, sharpImageService } from 'astro/config';
 
-export type ImageService = 'passthrough' | 'cloudflare' | 'compile' | 'custom';
+export type ImageService =
+	| 'passthrough'
+	| 'cloudflare'
+	| 'cloudflare-binding'
+	| 'compile'
+	| 'custom';
 
 export function setImageConfig(
 	service: ImageService,
@@ -20,6 +25,17 @@ export function setImageConfig(
 					command === 'dev'
 						? sharpImageService()
 						: { entrypoint: '@astrojs/cloudflare/image-service' },
+			};
+		case 'cloudflare-binding':
+			return {
+				...config,
+				service: command === 'dev' ? sharpImageService() : undefined,
+				endpoint:
+					command === 'dev'
+						? undefined
+						: {
+								entrypoint: '@astrojs/cloudflare/image-transform-endpoint',
+							},
 			};
 
 		case 'compile':

--- a/packages/integrations/cloudflare/src/utils/image-config.ts
+++ b/packages/integrations/cloudflare/src/utils/image-config.ts
@@ -29,13 +29,9 @@ export function setImageConfig(
 		case 'cloudflare-binding':
 			return {
 				...config,
-				service: command === 'dev' ? sharpImageService() : undefined,
-				endpoint:
-					command === 'dev'
-						? undefined
-						: {
-								entrypoint: '@astrojs/cloudflare/image-transform-endpoint',
-							},
+				endpoint: {
+					entrypoint: '@astrojs/cloudflare/image-transform-endpoint',
+				},
 			};
 
 		case 'compile':

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
 		workerEntryPoint: {
 			path: 'src/worker.ts',
 		},
-		imageService: 'cloudflare',
+		imageService: 'cloudflare-binding',
 	}),
 	vite: {
 		resolve: {

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/wrangler.jsonc
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/wrangler.jsonc
@@ -5,5 +5,8 @@
 	"assets": {
 		"directory": "./dist",
 		"binding": "ASSETS"
+	},
+	"images": {
+		"binding": "IMAGES"
 	}
 }


### PR DESCRIPTION
## Changes

Adds support for Cloudflare image binding service, from #14027. This is the only service that works with the environment API at the moment. Eventually we'll need to work out what to do with the other services in dev.

Stacked on #14357 so it can use the content layer in testing

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
