### PR TITLE
Always include the routeData in the prerender manifest for generation

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -74,7 +74,7 @@ export async function generatePages(
 
 	const app = prerenderEntry.app as BaseApp;
 	if (ssr) {
-		for (const [routeData, _] of pagesToGenerate) {
+		for (const routeData of pagesToGenerate) {
 			if (routeData.prerender) {
 				// i18n domains won't work with pre rendered routes at the moment, so we need to throw an error
 				if (config.i18n?.domains && Object.keys(config.i18n.domains).length > 0) {
@@ -88,7 +88,7 @@ export async function generatePages(
 			}
 		}
 	} else {
-		for (const [routeData, _] of pagesToGenerate) {
+		for (const routeData of pagesToGenerate) {
 			await generatePage(app, routeData, builtPaths, pipeline, routeToHeaders);
 		}
 	}


### PR DESCRIPTION
## Changes

- Some tests were failing because it couldn't find the index.html. That's because we were only rendering when the page was in its own separate chunk. This isn't the case when there's only a single page due to the way Vite bundles.
- We don't actually need this information, so labeled it as likely able to be removed.

## Testing

- Fixes the astro-assets.test.js tests, and likely many others.

## Docs

N/A, bug fix