### PR TITLE
Remove warning for bun, causing unexpected console spam

### DIFF
--- a/.changeset/rare-avocados-sin.md
+++ b/.changeset/rare-avocados-sin.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Remove warning for bun, causing unexpected console spam

--- a/.changeset/rare-avocados-sin.md
+++ b/.changeset/rare-avocados-sin.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Remove warning for bun, causing unexpected console spam
+Removes warning that caused unexpected console spam when using Bun

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -76,12 +76,6 @@ export async function getInfoOutput({
 		output += printRow(label, value, print);
 	}
 
-	if (packageManager === 'bun') {
-		console.warn(
-			'Bun is not officially supported by Astro. Unable to retreive certain version information.',
-		);
-	}
-
 	return output.trim();
 }
 


### PR DESCRIPTION
## Changes

Fixes #14401 

previously, Bun users were seeing this when they used `bun` to install their npm packages, and then ran `astro dev`, `astro build`, etc. 

<img width="1018" height="731" alt="image" src="https://github.com/user-attachments/assets/36a14f73-165e-4627-bbb2-be8c814eb469" />

This was introduced in https://github.com/withastro/astro/pull/14300 to intentionally add the message to `astro info`, but not realizing that the helper function `getInfoOutput()` was called outside of `astro info` during normal render, for debugging purposes.

This PR removes that warning for now, since we shouldn't be printing inside of a helper utility like that. We could add it back in the future, but ~~I also don't think it's communicating the correct message about our Bun support (tldr: we support Node, and Bun is Node compatible, so Astro should be expected to work correctly in Bun. if it does not, that's bun's problem to solve, but that is different from "Bun is not supported").~~ Update: wait I was wrong, this is Bun the *package installer*, not the runtime. AFAIK Astro runs for users who use Bun as their package installer, so I think this message is just wrong vs. not worded correctly. Please correct me if I'm incorrect on that, but we have many Astro users who use `bun` to install their packages so I can't imagine this is true. 

## Testing

Not tested, just removed a console log.

## Docs

Not needed.

