### PR TITLE
Restore docs smoke test speed up

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
         "!mod.js.map"
       ],
       "outputs": ["dist/**/*", "!vendor/**", "mod.js", "mod.js.map"],
-      "outputLogs": "new-only"
+      "outputLogs": "new-only",
+      "passThroughEnv": ["SKIP_OG", "PUBLIC_TWO_LANG"]
     },
     "build:ci": {
       "dependsOn": ["^build:ci"],


### PR DESCRIPTION
## Changes

**This PR ensures that the `SKIP_OG` and `PUBLIC_TWO_LANG` environment variables are passed through during the Astro Docs smoke test build process.**

As visible in these [recent docs smoke test logs](https://github.com/withastro/astro/actions/runs/18678706693/job/53254736650?pr=14564), when expanding the `Test` step, and expanding the `docs:build` section, Astro Docs is being built for all languages and includes Open Graph image generation.

This [should not be the case](https://github.com/withastro/astro/blob/main/.github/workflows/ci.yml#L266-L267) as we specifically set the `SKIP_OG` and `PUBLIC_TWO_LANG` environment variables to skip OG generation and build only two languages.

I assume this broke with [Turborepo 2.0](https://turborepo.com/blog/turbo-2-0):

> Strict Mode for environment variables is now the default, moving from Loose Mode

[Strict Mode](https://turborepo.com/docs/crafting-your-repository/using-environment-variables#strict-mode) filters the environment variables available to a task's runtime to only those that are specified in `turbo.json`.

This PR adds the two environment variables to the [`passThroughEnv`](https://turborepo.com/docs/reference/configuration#passthroughenv) array for the build task used in the smoke tests.

## Testing

I tested a simplified version of the action locally to confirm that the environment variables are now correctly passed through and the docs smoke test in this PR [confirms the fix](https://github.com/withastro/astro/actions/runs/18684552463/job/53273705195?pr=14596).

## Docs

None, internal CI change only.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
