### PR TITLE
refactor: build and error handling

### DIFF
--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -1,8 +1,8 @@
 import fs, { readFileSync } from 'node:fs';
 import { basename } from 'node:path/posix';
 import colors from 'picocolors';
+import type { BuildApp } from '../../core/build/app.js';
 import { getOutDirWithinCwd } from '../../core/build/common.js';
-import type { BuildPipeline } from '../../core/build/pipeline.js';
 import { getTimeStat } from '../../core/build/util.js';
 import { AstroError } from '../../core/errors/errors.js';
 import { AstroErrorData } from '../../core/errors/index.js';
@@ -50,12 +50,14 @@ type ImageData = {
 };
 
 export async function prepareAssetsGenerationEnv(
-	pipeline: BuildPipeline,
+	app: BuildApp,
 	totalCount: number,
 ): Promise<AssetEnv> {
-	const { config, logger, settings } = pipeline;
+	const settings = app.getSettings();
+	const logger = app.logger;
+	const manifest = app.getManifest();
 	let useCache = true;
-	const assetsCacheDir = new URL('assets/', config.cacheDir);
+	const assetsCacheDir = new URL('assets/', app.manifest.cacheDir);
 	const count = { total: totalCount, current: 1 };
 
 	// Ensure that the cache directory exists
@@ -72,11 +74,11 @@ export async function prepareAssetsGenerationEnv(
 	const isServerOutput = settings.buildOutput === 'server';
 	let serverRoot: URL, clientRoot: URL;
 	if (isServerOutput) {
-		serverRoot = config.build.server;
-		clientRoot = config.build.client;
+		serverRoot = manifest.buildServerDir;
+		clientRoot = manifest.buildClientDir;
 	} else {
-		serverRoot = getOutDirWithinCwd(config.outDir);
-		clientRoot = config.outDir;
+		serverRoot = getOutDirWithinCwd(manifest.outDir);
+		clientRoot = manifest.outDir;
 	}
 
 	return {
@@ -87,8 +89,8 @@ export async function prepareAssetsGenerationEnv(
 		assetsCacheDir,
 		serverRoot,
 		clientRoot,
-		imageConfig: config.image,
-		assetsFolder: config.build.assets,
+		imageConfig: settings.config.image,
+		assetsFolder: manifest.assetsDir,
 	};
 }
 

--- a/packages/astro/src/assets/endpoint/config.ts
+++ b/packages/astro/src/assets/endpoint/config.ts
@@ -52,5 +52,6 @@ function getImageEndpointData(
 		prerender: false,
 		fallbackRoutes: [],
 		origin: 'internal',
+		distURL: [],
 	};
 }

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -148,6 +148,7 @@ function createManifest(
 		trailingSlash: manifest?.trailingSlash ?? ASTRO_CONFIG_DEFAULTS.trailingSlash,
 		buildFormat: manifest?.buildFormat ?? ASTRO_CONFIG_DEFAULTS.build.format,
 		compressHTML: manifest?.compressHTML ?? ASTRO_CONFIG_DEFAULTS.compressHTML,
+		assetsDir: manifest?.assetsDir ?? ASTRO_CONFIG_DEFAULTS.build.assets,
 		serverLike: manifest?.serverLike ?? false,
 		assets: manifest?.assets ?? new Set(),
 		assetsPrefix: manifest?.assetsPrefix ?? undefined,
@@ -260,6 +261,7 @@ type AstroContainerManifest = Pick<
 	| 'csp'
 	| 'allowedDomains'
 	| 'serverLike'
+	| 'assetsDir'
 >;
 
 type AstroContainerConstructor = {
@@ -597,6 +599,7 @@ export class experimental_AstroContainer {
 			fallbackRoutes: [],
 			isIndex: false,
 			origin: 'internal',
+			distURL: [],
 		};
 	}
 

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -322,8 +322,8 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		return pathname;
 	}
 
-	async render(request: Request, renderOptions?: RenderOptions): Promise<Response> {
-		let routeData: RouteData | undefined;
+	public async render(request: Request, renderOptions?: RenderOptions): Promise<Response> {
+		let routeData: RouteData | undefined = renderOptions?.routeData;
 		let locals: object | undefined;
 		let clientAddress: string | undefined;
 		let addCookieHeader: boolean | undefined;
@@ -405,7 +405,6 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		try {
 			// Load route module. We also catch its error here if it fails on initialization
 			const componentInstance = await this.pipeline.getComponentByRoute(routeData);
-
 			const renderContext = await this.createRenderContext({
 				pipeline: this.pipeline,
 				locals,
@@ -638,5 +637,9 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		if (route.endsWith('/404')) return 404;
 		if (route.endsWith('/500')) return 500;
 		return 200;
+	}
+
+	public getManifest() {
+		return this.pipeline.manifest;
 	}
 }

--- a/packages/astro/src/core/app/manifest.ts
+++ b/packages/astro/src/core/app/manifest.ts
@@ -38,6 +38,7 @@ export function deserializeRouteData(rawRouteData: SerializedRouteData): RouteDa
 		}),
 		isIndex: rawRouteData.isIndex,
 		origin: rawRouteData.origin,
+		distURL: rawRouteData.distURL,
 	};
 }
 

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -106,6 +106,7 @@ export type SSRManifest = {
 	outDir: URL;
 	rootDir: URL;
 	publicDir: URL;
+	assetsDir: string;
 	buildClientDir: URL;
 	buildServerDir: URL;
 	csp: SSRManifestCSP | undefined;

--- a/packages/astro/src/core/build/app.ts
+++ b/packages/astro/src/core/build/app.ts
@@ -1,0 +1,37 @@
+import { BaseApp, type RenderErrorOptions } from '../app/index.js';
+import type { SSRManifest } from '../app/types.js';
+import type { BuildInternals } from './internal.js';
+import { BuildPipeline } from './pipeline.js';
+import type { StaticBuildOptions } from './types.js';
+
+export class BuildApp extends BaseApp<BuildPipeline> {
+	createPipeline(_streaming: boolean, manifest: SSRManifest, ..._args: any[]): BuildPipeline {
+		return BuildPipeline.create({
+			manifest,
+		});
+	}
+
+	public setInternals(internals: BuildInternals) {
+		this.pipeline.setInternals(internals);
+	}
+
+	public setOptions(options: StaticBuildOptions) {
+		this.pipeline.setOptions(options);
+	}
+
+	public getOptions() {
+		return this.pipeline.getOptions();
+	}
+
+	public getSettings() {
+		return this.pipeline.getSettings();
+	}
+
+	async renderError(request: Request, options: RenderErrorOptions): Promise<Response> {
+		if (options.status === 500) {
+			throw options.error;
+		} else {
+			return super.renderError(request, options);
+		}
+	}
+}

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -58,7 +58,7 @@ export function getOutFolder(
 }
 
 export function getOutFile(
-	astroConfig: AstroConfig,
+	buildFormat: NonNullable<AstroConfig['build']>['format'],
 	outFolder: URL,
 	pathname: string,
 	routeData: RouteData,
@@ -70,7 +70,7 @@ export function getOutFile(
 		case 'page':
 		case 'fallback':
 		case 'redirect':
-			switch (astroConfig.build.format) {
+			switch (buildFormat) {
 				case 'directory': {
 					if (STATUS_CODE_PAGES.has(pathname)) {
 						const baseName = npath.basename(pathname);

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -256,7 +256,12 @@ async function buildManifest(
 		// Add the built .html file as a staticFile
 		if (route.prerender && route.pathname) {
 			const outFolder = getOutFolder(opts.settings, route.pathname, route);
-			const outFile = getOutFile(opts.settings.config, outFolder, route.pathname, route);
+			const outFile = getOutFile(
+				opts.settings.config.build.format,
+				outFolder,
+				route.pathname,
+				route,
+			);
 			const file = outFile.toString().replace(opts.settings.config.build.client.toString(), '');
 			staticFiles.push(file);
 		}
@@ -339,6 +344,7 @@ async function buildManifest(
 		buildClientDir: opts.settings.config.build.client.toString(),
 		buildServerDir: opts.settings.config.build.server.toString(),
 		adapterName: opts.settings.adapter?.name ?? '',
+		assetsDir: opts.settings.config.build.assets,
 		routes,
 		serverLike: opts.settings.buildOutput === 'server',
 		site: settings.config.site,

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -165,7 +165,6 @@ export class RenderContext {
 	): Promise<Response> {
 		const { middleware, pipeline } = this;
 		const { logger, streaming, manifest } = pipeline;
-
 		const props =
 			Object.keys(this.props).length > 0
 				? this.props

--- a/packages/astro/src/core/routing/astro-designed-error-pages.ts
+++ b/packages/astro/src/core/routing/astro-designed-error-pages.ts
@@ -15,6 +15,7 @@ export const DEFAULT_404_ROUTE: RouteData = {
 	fallbackRoutes: [],
 	isIndex: false,
 	origin: 'internal',
+	distURL: [],
 };
 
 export function ensure404Route(manifest: RoutesList) {

--- a/packages/astro/src/core/server-islands/endpoint.ts
+++ b/packages/astro/src/core/server-islands/endpoint.ts
@@ -33,6 +33,7 @@ function getServerIslandRouteData(config: ConfigFields) {
 		fallbackRoutes: [],
 		route: SERVER_ISLAND_ROUTE,
 		origin: 'internal',
+		distURL: [],
 	};
 	return route;
 }

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -47,17 +47,21 @@ const STATUS_CODE_PAGES = new Set(['/404', '/500']);
  * Handles both "/foo" and "foo" `name` formats.
  * Handles `/404` and `/` correctly.
  */
-export function getOutputFilename(astroConfig: AstroConfig, name: string, routeData: RouteData) {
+export function getOutputFilename(
+	buildFormat: NonNullable<AstroConfig['build']>['format'],
+	name: string,
+	routeData: RouteData,
+) {
 	if (routeData.type === 'endpoint') {
 		return name;
 	}
 	if (name === '/' || name === '') {
 		return path.posix.join(name, 'index.html');
 	}
-	if (astroConfig.build.format === 'file' || STATUS_CODE_PAGES.has(name)) {
+	if (buildFormat === 'file' || STATUS_CODE_PAGES.has(name)) {
 		return `${removeTrailingForwardSlash(name || 'index')}.html`;
 	}
-	if (astroConfig.build.format === 'preserve' && !routeData.isIndex) {
+	if (buildFormat === 'preserve' && !routeData.isIndex) {
 		return `${removeTrailingForwardSlash(name || 'index')}.html`;
 	}
 	return path.posix.join(name, 'index.html');

--- a/packages/astro/src/entrypoints/prerender.ts
+++ b/packages/astro/src/entrypoints/prerender.ts
@@ -1,8 +1,8 @@
 import { server as actions } from 'virtual:astro:actions/entrypoint';
 import { manifest as _manifest } from 'virtual:astro:manifest';
-import { createApp } from 'astro/app/entrypoint';
+import { BuildApp } from '../core/build/app.js';
 
-const app = createApp();
+const app = new BuildApp(_manifest);
 const { renderers } = _manifest;
 
 // Export middleware lazy-loaded

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -119,6 +119,7 @@ async function createSerializedManifest(settings: AstroSettings): Promise<Serial
 		buildServerDir: settings.config.build.server.toString(),
 		buildClientDir: settings.config.build.client.toString(),
 		publicDir: settings.config.publicDir.toString(),
+		assetsDir: settings.config.build.assets,
 		trailingSlash: settings.config.trailingSlash,
 		buildFormat: settings.config.build.format,
 		compressHTML: settings.config.compressHTML,

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -65,7 +65,7 @@ export interface RouteData {
 	/**
 	 * The paths of the physical files emitted by this route. When a route **isn't** prerendered, the value is either `undefined` or an empty array.
 	 */
-	distURL?: URL[];
+	distURL: URL[];
 	/**
 	 *
 	 * regex used for matching an input URL against a requested route

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -219,6 +219,7 @@ export async function createDevelopmentManifest(settings: AstroSettings): Promis
 		trailingSlash: settings.config.trailingSlash,
 		buildFormat: settings.config.build.format,
 		compressHTML: settings.config.compressHTML,
+		assetsDir: settings.config.build.assets,
 		serverLike: settings.buildOutput === 'server',
 		assets: new Set(),
 		entryModules: {},


### PR DESCRIPTION
## Changes

This PR refactors the build phase by using `BuildApp` and `BuildPipeline`. 

`BuildApp` doesn't do much outside of the normal `App` that we were using before; the only thing that does differently is error propagation when calling `renderError`.

In `BuildPipeline`, I addressed the `TODO`, by aligning the function to what we do in `AppPipeline`, since it worked until now. Also, the `TODO` is incorrect, because `getComponentByRoute` is used in various places, internally, inside `BaseApp`. In fact,  `getComponentByRoute` is an abstract method that must be implemented in each pipeline.

I also took the opportunity to fix the following:
- reduce the usage of `AstroConfig` in favour of `SSRManifest`
- reduce the usage of `StaticBuildOptions` where possible, and use the information from the manifest
- make `distURL` mandatory, because it caused issues in the function `generatePath`, where we read the value. If undefined, it causes some tests to fail
- add missing information to the manifest, for essample the `assetsDir`

## Testing

The test `build-concurrency.test.js` now passes.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
