### PR TITLE
fix(astro): astro:config/server urls serialization

### DIFF
--- a/.changeset/full-peas-do.md
+++ b/.changeset/full-peas-do.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where `astro:config/server` values typed as URLs would be serialized as strings

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -68,7 +68,7 @@ function serializeClientConfig(manifest: SSRManifest): string {
 
 	const output = [];
 	for (const [key, value] of Object.entries(serClientConfig)) {
-		output.push(`export const ${key} = ${JSON.stringify(value)};`);
+		output.push(`export const ${key} = ${stringify(value)};`);
 	}
 	return output.join('\n') + '\n';
 }
@@ -102,7 +102,22 @@ function serializeServerConfig(manifest: SSRManifest): string {
 	};
 	const output = [];
 	for (const [key, value] of Object.entries(serverConfig)) {
-		output.push(`export const ${key} = ${JSON.stringify(value)};`);
+		output.push(`export const ${key} = ${stringify(value)};`);
 	}
 	return output.join('\n') + '\n';
+}
+
+function stringify(value: any): string {
+	if (Array.isArray(value)) {
+		return JSON.stringify(value);
+	}
+	if (value instanceof URL) {
+		return `new URL(${JSON.stringify(value)})`;
+	}
+	if (typeof value === 'object') {
+		return `{\n${Object.entries(value)
+			.map(([k, v]) => `${JSON.stringify(k)}: ${stringify(v)}`)
+			.join(',\n')}\n}`;
+	}
+	return JSON.stringify(value);
 }

--- a/packages/astro/test/fixtures/astro-manifest/src/pages/server.astro
+++ b/packages/astro/test/fixtures/astro-manifest/src/pages/server.astro
@@ -14,6 +14,7 @@ import { root, outDir, srcDir, build, cacheDir } from "astro:config/server";
 <p id="out-dir">{outDir}</p>
 <p id="src-dir">{srcDir}</p>
 <p id="root">{root}</p>
+<p id="root-type">{typeof root}</p>
 <p id="cache-dir">{cacheDir}</p>
 <p id="build-client">{build.client}</p>
 <p id="build-server">{build.server}</p>

--- a/packages/astro/test/serializeManifest.test.js
+++ b/packages/astro/test/serializeManifest.test.js
@@ -132,6 +132,8 @@ describe('astro:config/server', () => {
 			assert.ok($('#root').text().endsWith('/'));
 			assert.ok($('#build-client').text().endsWith('/dist/client/'));
 			assert.ok($('#build-server').text().endsWith('/dist/server/'));
+			// URL
+			assert.equal($('#root-type').text(), 'object');
 		});
 	});
 
@@ -152,6 +154,8 @@ describe('astro:config/server', () => {
 			assert.ok($('#root').text().endsWith('/'));
 			assert.ok($('#build-client').text().endsWith('/dist/client/'));
 			assert.ok($('#build-server').text().endsWith('/dist/server/'));
+			// URL
+			assert.equal($('#root-type').text(), 'object');
 		});
 	});
 
@@ -179,6 +183,8 @@ describe('astro:config/server', () => {
 			assert.ok($('#root').text().endsWith('/'));
 			assert.ok($('#build-client').text().endsWith('/dist/client/'));
 			assert.ok($('#build-server').text().endsWith('/dist/server/'));
+			// URL
+			assert.equal($('#root-type').text(), 'object');
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes the serizalization of `astro:config/server` URLS, which were emitted as strings instead of URLs

## Testing

Updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
