### PR TITLE
fix(astro): populate process.env during build

### DIFF
--- a/.changeset/brown-doors-unite.md
+++ b/.changeset/brown-doors-unite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where `process.env` wouldn't be properly populated during the build


### PR DESCRIPTION
## Changes

- Closes #14760
- Regression from https://github.com/withastro/astro/pull/14712: `process.env` was populated lazily when accessing `astro:env` secrets

## Testing

Manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
