### PR TITLE
Updates `tinyexec` to v1

### DIFF
--- a/.changeset/eight-areas-vanish.md
+++ b/.changeset/eight-areas-vanish.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates `tinyexec` dependency

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -152,7 +152,7 @@
     "semver": "^7.7.2",
     "shiki": "^3.12.0",
     "smol-toml": "^1.4.2",
-    "tinyexec": "^0.3.2",
+    "tinyexec": "^1.0.1",
     "tinyglobby": "^0.2.14",
     "tsconfck": "^3.1.6",
     "ultrahtml": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,8 +609,8 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2
       tinyexec:
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^1.0.1
+        version: 1.0.1
       tinyglobby:
         specifier: ^0.2.14
         version: 0.2.15


### PR DESCRIPTION
## Changes

The only change in v1 is that `tinyexec` now ships as ESM-only, which is non-breaking for us. This package was already lightweight (46 KB), but v1 is even smaller (27 KB)

See https://github.com/tinylibs/tinyexec/releases/tag/1.0.0

## Testing

Existing tests should pass

## Docs

N/A