### PR TITLE
Fix API route tests

### DIFF
--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -11,6 +11,12 @@ describe('API routes in SSR', () => {
 		site: 'https://mysite.dev/subsite/',
 		base: '/blog',
 		adapter: testAdapter(),
+		// Disable CSRF origin check for tests. These tests are for API route functionality,
+		// not for CSRF protection. The test client doesn't send proper origin headers,
+		// so the CSRF middleware would block requests before they reach the API handlers.
+		security: {
+			checkOrigin: false,
+		},
 	};
 
 	describe('Build', () => {


### PR DESCRIPTION

## Changes

- No code changes

## Testing

These tests are being hit by the origin check. They are not testing that so its safe to disable


## Docs

N/A, bug fix
