### PR TITLE
Fix compatibility with older Astro versions in @astrojs/node

### DIFF
--- a/.changeset/fix-node-peer-dependency.md
+++ b/.changeset/fix-node-peer-dependency.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes compatibility issue with older versions of Astro by making `getAllowedDomains()` call optional and updating peer dependency to require `astro@^5.14.3`

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -38,7 +38,7 @@
     "server-destroy": "^1.0.1"
   },
   "peerDependencies": {
-    "astro": "^5.7.0"
+    "astro": "^5.14.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.6",

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -37,7 +37,7 @@ export function createAppHandler(app: NodeApp, options: Options): RequestHandler
 		let request: Request;
 		try {
 			request = NodeApp.createRequest(req, {
-				allowedDomains: app.getAllowedDomains(),
+				allowedDomains: app.getAllowedDomains?.() ?? [],
 			});
 		} catch (err) {
 			logger.error(`Could not render ${req.url}`);


### PR DESCRIPTION
## Changes

- Make getAllowedDomains() call optional with fallback to empty array
- Update peer dependency to require astro@^5.14.3
- Fixes #14513

## Testing

N/A

## Docs

N/A