### PR TITLE
refactor: remove `getRunnableDevEnvironment`

### DIFF
--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -68,7 +68,7 @@ export function astroContentAssetPropagationPlugin({
 			if (!isRunnableDevEnvironment(server.environments.ssr)) {
 				return;
 			}
-			devModuleLoader = createViteLoader(server);
+			devModuleLoader = createViteLoader(server, server.environments.ssr);
 		},
 		async transform(_, id, options) {
 			if (hasContentFlag(id, PROPAGATED_ASSET_FLAG)) {

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -22,7 +22,7 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 	return {
 		name: '@astro/plugin-middleware',
 		applyToEnvironment(environment) {
-			return environment.name === 'ssr';
+			return environment.name === 'ssr' || environment.name === 'astro';
 		},
 		async resolveId(id) {
 			if (id === MIDDLEWARE_MODULE_ID) {

--- a/packages/astro/src/core/module-loader/index.ts
+++ b/packages/astro/src/core/module-loader/index.ts
@@ -1,3 +1,3 @@
 export type { LoaderEvents, ModuleInfo, ModuleLoader } from './runner.js';
 export { createLoader } from './runner.js';
-export { createViteLoader, getRunnableEnvironment } from './vite.js';
+export { createViteLoader } from './vite.js';

--- a/packages/astro/src/core/module-loader/vite.ts
+++ b/packages/astro/src/core/module-loader/vite.ts
@@ -2,15 +2,16 @@ import { EventEmitter } from 'node:events';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type * as vite from 'vite';
-import { isRunnableDevEnvironment, type RunnableDevEnvironment, type ViteDevServer } from 'vite';
+import type { RunnableDevEnvironment } from 'vite';
 import { collectErrorMetadata } from '../errors/dev/utils.js';
 import { getViteErrorPayload } from '../errors/dev/vite.js';
 import type { ModuleLoader, ModuleLoaderEventEmitter } from './runner.js';
 
-export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
+export function createViteLoader(
+	viteServer: vite.ViteDevServer,
+	ssrEnvironment: RunnableDevEnvironment,
+): ModuleLoader {
 	const events = new EventEmitter() as ModuleLoaderEventEmitter;
-
-	const ssrEnvironment = getRunnableEnvironment(viteServer);
 
 	let isTsconfigUpdated = false;
 	function isTsconfigUpdate(filePath: string) {
@@ -112,11 +113,4 @@ export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
 		},
 		events,
 	};
-}
-
-export function getRunnableEnvironment(viteDevServer: ViteDevServer): RunnableDevEnvironment {
-	if (isRunnableDevEnvironment(viteDevServer.environments.ssr)) {
-		return viteDevServer.environments.ssr;
-	}
-	throw new Error("The environment isn't a runnable dev environment.");
 }

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -31,7 +31,7 @@ export default async function astroPluginRoutes({
 	settings,
 	logger,
 	fsMod,
-	routesList: initialRoutesList
+	routesList: initialRoutesList,
 }: Payload): Promise<Plugin> {
 	logger.debug('update', 'Re-calculate routes');
 	let routeList = initialRoutesList;
@@ -90,7 +90,7 @@ export default async function astroPluginRoutes({
 		},
 
 		applyToEnvironment(environment) {
-			return environment.name === 'ssr';
+			return environment.name === 'astro' || environment.name === 'ssr';
 		},
 
 		load(id) {


### PR DESCRIPTION
## Changes

This PR removes the usage `getRunnableDevEnvironment`. It also applies the `applyEnvironment` function to some plugins of ours.

I did try to refactor `ModuleLoader` too, and break it down into two bits: the part related to environments, and the part related to the dev server; however, it has more repercussions than expected, so I believe this refactor should be made in another PR. 

## Testing

Checked that examples and cloudlfare still work as expected. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
