### PR TITLE
fix(astro): Astro.url.pathname returns a wrong file extension

### DIFF
--- a/.changeset/legal-camels-poke.md
+++ b/.changeset/legal-camels-poke.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Ensure Astro.url.pathname returns the correct file extension when build.format.preserved is enabled

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -467,7 +467,12 @@ function getUrlForPath(
 	switch (format) {
 		case 'directory':
 		case 'preserve': {
-			ending = trailingSlash === 'never' ? '' : '/';
+			const isNamedPathnameRegex = /\/[a-zA-Z-0-9]+/;
+			if (isNamedPathnameRegex.test(pathname)) {
+				ending = '.html'
+			} else {
+				ending = trailingSlash === 'never' ? '' : '/';
+			}
 			break;
 		}
 		case 'file':


### PR DESCRIPTION
## Changes

- `Astro.url.pathname` returns value with the correct file `.html` extension when `build.format: 'perserve'` is enabled in `astro.config.mjs`

Closes: https://github.com/withastro/astro/issues/13615

## Testing

Here's the screenshot after change:
`build.format: 'perserve'` is enabled in all screenshot

For `routeType: 'page'` with a described pathname. Now we have `.html` extension in `pathname` property
<img width="492" height="240" alt="Captura de Tela 2025-09-21 às 00 42 54" src="https://github.com/user-attachments/assets/268153c4-8ab8-49d9-80f7-6967ce9de60d" />

For `routeType: 'page'` without a described pathname (no change)
<img width="403" height="242" alt="Captura de Tela 2025-09-21 às 00 42 29" src="https://github.com/user-attachments/assets/203d64c1-902a-45b5-ae79-437d0ff20467" />

For `routeType: 'endpoint'` (no change)
<img width="370" height="242" alt="Captura de Tela 2025-09-21 às 00 42 10" src="https://github.com/user-attachments/assets/d74dd918-cf49-4058-bc2a-3f5cefc81b7f" />

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
I am not sure, but I think it is not needed.