### PR TITLE
feat(fonts)!: update default subsets

### DIFF
--- a/.changeset/red-parrots-drum.md
+++ b/.changeset/red-parrots-drum.md
@@ -1,0 +1,26 @@
+---
+'astro': patch
+---
+
+**BREAKING CHANGE to the experimental Fonts API only**
+
+Updates the default `subsets` to `["latin"]`
+
+Subsets have been a common source of confusion: they caused a lot of files to be downloaded by default. You now have to manually pick extra subsets.
+
+Review your Astro config and update subsets if you need, for example if you need greek characters:
+
+```diff
+import { defineConfig, fontProviders } from "astro/config"
+
+export default defineConfig({
+    experimental: {
+        fonts: [{
+            name: "Roboto",
+            cssVariable: "--font-roboto",
+            provider: fontProviders.google(),
++            subsets: ["latin", "greek"]
+        }]
+    }
+})
+```

--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -164,7 +164,7 @@ export const remoteFontFamilySchema = requiredFamilyAttributesSchema
 			 */
 			styles: z.array(styleSchema).nonempty().optional(),
 			/**
-			 * @default `["cyrillic-ext", "cyrillic", "greek-ext", "greek", "vietnamese", "latin-ext", "latin"]`
+			 * @default `["latin"]`
 			 *
 			 * An array of [font subsets](https://knaap.dev/posts/font-subsetting/):
 			 */

--- a/packages/astro/src/assets/fonts/constants.ts
+++ b/packages/astro/src/assets/fonts/constants.ts
@@ -5,7 +5,7 @@ export const LOCAL_PROVIDER_NAME = 'local';
 export const DEFAULTS: Defaults = {
 	weights: ['400'],
 	styles: ['normal', 'italic'],
-	subsets: ['cyrillic-ext', 'cyrillic', 'greek-ext', 'greek', 'vietnamese', 'latin-ext', 'latin'],
+	subsets: ['latin'],
 	// Technically serif is the browser default but most websites these days use sans-serif
 	fallbacks: ['sans-serif'],
 	optimizedFallbacks: true,


### PR DESCRIPTION
## Changes

- Updates the default subsets because previous defaults were confusing to basically everyone

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- Changeset
- https://github.com/withastro/docs/pull/12731
- [withastro/roadmap@`793d9de` (#1039)](https://github.com/withastro/roadmap/pull/1039/commits/793d9decd78373c3e2aed480e702f346ee8aca05)

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
