### PR TITLE
Updates `yargs-parser` to v22

### DIFF
--- a/.changeset/lazy-bushes-own.md
+++ b/.changeset/lazy-bushes-own.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/db': patch
+---
+
+Updates `yargs-parser` dependency

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -163,7 +163,7 @@
     "vite": "^6.3.6",
     "vitefu": "^1.1.1",
     "xxhash-wasm": "^1.1.0",
-    "yargs-parser": "^21.1.1",
+    "yargs-parser": "^22.0.0",
     "yocto-spinner": "^0.2.3",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.6",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -78,7 +78,7 @@
     "kleur": "^4.1.5",
     "nanoid": "^5.1.6",
     "prompts": "^2.4.2",
-    "yargs-parser": "^21.1.1",
+    "yargs-parser": "^22.0.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,8 +642,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       yargs-parser:
-        specifier: ^21.1.1
-        version: 21.1.1
+        specifier: ^22.0.0
+        version: 22.0.0
       yocto-spinner:
         specifier: ^0.2.3
         version: 0.2.3
@@ -4547,8 +4547,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       yargs-parser:
-        specifier: ^21.1.1
-        version: 21.1.1
+        specifier: ^22.0.0
+        version: 22.0.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -14185,6 +14185,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
@@ -22671,6 +22675,8 @@ snapshots:
       decamelize: 1.2.0
 
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs@15.4.1:
     dependencies:


### PR DESCRIPTION
## Changes

The only change in v22 is to ship as ESM-only, which is non-breaking for us. This reduces the dependency download size from 128 KB to 86 KB.

See https://github.com/yargs/yargs-parser/releases/tag/yargs-parser-v22.0.0


## Testing

Existing tests should pass

## Docs

n/a