### PR TITLE
feat: support i18n

### DIFF
--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -106,6 +106,7 @@ export type SSRManifestI18n = {
 	locales: Locales;
 	defaultLocale: string;
 	domainLookupTable: Record<string, string>;
+	domains: Record<string, string> | undefined;
 };
 
 export type SSRManifestCSP = {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -681,6 +681,7 @@ async function createBuildManifest(
 			defaultLocale: settings.config.i18n.defaultLocale,
 			locales: settings.config.i18n.locales,
 			domainLookupTable: {},
+			domains: settings.config.i18n.domains,
 		};
 	}
 

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -310,6 +310,7 @@ async function buildManifest(
 			locales: settings.config.i18n.locales,
 			defaultLocale: settings.config.i18n.defaultLocale,
 			domainLookupTable,
+			domains: settings.config.i18n.domains,
 		};
 	}
 

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -122,6 +122,7 @@ export function getLocaleAbsoluteUrl({ site, isBuild, ...rest }: GetLocaleAbsolu
 	const localeUrl = getLocaleRelativeUrl(rest);
 	const { domains, locale } = rest;
 	let url;
+	console.log('isBuild', domains, isBuild);
 	if (isBuild && domains && domains[locale]) {
 		const base = domains[locale];
 		url = joinPaths(base, localeUrl.replace(`/${rest.locale}`, ''));

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -122,7 +122,6 @@ export function getLocaleAbsoluteUrl({ site, isBuild, ...rest }: GetLocaleAbsolu
 	const localeUrl = getLocaleRelativeUrl(rest);
 	const { domains, locale } = rest;
 	let url;
-	console.log('isBuild', domains, isBuild);
 	if (isBuild && domains && domains[locale]) {
 		const base = domains[locale];
 		url = joinPaths(base, localeUrl.replace(`/${rest.locale}`, ''));

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -42,7 +42,7 @@ type GetLocaleRelativeUrl = GetLocaleOptions & {
 	base: string;
 	locales: Locales;
 	trailingSlash: AstroConfig['trailingSlash'];
-	format: AstroConfig['build']['format'];
+	format: NonNullable<AstroConfig['build']['format']>;
 	strategy?: RoutingStrategies;
 	defaultLocale: string;
 	domains: Record<string, string> | undefined;

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -2,7 +2,6 @@ import type * as vite from 'vite';
 import { AstroError } from '../core/errors/errors.js';
 import { AstroErrorData } from '../core/errors/index.js';
 import type { AstroSettings } from '../types/astro.js';
-import type { AstroConfig } from '../types/public/config.js';
 
 const virtualModuleId = 'astro:i18n';
 
@@ -10,41 +9,13 @@ type AstroInternationalization = {
 	settings: AstroSettings;
 };
 
-export interface I18nInternalConfig
-	extends Pick<AstroConfig, 'base' | 'site' | 'trailingSlash'>,
-		Pick<AstroConfig['build'], 'format'> {
-	i18n: AstroConfig['i18n'];
-	isBuild: boolean;
-}
-
 export default function astroInternationalization({
 	settings,
 }: AstroInternationalization): vite.Plugin {
-	const {
-		base,
-		build: { format },
-		i18n,
-		site,
-		trailingSlash,
-	} = settings.config;
+	const { i18n } = settings.config;
 	return {
 		name: 'astro:i18n',
 		enforce: 'pre',
-		config(_config, { command }) {
-			const i18nConfig: I18nInternalConfig = {
-				base,
-				format,
-				site,
-				trailingSlash,
-				i18n,
-				isBuild: command === 'build',
-			};
-			return {
-				define: {
-					__ASTRO_INTERNAL_I18N_CONFIG__: JSON.stringify(i18nConfig),
-				},
-			};
-		},
 		resolveId(id) {
 			if (id === virtualModuleId) {
 				if (i18n === undefined) throw new AstroError(AstroErrorData.i18nNotEnabled);

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -56,6 +56,7 @@ async function createSerializedManifest(settings: AstroSettings): Promise<Serial
 			locales: settings.config.i18n.locales,
 			domainLookupTable: {},
 			fallbackType: toFallbackType(settings.config.i18n.routing),
+			domains: settings.config.i18n.domains,
 		};
 	}
 

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -31,7 +31,7 @@ i18n = {
   defaultLocale: manifest.i18n.defaultLocale,
   locales: manifest.i18n.locales,
   routing: fromRoutingStrategy(manifest.i18n.strategy, manifest.i18n.fallbackType),
-  fallback: manifest.i18n.fallback,
+  fallback: manifest.i18n.fallback
   };
 }
 
@@ -66,6 +66,7 @@ if (manifest.i18n) {
    locales: manifest.i18n.locales,
    routing: fromRoutingStrategy(manifest.i18n.strategy, manifest.i18n.fallbackType),
    fallback: manifest.i18n.fallback,
+   domains: manifest.i18n.domains,
  };
 }
 

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -16,7 +16,7 @@ export { normalizeTheLocale, toCodes, toPaths } from '../i18n/index.js';
 
 const { trailingSlash, site, i18n, build } = config as ServerDeserializedManifest;
 const { format } = build;
-const isBuild = import.meta.env.MODE === 'build';
+const isBuild = import.meta.env.PROD;
 const { defaultLocale, locales, domains, fallback, routing } = i18n!;
 const base = import.meta.env.BASE_URL;
 

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error This is an internal module
+import * as config from 'astro:config/server';
 import { toFallbackType } from '../core/app/common.js';
 import { toRoutingStrategy } from '../core/app/index.js';
 import type { SSRManifest } from '../core/app/types.js';
@@ -5,16 +7,16 @@ import { IncorrectStrategyForI18n } from '../core/errors/errors-data.js';
 import { AstroError } from '../core/errors/index.js';
 import type { RedirectToFallback } from '../i18n/index.js';
 import * as I18nInternals from '../i18n/index.js';
-import type { I18nInternalConfig } from '../i18n/vite-plugin-i18n.js';
 import type { MiddlewareHandler } from '../types/public/common.js';
 import type { AstroConfig, ValidRedirectStatus } from '../types/public/config.js';
 import type { APIContext } from '../types/public/context.js';
+import type { ServerDeserializedManifest } from '../types/public/index.js';
 
 export { normalizeTheLocale, toCodes, toPaths } from '../i18n/index.js';
 
-const { trailingSlash, format, site, i18n, isBuild } =
-	// @ts-expect-error
-	__ASTRO_INTERNAL_I18N_CONFIG__ as I18nInternalConfig;
+const { trailingSlash, site, i18n, build } = config as ServerDeserializedManifest;
+const { format } = build;
+const isBuild = import.meta.env.MODE === 'build';
 const { defaultLocale, locales, domains, fallback, routing } = i18n!;
 const base = import.meta.env.BASE_URL;
 

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -385,6 +385,7 @@ if (i18n?.routing === 'manual') {
 			domainLookupTable: {},
 			fallbackType,
 			fallback: i18n.fallback,
+			domains: i18n.domains,
 		};
 		return I18nInternals.createMiddleware(manifest, base, trailingSlash, format);
 	};

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -177,6 +177,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			locales: settings.config.i18n.locales,
 			domainLookupTable: {},
 			fallbackType: toFallbackType(settings.config.i18n.routing),
+			domains: settings.config.i18n.domains,
 		};
 	}
 

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/astro.config.mjs
@@ -17,5 +17,16 @@ export default defineConfig({
 			},
 		},
 	},
+	i18n: {
+		defaultLocale: "en",
+		locales: ["en", "fr"],
+		routing: {
+			prefixDefaultLocale: false,
+			redirectToDefaultLocale: true
+		},
+		fallback: {
+			"fr": "en"
+		}
+	},
 	integrations: [mdx(), react()],
 });

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/fr/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/fr/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getAbsoluteLocaleUrlList } from "astro:i18n";
 export const prerender = false;
 import { getCollection, getEntry, render } from 'astro:content';
 import Hello from '../../components/Hello.tsx';

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/fr/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/fr/index.astro
@@ -1,0 +1,49 @@
+---
+export const prerender = false;
+import { getCollection, getEntry, render } from 'astro:content';
+import Hello from '../../components/Hello.tsx';
+import Island from '../../components/Island.astro';
+
+const workerRuntime = globalThis.navigator?.userAgent
+const blog = await getCollection('blog');
+const first = await getEntry('blog', 1);
+const dogs = await getCollection('dogs');
+const increment = await getEntry('increment', 'value');
+const { Content } = await render(increment);
+---
+<html>
+<head>
+	<meta charset="utf-8" />
+	<title>French index</title>
+</head>
+<body>
+<p>Last updated: {increment.data.lastUpdated.toLocaleTimeString()}</p>
+
+<h1>French Dogs</h1>
+<p>Running on: {workerRuntime ?? 'unknown runtime'}</p>
+<div id="framework">
+	<Hello client:load />
+</div>
+<Island server:defer/>
+<ul>
+	{dogs.map(dog => (
+		<li><a href={`/dogs/${dog.id}`}>{ dog.data?.breed }</a></li>
+	))}
+</ul>
+<section>
+	<Content />
+</section>
+<h1>Blog Posts</h1>
+
+<h2>{first.data.title}</h2>
+<ul>
+	{blog.map(post => (
+		<li><a href={`/blog/${post.id}`}>{ post.data?.title }</a></li>
+	))}
+</ul>
+
+
+
+
+</body>
+</html>

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/index.astro
@@ -19,6 +19,9 @@ const { Content } = await render(increment);
 <body>
 	<p>Last updated: {increment.data.lastUpdated.toLocaleTimeString()}</p>
 
+	<ul>
+		<li><a href="/fr">French index</a></li>
+	</ul>
 	<h1>Dogs</h1>
 	<p>Running on: {workerRuntime ?? 'unknown runtime'}</p>
 	<div id="framework">


### PR DESCRIPTION
## Changes

This PR adds support for i18n using the environment APIs in the new infrastructure.

- The i18n virtual module now uses `astro:config/server`
- We import the module using `* as config` because it doesn't have a default export, and we want to strictly type the `config` binding, so we get auto-completion
- Added `domains` to the SSRManifest. Until now, it wasn't needed. However, this is now required because we rely `astro:config/server`, which now depends on the virtual module of the manifest (we don't rely on `AstroConfig` anymore).
- removed unused code inside the i18n virtual module
- 

## Testing

Added a new page to the fixture and made sure (during TBD!) that pages that don't exist for the new locale are correctly redirected to the default locale. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
