### PR TITLE
fix(registry): add token into header when registry are private

### DIFF
--- a/.changeset/odd-hairs-turn.md
+++ b/.changeset/odd-hairs-turn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add token into header when fetch package with private registry.


### PR DESCRIPTION
## Changes

- Add token into header when fetch package with private registry.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
