### PR TITLE
chore: reword security document

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 To report a security issue, please [open a security advisory](https://github.com/withastro/astro/security/advisories/new) on GitHub with a detailed description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
 
-Please remember to include everything required for us to reproduce the issue, including but not limited to a publicly accessible git repository and/or StackBlitz repository. All code samples shared with our Security team will only be used to verify and diagnose the issue and will not be publicly shared with anyone outside of Astro's teams. Astro's Security Team members may share information only within the Astro teams on a need-to-know basis to fix the related issue in Astro.
+Please remember to include everything required for us to reproduce the issue, including but not limited to a **private accessible** repository. Maintainers will ask permissions to checkout the repository. All code samples shared with our Security team will only be used to verify and diagnose the issue and will not be publicly shared with anyone outside of Astro's teams. Astro's Security Team members may share information only within the Astro teams on a need-to-know basis to fix the related issue in Astro.
 
 Our Security team will respond to the security advisory within 3 working days.
 


### PR DESCRIPTION
## Changes

This PR rewords the `SECURITY.md` document regarding how users should provide a reproduction

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
