### PR TITLE
refactor(cli): use getters when possible

### DIFF
--- a/packages/astro/src/cli/definitions.ts
+++ b/packages/astro/src/cli/definitions.ts
@@ -17,7 +17,7 @@ export interface TextStyler {
 }
 
 export interface AstroVersionProvider {
-	getVersion: () => string;
+	readonly version: string;
 }
 
 export interface CommandRunner {
@@ -39,6 +39,6 @@ export interface CommandExecutor {
 }
 
 export interface OperatingSystemProvider {
-	getName: () => NodeJS.Platform;
-	getDisplayName: () => string;
+	readonly name: NodeJS.Platform;
+	readonly displayName: string;
 }

--- a/packages/astro/src/cli/docs/core/open-docs.ts
+++ b/packages/astro/src/cli/docs/core/open-docs.ts
@@ -36,7 +36,7 @@ export const openDocsCommand = defineCommand({
 		description: `Launches the Astro Docs website directly from the terminal.`,
 	},
 	async run({ url, operatingSystemProvider, logger, commandExecutor, cloudIdeProvider }: Options) {
-		const platform = cloudIdeProvider.getName() ?? operatingSystemProvider.getName();
+		const platform = cloudIdeProvider.name ?? operatingSystemProvider.name;
 		const input = getExecInputForPlatform(platform);
 		if (!input) {
 			logger.error(

--- a/packages/astro/src/cli/docs/definitions.ts
+++ b/packages/astro/src/cli/docs/definitions.ts
@@ -1,5 +1,5 @@
 import type { CloudIde } from './domain/cloud-ide.js';
 
 export interface CloudIdeProvider {
-	getName: () => CloudIde | null;
+	readonly name: CloudIde | null;
 }

--- a/packages/astro/src/cli/docs/infra/process-cloud-ide-provider.ts
+++ b/packages/astro/src/cli/docs/infra/process-cloud-ide-provider.ts
@@ -2,7 +2,7 @@ import type { CloudIdeProvider } from '../definitions.js';
 
 export function createProcessCloudIdeProvider(): CloudIdeProvider {
 	return {
-		getName() {
+		get name() {
 			return Boolean(process.env.GITPOD_REPO_ROOT) ? 'gitpod' : null;
 		},
 	};

--- a/packages/astro/src/cli/info/infra/cli-clipboard.ts
+++ b/packages/astro/src/cli/info/infra/cli-clipboard.ts
@@ -49,7 +49,7 @@ export function createCliClipboard({
 	return {
 		async copy(text) {
 			text = text.trim();
-			const platform = operatingSystemProvider.getName();
+			const platform = operatingSystemProvider.name;
 			const input = await getExecInputForPlatform({ platform, commandExecutor });
 			if (!input) {
 				logger.warn('SKIP_FORMAT', 'Clipboard command not found!');

--- a/packages/astro/src/cli/info/infra/cli-debug-info-provider.ts
+++ b/packages/astro/src/cli/info/infra/cli-debug-info-provider.ts
@@ -29,9 +29,9 @@ export function createCliDebugInfoProvider({
 	return {
 		async get() {
 			const debugInfo: DebugInfo = [
-				['Astro', `v${astroVersionProvider.getVersion()}`],
+				['Astro', `v${astroVersionProvider.version}`],
 				['Node', nodeVersionProvider.get()],
-				['System', operatingSystemProvider.getDisplayName()],
+				['System', operatingSystemProvider.displayName],
 				['Package Manager', packageManager.getName()],
 				['Output', config.output],
 			];

--- a/packages/astro/src/cli/info/infra/dev-debug-info-provider.ts
+++ b/packages/astro/src/cli/info/infra/dev-debug-info-provider.ts
@@ -24,9 +24,9 @@ export function createDevDebugInfoProvider({
 	return {
 		async get() {
 			const debugInfo: DebugInfo = [
-				['Astro', `v${astroVersionProvider.getVersion()}`],
+				['Astro', `v${astroVersionProvider.version}`],
 				['Node', nodeVersionProvider.get()],
-				['System', operatingSystemProvider.getDisplayName()],
+				['System', operatingSystemProvider.displayName],
 				['Package Manager', packageManager.getName()],
 				['Output', config.output],
 				['Adapter', config.adapter?.name ?? 'none'],

--- a/packages/astro/src/cli/infra/build-time-astro-version-provider.ts
+++ b/packages/astro/src/cli/infra/build-time-astro-version-provider.ts
@@ -3,7 +3,7 @@ import type { AstroVersionProvider } from '../definitions.js';
 export function createBuildTimeAstroVersionProvider(): AstroVersionProvider {
 	const version = process.env.PACKAGE_VERSION ?? '';
 	return {
-		getVersion() {
+		get version() {
 			return version;
 		},
 	};

--- a/packages/astro/src/cli/infra/process-operating-system-provider.ts
+++ b/packages/astro/src/cli/infra/process-operating-system-provider.ts
@@ -9,10 +9,10 @@ const PLATFORM_TO_OS: Partial<Record<NodeJS.Platform, string>> = {
 export function createProcessOperatingSystemProvider(): OperatingSystemProvider {
 	const platform = process.platform;
 	return {
-		getName() {
-			return platform;
+		get name() {
+			return platform
 		},
-		getDisplayName() {
+		get displayName() {
 			const system = PLATFORM_TO_OS[platform] ?? platform;
 			return `${system} (${process.arch})`;
 		},

--- a/packages/astro/src/cli/utils/format-version.ts
+++ b/packages/astro/src/cli/utils/format-version.ts
@@ -8,6 +8,6 @@ interface Options {
 
 export function formatVersion({ name, textStyler, astroVersionProvider }: Options) {
 	return `  ${textStyler.bgGreen(textStyler.black(` ${name} `))} ${textStyler.green(
-		`v${astroVersionProvider.getVersion()}`,
+		`v${astroVersionProvider.version}`,
 	)}`;
 }

--- a/packages/astro/test/units/cli/docs.test.js
+++ b/packages/astro/test/units/cli/docs.test.js
@@ -76,7 +76,7 @@ describe('CLI docs', () => {
 				process.env.GITPOD_REPO_ROOT = '/foo/bar/';
 				const cloudIdeaProvider = createProcessCloudIdeProvider();
 
-				const platform = cloudIdeaProvider.getName();
+				const platform = cloudIdeaProvider.name;
 
 				assert.equal(platform, 'gitpod');
 			});

--- a/packages/astro/test/units/cli/index.test.js
+++ b/packages/astro/test/units/cli/index.test.js
@@ -54,7 +54,7 @@ describe('CLI shared', () => {
 			it('returns the value from the build', () => {
 				const astroVersionProvider = createBuildTimeAstroVersionProvider();
 
-				assert.equal(astroVersionProvider.getVersion(), packageJson.version);
+				assert.equal(astroVersionProvider.version, packageJson.version);
 			});
 		});
 
@@ -163,7 +163,7 @@ Starts a local server to serve your static dist/ directory.
 			it('returns the value from process.platform', () => {
 				const operatingSystemProvider = createProcessOperatingSystemProvider();
 
-				const platform = operatingSystemProvider.getName();
+				const platform = operatingSystemProvider.name;
 
 				assert.equal(platform, process.platform);
 			});

--- a/packages/astro/test/units/cli/utils.js
+++ b/packages/astro/test/units/cli/utils.js
@@ -50,7 +50,7 @@ export function createSpyHelpDisplay(shouldFire) {
  * */
 export function createFakeAstroVersionProvider(version) {
 	return {
-		getVersion() {
+		get version() {
 			return version;
 		},
 	};
@@ -62,7 +62,7 @@ export function createFakeAstroVersionProvider(version) {
  * */
 export function createFakeCloudIdeProvider(cloudIde) {
 	return {
-		getName() {
+		get name() {
 			return cloudIde;
 		},
 	};
@@ -74,10 +74,10 @@ export function createFakeCloudIdeProvider(cloudIde) {
  */
 export function createFakeOperatingSystemProvider(platform) {
 	return {
-		getName() {
+		get name() {
 			return platform;
 		},
-		getDisplayName() {
+		get displayName() {
 			return platform;
 		},
 	};


### PR DESCRIPTION
## Changes

- Feedback from @ematipico on #14609
- Updates CLI abstractions to use getters when possible

## Testing

Updated, should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, refactor

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
