### PR TITLE
Move assets before generating pages

### DIFF
--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -90,9 +90,10 @@ export async function staticBuild(
 	const { settings } = opts;
 	if (settings.buildOutput === 'static') {
 		settings.timer.start('Static generate');
-		await generatePages(opts, internals, prerenderOutputDir);
 		// Move prerender and SSR assets to client directory before cleaning up
 		await ssrMoveAssets(opts, prerenderOutputDir);
+		// Generate the pages
+		await generatePages(opts, internals, prerenderOutputDir);
 		// Clean up prerender directory after generation
 		await fs.promises.rm(prerenderOutputDir, { recursive: true, force: true });
 		settings.timer.end('Static generate');


### PR DESCRIPTION
## Changes

- This fixes image tests where it is not able to find assets for optimization.
- The reason is that when we build the prerender output it goes into `dist/.prerender/` and assets are temporarily in `dist/.prerender/_astro/`. Previously we moved them after generation, which is fine for things like css and js, but since the image optimization tries to read the file, it was failing.

## Testing

- Fixes any tests breaking due to not being able to find images.

## Docs

N/A, bug fix