### PR TITLE
refactor(cli): create-key/cre

### DIFF
--- a/packages/astro/src/cli/create-key/core/create-key.ts
+++ b/packages/astro/src/cli/create-key/core/create-key.ts
@@ -1,12 +1,23 @@
 import type { Logger } from '../../../core/logger/core.js';
-import type { KeyGenerator } from '../definitions.js';
+import type { HelpDisplay, KeyGenerator } from '../definitions.js';
 
 interface CreateKeyOptions {
 	logger: Logger;
 	keyGenerator: KeyGenerator;
+	helpDisplay: HelpDisplay;
 }
 
-export async function createKey({ logger, keyGenerator }: CreateKeyOptions) {
+export async function createKey({ logger, keyGenerator, helpDisplay }: CreateKeyOptions) {
+	if (helpDisplay.shouldFire()) {
+		return helpDisplay.show({
+			commandName: 'astro create-key',
+			tables: {
+				Flags: [['--help (-h)', 'See all available flags.']],
+			},
+			description: 'Generates a key to encrypt props passed to Server islands.',
+		});
+	}
+
 	const key = await keyGenerator.generate();
 
 	logger.info(

--- a/packages/astro/src/cli/create-key/definitions.ts
+++ b/packages/astro/src/cli/create-key/definitions.ts
@@ -1,3 +1,23 @@
+import type { HelpPayload } from './domain/help-payload.js';
+
 export interface KeyGenerator {
 	generate: () => Promise<string>;
+}
+
+export interface HelpDisplay {
+	shouldFire: () => boolean;
+	show: (payload: HelpPayload) => void;
+}
+
+export interface TextStyler {
+	bgWhite: (msg: string) => string;
+	black: (msg: string) => string;
+	dim: (msg: string) => string;
+	green: (msg: string) => string;
+	bold: (msg: string) => string;
+	bgGreen: (msg: string) => string;
+}
+
+export interface AstroVersionProvider {
+	getVersion: () => string;
 }

--- a/packages/astro/src/cli/create-key/domain/help-payload.ts
+++ b/packages/astro/src/cli/create-key/domain/help-payload.ts
@@ -1,0 +1,7 @@
+export interface HelpPayload {
+	commandName: string;
+	headline?: string;
+	usage?: string;
+	tables?: Record<string, [command: string, help: string][]>;
+	description?: string;
+}

--- a/packages/astro/src/cli/create-key/infra/build-time-astro-version-provider.ts
+++ b/packages/astro/src/cli/create-key/infra/build-time-astro-version-provider.ts
@@ -1,0 +1,9 @@
+import type { AstroVersionProvider } from '../definitions.js';
+
+export function createBuildTimeAstroVersionProvider(): AstroVersionProvider {
+	return {
+		getVersion() {
+			return process.env.PACKAGE_VERSION ?? '';
+		},
+	};
+}

--- a/packages/astro/src/cli/create-key/infra/kleur-text-styler.ts
+++ b/packages/astro/src/cli/create-key/infra/kleur-text-styler.ts
@@ -1,0 +1,6 @@
+import * as colors from 'kleur/colors';
+import type { TextStyler } from '../definitions.js';
+
+export function createKleurTextStyler(): TextStyler {
+	return colors;
+}

--- a/packages/astro/src/cli/create-key/infra/logger-help-display.ts
+++ b/packages/astro/src/cli/create-key/infra/logger-help-display.ts
@@ -1,0 +1,76 @@
+import type { Logger } from '../../../core/logger/core.js';
+import type { Flags } from '../../flags.js';
+import type { AstroVersionProvider, HelpDisplay, TextStyler } from '../definitions.js';
+
+interface LoggerHelpDisplayOptions {
+	logger: Logger;
+	textStyler: TextStyler;
+	astroVersionProvider: AstroVersionProvider;
+	// TODO: find something better
+	flags: Flags;
+}
+
+export function createLoggerHelpDisplay({
+	logger,
+	flags,
+	textStyler,
+	astroVersionProvider,
+}: LoggerHelpDisplayOptions): HelpDisplay {
+	return {
+		shouldFire() {
+			return !!(flags.help || flags.h);
+		},
+		show({ commandName, description, headline, tables, usage }) {
+			const linebreak = () => '';
+			const title = (label: string) => `  ${textStyler.bgWhite(textStyler.black(` ${label} `))}`;
+			const table = (rows: [string, string][], { padding }: { padding: number }) => {
+				const split = process.stdout.columns < 60;
+				let raw = '';
+
+				for (const row of rows) {
+					if (split) {
+						raw += `    ${row[0]}\n    `;
+					} else {
+						raw += `${`${row[0]}`.padStart(padding)}`;
+					}
+					raw += '  ' + textStyler.dim(row[1]) + '\n';
+				}
+
+				return raw.slice(0, -1); // remove latest \n
+			};
+
+			let message = [];
+
+			if (headline) {
+				message.push(
+					linebreak(),
+					`  ${textStyler.bgGreen(textStyler.black(` ${commandName} `))} ${textStyler.green(
+						`v${astroVersionProvider.getVersion()}`,
+					)} ${headline}`,
+				);
+			}
+
+			if (usage) {
+				message.push(linebreak(), `  ${textStyler.green(commandName)} ${textStyler.bold(usage)}`);
+			}
+
+			if (tables) {
+				function calculateTablePadding(rows: [string, string][]) {
+					return rows.reduce((val, [first]) => Math.max(val, first.length), 0) + 2;
+				}
+
+				const tableEntries = Object.entries(tables);
+				const padding = Math.max(...tableEntries.map(([, rows]) => calculateTablePadding(rows)));
+				for (const [tableTitle, tableRows] of tableEntries) {
+					message.push(linebreak(), title(tableTitle), table(tableRows, { padding }));
+				}
+			}
+
+			if (description) {
+				message.push(linebreak(), `${description}`);
+			}
+
+			logger.info('SKIP_FORMAT', message.join('\n') + '\n');
+		},
+	};
+}

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -109,15 +109,32 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 			return;
 		}
 		case 'create-key': {
-			const [{ createKey }, { createLoggerFromFlags }, { createCryptoKeyGenerator }] =
-				await Promise.all([
-					import('./create-key/core/create-key.js'),
-					import('./flags.js'),
-					import('./create-key/infra/crypto-key-generator.js'),
-				]);
+			const [
+				{ createLoggerFromFlags },
+				{ createCryptoKeyGenerator },
+				{ createKleurTextStyler },
+				{ createBuildTimeAstroVersionProvider },
+				{ createLoggerHelpDisplay },
+				{ createKey },
+			] = await Promise.all([
+				import('./flags.js'),
+				import('./create-key/infra/crypto-key-generator.js'),
+				import('./create-key/infra/kleur-text-styler.js'),
+				import('./create-key/infra/build-time-astro-version-provider.js'),
+				import('./create-key/infra/logger-help-display.js'),
+				import('./create-key/core/create-key.js'),
+			]);
 			const logger = createLoggerFromFlags(flags);
 			const keyGenerator = createCryptoKeyGenerator();
-			await createKey({ logger, keyGenerator });
+			const textStyler = createKleurTextStyler();
+			const astroVersionProvider = createBuildTimeAstroVersionProvider();
+			const helpDisplay = createLoggerHelpDisplay({
+				logger,
+				flags,
+				textStyler,
+				astroVersionProvider,
+			});
+			await createKey({ logger, keyGenerator, helpDisplay });
 			return;
 		}
 		case 'docs': {

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -333,6 +333,7 @@ export function formatErrorMessage(err: ErrorWithMetadata, showFullStacktrace: b
 	return output.join('\n');
 }
 
+/** @deprecated Migrate to HelpDisplay */
 export function printHelp({
 	commandName,
 	headline,

--- a/packages/astro/test/units/cli/create-key.test.js
+++ b/packages/astro/test/units/cli/create-key.test.js
@@ -2,18 +2,29 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createKey } from '../../../dist/cli/create-key/core/create-key.js';
+import { createBuildTimeAstroVersionProvider } from '../../../dist/cli/create-key/infra/build-time-astro-version-provider.js';
+import { createLoggerHelpDisplay } from '../../../dist/cli/create-key/infra/logger-help-display.js';
+import packageJson from '../../../package.json' with { type: 'json' };
 import { createSpyLogger } from '../test-utils.js';
 
 describe('CLI create-key', () => {
 	describe('core', () => {
-		describe('create-key', () => {
+		describe('createKey()', () => {
 			it('logs the generated key', async () => {
 				const { logger, logs } = createSpyLogger();
+				/** @type {Array<import('../../../dist/cli/create-key/domain/help-payload.js').HelpPayload>} */
+				const payloads = [];
 
 				await createKey({
 					logger,
 					keyGenerator: {
 						generate: async () => 'FOO',
+					},
+					helpDisplay: {
+						shouldFire: () => false,
+						show: (payload) => {
+							payloads.push(payload);
+						},
 					},
 				});
 
@@ -25,6 +36,177 @@ describe('CLI create-key', () => {
 							'Generated a key to encrypt props passed to Server islands. To reuse the same key across builds, set this value as ASTRO_KEY in an environment variable on your build server.\n\nASTRO_KEY=FOO',
 					},
 				]);
+				assert.deepStrictEqual(payloads, []);
+			});
+
+			it('logs the help', async () => {
+				const { logger, logs } = createSpyLogger();
+				/** @type {Array<import('../../../dist/cli/create-key/domain/help-payload.js').HelpPayload>} */
+				const payloads = [];
+
+				await createKey({
+					logger,
+					keyGenerator: {
+						generate: async () => 'FOO',
+					},
+					helpDisplay: {
+						shouldFire: () => true,
+						show: (payload) => {
+							payloads.push(payload);
+						},
+					},
+				});
+
+				assert.deepStrictEqual(logs, []);
+				assert.deepStrictEqual(payloads, [
+					{
+						commandName: 'astro create-key',
+						tables: {
+							Flags: [['--help (-h)', 'See all available flags.']],
+						},
+						description: 'Generates a key to encrypt props passed to Server islands.',
+					},
+				]);
+			});
+		});
+	});
+
+	describe('infra', () => {
+		describe('createBuildTimeAstroVersionProvider()', () => {
+			it('returns the value from the build', () => {
+				const astroVersionProvider = createBuildTimeAstroVersionProvider();
+
+				assert.equal(astroVersionProvider.getVersion(), packageJson.version);
+			});
+		});
+
+		describe('createLoggerHelpDisplay()', () => {
+			describe('shouldFire()', () => {
+				it('returns false if no relevant flag is enabled', () => {
+					const { logger, logs } = createSpyLogger();
+					const helpDisplay = createLoggerHelpDisplay({
+						logger,
+						astroVersionProvider: {
+							getVersion: () => '1.0.0',
+						},
+						flags: {
+							_: [],
+						},
+						textStyler: {
+							bgWhite: (msg) => msg,
+							black: (msg) => msg,
+							dim: (msg) => msg,
+							green: (msg) => msg,
+							bold: (msg) => msg,
+							bgGreen: (msg) => msg,
+						},
+					});
+
+					assert.equal(helpDisplay.shouldFire(), false);
+					assert.deepStrictEqual(logs, []);
+				});
+
+				it('returns true if help flag is enabled', () => {
+					const { logger, logs } = createSpyLogger();
+					const helpDisplay = createLoggerHelpDisplay({
+						logger,
+						astroVersionProvider: {
+							getVersion: () => '1.0.0',
+						},
+						flags: {
+							_: [],
+							help: true,
+						},
+						textStyler: {
+							bgWhite: (msg) => msg,
+							black: (msg) => msg,
+							dim: (msg) => msg,
+							green: (msg) => msg,
+							bold: (msg) => msg,
+							bgGreen: (msg) => msg,
+						},
+					});
+
+					assert.equal(helpDisplay.shouldFire(), true);
+					assert.deepStrictEqual(logs, []);
+				});
+
+				it('returns true if h flag is enabled', () => {
+					const { logger, logs } = createSpyLogger();
+					const helpDisplay = createLoggerHelpDisplay({
+						logger,
+						astroVersionProvider: {
+							getVersion: () => '1.0.0',
+						},
+						flags: {
+							_: [],
+							h: true,
+						},
+						textStyler: {
+							bgWhite: (msg) => msg,
+							black: (msg) => msg,
+							dim: (msg) => msg,
+							green: (msg) => msg,
+							bold: (msg) => msg,
+							bgGreen: (msg) => msg,
+						},
+					});
+
+					assert.equal(helpDisplay.shouldFire(), true);
+					assert.deepStrictEqual(logs, []);
+				});
+			});
+
+			describe('show()', () => {
+				it('works', () => {
+					const { logger, logs } = createSpyLogger();
+					const helpDisplay = createLoggerHelpDisplay({
+						logger,
+						astroVersionProvider: {
+							getVersion: () => '1.0.0',
+						},
+						flags: {
+							_: [],
+						},
+						textStyler: {
+							bgWhite: (msg) => msg,
+							black: (msg) => msg,
+							dim: (msg) => msg,
+							green: (msg) => msg,
+							bold: (msg) => msg,
+							bgGreen: (msg) => msg,
+						},
+					});
+
+					helpDisplay.show({
+						commandName: 'astro preview',
+						usage: '[...flags]',
+						tables: {
+							Flags: [
+								['--port', `Specify which port to run on. Defaults to 4321.`],
+								['--host', `Listen on all addresses, including LAN and public addresses.`],
+							],
+						},
+						description: 'Starts a local server to serve your static dist/ directory.',
+					});
+
+					assert.deepStrictEqual(logs, [
+						{
+							type: 'info',
+							label: 'SKIP_FORMAT',
+							message:
+								`
+  astro preview [...flags]
+
+   Flags 
+  --port  Specify which port to run on. Defaults to 4321.
+  --host  Listen on all addresses, including LAN and public addresses.
+
+Starts a local server to serve your static dist/ directory.
+`,
+						},
+					]);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
## Changes

- Depends on #14501
- Updates the `create-key` command to display help, which involved creating a bunch of abstractions to allow unit testing

## Testing

Added unit tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, internal refactor

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
