### PR TITLE
chore: add `astro:env` examples to cloudflare 

### DIFF
--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -122,7 +122,6 @@ export function getLocaleAbsoluteUrl({ site, isBuild, ...rest }: GetLocaleAbsolu
 	const localeUrl = getLocaleRelativeUrl(rest);
 	const { domains, locale } = rest;
 	let url;
-	console.log('isBuild', domains, isBuild);
 	if (isBuild && domains && domains[locale]) {
 		const base = domains[locale];
 		url = joinPaths(base, localeUrl.replace(`/${rest.locale}`, ''));

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/astro.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import cloudflare from '@astrojs/cloudflare';
-import { defineConfig } from 'astro/config';
+import { defineConfig, envField } from 'astro/config';
 
 import mdx from '@astrojs/mdx';
 import { fileURLToPath } from 'node:url';
@@ -29,4 +29,11 @@ export default defineConfig({
 		}
 	},
 	integrations: [mdx(), react()],
+	env: {
+		schema: {
+			FOO: envField.string({ context: 'server', access: 'public' }),
+			BAR: envField.string({ context: 'client', access: 'public' }),
+			SECRET: envField.string({ context: 'server', access: 'secret' }),
+		}
+	}
 });

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/env.astro
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/env.astro
@@ -1,0 +1,18 @@
+---
+import { FOO, SECRET } from "astro:env/server";
+import { BAR } from "astro:env/client";
+
+const foo = FOO;
+const bar = BAR;
+const secret = SECRET;
+---
+
+<h1>{foo}</h1>
+<h1>{bar}</h1>
+<h1>{secret}</h1>
+
+<script>
+	import { BAR } from "astro:env/client";
+	
+	console.log(BAR);
+</script>

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/pages/index.astro
@@ -19,10 +19,13 @@ const { Content } = await render(increment);
 <body>
 	<p>Last updated: {increment.data.lastUpdated.toLocaleTimeString()}</p>
 
+	<h2>Translations</h2>
 	<ul>
 		<li><a href="/fr">French index</a></li>
 	</ul>
-	<h1>Dogs</h1>
+	<h2><code>astro:env</code></h2>
+	<a href="/env">Environment variables</a>
+	<h2>Dogs</h2>
 	<p>Running on: {workerRuntime ?? 'unknown runtime'}</p>
 	<div id="framework">
 		<Hello client:load />


### PR DESCRIPTION
## Changes

This PR adds `astro:env` in the vite plugin example.

The feature works out of the box in dev, so no changes to core are present.

## Testing

- I made sure the three kinds of secret are rendered
- I made sure that the tests still pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
