### PR TITLE
fix(fonts): hyphenate string weights in dev font hashes

### DIFF
--- a/.changeset/khaki-mangos-return.md
+++ b/.changeset/khaki-mangos-return.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Hyphenate string font weights in the dev font URL hash resolver so variable-weight ranges stop producing whitespace in hashed filenames, which was triggering 404s from the dev font proxy.

--- a/packages/astro/src/assets/fonts/implementations/url-proxy-hash-resolver.ts
+++ b/packages/astro/src/assets/fonts/implementations/url-proxy-hash-resolver.ts
@@ -44,5 +44,8 @@ function formatWeight(
 	if (typeof weight === 'number') {
 		return weight.toString();
 	}
-	return weight?.replace(/\s+/g, '-');
+	if (typeof weight === 'string') {
+		return weight.replace(/\s+/g, '-');
+	}
+	return weight;
 }


### PR DESCRIPTION
## Changes

- sanitize string font weights in the dev font hash resolver by replacing whitespace with hyphens
- prevents `/_astro/fonts/...` requests from including spaces (e.g. season-variable-300 900-normal-…) that 404 in dev mode

```sh
11:54:51 [404] (rewrite) /_astro/fonts/season-variable-300 550-normal-59ab9a31389bf782.woff2 687ms
```

## Testing

Existing test was failing even before making this change, so no new tests created:

```sh
✖ createDevUrlProxyHashResolver() (0.633458ms)
✖ fonts implementations (6.2725ms)
ℹ tests 19
ℹ suites 7
ℹ pass 18
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 123.715625

✖ failing tests:

test at packages/astro/test/units/assets/fonts/implementations.test.js:476:2
✖ createDevUrlProxyHashResolver() (0.633458ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  actual expected
  
  'foo-200 -700-italic-cyrillic-whatever.woff2'
  
      at TestContext.<anonymous> (file:///Users/z/Projects/astro/packages/astro/test/units/assets/fonts/implementations.test.js:525:10)
      at Test.runInAsyncScope (node:async_hooks:211:14)
      at Test.run (node:internal/test_runner/test:979:25)
      at Suite.processPendingSubtests (node:internal/test_runner/test:677:18)
      at Test.postRun (node:internal/test_runner/test:1090:19)
      at Test.run (node:internal/test_runner/test:1018:12)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:677:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: 'foo-200 700-italic-cyrillic-whatever.woff2',
    expected: 'foo-200-700-italic-cyrillic-whatever.woff2',
    operator: 'strictEqual'
```

But now passes:

```sh
✔ createDevUrlProxyHashResolver() (0.109333ms)
✔ fonts implementations (4.717125ms)
ℹ tests 19
ℹ suites 7
ℹ pass 19
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 123.876042
```


## Docs

no docs updates needed; behavior only affects the dev font proxy

