### PR TITLE
fix(types): remove invalid `name: never` from AddServerRenderer

### DIFF
--- a/.changeset/lazy-trains-switch.md
+++ b/.changeset/lazy-trains-switch.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix unsatisfiable type definition of AddServerRenderer when renderer is NamedSSRLoadedRendererValue.
+Fixes an unsatisfiable type definition when calling `addServerRenderer` on an experimental container instance

--- a/.changeset/lazy-trains-switch.md
+++ b/.changeset/lazy-trains-switch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix unsatisfiable type definition of AddServerRenderer when renderer is NamedSSRLoadedRendererValue.

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -112,7 +112,6 @@ export type ContainerRenderOptions = {
 export type AddServerRenderer =
 	| {
 			renderer: NamedSSRLoadedRendererValue;
-			name: never;
 	  }
 	| {
 			renderer: SSRLoadedRendererValue;
@@ -345,7 +344,7 @@ export class experimental_AstroContainer {
 	 * @param options.renderer The server renderer exported by integration.
 	 */
 	public addServerRenderer(options: AddServerRenderer): void {
-		const { renderer, name } = options;
+		const { renderer } = options;
 		if (!renderer.check || !renderer.renderToStaticMarkup) {
 			throw new Error(
 				"The renderer you passed isn't valid. A renderer is usually an object that exposes the `check` and `renderToStaticMarkup` functions.\n" +
@@ -357,11 +356,15 @@ export class experimental_AstroContainer {
 				name: renderer.name,
 				ssr: renderer,
 			});
-		} else {
+		} else if ('name' in options) {
 			this.#pipeline.manifest.renderers.push({
-				name,
+				name: options.name,
 				ssr: renderer,
 			});
+		} else {
+			throw new Error(
+				"The renderer name must be provided when adding a server renderer that is not a named renderer."
+			);
 		}
 	}
 


### PR DESCRIPTION
## Changes

- The `AddServerRenderer` type previously used `name: never` to forbid the `name` property when `renderer` was a `NamedSSRLoadedRendererValue`. However, this prevented the compiler from correctly matching the first union branch.
- Removing `name: never` from the name renderer union type branch will fix this.

<img width="1124" height="455" alt="image" src="https://github.com/user-attachments/assets/b0d39d6d-0044-456d-93ac-184465eba055" />

## Testing

- Verified that TypeScript correctly accepts both union branches.

## Docs

- The existing docs already describe the intended behavior, so no changes are needed after this fix.