### PR TITLE
Fix remaining Cloudflare build warnings

### DIFF
--- a/packages/integrations/cloudflare/src/entrypoints/server.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/server.ts
@@ -1,6 +1,12 @@
 import type { ExportedHandler } from '@cloudflare/workers-types';
 import { type Env, handle } from '../utils/handler.js';
 
-export default {
+const defaultExport = {
 	fetch: handle,
-} satisfies ExportedHandler<Env>;
+} satisfies ExportedHandler<Env> 
+
+export function createExports() {
+	return {
+		default: defaultExport
+	};
+}

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/data/dogs.json
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/data/dogs.json
@@ -23,9 +23,9 @@
       "Confident"
     ]
   },
-    {
+  {
     "breed": "Alsatian",
-    "id": "german-shepherd",
+    "id": "alsatian",
     "size": "Large",
     "origin": "Germany",
     "lifespan": "9-13 years",


### PR DESCRIPTION
## Changes

- server.ts had the wrong format, should export a `createExports`, fixes that.
- Duplicate JSON not used in the tests removed that caused warning

## Testing

N/A

## Docs

N/A