### PR TITLE
chore: use console info instead of log

### DIFF
--- a/benchmark/bench/_util.js
+++ b/benchmark/bench/_util.js
@@ -21,12 +21,12 @@ export function calculateStat(numbers) {
 }
 
 export async function makeProject(name) {
-	console.log('Making project:', name);
+	console.info('Making project:', name);
 	const projectDir = new URL(`../projects/${name}/`, import.meta.url);
 
 	const makeProjectMod = await import(`../make-project/${name}.js`);
 	await makeProjectMod.run(projectDir);
 
-	console.log('Finished making project:', name);
+	console.info('Finished making project:', name);
 	return projectDir;
 }

--- a/benchmark/bench/cli-startup.js
+++ b/benchmark/bench/cli-startup.js
@@ -12,24 +12,24 @@ export const defaultProject = 'render-default';
 export async function run(projectDir) {
 	const root = fileURLToPath(projectDir);
 
-	console.log('Benchmarking `astro --help`...');
+	console.info('Benchmarking `astro --help`...');
 	const helpStat = await benchmarkCommand('node', [astroBin, '--help'], root);
-	console.log('Done');
+	console.info('Done');
 
-	console.log('Benchmarking `astro preferences list`...');
+	console.info('Benchmarking `astro preferences list`...');
 	const infoStat = await benchmarkCommand('node', [astroBin, 'preferences', 'list'], root);
-	console.log('Done');
+	console.info('Done');
 
-	console.log('Result preview:');
-	console.log('='.repeat(10));
-	console.log(`#### CLI Startup\n\n`);
-	console.log(
+	console.info('Result preview:');
+	console.info('='.repeat(10));
+	console.info(`#### CLI Startup\n\n`);
+	console.info(
 		printResult({
 			'astro --help': helpStat,
 			'astro info': infoStat,
 		}),
 	);
-	console.log('='.repeat(10));
+	console.info('='.repeat(10));
 }
 
 /**

--- a/benchmark/bench/memory.js
+++ b/benchmark/bench/memory.js
@@ -17,7 +17,7 @@ export async function run(projectDir, outputFile) {
 	const root = fileURLToPath(projectDir);
 	const outputFilePath = fileURLToPath(outputFile);
 
-	console.log('Building and benchmarking...');
+	console.info('Building and benchmarking...');
 	await exec('node', ['--expose-gc', '--max_old_space_size=10000', astroBin, 'build'], {
 		nodeOptions: {
 			cwd: root,
@@ -29,15 +29,15 @@ export async function run(projectDir, outputFile) {
 		throwOnError: true,
 	});
 
-	console.log('Raw results written to', outputFilePath);
+	console.info('Raw results written to', outputFilePath);
 
-	console.log('Result preview:');
-	console.log('='.repeat(10));
-	console.log(`#### Memory\n\n`);
-	console.log(printResult(JSON.parse(await fs.readFile(outputFilePath, 'utf-8'))));
-	console.log('='.repeat(10));
+	console.info('Result preview:');
+	console.info('='.repeat(10));
+	console.info(`#### Memory\n\n`);
+	console.info(printResult(JSON.parse(await fs.readFile(outputFilePath, 'utf-8'))));
+	console.info('='.repeat(10));
 
-	console.log('Done!');
+	console.info('Done!');
 }
 
 /**

--- a/benchmark/bench/render.js
+++ b/benchmark/bench/render.js
@@ -19,7 +19,7 @@ export const defaultProject = 'render-default';
 export async function run(projectDir, outputFile) {
 	const root = fileURLToPath(projectDir);
 
-	console.log('Building...');
+	console.info('Building...');
 	await exec(astroBin, ['build'], {
 		nodeOptions: {
 			cwd: root,
@@ -28,7 +28,7 @@ export async function run(projectDir, outputFile) {
 		throwOnError: true,
 	});
 
-	console.log('Previewing...');
+	console.info('Previewing...');
 	const previewProcess = exec(astroBin, ['preview', '--port', port], {
 		nodeOptions: {
 			cwd: root,
@@ -37,27 +37,27 @@ export async function run(projectDir, outputFile) {
 		throwOnError: true,
 	});
 
-	console.log('Waiting for server ready...');
+	console.info('Waiting for server ready...');
 	await waitUntilBusy(port, { timeout: 5000 });
 
-	console.log('Running benchmark...');
+	console.info('Running benchmark...');
 	const result = await benchmarkRenderTime();
 
-	console.log('Killing server...');
+	console.info('Killing server...');
 	if (!previewProcess.kill('SIGTERM')) {
 		console.warn('Failed to kill server process id:', previewProcess.pid);
 	}
 
-	console.log('Writing results to', fileURLToPath(outputFile));
+	console.info('Writing results to', fileURLToPath(outputFile));
 	await fs.writeFile(outputFile, JSON.stringify(result, null, 2));
 
-	console.log('Result preview:');
-	console.log('='.repeat(10));
-	console.log(`#### Render\n\n`);
-	console.log(printResult(result));
-	console.log('='.repeat(10));
+	console.info('Result preview:');
+	console.info('='.repeat(10));
+	console.info(`#### Render\n\n`);
+	console.info(printResult(result));
+	console.info('='.repeat(10));
 
-	console.log('Done!');
+	console.info('Done!');
 }
 
 export async function benchmarkRenderTime(portToListen = port) {

--- a/benchmark/bench/server-stress.js
+++ b/benchmark/bench/server-stress.js
@@ -18,7 +18,7 @@ export const defaultProject = 'server-stress-default';
 export async function run(projectDir, outputFile) {
 	const root = fileURLToPath(projectDir);
 
-	console.log('Building...');
+	console.info('Building...');
 	await exec(astroBin, ['build'], {
 		nodeOptions: {
 			cwd: root,
@@ -27,7 +27,7 @@ export async function run(projectDir, outputFile) {
 		throwOnError: true,
 	});
 
-	console.log('Previewing...');
+	console.info('Previewing...');
 	const previewProcess = await exec(astroBin, ['preview', '--port', port], {
 		nodeOptions: {
 			cwd: root,
@@ -35,27 +35,27 @@ export async function run(projectDir, outputFile) {
 		},
 	});
 
-	console.log('Waiting for server ready...');
+	console.info('Waiting for server ready...');
 	await waitUntilBusy(port, { timeout: 5000 });
 
-	console.log('Running benchmark...');
+	console.info('Running benchmark...');
 	const result = await benchmarkCannon();
 
-	console.log('Killing server...');
+	console.info('Killing server...');
 	if (!previewProcess.kill('SIGTERM')) {
 		console.warn('Failed to kill server process id:', previewProcess.pid);
 	}
 
-	console.log('Writing results to', fileURLToPath(outputFile));
+	console.info('Writing results to', fileURLToPath(outputFile));
 	await fs.writeFile(outputFile, JSON.stringify(result, null, 2));
 
-	console.log('Result preview:');
-	console.log('='.repeat(10));
-	console.log(`#### Server stress\n\n`);
-	console.log(printResult(result));
-	console.log('='.repeat(10));
+	console.info('Result preview:');
+	console.info('='.repeat(10));
+	console.info(`#### Server stress\n\n`);
+	console.info(printResult(result));
+	console.info('='.repeat(10));
 
-	console.log('Done!');
+	console.info('Done!');
 }
 
 /**

--- a/benchmark/ci-helper.js
+++ b/benchmark/ci-helper.js
@@ -10,4 +10,4 @@ while ((m = resultRegex.exec(benchLogs))) {
 	processedLog += m[1] + '\n';
 }
 
-console.log(processedLog);
+console.info(processedLog);

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -7,7 +7,7 @@ import { makeProject } from './bench/_util.js';
 const args = mri(process.argv.slice(2));
 
 if (args.help || args.h) {
-	console.log(`\
+	console.info(`\
 astro-benchmark <command> [options]
 
 Command

--- a/benchmark/packages/timer/src/preview.ts
+++ b/benchmark/packages/timer/src/preview.ts
@@ -9,8 +9,7 @@ const preview: CreatePreviewServer = async function ({ serverEntrypoint, host, p
 	server.listen(port, host);
 	enableDestroy(server);
 
-	// biome-ignore lint/suspicious/noConsole: allowed
-	console.log(`Preview server listening on http://${host}:${port}`);
+	console.info(`Preview server listening on http://${host}:${port}`);
 
 	// Resolves once the server is closed
 	const closed = new Promise<void>((resolve, reject) => {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -48,7 +48,7 @@
       "suspicious": {
         // This one is specific to catch `console.log`. The rest of logs are permitted
         "noConsole": {
-          "level": "warn",
+          "level": "error",
           "options": {
             "allow": ["error", "warn", "info", "debug"]
           }
@@ -128,36 +128,6 @@
           "correctness": {
             "noUnusedVariables": "off",
             "noUnusedImports": "off"
-          }
-        }
-      }
-    },
-    {
-      "includes": ["**/packages/integrations/**/*.ts"],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noConsole": {
-              "level": "error",
-              "options": {
-                "allow": ["warn", "error", "info", "debug"]
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "includes": [
-        "**/packages/db/**/cli/**/*.ts",
-        "**/benchmark/**/*.js",
-        "**/packages/astro/src/cli/**/*.ts",
-        "**/packages/astro/astro.js"
-      ],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noConsole": "off"
           }
         }
       }

--- a/packages/astro/CHANGELOG-v4.md
+++ b/packages/astro/CHANGELOG-v4.md
@@ -1512,7 +1512,7 @@
     await actions.like(new FormData());
   } catch (error) {
     if (isInputError(error)) {
-      console.log(error.fields);
+      console.info(error.fields);
     }
   }
   ```
@@ -1644,7 +1644,7 @@
 
   const code = `const foo = 'hello'
   const bar = ' world'
-  console.log(foo + bar) // [!code focus]
+  console.info(foo + bar) // [!code focus]
   `;
   ---
 
@@ -2534,11 +2534,11 @@
     init(canvas, app, server) {
 
   -    app.addEventListener("app-toggled", (e) => {
-  -      console.log(`App is now ${state ? "enabled" : "disabled"}`);.
+  -      console.info(`App is now ${state ? "enabled" : "disabled"}`);.
   -    });
 
   +    app.onToggled(({ state }) => {
-  +        console.log(`App is now ${state ? "enabled" : "disabled"}`);
+  +        console.info(`App is now ${state ? "enabled" : "disabled"}`);
   +    });
 
   -    if (import.meta.hot) {
@@ -2549,12 +2549,12 @@
 
   -    if (import.meta.hot) {
   -      import.meta.hot.on("my-server-event", (data: {message: string}) => {
-  -        console.log(data.message);
+  -        console.info(data.message);
   -      });
   -    }
 
   +    server.on<{ message: string }>("my-server-event", (data) => {
-  +      console.log(data.message); // data is typed using the type parameter
+  +      console.info(data.message); // data is typed using the type parameter
   +    });
     },
   })
@@ -2565,7 +2565,7 @@
   ```ts
   "astro:server:setup": ({ toolbar }) => {
     toolbar.on<{ message: string }>("my-app:my-client-event", (data) => {
-      console.log(data.message);
+      console.info(data.message);
       toolbar.send("my-server-event", { message: "hello" });
     });
   }

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -465,7 +465,7 @@
     const response = await fetch('...');
     const data = await response.json();
 
-    console.log(routePattern); // [...locale]/[files]/[slug]
+    console.info(routePattern); // [...locale]/[files]/[slug]
 
     // Call your custom helper with `routePattern` to generate the static paths
     return data.flatMap((file) => getLocalizedData(file, routePattern));
@@ -2203,7 +2203,7 @@
   const container = await AstroContainer.create();
   container.insertPageRoute('/generic-error', GenericError);
   const result = await container.renderToString(Post);
-  console.log(result); // this should print the response from GenericError.astro
+  console.info(result); // this should print the response from GenericError.astro
   ```
 
   This new method only works for page routes, which means that endpoints aren't supported.
@@ -3691,7 +3691,7 @@
       name: 'my-integration',
       hooks: {
         'astro:routes:resolved': ({ routes }) => {
-          console.log(routes);
+          console.info(routes);
         },
       },
     };
@@ -3721,7 +3721,7 @@
   +                        Object.assign(route, { distURL })
   +                    }
   +                }
-                  console.log(routes)
+                  console.info(routes)
               }
           }
       }
@@ -3849,7 +3849,7 @@
   // src/middleware.js
 
   export const onRequest = (ctx, next) => {
-    console.log(ctx.isPrerendered); // it will log true
+    console.info(ctx.isPrerendered); // it will log true
     return next();
   };
   ```
@@ -3932,7 +3932,7 @@
   ---
   // src/pages/blog/[slug].astro
   const route = Astro.routePattern;
-  console.log(route); // it will log "blog/[slug]"
+  console.info(route); // it will log "blog/[slug]"
   ---
   ```
 
@@ -3940,7 +3940,7 @@
   // src/pages/index.js
 
   export const GET = (ctx) => {
-    console.log(ctx.routePattern); // it will log src/pages/index.js
+    console.info(ctx.routePattern); // it will log src/pages/index.js
     return new Response.json({ loreum: 'ipsum' });
   };
   ```
@@ -4492,7 +4492,7 @@
       name: 'my-integration',
       hooks: {
         'astro:routes:resolved': ({ routes }) => {
-          console.log(routes);
+          console.info(routes);
         },
       },
     };
@@ -4522,7 +4522,7 @@
   +                        Object.assign(route, { distURL })
   +                    }
   +                }
-                  console.log(routes)
+                  console.info(routes)
               }
           }
       }
@@ -5344,7 +5344,7 @@
   // src/middleware.js
 
   export const onRequest = (ctx, next) => {
-    console.log(ctx.isPrerendered); // it will log true
+    console.info(ctx.isPrerendered); // it will log true
     return next();
   };
   ```
@@ -5619,7 +5619,7 @@
   ---
   // src/pages/blog/[slug].astro
   const route = Astro.routePattern;
-  console.log(route); // it will log "blog/[slug]"
+  console.info(route); // it will log "blog/[slug]"
   ---
   ```
 
@@ -5627,7 +5627,7 @@
   // src/pages/index.js
 
   export const GET = (ctx) => {
-    console.log(ctx.routePattern); // it will log src/pages/index.js
+    console.info(ctx.routePattern); // it will log src/pages/index.js
     return new Response.json({ loreum: 'ipsum' });
   };
   ```

--- a/packages/astro/astro.js
+++ b/packages/astro/astro.js
@@ -65,14 +65,14 @@ Please upgrade Node.js to a supported version: "${engines}"\n`);
 				break;
 			}
 		}
-		console.log(
+		console.info(
 			`${ci.name} CI Environment Detected!\nAdditional steps may be needed to set your Node.js version:`,
 		);
-		console.log(`Documentation: https://docs.astro.build/en/guides/deploy/`);
+		console.info(`Documentation: https://docs.astro.build/en/guides/deploy/`);
 		if (CI_INSTRUCTIONS[platform]) {
-			console.log(`${ci.name} Documentation: ${CI_INSTRUCTIONS[platform]}`);
+			console.info(`${ci.name} Documentation: ${CI_INSTRUCTIONS[platform]}`);
 		}
-		console.log(``);
+		console.info(``);
 	}
 
 	process.exit(1);

--- a/packages/astro/e2e/fixtures/astro-component/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/astro-component/src/pages/index.astro
@@ -20,9 +20,9 @@ import Hero from '../components/Hero.astro';
 </html>
 
 <script>
-	console.log('Hello, Astro!');
+	console.info('Hello, Astro!');
 </script>
 
 <script is:inline>
-	console.log('Hello, inline Astro!');
+	console.info('Hello, inline Astro!');
 </script>

--- a/packages/astro/e2e/fixtures/client-only/src/components/react/ReactCounter.jsx
+++ b/packages/astro/e2e/fixtures/client-only/src/components/react/ReactCounter.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 // accessing browser globals as side effects is allowed if the component is client:only
-console.log(document.title)
+console.info(document.title)
 
 /** a counter written in React */
 export function Counter({ children, id }) {

--- a/packages/astro/e2e/fixtures/dev-toolbar/custom-plugin.js
+++ b/packages/astro/e2e/fixtures/dev-toolbar/custom-plugin.js
@@ -9,7 +9,7 @@ export default defineToolbarApp({
 		myButton.innerText = 'Click me!';
 
 		myButton.addEventListener('click', () => {
-			console.log('Clicked!');
+			console.info('Clicked!');
 		});
 
 		app.toggleNotification({

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/layout/Layout.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/layout/Layout.astro
@@ -8,7 +8,7 @@ import { ClientRouter } from 'astro:transitions';
 		<script is:inline>
 			// let playwright know when navigate() is done
 			document.addEventListener('astro:before-swap', (e) => {
-				e.viewTransition.ready.then(()=>console.log("ready"))
+				e.viewTransition.ready.then(()=>console.info("ready"))
 			});
 		</script>
   </head>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/audits-mutations-2.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/audits-mutations-2.astro
@@ -22,7 +22,7 @@ import Layout from "../layout/Layout.astro";
 			img.height = 100;
 
 			document.body.appendChild(img);
-			console.log("Image added to the page")
+			console.info("Image added to the page")
 		}
 	})
 </script>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/audits-mutations.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/audits-mutations.astro
@@ -21,7 +21,7 @@ import Layout from "../layout/Layout.astro";
 			img.height = 100;
 
 			document.body.appendChild(img);
-			console.log("Image added to the page")
+			console.info("Image added to the page")
 		}
 	})
 </script>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/audits-perf-body-unscrollable.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/audits-perf-body-unscrollable.astro
@@ -33,6 +33,6 @@ import walrus from "../light_walrus.avif";
         const dummyElement = document.createElement('div');
         document.body.appendChild(dummyElement);
 
-        console.log('mutation');
+        console.info('mutation');
     });
 </script>

--- a/packages/astro/e2e/fixtures/solid-recurse/src/components/Counter.jsx
+++ b/packages/astro/e2e/fixtures/solid-recurse/src/components/Counter.jsx
@@ -9,12 +9,12 @@ export default function Counter(props) {
 			id={props.id + '-' + type}
       data-type={type}
       ref={(el) =>
-        console.log(
+        console.info(
           ` ${type} ${type == el.dataset.type ? '==' : '!='} ${el.dataset.type}`
         )
       }
       onClick={() => {
-        console.log('click');
+        console.info('click');
         setCount((p) => ++p);
       }}
     >

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/abort2.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/abort2.astro
@@ -15,10 +15,10 @@ import { ClientRouter, fade } from 'astro:transitions';
 	import {navigate } from 'astro:transitions/client';
 
 	setTimeout(()=>{
-		[...document.getAnimations()].forEach((a) => a.addEventListener('cancel', (e) => console.log("[test]", e.type, a.animationName)));
-		console.log("[test] navigate to /one");
+		[...document.getAnimations()].forEach((a) => a.addEventListener('cancel', (e) => console.info("[test]", e.type, a.animationName)));
+		console.info("[test] navigate to /one");
 		navigate("/one");
 	}, 200);
-	console.log('[test] navigate to "."')
+	console.info('[test] navigate to "."')
 	navigate("/abort2");
 </script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/chaining.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/chaining.astro
@@ -14,35 +14,35 @@ import { swap } from "../../node_modules/astro/dist/transitions/swap-functions";
 	document.addEventListener('astro:before-swap', (e) => {
 		const originalSwap = e.swap;
 		e.swap = () => {
-			console.log(t, "99");
+			console.info(t, "99");
 			originalSwap();
-			console.log(t, "00");
+			console.info(t, "00");
 		}
 	})
 
 	document.addEventListener('astro:before-swap', (e) => {
 		e.swap = () => {
-			console.log(t, "3");
+			console.info(t, "3");
 			swap(e.newDocument);
-			console.log(t, "2");
+			console.info(t, "2");
 		}
 	})
 
 	document.addEventListener('astro:before-swap', (e) => {
 		const originalSwap = e.swap;
 		e.swap = () => {
-			console.log(t, "4");
+			console.info(t, "4");
 			originalSwap();
-			console.log(t, "1");
+			console.info(t, "1");
 		}
 	})
 
 	document.addEventListener('astro:before-swap', (e) => {
 		const originalSwap = e.swap;
 		e.swap = () => {
-			console.log(t, "5");
+			console.info(t, "5");
 			originalSwap();
-			console.log(t, "0");
+			console.info(t, "0");
 		}
 	})
 

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/inline-module.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/inline-module.astro
@@ -6,8 +6,8 @@ import { ClientRouter } from "astro:transitions";
   <head>
     <meta charset="utf-8" />
     <ClientRouter />
-		<script is:inline>document.addEventListener("astro:page-load", () => console.log("[test] page-load"))</script>
-    <script is:inline type="module">console.log("[test] inline module")</script>
+		<script is:inline>document.addEventListener("astro:page-load", () => console.info("[test] page-load"))</script>
+    <script is:inline type="module">console.info("[test] inline module")</script>
   </head>
   <body>
     <h1>Astro</h1>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/long-page.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/long-page.astro
@@ -55,6 +55,6 @@ import Layout from '../components/Layout.astro';
 <script is:inline>
 	// let playwright know when navigate() is done
 	document.addEventListener('astro:before-swap', (e) => {
-		e.viewTransition.ready.then(()=>console.log("ready"))
+		e.viewTransition.ready.then(()=>console.info("ready"))
 	});
 </script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/page-with-persistent-form.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/page-with-persistent-form.astro
@@ -11,7 +11,7 @@ import Layout from '../components/Layout.astro';
 		import {navigate} from "astro:transitions/client"
 		const form = document.querySelector("form");
 		form.addEventListener("submit", (e) => {
-			console.log("submit");
+			console.info("submit");
 			e.preventDefault();
 			navigate(`${location.pathname}?name=${input.value}`,{history: "replace"});
 			return false;

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/page1-with-scripts.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/page1-with-scripts.astro
@@ -6,8 +6,8 @@ import {ClientRouter} from "astro:transitions";
 		<meta charset="utf-8" />
 		<ClientRouter />
 		<title>Page 1</title>
-		<script is:inline data-astro-rerun>console.log('[test] 3');</script>
-		<script is:inline>console.log('[test] 1');</script>
+		<script is:inline data-astro-rerun>console.info('[test] 3');</script>
+		<script is:inline>console.info('[test] 1');</script>
 	</head>
 	<body>
 		<a id="link" href="/page2-with-scripts">to page 2</a>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/page2-with-scripts.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/page2-with-scripts.astro
@@ -6,8 +6,8 @@ import {ClientRouter} from "astro:transitions";
 		<meta charset="utf-8" />
 		<ClientRouter />
 		<title>Page 2</title>
-		<script is:inline data-astro-rerun>console.log('[test] 2');</script>
-		<script is:inline>console.log('[test] 1');</script>
+		<script is:inline data-astro-rerun>console.info('[test] 2');</script>
+		<script is:inline>console.info('[test] 1');</script>
 	</head>
 	<body>
 		<a id="link" href="/page3-with-scripts">to page 3</a>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/page3-with-scripts.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/page3-with-scripts.astro
@@ -6,9 +6,9 @@ import {ClientRouter} from "astro:transitions";
 		<meta charset="utf-8" />
 		<ClientRouter />
 		<title>Page 3</title>
-		<script is:inline>console.log('[test] 1');</script>
-		<script is:inline data-astro-rerun>console.log('[test] 2');</script>
-		<script is:inline data-astro-rerun>console.log('[test] 3');</script>
+		<script is:inline>console.info('[test] 1');</script>
+		<script is:inline data-astro-rerun>console.info('[test] 2');</script>
+		<script is:inline data-astro-rerun>console.info('[test] 3');</script>
 	</head>
 	<body>
 		<a id="link" href="/page1-with-scripts">to page 1</a>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/partial-swap.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/partial-swap.astro
@@ -7,13 +7,13 @@ import { ClientRouter } from "astro:transitions";
     <meta charset="utf-8" />
     <ClientRouter />
     <script is:inline>
-			console.log("[test] head script");
+			console.info("[test] head script");
 			document.addEventListener("astro:before-swap", e => e.swap = () => {});
 		</script>
   </head>
   <body>
     <h1>Astro</h1>
-		<script is:inline>console.log("[test] body script")</script>
+		<script is:inline>console.info("[test] body script")</script>
     <a id="link2" href="/partial-swap?v=2">revisit</a><br/>
     <a id="link3" href="/partial-swap?v=3">revisit</a>
   </body>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/persist-1.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/persist-1.astro
@@ -18,7 +18,7 @@ import Layout from '../components/Layout.astro';
 
 	document.addEventListener('astro:after-swap', () => {
 		const textInput = document.querySelector<HTMLInputElement>("form input:first-of-type")!;
-		console.log(textInput === document.activeElement, textInput.value, textInput.selectionStart, textInput.selectionEnd);
+		console.info(textInput === document.activeElement, textInput.value, textInput.selectionStart, textInput.selectionEnd);
 		const checkBox = document.querySelector<HTMLInputElement>("form input:nth-of-type(2)")!;
 		checkBox.checked = true;
 		checkBox.focus();

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/persist-2.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/persist-2.astro
@@ -10,7 +10,7 @@ import Layout from '../components/Layout.astro';
 <script>
 	document.addEventListener('astro:after-swap', () => {
 		const checkBox = document.querySelector<HTMLInputElement>("form input:nth-of-type(2)")!;
-		console.log(checkBox === document.activeElement, checkBox.checked);
+		console.info(checkBox === document.activeElement, checkBox.checked);
 	}, {once:true});
 </script>
 

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/skip.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/skip.astro
@@ -10,7 +10,7 @@ import Layout from '../components/Layout.astro';
 	const observer = new MutationObserver((mutations) => {
 		for (const mutation of mutations) {
 			if (mutation.type === 'attributes') {
-					console.log('[test]', mutation.attributeName, 
+					console.info('[test]', mutation.attributeName, 
 						(mutation.target as HTMLElement).getAttribute(mutation.attributeName!));
 			}
 		}

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/transition-name.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/transition-name.astro
@@ -31,7 +31,7 @@ import Layout from '../components/Layout.astro';
 		if (event instanceof AnimationEvent) {
 			const name = event.animationName;
 			const match = name.match(/^-ua-view-transition-group-anim-(.*)$/)
-			if (match) console.log("anim:",match[1]);
+			if (match) console.info("anim:",match[1]);
 		}
 	}
 </script>

--- a/packages/astro/src/cli/preferences/index.ts
+++ b/packages/astro/src/cli/preferences/index.ts
@@ -131,17 +131,17 @@ async function getPreference(
 		if (value && typeof value === 'object' && !Array.isArray(value)) {
 			if (Object.keys(value).length === 0) {
 				value = dlv(DEFAULT_PREFERENCES, key);
-				console.log(msg.preferenceDefaultIntro(key));
+				console.info(msg.preferenceDefaultIntro(key));
 			}
 			prettyPrint({ [key]: value });
 			return 0;
 		}
 		if (value === undefined) {
 			const defaultValue = await settings.preferences.get(key);
-			console.log(msg.preferenceDefault(key, defaultValue));
+			console.info(msg.preferenceDefault(key, defaultValue));
 			return 0;
 		}
-		console.log(msg.preferenceGet(key, value));
+		console.info(msg.preferenceGet(key, value));
 		return 0;
 	} catch {}
 	return 1;
@@ -160,7 +160,7 @@ async function setPreference(
 		}
 
 		await settings.preferences.set(key, coerce(key, value), { location });
-		console.log(msg.preferenceSet(key, value));
+		console.info(msg.preferenceSet(key, value));
 		return 0;
 	} catch (e) {
 		if (e instanceof Error) {
@@ -178,7 +178,7 @@ async function enablePreference(
 ) {
 	try {
 		await settings.preferences.set(key, true, { location });
-		console.log(msg.preferenceEnabled(key.replace('.enabled', '')));
+		console.info(msg.preferenceEnabled(key.replace('.enabled', '')));
 		return 0;
 	} catch {}
 	return 1;
@@ -191,7 +191,7 @@ async function disablePreference(
 ) {
 	try {
 		await settings.preferences.set(key, false, { location });
-		console.log(msg.preferenceDisabled(key.replace('.enabled', '')));
+		console.info(msg.preferenceDisabled(key.replace('.enabled', '')));
 		return 0;
 	} catch {}
 	return 1;
@@ -204,7 +204,7 @@ async function resetPreference(
 ) {
 	try {
 		await settings.preferences.set(key, undefined as any, { location });
-		console.log(msg.preferenceReset(key));
+		console.info(msg.preferenceReset(key));
 		return 0;
 	} catch {}
 	return 1;
@@ -240,7 +240,7 @@ function userValues(
 async function listPreferences(settings: AstroSettings, { location, json }: SubcommandOptions) {
 	if (json) {
 		const resolved = await settings.preferences.getAll();
-		console.log(JSON.stringify(resolved, null, 2));
+		console.info(JSON.stringify(resolved, null, 2));
 		return 0;
 	}
 	const { global, project, fromAstroConfig, defaults } = await settings.preferences.list({
@@ -257,11 +257,11 @@ async function listPreferences(settings: AstroSettings, { location, json }: Subc
 		const badge = bgGreen(black(` Your Preferences `));
 		const table = formatTable(flatUser, ['Preference', 'Value']);
 
-		console.log(['', badge, table].join('\n'));
+		console.info(['', badge, table].join('\n'));
 	} else {
 		const badge = bgGreen(black(` Your Preferences `));
 		const message = dim('No preferences set');
-		console.log(['', badge, '', message].join('\n'));
+		console.info(['', badge, '', message].join('\n'));
 	}
 	const flatUnset = annotate(Object.assign({}, flatDefault), '');
 	for (const key of userKeys) {
@@ -273,17 +273,17 @@ async function listPreferences(settings: AstroSettings, { location, json }: Subc
 		const badge = bgGreen(black(` Default Preferences `));
 		const table = formatTable(flatUnset, ['Preference', 'Value']);
 
-		console.log(['', badge, table].join('\n'));
+		console.info(['', badge, table].join('\n'));
 	} else {
 		const badge = bgGreen(black(` Default Preferences `));
 		const message = dim('All preferences have been set');
-		console.log(['', badge, '', message].join('\n'));
+		console.info(['', badge, '', message].join('\n'));
 	}
 	if (
 		fromAstroConfig.devToolbar?.enabled === false &&
 		flatUser['devToolbar.enabled']?.value !== false
 	) {
-		console.log(
+		console.info(
 			yellow(
 				'The dev toolbar is currently disabled. To enable it, set devToolbar: {enabled: true} in your astroConfig file.',
 			),
@@ -296,7 +296,7 @@ async function listPreferences(settings: AstroSettings, { location, json }: Subc
 function prettyPrint(value: Record<string, string | number | boolean>) {
 	const flattened = flattie(value);
 	const table = formatTable(flattened, ['Preference', 'Value']);
-	console.log(table);
+	console.info(table);
 }
 
 const chars = {

--- a/packages/astro/src/cli/telemetry/index.ts
+++ b/packages/astro/src/cli/telemetry/index.ts
@@ -8,7 +8,7 @@ interface TelemetryOptions {
 
 export async function notify() {
 	await telemetry.notify(() => {
-		console.log(msg.telemetryNotice() + '\n');
+		console.info(msg.telemetryNotice() + '\n');
 		return true;
 	});
 }

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -464,7 +464,7 @@ export class experimental_AstroContainer {
 	 * const container = await AstroContainer.create();
 	 * const result = await container.renderToString(Card);
 	 *
-	 * console.log(result); // it's a string
+	 * console.info(result); // it's a string
 	 * ```
 	 *
 	 *
@@ -495,7 +495,7 @@ export class experimental_AstroContainer {
 	 * const container = await AstroContainer.create();
 	 * const response = await container.renderToResponse(Card);
 	 *
-	 * console.log(response.status); // it's a number
+	 * console.info(response.status); // it's a number
 	 * ```
 	 *
 	 *

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -398,6 +398,5 @@ export function printHelp({
 		message.push(linebreak(), `${description}`);
 	}
 
-	// biome-ignore lint/suspicious/noConsole: allowed
-	console.log(message.join('\n') + '\n');
+	console.info(message.join('\n') + '\n');
 }

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -571,8 +571,7 @@ async function transition(
 		// This log doesn't make it worse than before, where we got error messages about uncaught exceptions, which can't be caught when the trigger was a click or history traversal.
 		// Needs more investigation on root causes if errors still occur sporadically
 		const err = e as Error;
-		// biome-ignore lint/suspicious/noConsole: allowed
-		console.log('[astro]', err.name, err.message, err.stack);
+		console.info('[astro]', err.name, err.message, err.stack);
 	}
 }
 

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -63,7 +63,7 @@ export interface RouteData {
 	 * For a route such as `/blog/[...id].astro`, the `generate` function would return something like this:
 	 *
 	 * ```js
-	 * console.log(generate({ id: 'presentation' })) // will log `/blog/presentation`
+	 * console.info(generate({ id: 'presentation' })) // will log `/blog/presentation`
 	 * ```
 	 */
 	generate: (data?: any) => string;

--- a/packages/astro/test/astro-attrs.test.js
+++ b/packages/astro/test/astro-attrs.test.js
@@ -101,6 +101,6 @@ describe('Attributes', async () => {
 		const html = await fixture.readFile('/namespaced-component/index.html');
 		const $ = cheerio.load(html);
 
-		assert.deepEqual($('span').attr('on:click'), '(event) => console.log(event)');
+		assert.deepEqual($('span').attr('on:click'), '(event) => console.info(event)');
 	});
 });

--- a/packages/astro/test/astro-expr.test.js
+++ b/packages/astro/test/astro-expr.test.js
@@ -106,7 +106,7 @@ describe('Expressions', () => {
 
 		assert.equal($('body').children().length, 2);
 		assert.equal(
-			$('body').html().includes('&lt;script&gt;console.log("pwnd")&lt;/script&gt;'),
+			$('body').html().includes('&lt;script&gt;console.info("pwnd")&lt;/script&gt;'),
 			true,
 		);
 		assert.equal($('#trusted').length, 1);

--- a/packages/astro/test/fixtures/_underscore in folder name/src/pages/index.astro
+++ b/packages/astro/test/fixtures/_underscore in folder name/src/pages/index.astro
@@ -5,7 +5,7 @@
 <body>
 <h1>Testing</h1>
 <script>
-	console.log('hi');
+	console.info('hi');
 </script>
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-attrs/src/pages/namespaced-component.astro
+++ b/packages/astro/test/fixtures/astro-attrs/src/pages/namespaced-component.astro
@@ -1,4 +1,4 @@
 ---
 import NamespacedSpan from '../components/NamespacedSpan.astro'
 ---
-<NamespacedSpan on:click={event => console.log(event)} />
+<NamespacedSpan on:click={event => console.info(event)} />

--- a/packages/astro/test/fixtures/astro-basic/src/pages/get-static-paths-with-mjs/[...file].js
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/get-static-paths-with-mjs/[...file].js
@@ -6,5 +6,5 @@ export function getStaticPaths() {
 }
 
 export function GET() {
-  return new Response('console.log("fileContent");')
+  return new Response('console.info("fileContent");')
 }

--- a/packages/astro/test/fixtures/astro-basic/src/pages/import-queries/_content.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/import-queries/_content.astro
@@ -1,3 +1,3 @@
 <h1>Hello</h1>
-<script>console.log('Should not log')</script>
+<script>console.info('Should not log')</script>
 <style>h1 { color: red; }</style>

--- a/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-console.log(doesntExist)
+console.info(doesntExist)
 ---
 
 <html lang="en">

--- a/packages/astro/test/fixtures/astro-client-only/src/components/logResize.js
+++ b/packages/astro/test/fixtures/astro-client-only/src/components/logResize.js
@@ -1,3 +1,3 @@
 window.addEventListener("resize", function() {
-  console.log("window resized");
+  console.info("window resized");
 });

--- a/packages/astro/test/fixtures/astro-component-bundling/src/pages/astro-in-client.astro
+++ b/packages/astro/test/fixtures/astro-component-bundling/src/pages/astro-in-client.astro
@@ -7,7 +7,7 @@ import AstroComponent from '../components/AstroComponent.astro';
 	<AstroComponent />
 	<script>
 		import AstroComponent from '../components/AstroComponent.astro';
-		console.log(AstroComponent);
+		console.info(AstroComponent);
 	</script>
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/basic.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/basic.astro
@@ -4,6 +4,6 @@ import {Code} from 'astro:components';
 <html>
 <head><title>Code component</title></head>
 <body>
-  <Code code="console.log('hello world');" lang="js" />
+  <Code code="console.info('hello world');" lang="js" />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/css-theme.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/css-theme.astro
@@ -4,6 +4,6 @@ import {Code} from 'astro:components';
 <html>
 <head><title>Code component</title></head>
 <body>
-  <Code code="console.log('color: #000001');" lang="js" theme="css-variables" />
+  <Code code="console.info('color: #000001');" lang="js" theme="css-variables" />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/custom-theme.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/custom-theme.astro
@@ -4,6 +4,6 @@ import {Code} from 'astro:components';
 <html>
 <head><title>Code component</title></head>
 <body>
-  <Code code="console.log('hello world');" lang="js" theme="nord" />
+  <Code code="console.info('hello world');" lang="js" theme="nord" />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/imported.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/imported.astro
@@ -14,7 +14,7 @@ const rinfo = {
 <head><title>Code component</title></head>
 <body>
 	<section id="theme">
-  	<Code code="console.log('Hello, World!')" lang="js" theme={serendipity} />
+  	<Code code="console.info('Hello, World!')" lang="js" theme={serendipity} />
 	</section>
 	<section id="lang">
   	<Code code="programa Rinfo" lang={rinfo} />

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/inline.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/inline.astro
@@ -5,6 +5,6 @@ import {Code} from 'astro:components';
 <head><title>Code component</title></head>
 <body>
   Simple:
-  <Code code="console.log('inline code');" lang="js" inline />
+  <Code code="console.info('inline code');" lang="js" inline />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/no-lang.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/no-lang.astro
@@ -4,6 +4,6 @@ import {Code} from 'astro:components';
 <html>
 <head><title>Code component</title></head>
 <body>
-  <Code code="console.log('hello world');" />
+  <Code code="console.info('hello world');" />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-false.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-false.astro
@@ -4,6 +4,6 @@ import {Code} from 'astro:components';
 <html>
 <head><title>Code component</title></head>
 <body>
-  <Code code="console.log('hello world');" lang="js" wrap={false} />
+  <Code code="console.info('hello world');" lang="js" wrap={false} />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-null.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-null.astro
@@ -4,6 +4,6 @@ import {Code} from 'astro:components';
 <html>
 <head><title>Code component</title></head>
 <body>
-  <Code code="console.log('hello world');" lang="js" wrap={null} />
+  <Code code="console.info('hello world');" lang="js" wrap={null} />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-true.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-true.astro
@@ -4,6 +4,6 @@ import {Code} from 'astro:components';
 <html>
 <head><title>Code component</title></head>
 <body>
-  <Code code="console.log('hello world');" lang="js" wrap />
+  <Code code="console.info('hello world');" lang="js" wrap />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-directives/src/pages/define-vars.astro
+++ b/packages/astro/test/fixtures/astro-directives/src/pages/define-vars.astro
@@ -22,19 +22,19 @@ let undef: undefined;
   </head>
   <body>
     <script id="inline" define:vars={{ foo }}>
-			console.log(foo);
+			console.info(foo);
 		</script>
     <script id="inline-2" define:vars={{ foo }}>
-			console.log(foo);
+			console.info(foo);
 		</script>
 		<script id="inline-3" define:vars={{ 'dash-case': foo }}>
-			console.log(foo);
+			console.info(foo);
 		</script>
 		<script id="inline-4" define:vars={{ bar }}>
-			console.log(bar);
+			console.info(bar);
 		</script>
 		<script id="inline-5" define:vars={{ undef }}>
-			console.log(undef);
+			console.info(undef);
 		</script>
     <div id="compound-style" style={{ color: `var(--fg)` }}></div>
 		<Title />

--- a/packages/astro/test/fixtures/astro-dynamic/src/components/logResize.js
+++ b/packages/astro/test/fixtures/astro-dynamic/src/components/logResize.js
@@ -1,3 +1,3 @@
 window.addEventListener("resize", function() {
-    console.log("window resized");
+    console.info("window resized");
 });

--- a/packages/astro/test/fixtures/astro-env-content-collections/src/content.config.ts
+++ b/packages/astro/test/fixtures/astro-env-content-collections/src/content.config.ts
@@ -1,7 +1,7 @@
 import { defineCollection, z } from "astro:content";
 import { FOO } from "astro:env/client"
 
-console.log({ FOO, BAR: import.meta.env.BAR })
+console.info({ FOO, BAR: import.meta.env.BAR })
 
 export const collections = {
     foo: defineCollection({

--- a/packages/astro/test/fixtures/astro-env/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-env/src/pages/index.astro
@@ -2,7 +2,7 @@
 import { FOO } from "astro:env/client"
 import { BAZ } from "astro:env/server"
 
-console.log({ BAZ })
+console.info({ BAZ })
 ---
 
 <div id="server-rendered">{FOO}</div>

--- a/packages/astro/test/fixtures/astro-envs/src/data/hi.md
+++ b/packages/astro/test/fixtures/astro-envs/src/data/hi.md
@@ -3,5 +3,5 @@
 <h1>import.meta.env.KITTEN</h1>
 
 ```js
-console.log(import.meta.env.KITTEN)
+console.info(import.meta.env.KITTEN)
 ```

--- a/packages/astro/test/fixtures/astro-expr/src/pages/escape.astro
+++ b/packages/astro/test/fixtures/astro-expr/src/pages/escape.astro
@@ -4,7 +4,7 @@
 </head>
 <body>
 	<span id="single-escape">{'Astro & Vite'}</span>
-	{'<script>console.log("pwnd")</script>'}
-	<Fragment set:html={'<script id="trusted">console.log("yay!")</script>'} />
+	{'<script>console.info("pwnd")</script>'}
+	<Fragment set:html={'<script id="trusted">console.info("yay!")</script>'} />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-external-files/public/external-file.js
+++ b/packages/astro/test/fixtures/astro-external-files/public/external-file.js
@@ -1,1 +1,1 @@
-console.log('external!');
+console.info('external!');

--- a/packages/astro/test/fixtures/astro-manifest-invalid/src/pages/client.astro
+++ b/packages/astro/test/fixtures/astro-manifest-invalid/src/pages/client.astro
@@ -14,7 +14,7 @@
 <script>
 	import { outDir } from "astro:config/server"
 	
-	console.log(outDir)
+	console.info(outDir)
 </script>
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-scripts/public/another_external.js
+++ b/packages/astro/test/fixtures/astro-scripts/public/another_external.js
@@ -1,2 +1,2 @@
 let variable = 'foo';
-console.log(`${variable} bar`);
+console.info(`${variable} bar`);

--- a/packages/astro/test/fixtures/astro-scripts/public/regular_script.js
+++ b/packages/astro/test/fixtures/astro-scripts/public/regular_script.js
@@ -1,1 +1,1 @@
-console.log('here i am');
+console.info('here i am');

--- a/packages/astro/test/fixtures/astro-scripts/public/something.js
+++ b/packages/astro/test/fixtures/astro-scripts/public/something.js
@@ -1,1 +1,1 @@
-console.log('this is a widget');
+console.info('this is a widget');

--- a/packages/astro/test/fixtures/astro-scripts/src/components/Glob/GlobComponent.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/Glob/GlobComponent.astro
@@ -1,4 +1,4 @@
 <script>
-  console.log(`Boom! ${new Date()}`);
+  console.info(`Boom! ${new Date()}`);
 </script>
 <h2>My Component</h2>

--- a/packages/astro/test/fixtures/astro-scripts/src/components/Inline.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/Inline.astro
@@ -7,5 +7,5 @@
 	}
 	const props: Props = { name: 'some string' };
 
-  console.log('some content here.', props);
+  console.info('some content here.', props);
 </script>

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/inline-in-page.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/inline-in-page.astro
@@ -9,7 +9,7 @@ import '../styles/global.css';
 <body>
 	<h1>Testing</h1>
 	<script>
-		console.log('hi');
+		console.info('hi');
 	</script>
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/with-styles.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/with-styles.astro
@@ -10,7 +10,7 @@ import '../styles/global.css';
 		<h1>Testing</h1>
 		<script>
 			import "../styles/one.css";
-			console.log("This component imports styles.");
+			console.info("This component imports styles.");
 		</script>
 	</body>
 </html>

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/another_external.js
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/another_external.js
@@ -1,1 +1,1 @@
-console.log('another external');
+console.info('another external');

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/hoist_external_imported_inline.js
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/hoist_external_imported_inline.js
@@ -1,1 +1,1 @@
-console.log("I AM IMPORTED INLINE");
+console.info("I AM IMPORTED INLINE");

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/no_hoist_module.js
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/no_hoist_module.js
@@ -1,1 +1,1 @@
-console.log('no hoist module');
+console.info('no hoist module');

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/no_hoist_nonmodule.js
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/no_hoist_nonmodule.js
@@ -1,1 +1,1 @@
-console.log('no hoist nonmodule');
+console.info('no hoist nonmodule');

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/some-files/one.ts
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/some-files/one.ts
@@ -1,1 +1,1 @@
-console.log('some-files/one');
+console.info('some-files/one');

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/some-files/two.ts
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/some-files/two.ts
@@ -1,1 +1,1 @@
-console.log('some-files/two');
+console.info('some-files/two');

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/something.js
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/something.js
@@ -1,1 +1,1 @@
-console.log('some script');
+console.info('some script');

--- a/packages/astro/test/fixtures/astro-slots-nested/src/components/react/Parent.jsx
+++ b/packages/astro/test/fixtures/astro-slots-nested/src/components/react/Parent.jsx
@@ -4,7 +4,7 @@ export default function Parent({ children }) {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
-    console.log('mount');
+    console.info('mount');
   }, []);
 
   return (

--- a/packages/astro/test/fixtures/before-hydration/src/scripts/global.js
+++ b/packages/astro/test/fixtures/before-hydration/src/scripts/global.js
@@ -1,1 +1,1 @@
-console.log('testing');
+console.info('testing');

--- a/packages/astro/test/fixtures/build-assets/src/pages/index.astro
+++ b/packages/astro/test/fixtures/build-assets/src/pages/index.astro
@@ -16,7 +16,7 @@ import SomeComponent from '../components/SomeComponent';
 		</style>
 
 		<script>
-			console.log("Hello world!")
+			console.info("Hello world!")
 		</script>
 	</body>
 </html>

--- a/packages/astro/test/fixtures/build-readonly-file/src/pages/index.astro
+++ b/packages/astro/test/fixtures/build-readonly-file/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
 ---
 <script>
-    console.log('test');
+    console.info('test');
 </script>

--- a/packages/astro/test/fixtures/content-collections-base/src/components/One.astro
+++ b/packages/astro/test/fixtures/content-collections-base/src/components/One.astro
@@ -2,6 +2,6 @@
 	div { color: blue; }
 </style>
 <script>
-	console.log('hi');
+	console.info('hi');
 </script>
 <div>Testing</div>

--- a/packages/astro/test/fixtures/content-collections/src/components/ScriptCompA.astro
+++ b/packages/astro/test/fixtures/content-collections/src/components/ScriptCompA.astro
@@ -1,1 +1,1 @@
-<script>console.log('ScriptCompA')</script>
+<script>console.info('ScriptCompA')</script>

--- a/packages/astro/test/fixtures/content-collections/src/components/ScriptCompB.astro
+++ b/packages/astro/test/fixtures/content-collections/src/components/ScriptCompB.astro
@@ -1,1 +1,1 @@
-<script>console.log('ScriptCompB')</script>
+<script>console.info('ScriptCompB')</script>

--- a/packages/astro/test/fixtures/core-image-ssg/src/client/client-image.ts
+++ b/packages/astro/test/fixtures/core-image-ssg/src/client/client-image.ts
@@ -1,2 +1,2 @@
 import light_walrus from "../assets/light_walrus.avif";
-console.log(light_walrus);
+console.info(light_walrus);

--- a/packages/astro/test/fixtures/extension-matching/src/pages/index.astro
+++ b/packages/astro/test/fixtures/extension-matching/src/pages/index.astro
@@ -7,6 +7,6 @@ try {
 	console.error('Failed to load virtual module:', e)
 }
 
-console.log('Loaded virtual module:', success)
+console.info('Loaded virtual module:', success)
 ---
 <h1>{String(success)}</h1>

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/A.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/A.astro
@@ -1,3 +1,3 @@
 <script>
-	console.log('A');
+	console.info('A');
 </script>

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/B.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/B.astro
@@ -1,3 +1,3 @@
 <script>
-	console.log('B');
+	console.info('B');
 </script>

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/C.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/C.astro
@@ -1,3 +1,3 @@
 <script>
-	console.log('C');
+	console.info('C');
 </script>

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/D.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/D.astro
@@ -1,3 +1,3 @@
 <script>
-	console.log('D');
+	console.info('D');
 </script>

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/E.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/E.astro
@@ -1,3 +1,3 @@
 <script>
-	console.log('E');
+	console.info('E');
 </script>

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/LargeScript.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/LargeScript.astro
@@ -1,5 +1,5 @@
 <script>
-  console.log(`
+  console.info(`
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur posuere commodo venenatis.
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
 Nam non ligula vel metus efficitur hendrerit. In hac habitasse platea dictumst. Praesent et

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/shared-scripts/B.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/shared-scripts/B.astro
@@ -1,4 +1,4 @@
 <script>
   import './script.ts';
-  console.log('shared-script B');
+  console.info('shared-script B');
 </script>

--- a/packages/astro/test/fixtures/hoisted-imports/src/components/shared-scripts/script.ts
+++ b/packages/astro/test/fixtures/hoisted-imports/src/components/shared-scripts/script.ts
@@ -1,1 +1,1 @@
-console.log('shared-scripts');
+console.info('shared-scripts');

--- a/packages/astro/test/fixtures/html-escape/src/components/Test.html
+++ b/packages/astro/test/fixtures/html-escape/src/components/Test.html
@@ -1,4 +1,4 @@
 <div>${foo}</div>
 <span ${attr}></span>
 <custom-element x-data="`${test}`"></custom-element>
-<script>console.log(`hello ${"world"}!`)</script>
+<script>console.info(`hello ${"world"}!`)</script>

--- a/packages/astro/test/fixtures/i18n-routing-fallback-index/src/pages/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback-index/src/pages/index.astro
@@ -2,7 +2,7 @@
 <head>
 	<title>Astro</title>
 	<script>
-		console.log("this is a script")
+		console.info("this is a script")
 	</script>
 </head>
 <body>

--- a/packages/astro/test/fixtures/i18n-routing-fallback/src/pages/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback/src/pages/index.astro
@@ -5,7 +5,7 @@ const locale = Astro.currentLocale
 <head>
 	<title>Astro</title>
 	<script>
-		console.log("this is a script")
+		console.info("this is a script")
 	</script>
 </head>
 <body>

--- a/packages/astro/test/fixtures/legacy-content-collections/src/components/ScriptCompA.astro
+++ b/packages/astro/test/fixtures/legacy-content-collections/src/components/ScriptCompA.astro
@@ -1,1 +1,1 @@
-<script>console.log('ScriptCompA')</script>
+<script>console.info('ScriptCompA')</script>

--- a/packages/astro/test/fixtures/legacy-content-collections/src/components/ScriptCompB.astro
+++ b/packages/astro/test/fixtures/legacy-content-collections/src/components/ScriptCompB.astro
@@ -1,1 +1,1 @@
-<script>console.log('ScriptCompB')</script>
+<script>console.info('ScriptCompB')</script>

--- a/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-sequence-request-clone/src/middleware.js
@@ -4,7 +4,7 @@ const middleware1 = defineMiddleware((_, next) => next('/'));
 
 const middleware2 = defineMiddleware(async ({ request, cookies }, next) => {
 	cookies.set('cookie1', 'Cookie from middleware 1');
-	console.log(await request.clone().text());
+	console.info(await request.clone().text());
 	return next();
 });
 

--- a/packages/astro/test/fixtures/middleware-sequence-rewrite/src/middleware.ts
+++ b/packages/astro/test/fixtures/middleware-sequence-rewrite/src/middleware.ts
@@ -4,7 +4,7 @@ import { sequence } from 'astro:middleware';
 export const mid1: MiddlewareHandler = async ({ cookies, url, rewrite, request }, next) => {
 	cookies.set('cookie1', 'Cookie from middleware 1');
 	if (url.pathname === '/') {
-		console.log('Rewriting');
+		console.info('Rewriting');
 		return rewrite('/another');
 	}
 	return next();

--- a/packages/astro/test/fixtures/middleware-virtual/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-virtual/src/middleware.js
@@ -1,6 +1,6 @@
 import { defineMiddleware } from 'astro:middleware';
 
 export const onRequest = defineMiddleware(async (context, next) => {
-	console.log('[MIDDLEWARE] in ' + context.url.toString());
+	console.info('[MIDDLEWARE] in ' + context.url.toString());
 	return next();
 });

--- a/packages/astro/test/fixtures/reroute/src/pages/post/post-b.astro
+++ b/packages/astro/test/fixtures/reroute/src/pages/post/post-b.astro
@@ -5,7 +5,7 @@ if (Astro.request.method === 'POST') {
 		const data = await Astro.request.json();
 		email = data.email?.toString().trim();
 	} catch (e) {
-		console.log(e)
+		console.info(e)
 	}
 }
 ---

--- a/packages/astro/test/fixtures/reuse-injected-entrypoint/src/to-inject.astro
+++ b/packages/astro/test/fixtures/reuse-injected-entrypoint/src/to-inject.astro
@@ -2,5 +2,5 @@
 ---
 <h1>to-inject.astro</h1>
 <script>
-	console.log('to-inject.astro');
+	console.info('to-inject.astro');
 </script>

--- a/packages/astro/test/fixtures/rewrite-i18n-manual-routing/src/middleware.js
+++ b/packages/astro/test/fixtures/rewrite-i18n-manual-routing/src/middleware.js
@@ -1,5 +1,5 @@
 export const onRequest = async (_ctx, next) => {
 	const response = await next('/');
-	console.log('expected response.status is', response.status);
+	console.info('expected response.status is', response.status);
 	return response;
 };

--- a/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-b.astro
+++ b/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-b.astro
@@ -5,7 +5,7 @@ if (Astro.request.method === 'POST') {
 		const data = await Astro.request.formData();
 		email = data.get('email');
 	} catch (e) {
-		console.log(e)
+		console.info(e)
 	}
 }
 ---

--- a/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-body-used.astro
+++ b/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-body-used.astro
@@ -4,7 +4,7 @@ if (Astro.request.method === 'POST') {
 	try {
 		data = await Astro.request.text();
 	} catch (e) {
-		console.log(e)
+		console.info(e)
 	}
 }
 

--- a/packages/astro/test/fixtures/sessions/src/middleware.ts
+++ b/packages/astro/test/fixtures/sessions/src/middleware.ts
@@ -10,7 +10,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const { action, setActionResult, serializeActionResult } =
     getActionContext(context);
 
-		console.log(action?.name)
+		console.info(action?.name)
 
 	const actionPayload = await context.session.get(ACTION_SESSION_KEY);
 

--- a/packages/astro/test/fixtures/solid-component/src/components/Counter.jsx
+++ b/packages/astro/test/fixtures/solid-component/src/components/Counter.jsx
@@ -11,7 +11,7 @@ export default function Counter(props) {
 						<Match when={page % 2 === 0}>
 							<button
 								onClick={() => {
-									console.log(page);
+									console.info(page);
 								}}
 							>
 								even {page}
@@ -20,7 +20,7 @@ export default function Counter(props) {
 						<Match when={page % 2 === 1}>
 							<button
 								onClick={() => {
-									console.log(page);
+									console.info(page);
 								}}
 							>
 								odd {page}

--- a/packages/astro/test/fixtures/solid-component/src/components/async-components.jsx
+++ b/packages/astro/test/fixtures/solid-component/src/components/async-components.jsx
@@ -10,9 +10,9 @@ export function AsyncComponent(props) {
 	const id = createUniqueId();
 
 	const [data] = createResource(async () => {
-		// console.log("Start rendering async component " + props.title);
+		// console.info("Start rendering async component " + props.title);
 		await sleep(props.delay ?? SLEEP_MS);
-		// console.log("Finish rendering async component " + props.title);
+		// console.info("Finish rendering async component " + props.title);
 		return 'Async result for component id=' + id;
 	});
 

--- a/packages/astro/test/fixtures/space in folder name/app/src/pages/index.astro
+++ b/packages/astro/test/fixtures/space in folder name/app/src/pages/index.astro
@@ -5,7 +5,7 @@
 <body>
 	<h1>Testing</h1>
 	<script>
-		console.log('hi');
+		console.info('hi');
 	</script>
 </body>
 </html>

--- a/packages/astro/test/fixtures/ssr-prerender/src/pages/static.astro
+++ b/packages/astro/test/fixtures/ssr-prerender/src/pages/static.astro
@@ -8,7 +8,7 @@ const { searchParams } = Astro.url;
 <head>
 	<title>Static Page</title>
 	<script>
-		console.log('hello world');
+		console.info('hello world');
 	</script>
 </head>
 	<body>

--- a/packages/astro/test/fixtures/ssr-request/src/pages/request.astro
+++ b/packages/astro/test/fixtures/ssr-request/src/pages/request.astro
@@ -13,7 +13,7 @@ const pathname = Astro.url.pathname;
 		}
 	</style>
 	<script>
-		console.log('hello world');
+		console.info('hello world');
 	</script>
 </head>
 <body>

--- a/packages/astro/test/fixtures/ssr-request/src/scripts/inject-script.js
+++ b/packages/astro/test/fixtures/ssr-request/src/scripts/inject-script.js
@@ -1,1 +1,1 @@
-console.log("this is injected by injectScript");
+console.info("this is injected by injectScript");

--- a/packages/astro/test/fixtures/ssr-script/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-script/src/pages/index.astro
@@ -4,6 +4,6 @@
 	</head>
 	<body>
 		<h1>Testing</h1>
-		<script>console.log('hello world');</script>
+		<script>console.info('hello world');</script>
 	</body>
 </html>

--- a/packages/astro/test/html-escape.test.js
+++ b/packages/astro/test/html-escape.test.js
@@ -31,7 +31,7 @@ describe('HTML Escape', () => {
 			assert.equal(ce.attr('x-data'), '`${test}`');
 
 			const script = $('script');
-			assert.equal(script.text(), 'console.log(`hello ${"world"}!`)');
+			assert.equal(script.text(), 'console.info(`hello ${"world"}!`)');
 		});
 	});
 
@@ -64,7 +64,7 @@ describe('HTML Escape', () => {
 			assert.equal(ce.attr('x-data'), '`${test}`');
 
 			const script = $('script');
-			assert.equal(script.text(), 'console.log(`hello ${"world"}!`)');
+			assert.equal(script.text(), 'console.info(`hello ${"world"}!`)');
 		});
 	});
 });

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1022,7 +1022,7 @@ describe('[SSG] i18n routing', () => {
 		it('should render the page with client scripts', async () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
-			assert.equal($('script').text().includes('console.log("this is a script")'), true);
+			assert.equal($('script').text().includes('console.info("this is a script")'), true);
 		});
 
 		describe('with localised index pages', () => {

--- a/packages/astro/test/reuse-injected-entrypoint.test.js
+++ b/packages/astro/test/reuse-injected-entrypoint.test.js
@@ -13,13 +13,13 @@ const routes = [
 		description: 'matches /injected-a to to-inject.astro',
 		url: '/injected-a',
 		h1: 'to-inject.astro',
-		scriptContent: 'console.log("to-inject.astro");',
+		scriptContent: 'console.info("to-inject.astro");',
 	},
 	{
 		description: 'matches /injected-b to to-inject.astro',
 		url: '/injected-b',
 		h1: 'to-inject.astro',
-		scriptContent: 'console.log("to-inject.astro");',
+		scriptContent: 'console.info("to-inject.astro");',
 	},
 	{
 		description: 'matches /dynamic-a/id-1 to [id].astro',

--- a/packages/astro/test/ssr-script.test.js
+++ b/packages/astro/test/ssr-script.test.js
@@ -54,7 +54,7 @@ describe('Inline scripts in SSR', () => {
 		it('Inlined scripts get included without base path in the script', async () => {
 			const html = await fetchHTML(fixture, '/hello/');
 			const $ = cheerioLoad(html);
-			assert.equal($('script').html(), 'console.log("hello world");');
+			assert.equal($('script').html(), 'console.info("hello world");');
 		});
 	});
 });

--- a/packages/astro/test/units/render/components.test.js
+++ b/packages/astro/test/units/render/components.test.js
@@ -9,7 +9,7 @@ describe('core/render components', () => {
 			'/src/pages/index.astro': `
 				---
 				const TagA = 'p style=color:red;'
-				const TagB = 'p><script id="pwnd">console.log("pwnd")</script>'
+				const TagB = 'p><script id="pwnd">console.info("pwnd")</script>'
 				---
 				<html>
 					<head><title>testing</title></head>

--- a/packages/astro/test/units/vite-plugin-astro/hmr.test.js
+++ b/packages/astro/test/units/vite-plugin-astro/hmr.test.js
@@ -10,8 +10,8 @@ describe('isStyleOnlyChanged', () => {
 	});
 
 	it('should return false if script has changed', () => {
-		const oldCode = '<script>console.log("Hello");</script><style>body { color: red; }</style>';
-		const newCode = '<script>console.log("Hi");</script><style>body { color: red; }</style>';
+		const oldCode = '<script>console.info("Hello");</script><style>body { color: red; }</style>';
+		const newCode = '<script>console.info("Hi");</script><style>body { color: red; }</style>';
 		assert.equal(isStyleOnlyChanged(oldCode, newCode), false);
 	});
 

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -18,8 +18,7 @@ process.on('SIGTERM', exit);
 
 export async function main() {
 	// Add some extra spacing from the noisy npm/pnpm init output
-	// biome-ignore lint/suspicious/noConsole: allowed
-	console.log('');
+	console.info('');
 	// NOTE: In the v7.x version of npm, the default behavior of `npm init` was changed
 	// to no longer require `--` to pass args and instead pass `--` directly to us. This
 	// broke our arg parser, since `--` is a special kind of flag. Filtering for `--` here
@@ -46,8 +45,7 @@ export async function main() {
 		await step(ctx);
 	}
 
-	// biome-ignore lint/suspicious/noConsole: allowed
-	console.log('');
+	console.info('');
 
 	const labels = {
 		start: 'Project initializing...',

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -36,9 +36,9 @@ export async function cmd({
 
 	// // push the database schema
 	if (migrationQueries.length === 0) {
-		console.log('Database schema is up to date.');
+		console.info('Database schema is up to date.');
 	} else {
-		console.log(`Database schema is out of date.`);
+		console.info(`Database schema is out of date.`);
 	}
 
 	if (isForceReset) {
@@ -50,20 +50,20 @@ export async function cmd({
 		});
 
 		if (!begin) {
-			console.log('Canceled.');
+			console.info('Canceled.');
 			process.exit(0);
 		}
 
-		console.log(`Force-pushing to the database. All existing data will be erased.`);
+		console.info(`Force-pushing to the database. All existing data will be erased.`);
 	} else if (confirmations.length > 0) {
-		console.log('\n' + formatDataLossMessage(confirmations) + '\n');
+		console.info('\n' + formatDataLossMessage(confirmations) + '\n');
 		throw new Error('Exiting.');
 	}
 
 	if (isDryRun) {
-		console.log('Statements:', JSON.stringify(migrationQueries, undefined, 2));
+		console.info('Statements:', JSON.stringify(migrationQueries, undefined, 2));
 	} else {
-		console.log(`Pushing database schema updates...`);
+		console.info(`Pushing database schema updates...`);
 		await pushSchema({
 			statements: migrationQueries,
 			dbInfo,

--- a/packages/db/src/core/cli/commands/shell/index.ts
+++ b/packages/db/src/core/cli/commands/shell/index.ts
@@ -26,7 +26,7 @@ export async function cmd({
 	if (flags.remote) {
 		const db = createRemoteDatabaseClient(dbInfo);
 		const result = await db.run(sql.raw(query));
-		console.log(result);
+		console.info(result);
 	} else {
 		const { ASTRO_DATABASE_FILE } = getAstroEnv();
 		const dbUrl = normalizeDatabaseUrl(
@@ -35,6 +35,6 @@ export async function cmd({
 		);
 		const db = createLocalDatabaseClient({ url: dbUrl });
 		const result = await db.run(sql.raw(query));
-		console.log(result);
+		console.info(result);
 	}
 }

--- a/packages/db/src/core/cli/commands/verify/index.ts
+++ b/packages/db/src/core/cli/commands/verify/index.ts
@@ -44,9 +44,9 @@ export async function cmd({
 	}
 
 	if (isJson) {
-		console.log(JSON.stringify(result));
+		console.info(JSON.stringify(result));
 	} else {
-		console.log(result.message);
+		console.info(result.message);
 	}
 
 	process.exit(result.exitCode);

--- a/packages/db/src/core/cli/index.ts
+++ b/packages/db/src/core/cli/index.ts
@@ -22,11 +22,11 @@ export async function cli({
 			return await cmd({ astroConfig, dbConfig, flags });
 		}
 		case 'gen': {
-			console.log('"astro db gen" is no longer needed! Visit the docs for more information.');
+			console.info('"astro db gen" is no longer needed! Visit the docs for more information.');
 			return;
 		}
 		case 'sync': {
-			console.log('"astro db sync" is no longer needed! Visit the docs for more information.');
+			console.info('"astro db sync" is no longer needed! Visit the docs for more information.');
 			return;
 		}
 		case 'push': {

--- a/packages/db/src/core/cli/print-help.ts
+++ b/packages/db/src/core/cli/print-help.ts
@@ -65,5 +65,5 @@ export function printHelp({
 		message.push(linebreak(), `${description}`);
 	}
 
-	console.log(message.join('\n') + '\n');
+	console.info(message.join('\n') + '\n');
 }

--- a/packages/db/src/core/queries.ts
+++ b/packages/db/src/core/queries.ts
@@ -191,8 +191,7 @@ function getDefaultValueSql(columnName: string, column: DBColumnWithDefault): st
 			try {
 				stringified = JSON.stringify(column.schema.default);
 			} catch {
-				// biome-ignore lint/suspicious/noConsole: allowed
-				console.log(
+				console.info(
 					`Invalid default value for column ${colors.bold(
 						columnName,
 					)}. Defaults must be valid JSON when using the \`json()\` type.`,

--- a/packages/db/test/fixtures/recipes/src/pages/index.astro
+++ b/packages/db/test/fixtures/recipes/src/pages/index.astro
@@ -10,7 +10,7 @@ const ingredientsByRecipe = await db
 	.from(Ingredient)
 	.innerJoin(Recipe, eq(Ingredient.recipeId, Recipe.id));
 
-console.log(ingredientsByRecipe);
+console.info(ingredientsByRecipe);
 ---
 
 <h2>Shopping list</h2>

--- a/packages/integrations/cloudflare/CHANGELOG.md
+++ b/packages/integrations/cloudflare/CHANGELOG.md
@@ -156,7 +156,7 @@
         },
         async queue(batch, _env) {
           let messages = JSON.stringify(batch.messages);
-          console.log(`consumed from our queue: ${messages}`);
+          console.info(`consumed from our queue: ${messages}`);
         },
       } satisfies ExportedHandler<Env>,
       MyDurableObject,

--- a/packages/integrations/cloudflare/test/astro-env.test.js
+++ b/packages/integrations/cloudflare/test/astro-env.test.js
@@ -18,11 +18,11 @@ describe('astro:env', () => {
 			wrangler = wranglerCli(fileURLToPath(root));
 			await new Promise((resolve) => {
 				wrangler.stdout.on('data', (data) => {
-					// console.log('[stdout]', data.toString());
+					// console.info('[stdout]', data.toString());
 					if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 				});
 				wrangler.stderr.on('data', (_data) => {
-					// console.log('[stderr]', data.toString());
+					// console.info('[stderr]', data.toString());
 				});
 			});
 		});

--- a/packages/integrations/cloudflare/test/compile-image-service.test.js
+++ b/packages/integrations/cloudflare/test/compile-image-service.test.js
@@ -13,11 +13,11 @@ describe('CompileImageService', () => {
 		wrangler = wranglerCli(fileURLToPath(root));
 		await new Promise((resolve) => {
 			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
+				// console.info('[stdout]', data.toString());
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', data.toString());
+				// console.info('[stderr]', data.toString());
 			});
 		});
 	});

--- a/packages/integrations/cloudflare/test/fixtures/astro-env/src/middleware.ts
+++ b/packages/integrations/cloudflare/test/fixtures/astro-env/src/middleware.ts
@@ -4,6 +4,6 @@ import { API_SECRET } from 'astro:env/server'
 const secret = API_SECRET
 
 export const onRequest = defineMiddleware((_ctx, next) => {
-    console.log({ secret })
+    console.info({ secret })
     return next()
 })

--- a/packages/integrations/cloudflare/test/fixtures/custom-entryfile/src/worker.ts
+++ b/packages/integrations/cloudflare/test/fixtures/custom-entryfile/src/worker.ts
@@ -16,14 +16,14 @@ export function createExports(manifest: SSRManifest) {
 	return {
 		default: {
 			async fetch(request, env, ctx) {
-				console.log("env", env)
+				console.info("env", env)
 				await env.MY_QUEUE.send("log");
 				// @ts-expect-error - The types are identical, I don't get why this is an error.
 				return handle(manifest, app, request, env, ctx);
 			},
 			async queue(batch, _env) {
 				let messages = JSON.stringify(batch.messages);
-    		console.log(`consumed from our queue: ${messages}`);
+    		console.info(`consumed from our queue: ${messages}`);
 			}
 		} satisfies ExportedHandler<Env>,
 		MyDurableObject: MyDurableObject,

--- a/packages/integrations/cloudflare/test/fixtures/sessions/src/middleware.ts
+++ b/packages/integrations/cloudflare/test/fixtures/sessions/src/middleware.ts
@@ -10,7 +10,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const { action, setActionResult, serializeActionResult } =
     getActionContext(context);
 
-		console.log(action?.name)
+		console.info(action?.name)
 
 	const actionPayload = await context.session.get(ACTION_SESSION_KEY);
 

--- a/packages/integrations/cloudflare/test/module-loader.test.js
+++ b/packages/integrations/cloudflare/test/module-loader.test.js
@@ -14,11 +14,11 @@ describe('CloudflareModuleLoading', () => {
 		wrangler = wranglerCli(fileURLToPath(root));
 		await new Promise((resolve) => {
 			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
+				// console.info('[stdout]', data.toString());
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', data.toString());
+				// console.info('[stderr]', data.toString());
 			});
 		});
 	});

--- a/packages/integrations/cloudflare/test/sessions.test.js
+++ b/packages/integrations/cloudflare/test/sessions.test.js
@@ -16,11 +16,11 @@ describe('sessions', () => {
 		wrangler = wranglerCli(fileURLToPath(root));
 		await new Promise((resolve) => {
 			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
+				// console.info('[stdout]', data.toString());
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', _data.toString());
+				// console.info('[stderr]', _data.toString());
 			});
 		});
 	});

--- a/packages/integrations/cloudflare/test/with-solid-js.test.js
+++ b/packages/integrations/cloudflare/test/with-solid-js.test.js
@@ -14,11 +14,11 @@ describe('SolidJS', () => {
 		wrangler = wranglerCli(fileURLToPath(root));
 		await new Promise((resolve) => {
 			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
+				// console.info('[stdout]', data.toString());
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', data.toString());
+				// console.info('[stderr]', data.toString());
 			});
 		});
 	});

--- a/packages/integrations/cloudflare/test/with-svelte.test.js
+++ b/packages/integrations/cloudflare/test/with-svelte.test.js
@@ -14,11 +14,11 @@ describe('Svelte', () => {
 		wrangler = wranglerCli(fileURLToPath(root));
 		await new Promise((resolve) => {
 			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
+				// console.info('[stdout]', data.toString());
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', data.toString());
+				// console.info('[stderr]', data.toString());
 			});
 		});
 	});

--- a/packages/integrations/cloudflare/test/with-vue.test.js
+++ b/packages/integrations/cloudflare/test/with-vue.test.js
@@ -14,11 +14,11 @@ describe('Vue', () => {
 		wrangler = wranglerCli(fileURLToPath(root));
 		await new Promise((resolve) => {
 			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
+				// console.info('[stdout]', data.toString());
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', data.toString());
+				// console.info('[stderr]', data.toString());
 			});
 		});
 	});

--- a/packages/integrations/cloudflare/test/wrangler-preview-platform.test.js
+++ b/packages/integrations/cloudflare/test/wrangler-preview-platform.test.js
@@ -15,11 +15,11 @@ describe('WranglerPreviewPlatform', () => {
 		wrangler = wranglerCli(fileURLToPath(root));
 		await new Promise((resolve) => {
 			wrangler.stdout.on('data', (data) => {
-				// console.log('[stdout]', data.toString());
+				// console.info('[stdout]', data.toString());
 				if (data.toString().includes('http://127.0.0.1:8788')) resolve();
 			});
 			wrangler.stderr.on('data', (_data) => {
-				// console.log('[stderr]', data.toString());
+				// console.info('[stderr]', data.toString());
 			});
 		});
 	});

--- a/packages/integrations/markdoc/test/fixtures/propagated-assets/src/components/LogHello.astro
+++ b/packages/integrations/markdoc/test/fixtures/propagated-assets/src/components/LogHello.astro
@@ -1,5 +1,5 @@
 <p>I'm gonna log hello</p>
 
 <script>
-	console.log('hello');
+	console.info('hello');
 </script>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/HelloWorld.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/HelloWorld.astro
@@ -7,5 +7,5 @@
 <style>h3 { color: red }</style>
 
 <script>
-console.log('hellooooo')
+console.info('hellooooo')
 </script>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/WithHoistedScripts.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/WithHoistedScripts.astro
@@ -2,5 +2,5 @@
 ---
 
 <script>
-	console.log('hoisted')
+	console.info('hoisted')
 	</script>

--- a/packages/integrations/mdx/test/fixtures/mdx-script-style-raw/src/pages/index.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-script-style-raw/src/pages/index.mdx
@@ -1,7 +1,7 @@
 # Script style raw
 
 <script id="test-script">
-{`console.log('raw script')`}
+{`console.info('raw script')`}
 </script>
 
 <style id="test-style">

--- a/packages/integrations/mdx/test/mdx-script-style-raw.test.js
+++ b/packages/integrations/mdx/test/mdx-script-style-raw.test.js
@@ -32,7 +32,7 @@ describe('MDX script style raw', () => {
 
 			const scriptContent = document.getElementById('test-script').innerHTML;
 			assert.equal(
-				scriptContent.includes("console.log('raw script')"),
+				scriptContent.includes("console.info('raw script')"),
 				true,
 				'script should not be html-escaped',
 			);
@@ -59,7 +59,7 @@ describe('MDX script style raw', () => {
 
 			const scriptContent = document.getElementById('test-script').innerHTML;
 			assert.equal(
-				scriptContent.includes("console.log('raw script')"),
+				scriptContent.includes("console.info('raw script')"),
 				true,
 				'script should not be html-escaped',
 			);

--- a/packages/integrations/netlify/test/functions/fixtures/sessions/src/middleware.ts
+++ b/packages/integrations/netlify/test/functions/fixtures/sessions/src/middleware.ts
@@ -10,7 +10,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const { action, setActionResult, serializeActionResult } =
     getActionContext(context);
 
-		console.log(action?.name)
+		console.info(action?.name)
 
 	const actionPayload = await context.session.get(ACTION_SESSION_KEY);
 

--- a/packages/integrations/vue/test/toTsx.test.js
+++ b/packages/integrations/vue/test/toTsx.test.js
@@ -12,7 +12,7 @@ describe('toTSX function', () => {
       <script setup>
         // This is a comment in script setup
         // defineProps(['msg']);
-				// console.log('foo)
+				// console.info('foo)
       </script>
     `;
 
@@ -36,7 +36,7 @@ describe('toTSX function', () => {
 					msg: String
 				});
 				const handleClick = () => {
-					console.log('foo');
+					console.info('foo');
 				}
       </script>
     `;

--- a/packages/language-tools/astro-check/test/fixture/fileWithErrors.astro
+++ b/packages/language-tools/astro-check/test/fixture/fileWithErrors.astro
@@ -1,3 +1,3 @@
 ---
-console.log(doesntExist);
+console.info(doesntExist);
 ---

--- a/packages/language-tools/astro-check/test/fixture/fileWithNoErrors.astro
+++ b/packages/language-tools/astro-check/test/fixture/fileWithNoErrors.astro
@@ -1,4 +1,4 @@
 ---
 const doesntExist = "Hey, I do exists!";
-console.log(doesntExist);
+console.info(doesntExist);
 ---

--- a/packages/language-tools/language-server/test/check/check.test.ts
+++ b/packages/language-tools/language-server/test/check/check.test.ts
@@ -39,7 +39,7 @@ describe('AstroCheck', async () => {
 		assert.notStrictEqual(result.fileResult[0].fileContent, undefined);
 		assert.deepStrictEqual(
 			result.fileResult[0].fileContent,
-			`---${os.EOL}console.log(doesntExist);${os.EOL}---${os.EOL}`,
+			`---${os.EOL}console.info(doesntExist);${os.EOL}---${os.EOL}`,
 		);
 	});
 

--- a/packages/language-tools/language-server/test/check/fixture/fileWithErrors.astro
+++ b/packages/language-tools/language-server/test/check/fixture/fileWithErrors.astro
@@ -1,3 +1,3 @@
 ---
-console.log(doesntExist);
+console.info(doesntExist);
 ---

--- a/packages/language-tools/language-server/test/check/fixture/fileWithNoErrors.astro
+++ b/packages/language-tools/language-server/test/check/fixture/fileWithNoErrors.astro
@@ -1,4 +1,4 @@
 ---
 const doesntExist = "Hey, I do exists!";
-console.log(doesntExist);
+console.info(doesntExist);
 ---

--- a/packages/language-tools/language-server/test/check/fixture/tsFileWithErrors.ts
+++ b/packages/language-tools/language-server/test/check/fixture/tsFileWithErrors.ts
@@ -1,1 +1,1 @@
-console.log(doesntExistTS);
+console.info(doesntExistTS);

--- a/packages/language-tools/language-server/test/fixture/renameThis.ts
+++ b/packages/language-tools/language-server/test/fixture/renameThis.ts
@@ -1,3 +1,3 @@
 export function sayHello() {
-	console.log('Hello');
+	console.info('Hello');
 }

--- a/packages/language-tools/language-server/test/fixture/src/pages/index.astro
+++ b/packages/language-tools/language-server/test/fixture/src/pages/index.astro
@@ -3,7 +3,7 @@ import { getCollection } from "astro:content";
 
 const articles = await getCollection("blog");
 
-console.log(articles);
+console.info(articles);
 ---
 
 {articles.map((article) => (

--- a/packages/language-tools/language-server/test/typescript/diagnostics.test.ts
+++ b/packages/language-tools/language-server/test/typescript/diagnostics.test.ts
@@ -77,7 +77,7 @@ describe('TypeScript - Diagnostics', async () => {
 
 	it('can get diagnostics in script tags', async () => {
 		const document = await languageServer.openFakeDocument(
-			`<script>const something: string = "Hello";something;</script><div><script>console.log(doesnotexist);</script></div>`,
+			`<script>const something: string = "Hello";something;</script><div><script>console.info(doesnotexist);</script></div>`,
 			'astro',
 		);
 		const diagnostics = (await languageServer.handle.sendDocumentDiagnosticRequest(

--- a/packages/language-tools/language-server/test/typescript/scripts.test.ts
+++ b/packages/language-tools/language-server/test/typescript/scripts.test.ts
@@ -10,7 +10,7 @@ describe('TypeScript - Diagnostics', async () => {
 
 	it('treats script tags as modules', async () => {
 		const document = await languageServer.openFakeDocument(
-			'<script>import * as path from "node:path";path;const hello = "Hello, Astro!";</script><script>console.log(hello);</script>',
+			'<script>import * as path from "node:path";path;const hello = "Hello, Astro!";</script><script>console.info(hello);</script>',
 			'astro',
 		);
 		const diagnostics = (await languageServer.handle.sendDocumentDiagnosticRequest(
@@ -22,7 +22,7 @@ describe('TypeScript - Diagnostics', async () => {
 
 	it('treats inline script tags as not isolated modules', async () => {
 		const document = await languageServer.openFakeDocument(
-			'<script is:inline>const hello = "Hello, Astro!";</script><script is:inline>console.log(hello);</script>',
+			'<script is:inline>const hello = "Hello, Astro!";</script><script is:inline>console.info(hello);</script>',
 			'astro',
 		);
 

--- a/packages/language-tools/language-server/test/units/parseJS.test.ts
+++ b/packages/language-tools/language-server/test/units/parseJS.test.ts
@@ -5,7 +5,7 @@ import { extractScriptTags } from '../../dist/core/parseJS.js';
 
 describe('parseJS - Can find all the scripts in an Astro file', () => {
 	it('Can find all the scripts in an Astro file, including nested tags', () => {
-		const input = `<script>console.log('hi')</script><div><script>console.log('hi2')</script></div>`;
+		const input = `<script>console.info('hi')</script><div><script>console.info('hi2')</script></div>`;
 		const { ranges } = astro2tsx(input, 'file.astro');
 		const scriptTags = extractScriptTags(ranges.scripts);
 
@@ -21,7 +21,7 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 	});
 
 	it('returns the proper capabilities for inline script tags', async () => {
-		const input = `<script is:inline>console.log('hi')</script>`;
+		const input = `<script is:inline>console.info('hi')</script>`;
 		const { ranges } = astro2tsx(input, 'file.astro');
 		const scriptTags = extractScriptTags(ranges.scripts);
 

--- a/packages/language-tools/ts-plugin/test/fixtures/script.ts
+++ b/packages/language-tools/ts-plugin/test/fixtures/script.ts
@@ -1,5 +1,5 @@
 export function sayHello() {
-	console.log("Hello")
+	console.info("Hello")
 }
 
 MyAstroCompon

--- a/packages/language-tools/vscode/test/grammar/fixtures/attributes.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/attributes.astro
@@ -5,10 +5,10 @@
 <div class.astro></div>
 <div i18nReady></div>
 
-<div onclick="console.log()"></div>
+<div onclick="console.info()"></div>
 
-<div onload={"console.log('')"}></div>
+<div onload={"console.info('')"}></div>
 
-<div onload=`console.log('')`></div>
+<div onload=`console.info('')`></div>
 
 <div class=`\${not-a-variable}`></div>

--- a/packages/language-tools/vscode/test/grammar/fixtures/attributes.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/attributes.astro.snap
@@ -40,7 +40,7 @@
 #                 ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
 #                    ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
 >
-><div onclick="console.log()"></div>
+><div onclick="console.info()"></div>
 #^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
 # ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
 #    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro
@@ -54,7 +54,7 @@
 #                               ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
 #                                  ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
 >
-><div onload={"console.log('')"}></div>
+><div onload={"console.info('')"}></div>
 #^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
 # ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
 #    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro
@@ -68,7 +68,7 @@
 #                                  ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
 #                                     ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
 >
-><div onload=`console.log('')`></div>
+><div onload=`console.info('')`></div>
 #^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
 # ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
 #    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/events.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/events.astro
@@ -1,3 +1,3 @@
-<button onclick="(hello) => {console.log('hello')};">Click Me!</button>
+<button onclick="(hello) => {console.info('hello')};">Click Me!</button>
 
-<button onclick='(hello) => {console.log("hello")};'>Click Me!</button>
+<button onclick='(hello) => {console.info("hello")};'>Click Me!</button>

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/events.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/events.astro.snap
@@ -1,4 +1,4 @@
-><button onclick="(hello) => {console.log('hello')};">Click Me!</button>
+><button onclick="(hello) => {console.info('hello')};">Click Me!</button>
 #^ source.astro meta.scope.tag.button.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
 # ^^^^^^ source.astro meta.scope.tag.button.astro meta.tag.start.astro entity.name.tag.astro
 #       ^ source.astro meta.scope.tag.button.astro meta.tag.start.astro
@@ -13,7 +13,7 @@
 #                                                                ^^^^^^ source.astro meta.scope.tag.button.astro meta.tag.end.astro entity.name.tag.astro
 #                                                                      ^ source.astro meta.scope.tag.button.astro meta.tag.end.astro punctuation.definition.tag.end.astro
 >
-><button onclick='(hello) => {console.log("hello")};'>Click Me!</button>
+><button onclick='(hello) => {console.info("hello")};'>Click Me!</button>
 #^ source.astro meta.scope.tag.button.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
 # ^^^^^^ source.astro meta.scope.tag.button.astro meta.tag.start.astro entity.name.tag.astro
 #       ^ source.astro meta.scope.tag.button.astro meta.tag.start.astro

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/jstypes.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/jstypes.astro
@@ -1,15 +1,15 @@
 <script type="text/javascript">
-	console.log("")
+	console.info("")
 </script>
 
 <script type="text/partytown">
-	console.log("")
+	console.info("")
 </script>
 
 <script type="application/javascript">
-	console.log("")
+	console.info("")
 </script>
 
 <script type="application/node">
-	console.log("")
+	console.info("")
 </script>

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/jstypes.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/jstypes.astro.snap
@@ -8,7 +8,7 @@
 #              ^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro
 #                             ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.end.astro
 #                              ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro punctuation.definition.tag.end.astro
->	console.log("")
+>	console.info("")
 #^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.embedded.block.astro source.js
 ></script>
 #^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
@@ -25,7 +25,7 @@
 #              ^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.partytown.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro
 #                            ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.partytown.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.end.astro
 #                             ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.partytown.astro meta.tag.start.astro punctuation.definition.tag.end.astro
->	console.log("")
+>	console.info("")
 #^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.partytown.astro meta.embedded.block.astro source.js
 ></script>
 #^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
@@ -42,7 +42,7 @@
 #              ^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro
 #                                    ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.end.astro
 #                                     ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro punctuation.definition.tag.end.astro
->	console.log("")
+>	console.info("")
 #^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.embedded.block.astro source.js
 ></script>
 #^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
@@ -59,7 +59,7 @@
 #              ^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.node.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro
 #                              ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.node.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.end.astro
 #                               ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.node.astro meta.tag.start.astro punctuation.definition.tag.end.astro
->	console.log("")
+>	console.info("")
 #^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.node.astro meta.embedded.block.astro source.js
 ></script>
 #^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/script.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/script.astro
@@ -1,3 +1,3 @@
 <script>
-	console.log("Hello!")
+	console.info("Hello!")
 </script>

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/script.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/script.astro.snap
@@ -2,7 +2,7 @@
 #^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
 # ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
 #       ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.end.astro
->	console.log("Hello!")
+>	console.info("Hello!")
 #^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.embedded.block.astro source.js
 ></script>
 #^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro

--- a/packages/language-tools/vscode/test/grammar/fixtures/text.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/text.astro
@@ -1,7 +1,7 @@
 ---
 const cool = "our frontmatter"
-console.log("Hello, World!")
-console.log(`This is ${cool}!`)
+console.info("Hello, World!")
+console.info(`This is ${cool}!`)
 ---
 
 This is some text<div>

--- a/packages/language-tools/vscode/test/grammar/fixtures/text.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/text.astro.snap
@@ -2,9 +2,9 @@
 #^^^ source.astro comment
 >const cool = "our frontmatter"
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro source.ts
->console.log("Hello, World!")
+>console.info("Hello, World!")
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro source.ts
->console.log(`This is ${cool}!`)
+>console.info(`This is ${cool}!`)
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro source.ts
 >---
 #^^^ source.astro comment

--- a/packages/markdown/remark/test/highlight.test.js
+++ b/packages/markdown/remark/test/highlight.test.js
@@ -5,7 +5,7 @@ import { createMarkdownProcessor } from '../dist/index.js';
 describe('highlight', () => {
 	it('highlights using shiki by default', async () => {
 		const processor = await createMarkdownProcessor();
-		const { code } = await processor.render('```js\nconsole.log("Hello, world!");\n```');
+		const { code } = await processor.render('```js\nconsole.info("Hello, world!");\n```');
 		assert.match(code, /background-color:/);
 	});
 
@@ -22,7 +22,7 @@ describe('highlight', () => {
 				type: 'prism',
 			},
 		});
-		const { code } = await processor.render('```js\nconsole.log("Hello, world!");\n```');
+		const { code } = await processor.render('```js\nconsole.info("Hello, world!");\n```');
 		assert.ok(code.includes('token'));
 	});
 

--- a/scripts/smoke/check.js
+++ b/scripts/smoke/check.js
@@ -12,7 +12,7 @@ function checkExamples() {
 	let examples = readdirSync('./examples', { withFileTypes: true });
 	examples = examples.filter((dirent) => dirent.isDirectory()).filter((dirent) => !skippedExamples.includes(dirent.name));
 
-	console.log(`Running astro check on ${examples.length} examples...`);
+	console.info(`Running astro check on ${examples.length} examples...`);
 
 	// Run astro check in parallel with 5 at most
 	const checkPromises = [];
@@ -61,7 +61,7 @@ function checkExamples() {
 			process.exit(1);
 		}
 
-		console.log('No errors found!');
+		console.info('No errors found!');
 	});
 }
 


### PR DESCRIPTION
## Changes

This PR replaces `console.log` with `console.info`.

`console.log` is primarily for debugging, and `console.info` provides the same level of logging capability as `console.log`.

I updated the `biome.json` configuration file

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
