### PR TITLE
Prevent high CPU usage by only running in astro projects

### DIFF
--- a/packages/language-tools/ts-plugin/src/index.ts
+++ b/packages/language-tools/ts-plugin/src/index.ts
@@ -5,10 +5,27 @@ import { getFrontmatterLanguagePlugin } from './frontmatter.js';
 import { getLanguagePlugin } from './language.js';
 
 export = createLanguageServicePlugin((ts, info) => {
+	const currentDir = info.project.getCurrentDirectory();
+
+	// Check if this is an Astro project by looking for astro.config.* file
+	if (ts.sys.readDirectory) {
+		const hasAstroConfig =
+			ts.sys.readDirectory(
+				currentDir,
+				['js', 'mjs', 'cjs', 'ts', 'mts', 'cts'],
+				undefined,
+				['astro.config.*'],
+				1,
+			).length > 0;
+
+		if (!hasAstroConfig) {
+			return { languagePlugins: [] };
+		}
+	}
+
 	let collectionConfig = undefined;
 
 	try {
-		const currentDir = info.project.getCurrentDirectory();
 		const fileContent = ts.sys.readFile(currentDir + '/.astro/collections/collections.json');
 		if (fileContent) {
 			collectionConfig = {


### PR DESCRIPTION
## Changes

Closes #14641
- Fix high CPU usage (110%) from VS Code extension on Apple Silicon
- Add check to only run TypeScript plugin in Astro projects, returns empty plugins for non-Astro projects to save resources

## Testing

<!-- How was this change tested? -->
- To test the fix:
  - Open non-Astro project → CPU usage should be normal
  - Open Astro project → Extension should work as before
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->
No docs needed. This fix only improves performance. Users don't need to change anything.
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
