### PR TITLE
feat: cleanup integration api

### DIFF
--- a/.changeset/beige-clowns-read.md
+++ b/.changeset/beige-clowns-read.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/vercel': major
+'astro': major
+---
+
+TODO: entrypoints

--- a/.changeset/beige-clowns-read.md
+++ b/.changeset/beige-clowns-read.md
@@ -3,4 +3,26 @@
 'astro': major
 ---
 
-TODO: entrypoints
+Removes `entryPoints` on `astro:build:ssr` hook (Integration API)
+
+In Astro 5.0, `functionPerRoute` was deprecated. That meant that `entryPoints` on the `astro:build:ssr` hook was always empty.
+
+Astro 6.0 removes the `entryPoints` map passed to this hook entirely.
+
+#### What should I do?
+
+Remove any instance of `entryPoints` passed to `astro:build:ssr`:
+
+```diff
+// my-integration.mjs
+const integration = () => {
+    return {
+        name: 'my-integration',
+        hooks: {
+            'astro:build:ssr': (params) => {
+-                someLogic(params.entryPoints)
+            },
+        }
+    }
+}
+```

--- a/.changeset/beige-clowns-read.md
+++ b/.changeset/beige-clowns-read.md
@@ -1,5 +1,4 @@
 ---
-'@astrojs/vercel': major
 'astro': major
 ---
 

--- a/.changeset/beige-clowns-read.md
+++ b/.changeset/beige-clowns-read.md
@@ -4,13 +4,13 @@
 
 Removes `entryPoints` on `astro:build:ssr` hook (Integration API)
 
-In Astro 5.0, `functionPerRoute` was deprecated. That meant that `entryPoints` on the `astro:build:ssr` hook was always empty.
+In Astro 5.0, `functionPerRoute` was deprecated. That meant that `entryPoints` on the `astro:build:ssr` hook was always empty. Astro integrations may have continued to work, even while `entryPoints` was not providing any useful data.
 
-Astro 6.0 removes the `entryPoints` map passed to this hook entirely.
+Astro 6.0 removes the `entryPoints` map passed to this hook entirely. Integrations may no longer include `entryPoints`.
 
 #### What should I do?
 
-Remove any instance of `entryPoints` passed to `astro:build:ssr`:
+Remove any instance of `entryPoints` passed to `astro:build:ssr`. This should be safe to remove because this logic was not providing any useful data, but you may need to restructure your code accordingly for its removal:
 
 ```diff
 // my-integration.mjs

--- a/.changeset/cuddly-worlds-beam.md
+++ b/.changeset/cuddly-worlds-beam.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/sitemap': major
+'astro': major
+---
+
+TODO: routes

--- a/.changeset/cuddly-worlds-beam.md
+++ b/.changeset/cuddly-worlds-beam.md
@@ -1,5 +1,4 @@
 ---
-'@astrojs/sitemap': major
 'astro': major
 ---
 

--- a/.changeset/cuddly-worlds-beam.md
+++ b/.changeset/cuddly-worlds-beam.md
@@ -3,4 +3,39 @@
 'astro': major
 ---
 
-TODO: routes
+Removes `routes` on `astro:build:done` hook (Integration API)
+
+In Astro 5.0, accessing `routes` on the `astro:build:done` hook was deprecated.
+
+Astro 6.0 removes the `routes` array passed to this hook entirely. Instead, the `astro:routes:resolved` hook should be used. 
+
+#### What should I do?
+
+Remove any instance of `routes` passed to `astro:build:done` and replace it with the new `astro:routes:resolved` hook. Access `distURL` on the newly exposed `assets` map:
+
+```diff
+// my-integration.mjs
+const integration = () => {
++    let routes
+    return {
+        name: 'my-integration',
+        hooks: {
++            'astro:routes:resolved': (params) => {
++                routes = params.routes
++            },
+            'astro:build:done': ({
+-                routes
++                assets
+            }) => {
++                for (const route of routes) {
++                    const distURL = assets.get(route.pattern)
++                    if (distURL) {
++                        Object.assign(route, { distURL })
++                    }
++                }
+                console.log(routes)
+            }
+        }
+    }
+}
+```

--- a/.changeset/cuddly-worlds-beam.md
+++ b/.changeset/cuddly-worlds-beam.md
@@ -4,13 +4,13 @@
 
 Removes `routes` on `astro:build:done` hook (Integration API)
 
-In Astro 5.0, accessing `routes` on the `astro:build:done` hook was deprecated.
+In Astro 5.0, accessing `routes` on the `astro:build:done` hook was deprecated in favour of a new `astro:routes:resolved` hook. However, Astro integrations may have continued to function using the `routes` array.
 
-Astro 6.0 removes the `routes` array passed to this hook entirely. Instead, the `astro:routes:resolved` hook should be used. 
+Astro 6.0 removes the `routes` array passed to this hook entirely. Instead, the `astro:routes:resolved` hook must be used. 
 
 #### What should I do?
 
-Remove any instance of `routes` passed to `astro:build:done` and replace it with the new `astro:routes:resolved` hook. Access `distURL` on the newly exposed `assets` map:
+Remove any instance of `routes` passed to `astro:build:done` in your Astro integration and replace it with the new `astro:routes:resolved` hook. You can access `distURL` on the newly exposed `assets` map:
 
 ```diff
 // my-integration.mjs

--- a/.changeset/cuddly-worlds-beam.md
+++ b/.changeset/cuddly-worlds-beam.md
@@ -16,23 +16,23 @@ Remove any instance of `routes` passed to `astro:build:done` and replace it with
 ```diff
 // my-integration.mjs
 const integration = () => {
-+    let routes
++   let routes
     return {
         name: 'my-integration',
         hooks: {
-+            'astro:routes:resolved': (params) => {
-+                routes = params.routes
-+            },
++           'astro:routes:resolved': (params) => {
++               routes = params.routes
++           },
             'astro:build:done': ({
--                routes
-+                assets
+-               routes
++               assets
             }) => {
-+                for (const route of routes) {
-+                    const distURL = assets.get(route.pattern)
-+                    if (distURL) {
-+                        Object.assign(route, { distURL })
-+                    }
-+                }
++               for (const route of routes) {
++                   const distURL = assets.get(route.pattern)
++                   if (distURL) {
++                       Object.assign(route, { distURL })
++                   }
++               }
                 console.log(routes)
             }
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,11 +219,11 @@ jobs:
         with:
           repository: withastro/docs
           path: smoke/docs
-          # For a commit event on the `next` branch (`ref_name`), use the `5.0.0-beta` branch.
-          # For a pull_request event merging into the `next` branch (`base_ref`), use the `5.0.0-beta` branch.
+          # For a commit event on the `next` branch (`ref_name`), use the `v6` branch.
+          # For a pull_request event merging into the `next` branch (`base_ref`), use the `v6` branch.
           # NOTE: For a pull_request event, the `ref_name` is something like `<pr-number>/merge` than the branch name.
           # NOTE: Perhaps docs repo should use a consistent `next` branch in the future.
-          ref: ${{ (github.ref_name == 'next' || github.base_ref == 'next') && '5.0.0-beta' || 'main' }}
+          ref: ${{ (github.ref_name == 'next' || github.base_ref == 'next') && 'v6' || 'main' }}
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -23,7 +23,6 @@ import { AstroError, AstroErrorData } from '../errors/index.js';
 import type { Logger } from '../logger/core.js';
 import { levels, timerMessage } from '../logger/core.js';
 import { createRoutesList } from '../routing/index.js';
-import { getServerIslandRouteData } from '../server-islands/endpoint.js';
 import { clearContentLayerCache } from '../sync/index.js';
 import { ensureProcessNodeEnv } from '../util.js';
 import { collectPagesData } from './page-data.js';
@@ -242,8 +241,7 @@ class AstroBuilder {
 			pages: pageNames,
 			routes: Object.values(allPages)
 				.flat()
-				.map((pageData) => pageData.route)
-				.concat(hasServerIslands ? getServerIslandRouteData(this.settings.config) : []),
+				.map((pageData) => pageData.route),
 			logger: this.logger,
 		});
 

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -1,5 +1,5 @@
 import type { Rollup } from 'vite';
-import type { RouteData, SSRResult } from '../../types/public/internal.js';
+import type { SSRResult } from '../../types/public/internal.js';
 import { prependForwardSlash, removeFileExtension } from '../path.js';
 import { viteID } from '../util.js';
 import { makePageDataKey } from './plugins/util.js';

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -89,7 +89,6 @@ export interface BuildInternals {
 	// The SSR manifest entry chunk.
 	manifestEntryChunk?: Rollup.OutputChunk;
 	manifestFileName?: string;
-	entryPoints: Map<RouteData, URL>;
 	componentMetadata: SSRResult['componentMetadata'];
 	middlewareEntryPoint: URL | undefined;
 	astroActionsEntryPoint: URL | undefined;
@@ -121,7 +120,6 @@ export function createBuildInternals(): BuildInternals {
 		discoveredScripts: new Set(),
 		staticFiles: new Set(),
 		componentMetadata: new Map(),
-		entryPoints: new Map(),
 		prerenderOnlyChunks: [],
 		astroActionsEntryPoint: undefined,
 		middlewareEntryPoint: undefined,

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -140,7 +140,6 @@ export function pluginManifest(
 					config: options.settings.config,
 					manifest,
 					logger: options.logger,
-					entryPoints: internals.entryPoints,
 					middlewareEntryPoint: shouldPassMiddlewareEntryPoint
 						? internals.middlewareEntryPoint
 						: undefined,

--- a/packages/astro/src/core/server-islands/endpoint.ts
+++ b/packages/astro/src/core/server-islands/endpoint.ts
@@ -17,7 +17,7 @@ export const SERVER_ISLAND_BASE_PREFIX = '_server-islands';
 
 type ConfigFields = Pick<SSRManifest, 'base' | 'trailingSlash'>;
 
-export function getServerIslandRouteData(config: ConfigFields) {
+function getServerIslandRouteData(config: ConfigFields) {
 	const segments = [
 		[{ content: '_server-islands', dynamic: false, spread: false }],
 		[{ content: 'name', dynamic: true, spread: false }],

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -30,7 +30,6 @@ import type {
 	BaseIntegrationHooks,
 	HookParameters,
 	IntegrationResolvedRoute,
-	IntegrationRouteData,
 	RouteOptions,
 	RouteToHeaders,
 } from '../types/public/integrations.js';
@@ -548,7 +547,6 @@ type RunHookBuildSsr = {
 	config: AstroConfig;
 	manifest: SerializedSSRManifest;
 	logger: Logger;
-	entryPoints: Map<RouteData, URL>;
 	middlewareEntryPoint: URL | undefined;
 };
 
@@ -556,13 +554,8 @@ export async function runHookBuildSsr({
 	config,
 	manifest,
 	logger,
-	entryPoints,
 	middlewareEntryPoint,
 }: RunHookBuildSsr) {
-	const entryPointsMap = new Map();
-	for (const [key, value] of entryPoints) {
-		entryPointsMap.set(toIntegrationRouteData(key), value);
-	}
 	for (const integration of config.integrations) {
 		await runHookInternal({
 			integration,
@@ -570,7 +563,6 @@ export async function runHookBuildSsr({
 			logger,
 			params: () => ({
 				manifest,
-				entryPoints: entryPointsMap,
 				middlewareEntryPoint,
 			}),
 		});
@@ -602,7 +594,6 @@ export async function runHookBuildGenerated({
 type RunHookBuildDone = {
 	settings: AstroSettings;
 	pages: string[];
-	// TODO: remove in Astro 6
 	routes: RouteData[];
 	logger: Logger;
 };
@@ -610,7 +601,6 @@ type RunHookBuildDone = {
 export async function runHookBuildDone({ settings, pages, routes, logger }: RunHookBuildDone) {
 	const dir = getClientOutputDirectory(settings);
 	await fsMod.promises.mkdir(dir, { recursive: true });
-	const integrationRoutes = routes.map(toIntegrationRouteData);
 
 	for (const integration of settings.config.integrations) {
 		await runHookInternal({
@@ -620,7 +610,6 @@ export async function runHookBuildDone({ settings, pages, routes, logger }: RunH
 			params: () => ({
 				pages: pages.map((p) => ({ pathname: p })),
 				dir,
-				routes: integrationRoutes,
 				assets: new Map(
 					routes.filter((r) => r.distURL !== undefined).map((r) => [r.route, r.distURL!]),
 				),
@@ -699,22 +688,5 @@ export function toIntegrationResolvedRoute(route: RouteData): IntegrationResolve
 		redirectRoute: route.redirectRoute
 			? toIntegrationResolvedRoute(route.redirectRoute)
 			: undefined,
-	};
-}
-
-function toIntegrationRouteData(route: RouteData): IntegrationRouteData {
-	return {
-		route: route.route,
-		component: route.component,
-		generate: route.generate,
-		params: route.params,
-		pathname: route.pathname,
-		segments: route.segments,
-		prerender: route.prerender,
-		redirect: route.redirect,
-		redirectRoute: route.redirectRoute ? toIntegrationRouteData(route.redirectRoute) : undefined,
-		type: route.type,
-		pattern: route.pattern,
-		distURL: route.distURL,
 	};
 }

--- a/packages/astro/src/types/public/integrations.ts
+++ b/packages/astro/src/types/public/integrations.ts
@@ -255,20 +255,6 @@ export interface AstroIntegration {
 	} & Partial<Record<string, unknown>>;
 }
 
-/**
- * A smaller version of the {@link RouteData} that is used in the integrations.
- * @deprecated Use {@link IntegrationResolvedRoute}
- */
-export type IntegrationRouteData = Omit<
-	RouteData,
-	'isIndex' | 'fallbackRoutes' | 'redirectRoute' | 'origin'
-> & {
-	/**
-	 * {@link RouteData.redirectRoute}
-	 */
-	redirectRoute?: IntegrationRouteData;
-};
-
 export type RouteToHeaders = Map<string, HeaderPayload>;
 
 export type HeaderPayload = {

--- a/packages/astro/src/types/public/integrations.ts
+++ b/packages/astro/src/types/public/integrations.ts
@@ -212,12 +212,6 @@ export interface BaseIntegrationHooks {
 	'astro:build:ssr': (options: {
 		manifest: SerializedSSRManifest;
 		/**
-		 * This maps a {@link RouteData} to an {@link URL}, this URL represents
-		 * the physical file you should import.
-		 */
-		// TODO: Change in Astro 6.0
-		entryPoints: Map<IntegrationRouteData, URL>;
-		/**
 		 * File path of the emitted middleware
 		 */
 		middlewareEntryPoint: URL | undefined;
@@ -239,8 +233,6 @@ export interface BaseIntegrationHooks {
 	'astro:build:done': (options: {
 		pages: { pathname: string }[];
 		dir: URL;
-		/** @deprecated Use the `assets` map and the new `astro:routes:resolved` hook */
-		routes: IntegrationRouteData[];
 		assets: Map<string, URL[]>;
 		logger: AstroIntegrationLogger;
 	}) => void | Promise<void>;

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -349,8 +349,8 @@ describe('Middleware API in PROD mode, SSR', () => {
 						edgeMiddleware: true,
 					},
 				},
-				setMiddlewareEntryPoint(entryPointsOrMiddleware) {
-					middlewarePath = entryPointsOrMiddleware;
+				setMiddlewareEntryPoint(middlewareEntryPoint) {
+					middlewarePath = middlewareEntryPoint;
 				},
 			}),
 		});

--- a/packages/astro/test/static-build-page-dist-url.test.js
+++ b/packages/astro/test/static-build-page-dist-url.test.js
@@ -3,8 +3,8 @@ import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Static build: pages routes have distURL', () => {
-	/** @type {RouteData[]} */
-	let checkRoutes;
+	/** @type {Map<string, URL[]>} */
+	let assets;
 	before(async () => {
 		/** @type {import('./test-utils').Fixture} */
 		const fixture = await loadFixture({
@@ -13,8 +13,8 @@ describe('Static build: pages routes have distURL', () => {
 				{
 					name: '@astrojs/distURL',
 					hooks: {
-						'astro:build:done': ({ routes }) => {
-							checkRoutes = routes.filter((p) => p.type === 'page');
+						'astro:build:done': (params) => {
+							assets = params.assets;
 						},
 					},
 				},
@@ -23,11 +23,11 @@ describe('Static build: pages routes have distURL', () => {
 		await fixture.build();
 	});
 	it('Pages routes have distURL', async () => {
-		assert.equal(checkRoutes.length > 0, true, 'Pages not found: build end hook not being called');
-		checkRoutes.forEach((p) => {
-			p.distURL.forEach((distURL) => {
-				assert.equal(distURL instanceof URL, true, `${p.pathname} doesn't include distURL`);
-			});
-		});
+		assert.equal(assets.size > 0, true, 'Pages not found: build end hook not being called');
+		for (const [p, distURL] of assets.entries()) {
+			for (const url of distURL) {
+				assert.equal(url instanceof URL, true, `${p.pathname} doesn't include distURL`);
+			}
+		}
 	});
 });

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -15,7 +15,6 @@ import { viteID } from '../dist/core/util.js';
  * 	extendAdapter?: AstroAdapter;
  * 	setEntryPoints?: (entryPoints: EntryPoints) => void;
  * 	setMiddlewareEntryPoint?: (middlewareEntryPoint: MiddlewareEntryPoint) => void;
- * 	setRoutes?: (routes: Routes) => void;
  * 	env: Record<string, string | undefined>;
  * }} param0
  * @returns {AstroIntegration}
@@ -26,7 +25,6 @@ export default function ({
 	extendAdapter,
 	setEntryPoints,
 	setMiddlewareEntryPoint,
-	setRoutes,
 	setManifest,
 	setRouteToHeaders,
 	env,
@@ -135,11 +133,6 @@ export default function ({
 				}
 				if (setManifest) {
 					setManifest(manifest);
-				}
-			},
-			'astro:build:done': ({ routes }) => {
-				if (setRoutes) {
-					setRoutes(routes);
 				}
 			},
 			'astro:build:generated': ({ experimentalRouteToHeaders }) => {

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -3,7 +3,6 @@ import { viteID } from '../dist/core/util.js';
 /**
  * @typedef {import('../src/types/public/integrations.js').AstroAdapter} AstroAdapter
  * @typedef {import('../src/types/public/integrations.js').AstroIntegration} AstroIntegration
- * @typedef {import('../src/types/public/integrations.js').HookParameters<"astro:build:ssr">['entryPoints']} EntryPoints
  * @typedef {import('../src/types/public/integrations.js').HookParameters<"astro:build:ssr">['middlewareEntryPoint']} MiddlewareEntryPoint
  * @typedef {import('../src/types/public/integrations.js').HookParameters<"astro:build:done">['routes']} Routes
  */
@@ -13,7 +12,6 @@ import { viteID } from '../dist/core/util.js';
  * @param {{
  * 	provideAddress?: boolean;
  * 	extendAdapter?: AstroAdapter;
- * 	setEntryPoints?: (entryPoints: EntryPoints) => void;
  * 	setMiddlewareEntryPoint?: (middlewareEntryPoint: MiddlewareEntryPoint) => void;
  * 	env: Record<string, string | undefined>;
  * }} param0
@@ -23,7 +21,6 @@ export default function ({
 	provideAddress = true,
 	staticHeaders = false,
 	extendAdapter,
-	setEntryPoints,
 	setMiddlewareEntryPoint,
 	setManifest,
 	setRouteToHeaders,
@@ -124,10 +121,7 @@ export default function ({
 					...extendAdapter,
 				});
 			},
-			'astro:build:ssr': ({ entryPoints, middlewareEntryPoint, manifest }) => {
-				if (setEntryPoints) {
-					setEntryPoints(entryPoints);
-				}
+			'astro:build:ssr': ({ middlewareEntryPoint, manifest }) => {
 				if (setMiddlewareEntryPoint) {
 					setMiddlewareEntryPoint(middlewareEntryPoint);
 				}

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { AstroConfig, AstroIntegration } from 'astro';
+import type { AstroConfig, AstroIntegration, IntegrationResolvedRoute } from 'astro';
 import type { EnumChangefreq, LinkItem as LinkItemBase, SitemapItemLoose } from 'sitemap';
 import { ZodError } from 'zod';
 
@@ -76,17 +76,22 @@ const isStatusCodePage = (locales: string[]) => {
 	};
 };
 const createPlugin = (options?: SitemapOptions): AstroIntegration => {
+	let _routes: Array<IntegrationResolvedRoute>
 	let config: AstroConfig;
 
 	return {
 		name: PKG_NAME,
 
 		hooks: {
+			'astro:routes:resolved': ({ routes }) => {
+				_routes = routes;
+			},
+
 			'astro:config:done': async ({ config: cfg }) => {
 				config = cfg;
 			},
 
-			'astro:build:done': async ({ dir, routes, pages, logger }) => {
+			'astro:build:done': async ({ dir, pages, logger }) => {
 				try {
 					if (!config.site) {
 						logger.warn(
@@ -112,7 +117,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							return new URL(fullPath, finalSiteUrl).href;
 						});
 
-					const routeUrls = routes.reduce<string[]>((urls, r) => {
+					const routeUrls = _routes.reduce<string[]>((urls, r) => {
 						// Only expose pages, not endpoints or redirects
 						if (r.type !== 'page') return urls;
 
@@ -120,7 +125,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 						 * Dynamic URLs have entries with `undefined` pathnames
 						 */
 						if (r.pathname) {
-							if (shouldIgnoreStatus(r.pathname ?? r.route)) return urls;
+							if (shouldIgnoreStatus(r.pathname ?? r.pattern)) return urls;
 
 							// `finalSiteUrl` may end with a trailing slash
 							// or not because of base paths.


### PR DESCRIPTION
## Changes

- Closes #14444
- Removes `routes` from `astro:build:done`
- Removes `entryPoints` from `astro:build:ssr` as it was unused since the removal of `functionPerRoute`
- Removes the `IntegrationRouteData` type

## Testing

Updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/12445

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
