### PR TITLE
Remove loadRemoteImage from loadLocalImage

### DIFF
--- a/.changeset/spotty-stars-unite.md
+++ b/.changeset/spotty-stars-unite.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Remove `loadRemoteImage` fallback for `loadLocalImage`

--- a/packages/astro/src/assets/endpoint/node.ts
+++ b/packages/astro/src/assets/endpoint/node.ts
@@ -44,15 +44,9 @@ async function loadLocalImage(src: string, url: URL) {
 
 	try {
 		buffer = await readFile(fileUrl);
-	} catch {
-		// Fallback to try to load the file using `fetch`
-		try {
-			const sourceUrl = new URL(src, url.origin);
-			buffer = await loadRemoteImage(sourceUrl);
-		} catch (err: unknown) {
-			console.error('Could not process image request:', err);
-			return undefined;
-		}
+	} catch (err: unknown) {
+		console.error('Could not process image request:', err);
+		return undefined;
 	}
 
 	return buffer;


### PR DESCRIPTION
## Changes

- What does this change?
`loadLocalImage` has a fallback to `loadRemoteImage` if the file is not found locally. This introduces SSRF attacks since it also bypasses the whitelist configuration in `isRemoteAllowed`.


## Testing

Tested building and running. 

## Docs

This should have no changes as this was a fallback for local images. 
