### PR TITLE
feat(node): handle redirects dynamically in static mode

### DIFF
--- a/.changeset/weak-eagles-give.md
+++ b/.changeset/weak-eagles-give.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/node': minor
+'astro': patch
+---
+
+Handle configured redirects dynamically in static mode

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -250,7 +250,7 @@ async function buildManifest(
 		const pageData = internals.pagesByKeys.get(makePageDataKey(route.route, route.component));
 		if (!pageData) continue;
 
-		if (route.prerender && !needsStaticHeaders) {
+		if (route.prerender && route.type !== 'redirect' && !needsStaticHeaders) {
 			continue;
 		}
 		const scripts: SerializedRouteInfo['scripts'] = [];

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -72,6 +72,9 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 				}
 
 				updateConfig({
+					build: {
+						redirects: false,
+					},
 					image: {
 						endpoint: {
 							route: config.image.endpoint.route ?? '_image',

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -45,7 +45,9 @@ export function createAppHandler(app: NodeApp, options: Options): RequestHandler
 			return;
 		}
 
-		const routeData = app.match(request);
+		// Redirects are considered prerendered routes in static mode, but we want to
+		// handle them dynamically, so prerendered routes are included here.
+		const routeData = app.match(request, true);
 		if (routeData) {
 			const response = await als.run(request.url, () =>
 				app.render(request, {

--- a/packages/integrations/node/test/fixtures/redirects/astro.config.mjs
+++ b/packages/integrations/node/test/fixtures/redirects/astro.config.mjs
@@ -1,0 +1,20 @@
+import { defineConfig } from 'astro/config';
+import nodejs from '@astrojs/node';
+
+export default defineConfig({
+	adapter: nodejs({ mode: 'standalone' }),
+  redirects: {
+    '/old-page': '/new-page',
+    '/old-page-301': {
+      status: 301,
+      destination: '/new-page-301',
+    },
+    '/old-page-302': {
+      status: 302,
+      destination: '/new-page-302',
+    },
+    '/dynamic/[slug]': '/pages/[slug]',
+    '/spread/[...path]': '/content/[...path]',
+    '/external': 'https://example.com',
+  },
+});

--- a/packages/integrations/node/test/fixtures/redirects/package.json
+++ b/packages/integrations/node/test/fixtures/redirects/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/redirects",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/node": "workspace:*"
+  }
+}

--- a/packages/integrations/node/test/fixtures/redirects/src/pages/content/[...path].astro
+++ b/packages/integrations/node/test/fixtures/redirects/src/pages/content/[...path].astro
@@ -1,0 +1,9 @@
+---
+// Spread route for testing spread redirects
+
+export function getStaticPaths() {
+	return [
+		{ params: { path: 'some/nested/path' } },
+	];
+}
+---

--- a/packages/integrations/node/test/fixtures/redirects/src/pages/new-page-301.astro
+++ b/packages/integrations/node/test/fixtures/redirects/src/pages/new-page-301.astro
@@ -1,0 +1,3 @@
+---
+// This is the destination page for 301 redirects
+---

--- a/packages/integrations/node/test/fixtures/redirects/src/pages/new-page-302.astro
+++ b/packages/integrations/node/test/fixtures/redirects/src/pages/new-page-302.astro
@@ -1,0 +1,3 @@
+---
+// This is the destination page for 302 redirects
+---

--- a/packages/integrations/node/test/fixtures/redirects/src/pages/new-page.astro
+++ b/packages/integrations/node/test/fixtures/redirects/src/pages/new-page.astro
@@ -1,0 +1,3 @@
+---
+// This is the destination page for redirects
+---

--- a/packages/integrations/node/test/fixtures/redirects/src/pages/pages/[slug].astro
+++ b/packages/integrations/node/test/fixtures/redirects/src/pages/pages/[slug].astro
@@ -1,0 +1,9 @@
+---
+// Dynamic page for testing dynamic redirects
+
+export function getStaticPaths() {
+	return [
+		{ params: { slug: 'test-slug' } },
+	];
+}
+---

--- a/packages/integrations/node/test/redirects.test.js
+++ b/packages/integrations/node/test/redirects.test.js
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import nodejs from '../dist/index.js';
+import { loadFixture, waitServerListen } from './test-utils.js';
+
+describe('Redirects', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let server;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/redirects/',
+			adapter: nodejs({ mode: 'standalone' }),
+		});
+		await fixture.build();
+		const { startServer } = await fixture.loadAdapterEntryModule();
+		const res = startServer();
+		server = res.server;
+		await waitServerListen(server.server);
+	});
+
+	after(async () => {
+		await server.stop();
+		await fixture.clean();
+	});
+
+	function fetchEndpoint(url, options = {}) {
+		return fetch(
+			`http://${server.host}:${server.port}/${url}`,
+			{ ...options, redirect: 'manual' },
+		);
+	}
+
+	it('should redirect with default 301 status for simple redirects', async () => {
+		const response = await fetchEndpoint('old-page');
+		assert.equal(response.status, 301);
+		assert.equal(response.headers.get('location'), '/new-page');
+	});
+
+	it('should redirect with custom 301 status', async () => {
+		const response = await fetchEndpoint('old-page-301');
+		assert.equal(response.status, 301);
+		assert.equal(response.headers.get('location'), '/new-page-301');
+	});
+
+	it('should redirect with custom 302 status', async () => {
+		const response = await fetchEndpoint('old-page-302');
+		assert.equal(response.status, 302);
+		assert.equal(response.headers.get('location'), '/new-page-302');
+	});
+
+	it('should handle dynamic redirects with parameters', async () => {
+		const response = await fetchEndpoint('dynamic/test-slug');
+		assert.equal(response.status, 301);
+		assert.equal(response.headers.get('location'), '/pages/test-slug');
+	});
+
+	it('should handle spread redirects with parameters', async () => {
+		const response = await fetchEndpoint('spread/some/nested/path');
+		assert.equal(response.status, 301);
+		assert.equal(response.headers.get('location'), '/content/some/nested/path');
+	});
+
+	it('should redirect to external URL', async () => {
+		const response = await fetchEndpoint('external');
+		assert.equal(response.status, 301);
+		assert.equal(response.headers.get('location'), 'https://example.com/');
+	});
+});


### PR DESCRIPTION
## Changes

Currently, node adapter uses the default HTML files with meta refresh when in static mode. This is not ideal, because it adds extra flash of page on redirections for users, and doesn't apply the proper status code for redirections. It's also likely less friendly to search engines.

This change makes configured redirect handled in the same way for node adapter across static and server mode, align with behaviors for other adapters.

## Testing

A new test has been added to test the redirect behavior on static mode.

## Docs

While this changes the behavior of node adapter in static mode, it's still within the behavior described in the current document:

In [Routing](https://docs.astro.build/en/guides/routing/#configured-redirects), it says:
> When running `astro build`, Astro will output HTML files with the [meta refresh](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#examples) tag by default. Supported adapters will instead write out the host’s configuration file with the redirects.

And in [Configuration Reference](https://docs.astro.build/en/reference/configuration-reference/#redirects), it says:
> When using SSR or with a static adapter in `output: static` mode, status codes are supported. Astro will serve redirected GET requests with a status of `301` and use a status of `308` for any other request method.

So this change brings node adapter into the "supported adapters" in the first document, and fulfills the description by the second document.