### PR TITLE
fix: flag `serverLike` incorrectly computed

### DIFF
--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -145,6 +145,7 @@ function createManifest(
 		trailingSlash: manifest?.trailingSlash ?? ASTRO_CONFIG_DEFAULTS.trailingSlash,
 		buildFormat: manifest?.buildFormat ?? ASTRO_CONFIG_DEFAULTS.build.format,
 		compressHTML: manifest?.compressHTML ?? ASTRO_CONFIG_DEFAULTS.compressHTML,
+		serverLike: manifest?.serverLike ?? false,
 		assets: manifest?.assets ?? new Set(),
 		assetsPrefix: manifest?.assetsPrefix ?? undefined,
 		entryModules: manifest?.entryModules ?? {},
@@ -254,6 +255,7 @@ type AstroContainerManifest = Pick<
 	| 'cacheDir'
 	| 'csp'
 	| 'allowedDomains'
+	| 'serverLike'
 >;
 
 type AstroContainerConstructor = {
@@ -287,7 +289,6 @@ export class experimental_AstroContainer {
 			}),
 			manifest: createManifest(manifest, renderers),
 			streaming,
-			serverLike: true,
 			renderers: renderers ?? manifest?.renderers ?? [],
 			resolve: async (specifier: string) => {
 				if (this.#withManifest) {

--- a/packages/astro/src/container/pipeline.ts
+++ b/packages/astro/src/container/pipeline.ts
@@ -19,26 +19,18 @@ export class ContainerPipeline extends Pipeline {
 		SinglePageBuiltModule
 	>();
 
+	getName(): string {
+		return 'ContainerPipeline';
+	}
+
 	static create({
 		logger,
 		manifest,
 		renderers,
 		resolve,
-		serverLike,
 		streaming,
-	}: Pick<
-		ContainerPipeline,
-		'logger' | 'manifest' | 'renderers' | 'resolve' | 'serverLike' | 'streaming'
-	>) {
-		return new ContainerPipeline(
-			logger,
-			manifest,
-			'development',
-			renderers,
-			resolve,
-			serverLike,
-			streaming,
-		);
+	}: Pick<ContainerPipeline, 'logger' | 'manifest' | 'renderers' | 'resolve' | 'streaming'>) {
+		return new ContainerPipeline(logger, manifest, 'development', renderers, resolve, streaming);
 	}
 
 	componentMetadata(_routeData: RouteData): Promise<SSRResult['componentMetadata']> | void {}

--- a/packages/astro/src/core/app/dev/pipeline.ts
+++ b/packages/astro/src/core/app/dev/pipeline.ts
@@ -13,6 +13,10 @@ import { findRouteToRewrite } from '../../routing/rewrite.js';
 type DevPipelineCreate = Pick<DevPipeline, 'logger' | 'manifest' | 'streaming'>;
 
 export class DevPipeline extends Pipeline {
+	getName(): string {
+		return 'DevPipeline';
+	}
+
 	static create({ logger, manifest, streaming }: DevPipelineCreate) {
 		async function resolve(specifier: string): Promise<string> {
 			if (specifier.startsWith('/')) {
@@ -28,7 +32,6 @@ export class DevPipeline extends Pipeline {
 			'production',
 			manifest.renderers,
 			resolve,
-			true,
 			streaming,
 			undefined,
 			undefined,
@@ -126,7 +129,7 @@ export class DevPipeline extends Pipeline {
 			trailingSlash: this.manifest.trailingSlash,
 			buildFormat: this.manifest.buildFormat,
 			base: this.manifest.base,
-			outDir: this.serverLike ? this.manifest.buildClientDir : this.manifest.outDir,
+			outDir: this.manifest?.serverLike ? this.manifest.buildClientDir : this.manifest.outDir,
 		});
 
 		const componentInstance = await this.getComponentByRoute(routeData);

--- a/packages/astro/src/core/app/pipeline.ts
+++ b/packages/astro/src/core/app/pipeline.ts
@@ -10,6 +10,10 @@ import {
 import { findRouteToRewrite } from '../routing/rewrite.js';
 
 export class AppPipeline extends Pipeline {
+	getName(): string {
+		return 'AppPipeline';
+	}
+
 	static create({
 		logger,
 		manifest,
@@ -32,7 +36,6 @@ export class AppPipeline extends Pipeline {
 			'production',
 			manifest.renderers,
 			resolve,
-			true,
 			streaming,
 			undefined,
 			undefined,
@@ -84,7 +87,7 @@ export class AppPipeline extends Pipeline {
 			trailingSlash: this.manifest.trailingSlash,
 			buildFormat: this.manifest.buildFormat,
 			base: this.manifest.base,
-			outDir: this.serverLike ? this.manifest.buildClientDir : this.manifest.outDir,
+			outDir: this.manifest?.serverLike ? this.manifest.buildClientDir : this.manifest.outDir,
 		});
 
 		const componentInstance = await this.getComponentByRoute(routeData);

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -75,6 +75,13 @@ export type SSRManifest = {
 	assetsPrefix?: AssetsPrefix;
 	renderers: SSRLoadedRenderer[];
 	/**
+	 * Based on Astro config's `output` option, `true` if "server" or "hybrid".
+	 *
+	 * Whether this application is SSR-like. If so, this has some implications, such as
+	 * the creation of `dist/client` and `dist/server` folders.
+	 */
+	serverLike: boolean;
+	/**
 	 * Map of directive name (e.g. `load`) to the directive script code
 	 */
 	clientDirectives: Map<string, string>;

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -46,10 +46,7 @@ export abstract class Pipeline {
 		readonly runtimeMode: RuntimeMode,
 		readonly renderers: SSRLoadedRenderer[],
 		readonly resolve: (s: string) => Promise<string>,
-		/**
-		 * Based on Astro config's `output` option, `true` if "server" or "hybrid".
-		 */
-		readonly serverLike: boolean,
+
 		readonly streaming: boolean,
 		/**
 		 * Used to provide better error messages for `Astro.clientAddress`
@@ -105,6 +102,11 @@ export abstract class Pipeline {
 	 * @param routeData
 	 */
 	abstract getComponentByRoute(routeData: RouteData): Promise<ComponentInstance>;
+
+	/**
+	 * The current name of the pipeline. Useful for debugging
+	 */
+	abstract getName(): string;
 
 	/**
 	 * Resolves the middleware from the manifest, and returns the `onRequest` function. If `onRequest` isn't there,

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -48,7 +48,7 @@ export async function generatePages(
 	const prerenderEntryFileName = internals.prerenderEntryFileName;
 	if (!prerenderEntryFileName) {
 		throw new Error(
-			`Prerender entry filename not found in build internals. This is likely a bug in Astro.`
+			`Prerender entry filename not found in build internals. This is likely a bug in Astro.`,
 		);
 	}
 	const prerenderEntryUrl = new URL(prerenderEntryFileName, prerenderOutputDir);
@@ -296,7 +296,7 @@ async function getPathsForRoute(
 	pipeline: BuildPipeline,
 	builtPaths: Set<string>,
 ): Promise<Array<string>> {
-	const { logger, options, routeCache, serverLike, manifest } = pipeline;
+	const { logger, options, routeCache, manifest } = pipeline;
 	let paths: Array<string> = [];
 	if (route.pathname) {
 		paths.push(route.pathname);
@@ -317,7 +317,7 @@ async function getPathsForRoute(
 			route,
 			routeCache,
 			logger,
-			ssr: serverLike,
+			ssr: manifest.serverLike,
 			base: manifest.base,
 			trailingSlash: manifest.trailingSlash,
 		}).catch((err) => {

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -5,9 +5,7 @@ import type * as vite from 'vite';
 import { getAssetsPrefix } from '../../../assets/utils/getAssetsPrefix.js';
 import { normalizeTheLocale } from '../../../i18n/index.js';
 import { runHookBuildSsr } from '../../../integrations/hooks.js';
-import {
-	SERIALIZED_MANIFEST_RESOLVED_ID,
-} from '../../../manifest/serialized.js';
+import { SERIALIZED_MANIFEST_RESOLVED_ID } from '../../../manifest/serialized.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../../vite-plugin-scripts/index.js';
 import { toFallbackType } from '../../app/common.js';
 import { serializeRouteData, toRoutingStrategy } from '../../app/index.js';
@@ -68,15 +66,19 @@ const replaceExp = new RegExp(`['"]${MANIFEST_REPLACE}['"]`, 'g');
 export async function manifestBuildPostHook(
 	options: StaticBuildOptions,
 	internals: BuildInternals,
-	{ ssrOutputs, prerenderOutputs, mutate }: {
-		ssrOutputs: vite.Rollup.RollupOutput[],
-		prerenderOutputs: vite.Rollup.RollupOutput[],
+	{
+		ssrOutputs,
+		prerenderOutputs,
+		mutate,
+	}: {
+		ssrOutputs: vite.Rollup.RollupOutput[];
+		prerenderOutputs: vite.Rollup.RollupOutput[];
 		mutate: (chunk: OutputChunk, envs: ['server'], code: string) => void;
 	},
 ) {
 	const manifest = await createManifest(options, internals);
 
-	if(ssrOutputs.length > 0) {
+	if (ssrOutputs.length > 0) {
 		let manifestEntryChunk: OutputChunk | undefined;
 
 		// Find the serialized manifest chunk in SSR outputs
@@ -245,7 +247,7 @@ async function buildManifest(
 		});
 
 		// Add the built .html file as a staticFile
-		if(route.prerender && route.pathname) {
+		if (route.prerender && route.pathname) {
 			const outFolder = getOutFolder(opts.settings, route.pathname, route);
 			const outFile = getOutFile(opts.settings.config, outFolder, route.pathname, route);
 			const file = outFile.toString().replace(opts.settings.config.build.client.toString(), '');
@@ -319,6 +321,7 @@ async function buildManifest(
 		buildServerDir: opts.settings.config.build.server.toString(),
 		adapterName: opts.settings.adapter?.name ?? '',
 		routes,
+		serverLike: opts.settings.buildOutput === 'server',
 		site: settings.config.site,
 		base: settings.config.base,
 		userAssetsBase: settings.config?.vite?.base,

--- a/packages/astro/src/core/middleware/sequence.ts
+++ b/packages/astro/src/core/middleware/sequence.ts
@@ -59,7 +59,7 @@ export function sequence(...handlers: MiddlewareHandler[]): MiddlewareHandler {
 						// This case isn't valid because when building for SSR, the prerendered route disappears from the server output because it becomes an HTML file,
 						// so Astro can't retrieve it from the emitted manifest.
 						if (
-							pipeline.serverLike === true &&
+							pipeline.manifest.serverLike === true &&
 							handleContext.isPrerendered === false &&
 							routeData.prerender === true
 						) {

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -164,7 +164,7 @@ export class RenderContext {
 		slots: Record<string, any> = {},
 	): Promise<Response> {
 		const { middleware, pipeline } = this;
-		const { logger, serverLike, streaming, manifest } = pipeline;
+		const { logger, streaming, manifest } = pipeline;
 
 		const props =
 			Object.keys(this.props).length > 0
@@ -175,7 +175,7 @@ export class RenderContext {
 						routeCache: this.pipeline.routeCache,
 						pathname: this.pathname,
 						logger,
-						serverLike,
+						serverLike: manifest.serverLike,
 						base: manifest.base,
 						trailingSlash: manifest.trailingSlash,
 					});
@@ -207,7 +207,7 @@ export class RenderContext {
 				// This case isn't valid because when building for SSR, the prerendered route disappears from the server output because it becomes an HTML file,
 				// so Astro can't retrieve it from the emitted manifest.
 				if (
-					this.pipeline.serverLike === true &&
+					this.pipeline.manifest.serverLike === true &&
 					this.routeData.prerender === false &&
 					routeData.prerender === true
 				) {
@@ -360,7 +360,7 @@ export class RenderContext {
 		// Allow i18n fallback rewrites - if the target route has fallback routes, this is likely an i18n scenario
 		const isI18nFallback = routeData.fallbackRoutes && routeData.fallbackRoutes.length > 0;
 		if (
-			this.pipeline.serverLike &&
+			this.pipeline.manifest.serverLike &&
 			!this.routeData.prerender &&
 			routeData.prerender &&
 			!isI18nFallback

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -122,6 +122,7 @@ async function createSerializedManifest(settings: AstroSettings): Promise<Serial
 		trailingSlash: settings.config.trailingSlash,
 		buildFormat: settings.config.build.format,
 		compressHTML: settings.config.compressHTML,
+		serverLike: settings.buildOutput === 'server',
 		assets: [],
 		entryModules: {},
 		routes: [],

--- a/packages/astro/src/vite-plugin-app/app.ts
+++ b/packages/astro/src/vite-plugin-app/app.ts
@@ -485,7 +485,7 @@ async function matchRoute(
 	pipeline: AstroServerPipeline,
 	manifest: SSRManifest,
 ): Promise<MatchedRoute | undefined> {
-	const { logger, routeCache, serverLike } = pipeline;
+	const { logger, routeCache } = pipeline;
 	const matches = matchAllRoutes(pathname, routesList);
 
 	const preloadedMatches = await getSortedPreloadedMatches({
@@ -504,7 +504,7 @@ async function matchRoute(
 				routeCache,
 				pathname: pathname,
 				logger,
-				serverLike,
+				serverLike: pipeline.manifest.serverLike,
 				base: manifest.base,
 				trailingSlash: manifest.trailingSlash,
 			});

--- a/packages/astro/src/vite-plugin-app/pipeline.ts
+++ b/packages/astro/src/vite-plugin-app/pipeline.ts
@@ -26,6 +26,10 @@ import { createResolve } from '../vite-plugin-astro-server/resolve.js';
 import { PAGE_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
 
 export class AstroServerPipeline extends Pipeline {
+	getName(): string {
+		return 'AstroServerPipeline';
+	}
+
 	// renderers are loaded on every request,
 	// so it needs to be mutable here unlike in other environments
 	override renderers = new Array<SSRLoadedRenderer>();
@@ -45,9 +49,8 @@ export class AstroServerPipeline extends Pipeline {
 		readonly defaultRoutes = createDefaultRoutes(manifest),
 	) {
 		const resolve = createResolve(loader, manifest.rootDir);
-		const serverLike = settings?.buildOutput === 'server';
 		const streaming = true;
-		super(logger, manifest, 'development', [], resolve, serverLike, streaming);
+		super(logger, manifest, 'development', [], resolve, streaming);
 	}
 
 	static create(

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -219,6 +219,7 @@ export async function createDevelopmentManifest(settings: AstroSettings): Promis
 		trailingSlash: settings.config.trailingSlash,
 		buildFormat: settings.config.build.format,
 		compressHTML: settings.config.compressHTML,
+		serverLike: settings.buildOutput === 'server',
 		assets: new Set(),
 		entryModules: {},
 		routes: [],

--- a/packages/astro/src/vite-plugin-css/index.ts
+++ b/packages/astro/src/vite-plugin-css/index.ts
@@ -36,11 +36,7 @@ export function astroDevCssPlugin({ routesList, command }: AstroVitePluginOption
 				return next();
 			});
 		},
-
-		applyToEnvironment(env) {
-			return env.name === 'ssr' || env.name === 'astro';
-		},
-
+		
 		resolveId(id) {
 			if (id === MODULE_DEV_CSS) {
 				return RESOLVED_MODULE_DEV_CSS;


### PR DESCRIPTION
## Changes

This PR fixes many failures around `i18n-routing.test.js`. The flag `AppPipeline.serverLike` was always set to `true`, which caused many false negatives.

This PR moves `serverLike` inside the `SSRManifest`, so we know it's always correctly computed during the build.

Also, I added a `getName` method to the `BasePipeline`. Now that we have many classes that extend from the `BasePipeline`, I found it very difficult to understand which instance was building the page.

With `getName`, that should be easy. 

## Testing

Some tests around rewrites and redirects are now passing. Some are still failing, and i will address them later

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
