### PR TITLE
environments: get images to build in fixture

### DIFF
--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -379,6 +379,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					vite.build.rollupOptions.output.banner ||=
 						'globalThis.process ??= {}; globalThis.process.env ??= {};';
 
+					vite.build.rollupOptions.external = ['sharp'];
+
 					// Cloudflare env is only available per request. This isn't feasible for code that access env vars
 					// in a global way, so we shim their access as `process.env.*`. This is not the recommended way for users to access environment variables. But we'll add this for compatibility for chosen variables. Mainly to support `@astrojs/db`
 					vite.define = {

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/package.json
@@ -3,16 +3,18 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-	  "dev": "astro dev"
+		"dev": "astro dev",
+		"build": "astro build"
 	},
 	"dependencies": {
 		"@astrojs/cloudflare": "workspace:*",
 		"@astrojs/mdx": "^4.3.5",
 		"@astrojs/react": "workspace:*",
+		"@types/react": "^18.3.24",
+		"@types/react-dom": "^18.3.7",
 		"astro": "workspace:*",
-    "@types/react": "^18.3.24",
-    "@types/react-dom": "^18.3.7",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"sharp": "^0.34.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4910,6 +4910,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      sharp:
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/integrations/cloudflare/test/fixtures/with-base:
     dependencies:


### PR DESCRIPTION
## Changes

- Configures sharp as external so local builds work

## Testing

- Building the vite-plugin fixture

## Docs

N/A, bug fix