### PR TITLE
fix: remove impossible i18n case

### DIFF
--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -399,11 +399,6 @@ export function redirectToFallback({
 				if (pathFallbackLocale === defaultLocale && strategy === 'pathname-prefix-other-locales') {
 					if (context.url.pathname.includes(`${base}`)) {
 						newPathname = context.url.pathname.replace(`/${urlLocale}`, ``);
-						// Ensure the pathname are non-empty. Redirects like "/fr" => "" may create infinite loops,
-						// as the "Location" response header is empty.
-						if (newPathname === '') {
-							newPathname = '/';
-						}
 					} else {
 						newPathname = context.url.pathname.replace(`/${urlLocale}`, `/`);
 					}

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -774,50 +774,6 @@ describe('[SSG] i18n routing', () => {
 		});
 	});
 
-	describe('i18n routing with routing strategy [prefix-other-locales] with root base', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let fixture;
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
-
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/i18n-routing-prefix-other-locales/',
-				output: 'server',
-				adapter: testAdapter(),
-				base: '/',
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'pt', 'fr'],
-					fallback: {
-						fr: 'en',
-					},
-					routing: {
-						prefixDefaultLocale: false,
-						redirectToDefaultLocale: true,
-						fallbackType: 'redirect',
-					},
-				},
-			});
-			await fixture.build();
-			devServer = await fixture.startDevServer();
-		});
-
-		afterEach(async () => {
-			devServer.stop();
-		});
-
-		it('should redirect to English page', async () => {
-			const response = await fixture.fetch('/fr', { redirect: 'manual' });
-			assert.equal(response.headers.get('Location'), '/');
-			assert.equal(response.status, 302);
-
-			const followRedirectResponse = await fixture.fetch('/fr');
-			assert.equal(followRedirectResponse.status, 200);
-			assert.equal((await followRedirectResponse.text()).includes('Hello'), true);
-		});
-	});
-
 	describe('i18n routing with routing strategy [pathname-prefix-always-no-redirect]', () => {
 		/** @type {import('./test-utils').Fixture} */
 		let fixture;


### PR DESCRIPTION
## Changes

- #13730 introduced a fix around infinite redirects
- However in 6.0, it's not possible to get into this sitation anymore, see #14406
- So I reverted the PR on next only 

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, already covered by the changeset and docs added in #14406

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
