### PR TITLE
feat(assets): Always allow cropping and never upscale

### DIFF
--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -71,32 +71,29 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 		// always call rotate to adjust for EXIF data orientation
 		result.rotate();
 
-		// If `fit` isn't set then use old behavior:
-		// - Do not use both width and height for resizing, and prioritize width over height
-		// - Allow enlarging images
+		if (transform.width && transform.height) {
+			const fit: keyof FitEnum | undefined = transform.fit
+				? (fitMap[transform.fit] ?? 'inside')
+				: undefined;
 
-		const withoutEnlargement = Boolean(transform.fit);
-		if (transform.width && transform.height && transform.fit) {
-			const fit: keyof FitEnum = fitMap[transform.fit] ?? 'inside';
 			result.resize({
 				width: Math.round(transform.width),
 				height: Math.round(transform.height),
 				fit,
 				position: transform.position,
-				withoutEnlargement,
+				withoutEnlargement: true,
 			});
 		} else if (transform.height && !transform.width) {
 			result.resize({
 				height: Math.round(transform.height),
-				withoutEnlargement,
+				withoutEnlargement: true,
 			});
 		} else if (transform.width) {
 			result.resize({
 				width: Math.round(transform.width),
-				withoutEnlargement,
+				withoutEnlargement: true,
 			});
 		}
-
 		if (transform.format) {
 			let quality: number | string | undefined = undefined;
 			if (transform.quality) {

--- a/packages/astro/test/core-image-service.test.js
+++ b/packages/astro/test/core-image-service.test.js
@@ -111,19 +111,17 @@ describe('astro image service', () => {
 				assert.equal(height, originalHeight);
 			});
 
-			// To match old behavior, we should upscale if the requested size is larger than the original
-			it('does upscale image if requested size is larger than original and fit is unset', async () => {
+			it('does not upscale image if requested size is larger than original and fit is unset', async () => {
 				const url = new URL(src);
 				url.searchParams.set('w', '3000');
 				url.searchParams.set('h', '2000');
 				url.searchParams.delete('fit');
 				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
-				assert.equal(width, 3000);
-				assert.equal(height, 2000);
+				assert.equal(width, originalWidth);
+				assert.equal(height, originalHeight);
 			});
 
-			// To match old behavior, we should upscale if the requested size is larger than the original
-			it('does not upscale is only one dimension is provided and fit is set', async () => {
+			it('does not upscale if only one dimension is provided and fit is set', async () => {
 				const url = new URL(src);
 				url.searchParams.set('w', '3000');
 				url.searchParams.delete('h');


### PR DESCRIPTION
## Changes

- Previously, you could only freeform resize an image if you specified width, height and fit. Failure to specify fit would result in a resize only based on width (or height, if you had only provided that). It's always been confusing tbh so this PR just removes that, if you specify both, we resize by both.
- You can still achieve the previous behavior by setting the fit to `inside` at least
- Closes https://github.com/withastro/astro/issues/13995 and https://github.com/withastro/astro/issues/14465

## Testing

Updated tests that tested old behaviour to test new behavior, ha

## Docs

https://github.com/withastro/docs/pull/12639
