### PR TITLE
Fix name of new flag in changelog

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -50,7 +50,7 @@
 
   Previously, when two dynamic routes `/[foo]` and `/[bar]` returned values on their `getStaticPaths` that resulted in the same final path, only one of the routes would be rendered while the other would be silently ignored. Now, when this happens, a warning will be displayed explaining which routes collided and on which path.
 
-  Additionally, a new experimental flag `failOnPrerenderCollision` can be used to fail the build when such a collision occurs.
+  Additionally, a new experimental flag `failOnPrerenderConflict` can be used to fail the build when such a collision occurs.
 
 ### Patch Changes
 


### PR DESCRIPTION
## Changes

- Fixes a typo in the changelog.

## Testing

Tried to use the name from the changelog and received an error. Switched to the new name and it succeeded.

## Docs

I've confirmed [the docs do not have this typo](https://github.com/withastro/docs/blob/db947a549bc43f0e04a1075ef91d6d0b67f061d7/src/content/docs/en/reference/experimental-flags/fail-on-prerender-conflict.mdx#L23).