### PR TITLE
chore(fonts): remove config generics

### DIFF
--- a/packages/astro/src/config/index.ts
+++ b/packages/astro/src/config/index.ts
@@ -1,5 +1,4 @@
 import type { UserConfig as ViteUserConfig, UserConfigFn as ViteUserConfigFn } from 'vite';
-import type { FontFamily } from '../assets/fonts/types.js';
 import { createRoutesList } from '../core/routing/index.js';
 import type {
 	AstroInlineConfig,
@@ -16,8 +15,7 @@ import { createDevelopmentManifest } from '../vite-plugin-astro-server/plugin.js
 export function defineConfig<
 	const TLocales extends Locales = never,
 	const TDriver extends SessionDriverName = never,
-	const TFontFamilies extends FontFamily[] = never,
->(config: AstroUserConfig<TLocales, TDriver, TFontFamilies>) {
+>(config: AstroUserConfig<TLocales, TDriver>) {
 	return config;
 }
 

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -194,10 +194,10 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
  * Docs: https://docs.astro.build/reference/configuration-reference/
  *
  * Generics do not follow semver and may change at any time.
- */ export interface AstroUserConfig<
+ */
+export interface AstroUserConfig<
 	TLocales extends Locales = never,
 	TSession extends SessionDriverName = never,
-	TFontFamilies extends FontFamily[] = never,
 > {
 	/**
 	 * @docs
@@ -2136,7 +2136,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * For a complete overview, and to give feedback on this experimental API,
 		 * see the [Fonts RFC](https://github.com/withastro/roadmap/pull/1039).
 		 */
-		fonts?: [TFontFamilies] extends [never] ? FontFamily[] : TFontFamilies;
+		fonts?: FontFamily[];
 
 		/**
 		 * @name experimental.headingIdCompat

--- a/packages/astro/test/types/define-config.ts
+++ b/packages/astro/test/types/define-config.ts
@@ -1,7 +1,5 @@
 import { describe, it } from 'node:test';
 import { expectTypeOf } from 'expect-type';
-import type { AstroFontProvider, FontFamily } from '../../dist/assets/fonts/types.js';
-import { defineAstroFontProvider, fontProviders } from '../../dist/config/entrypoint.js';
 import { defineConfig } from '../../dist/config/index.js';
 import type { AstroUserConfig } from '../../dist/types/public/index.js';
 
@@ -12,7 +10,7 @@ function assertType<T>(data: T, cb: (data: NoInfer<T>) => void) {
 describe('defineConfig()', () => {
 	it('Infers i18n generics correctly', () => {
 		assertType(defineConfig({}), (config) => {
-			expectTypeOf(config).toEqualTypeOf<AstroUserConfig<never, never, never>>();
+			expectTypeOf(config).toEqualTypeOf<AstroUserConfig<never, never>>();
 			expectTypeOf(config.i18n!.defaultLocale).toEqualTypeOf<string>();
 		});
 
@@ -24,7 +22,7 @@ describe('defineConfig()', () => {
 				},
 			}),
 			(config) => {
-				expectTypeOf(config).toEqualTypeOf<AstroUserConfig<['en'], never, never>>();
+				expectTypeOf(config).toEqualTypeOf<AstroUserConfig<['en'], never>>();
 				expectTypeOf(config.i18n!.defaultLocale).toEqualTypeOf<'en'>();
 			},
 		);
@@ -37,7 +35,7 @@ describe('defineConfig()', () => {
 				},
 			}),
 			(config) => {
-				expectTypeOf(config).toEqualTypeOf<AstroUserConfig<['en', 'fr'], never, never>>();
+				expectTypeOf(config).toEqualTypeOf<AstroUserConfig<['en', 'fr'], never>>();
 				expectTypeOf(config.i18n!.defaultLocale).toEqualTypeOf<'en' | 'fr'>();
 			},
 		);
@@ -53,124 +51,10 @@ describe('defineConfig()', () => {
 				expectTypeOf(config).toEqualTypeOf<
 					AstroUserConfig<
 						['en', { readonly path: 'french'; readonly codes: ['fr', 'fr-FR'] }],
-						never,
 						never
 					>
 				>();
 				expectTypeOf(config.i18n!.defaultLocale).toEqualTypeOf<'en' | 'fr' | 'fr-FR'>();
-			},
-		);
-	});
-
-	it('Infers fonts generics correctly', () => {
-		assertType(defineConfig({}), (config) => {
-			expectTypeOf(config).toEqualTypeOf<AstroUserConfig<never, never, never>>();
-			expectTypeOf(config.experimental!.fonts!).toEqualTypeOf<FontFamily[]>();
-		});
-
-		assertType(
-			defineConfig({
-				experimental: {
-					fonts: [],
-				},
-			}),
-			(config) => {
-				expectTypeOf(config).toEqualTypeOf<AstroUserConfig<never, never, []>>();
-				expectTypeOf(config.experimental!.fonts!).toEqualTypeOf<[]>();
-			},
-		);
-
-		const provider = defineAstroFontProvider({ entrypoint: '' });
-
-		assertType(
-			defineConfig({
-				experimental: {
-					fonts: [
-						{
-							name: 'bar',
-							cssVariable: '--font-bar',
-							provider: 'local',
-							variants: [{ src: [''], weight: 400, style: 'normal' }],
-						},
-						{ name: 'baz', cssVariable: '--font-baz', provider },
-					],
-				},
-			}),
-			(config) => {
-				expectTypeOf(config).toEqualTypeOf<
-					AstroUserConfig<
-						never,
-						never,
-						[
-							{
-								readonly name: 'bar';
-								readonly cssVariable: '--font-bar';
-								readonly provider: 'local';
-								readonly variants: [
-									{ readonly src: ['']; readonly weight: 400; readonly style: 'normal' },
-								];
-							},
-							{
-								readonly name: 'baz';
-								readonly cssVariable: '--font-baz';
-								readonly provider: AstroFontProvider;
-							},
-						]
-					>
-				>();
-				expectTypeOf(config.experimental!.fonts!).toEqualTypeOf<
-					[
-						{
-							readonly name: 'bar';
-							readonly cssVariable: '--font-bar';
-							readonly provider: 'local';
-							readonly variants: [
-								{ readonly src: ['']; readonly weight: 400; readonly style: 'normal' },
-							];
-						},
-						{
-							readonly name: 'baz';
-							readonly cssVariable: '--font-baz';
-							readonly provider: AstroFontProvider;
-						},
-					]
-				>();
-			},
-		);
-	});
-
-	it('Allows disabling font fallbacks', () => {
-		assertType(
-			defineConfig({
-				experimental: {
-					fonts: [
-						{
-							provider: fontProviders.google(),
-							name: 'Roboto',
-							fallbacks: [],
-							cssVariable: '--font-roboto',
-						},
-					],
-				},
-			}),
-			(config) => {
-				expectTypeOf(config).toEqualTypeOf<
-					AstroUserConfig<
-						never,
-						never,
-						[
-							{
-								readonly provider: {
-									entrypoint: string | URL;
-									config?: Record<string, any> | undefined;
-								};
-								readonly name: 'Roboto';
-								readonly fallbacks: [];
-								readonly cssVariable: '--font-roboto';
-							},
-						]
-					>
-				>();
 			},
 		);
 	});


### PR DESCRIPTION
## Changes

- I initially wanted to do fancy things with generics for fonts, but it is not relevant anymore so I'm removing it

## Testing

Types tests updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No changeset because it does not affect the public API

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
