### PR TITLE
Fixes CSS when both static/client styles exist

### DIFF
--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -31,7 +31,8 @@ describe('CSS', function () {
 				html = await fixture.readFile('/index.html');
 				$ = cheerio.load(html);
 				const bundledCSSHREF = $('link[rel=stylesheet][href^=/_astro/]').attr('href');
-				bundledCSS = (await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/')))
+				const bundledCSSFilePath = bundledCSSHREF.replace(/^\/?/, '/');
+				bundledCSS = (await fixture.readFile(bundledCSSFilePath))
 					.replace(/\s/g, '')
 					.replace('/n', '');
 			},


### PR DESCRIPTION
## Changes

- Weren't properly copying over styles from the prerender into the destination outputDir, this fixes that.

## Testing

- All 0-css.test.js tests pass (except 1 dev one) now!

## Docs

N/A, bug fix