### PR TITLE
fix heading level in config reference docs

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -595,6 +595,7 @@ export interface AstroUserConfig<
 		/**
 		 * @docs
 		 * @name security.allowedDomains
+		 * @kind h4
 		 * @type {RemotePattern[]}
 		 * @default `[]`
 		 * @version 5.14.2


### PR DESCRIPTION
## Changes

Adds the appropriate heading level for `security.allowedDomains` so it renders properly in docs as a sub heading of `security`.

Only affects docs rendering, so no changeset/release of Astro is needed.

## Testing

No tests, just fixing docs rendering

## Docs

All about the docs!
