### PR TITLE
refactor(astro): export zod and index from src

### DIFF
--- a/packages/astro/index.d.ts
+++ b/packages/astro/index.d.ts
@@ -1,2 +1,0 @@
-export type * from './dist/types/public/index.js';
-export * from './dist/core/index.js';

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
-  "types": "./index.d.ts",
+  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       "app": [
@@ -27,10 +27,7 @@
     }
   },
   "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "default": "./dist/core/index.js"
-    },
+    ".": "./dist/index.js",
     "./env": "./env.d.ts",
     "./env/runtime": "./dist/env/runtime.js",
     "./env/setup": "./dist/env/setup.js",
@@ -69,10 +66,7 @@
     "./content/runtime-assets": "./dist/content/runtime-assets.js",
     "./debug": "./components/Debug.astro",
     "./package.json": "./package.json",
-    "./zod": {
-      "types": "./zod.d.ts",
-      "default": "./zod.mjs"
-    },
+    "./zod": "./dist/zod.js",
     "./errors": "./dist/core/errors/userError.js",
     "./middleware": "./dist/core/middleware/index.js",
     "./virtual-modules/*": "./dist/virtual-modules/*"
@@ -86,17 +80,13 @@
     "dist",
     "types",
     "astro.js",
-    "index.d.ts",
-    "zod.d.ts",
-    "zod.mjs",
     "env.d.ts",
     "client.d.ts",
     "jsx-runtime.d.ts",
     "templates",
     "astro-jsx.d.ts",
     "types.d.ts",
-    "README.md",
-    "vendor"
+    "README.md"
   ],
   "scripts": {
     "prebuild": "astro-scripts prebuild --to-string \"src/runtime/server/astro-island.ts\" \"src/runtime/client/{idle,load,media,only,visible}.ts\"",

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -1,0 +1,2 @@
+export * from './core/index.js';
+export type * from './types/public/index.js';

--- a/packages/astro/src/zod.ts
+++ b/packages/astro/src/zod.ts
@@ -1,3 +1,5 @@
 import * as mod from 'zod';
+
+export * from 'zod';
 export { mod as z };
 export default mod;

--- a/packages/astro/zod.d.ts
+++ b/packages/astro/zod.d.ts
@@ -1,5 +1,0 @@
-import * as mod from 'zod';
-export * from 'zod';
-export { mod as z };
-export default mod;
-export as namespace Zod;


### PR DESCRIPTION
## Changes

- Instead of having to manually maintain js and dts file in the package root, use built files from `dist`

## Testing

Should still pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No changeset as this is a refactor. Debatable since things in `package.json#exports` change

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
