### PR TITLE
chore: handle invalidation of manifest

### DIFF
--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -2,7 +2,7 @@ import type fsMod from 'node:fs';
 import { extname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { bold } from 'kleur/colors';
-import { isRunnableDevEnvironment, normalizePath, type Plugin, type ViteDevServer } from 'vite';
+import { normalizePath, type Plugin, type ViteDevServer } from 'vite';
 import { serializeRouteData } from '../core/app/index.js';
 import type { SerializedRouteInfo } from '../core/app/types.js';
 import { warnMissingAdapter } from '../core/dev/adapter-validation.js';
@@ -83,12 +83,10 @@ export default async function astroPluginRoutes({
 				};
 			});
 			let environment = server.environments.ssr;
-			if (isRunnableDevEnvironment(environment)) {
-				const virtualMod = environment.moduleGraph.getModuleById(ASTRO_ROUTES_MODULE_ID_RESOLVED);
-				if (!virtualMod) return;
+			const virtualMod = environment.moduleGraph.getModuleById(ASTRO_ROUTES_MODULE_ID_RESOLVED);
+			if (!virtualMod) return;
 
-				environment.moduleGraph.invalidateModule(virtualMod);
-			}
+			environment.moduleGraph.invalidateModule(virtualMod);
 		}
 	}
 	return {


### PR DESCRIPTION
## Changes

This PR handles the invalidation of the manifest module when changes occur in the `srdDir` directory.

When a path that changed is detected, we invalidate the module itself, so the new routes can be calculated and passed to the `DevApp`

## Testing

Manual testing by changing/deleting/adding routes inside the pages/ folder, and made sure that the data is up-to-date.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
