### PR TITLE
feat: remove renderScript option

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -106,7 +106,7 @@
     "test:integration": "astro-scripts test \"test/*.test.js\""
   },
   "dependencies": {
-    "@astrojs/compiler": "0.0.0-render-script-20251002135111",
+    "@astrojs/compiler": "0.0.0-render-script-20251003120459",
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/markdown-remark": "workspace:*",
     "@astrojs/telemetry": "workspace:*",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -106,7 +106,7 @@
     "test:integration": "astro-scripts test \"test/*.test.js\""
   },
   "dependencies": {
-    "@astrojs/compiler": "0.0.0-next-result-create-astro-20250926081949",
+    "@astrojs/compiler": "0.0.0-render-script-20251002135111",
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/markdown-remark": "workspace:*",
     "@astrojs/telemetry": "workspace:*",

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -55,7 +55,6 @@ export async function compile({
 				astroConfig.devToolbar &&
 				astroConfig.devToolbar.enabled &&
 				(await preferences.get('devToolbar.enabled')),
-			renderScript: true,
 			preprocessStyle: createStylePreprocessor({
 				filename,
 				viteConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,8 +471,8 @@ importers:
   packages/astro:
     dependencies:
       '@astrojs/compiler':
-        specifier: 0.0.0-next-result-create-astro-20250926081949
-        version: 0.0.0-next-result-create-astro-20250926081949
+        specifier: 0.0.0-render-script-20251002135111
+        version: 0.0.0-render-script-20251002135111
       '@astrojs/internal-helpers':
         specifier: workspace:*
         version: link:../internal-helpers
@@ -6498,8 +6498,8 @@ packages:
     resolution: {integrity: sha512-bVzyKzEpIwqjihBU/aUzt1LQckJuHK0agd3/ITdXhPUYculrc6K1/K7H+XG4rwjXtg+ikT3PM05V1MVYWiIvQw==}
     engines: {node: '>=18.14.1'}
 
-  '@astrojs/compiler@0.0.0-next-result-create-astro-20250926081949':
-    resolution: {integrity: sha512-iZAPYDe2R9fU1GA26epcy4iOvDgla3oWirzqOsc3nkKeSTcUYtY1rZq/D02oKCVHepAkFlRS1bS27+G+jIeX0Q==}
+  '@astrojs/compiler@0.0.0-render-script-20251002135111':
+    resolution: {integrity: sha512-2uXb13LRkCusMu47FhvX8y0vBKpEs+kOfw6siITKBDN0//FSp/WUse1/b8n2Deit34PwTAte8KNLUp6fIMogSA==}
 
   '@astrojs/compiler@2.12.2':
     resolution: {integrity: sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==}
@@ -14256,7 +14256,7 @@ snapshots:
       log-update: 5.0.1
       sisteransi: 1.0.5
 
-  '@astrojs/compiler@0.0.0-next-result-create-astro-20250926081949': {}
+  '@astrojs/compiler@0.0.0-render-script-20251002135111': {}
 
   '@astrojs/compiler@2.12.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,8 +471,8 @@ importers:
   packages/astro:
     dependencies:
       '@astrojs/compiler':
-        specifier: 0.0.0-render-script-20251002135111
-        version: 0.0.0-render-script-20251002135111
+        specifier: 0.0.0-render-script-20251003120459
+        version: 0.0.0-render-script-20251003120459
       '@astrojs/internal-helpers':
         specifier: workspace:*
         version: link:../internal-helpers
@@ -6498,8 +6498,8 @@ packages:
     resolution: {integrity: sha512-bVzyKzEpIwqjihBU/aUzt1LQckJuHK0agd3/ITdXhPUYculrc6K1/K7H+XG4rwjXtg+ikT3PM05V1MVYWiIvQw==}
     engines: {node: '>=18.14.1'}
 
-  '@astrojs/compiler@0.0.0-render-script-20251002135111':
-    resolution: {integrity: sha512-2uXb13LRkCusMu47FhvX8y0vBKpEs+kOfw6siITKBDN0//FSp/WUse1/b8n2Deit34PwTAte8KNLUp6fIMogSA==}
+  '@astrojs/compiler@0.0.0-render-script-20251003120459':
+    resolution: {integrity: sha512-HWimO47p1zcg/H7/OtiABemJtvFxXDJ7r551Xkwq6c+FIZTps2/sIN1/qAEiuW5UmGChqaI+ILPMcSzFOWidSA==}
 
   '@astrojs/compiler@2.12.2':
     resolution: {integrity: sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==}
@@ -14256,7 +14256,7 @@ snapshots:
       log-update: 5.0.1
       sisteransi: 1.0.5
 
-  '@astrojs/compiler@0.0.0-render-script-20251002135111': {}
+  '@astrojs/compiler@0.0.0-render-script-20251003120459': {}
 
   '@astrojs/compiler@2.12.2': {}
 


### PR DESCRIPTION
## Changes

- See https://github.com/withastro/compiler/pull/1114
- In v5, `renderScript` became the default so we update the compiler and remove the option
- Depends on #14480

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, internal change

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
