### PR TITLE
fix(fonts): less aggressive filtering

### DIFF
--- a/.changeset/three-apples-roll.md
+++ b/.changeset/three-apples-roll.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where the experimental Fonts API would filter available font files too aggressively, which could prevent the download of woff files when using the google provider

--- a/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
+++ b/packages/astro/src/assets/fonts/logic/normalize-remote-font-faces.ts
@@ -14,7 +14,7 @@ export function normalizeRemoteFontFaces({
 	return (
 		fonts
 			// Avoid getting too much font files
-			.filter((font) => (typeof font.meta?.priority === 'number' ? font.meta.priority === 0 : true))
+			.filter((font) => (typeof font.meta?.priority === 'number' ? font.meta.priority <= 1 : true))
 			// Collect URLs
 			.map((font) => {
 				// The index keeps track of encountered URLs. We can't use the index on font.src.map

--- a/packages/astro/test/units/assets/fonts/logic.test.js
+++ b/packages/astro/test/units/assets/fonts/logic.test.js
@@ -368,16 +368,20 @@ describe('fonts logic', () => {
 							src: [],
 							meta: { priority: 0 },
 						},
-						// Will be ignored
 						{
 							src: [],
 							meta: { priority: 1 },
+						},
+						// Will be ignored
+						{
+							src: [],
+							meta: { priority: 2 },
 						},
 					],
 					urlProxy,
 					fontTypeExtractor: createFontTypeExtractor({ errorHandler: simpleErrorHandler }),
 				}).length,
-				4,
+				5,
 			);
 		});
 


### PR DESCRIPTION
## Changes

- After RFC feedback, see https://github.com/withastro/roadmap/pull/1039#issuecomment-3468823847 pt 3
- Basically unifont providers can return a priority for font files, to indicate which ones act as fallbacks. Only the google provider implements this, and we used to only download woff2 files. I made the filtering less agressive by allowing to get 1 fallback, usually woff

## Testing

Unit test updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
