### PR TITLE
Remove non-sensical routing tests for format: file

### DIFF
--- a/packages/astro/test/preview-routing.test.js
+++ b/packages/astro/test/preview-routing.test.js
@@ -282,69 +282,6 @@ describe('Preview Routing', () => {
 			});
 		});
 
-		describe('Subpath without trailing slash and trailingSlash: always', () => {
-			/** @type {import('./test-utils').Fixture} */
-			let fixture;
-			/** @type {import('./test-utils').PreviewServer} */
-			let previewServer;
-
-			before(async () => {
-				fixture = await loadFixture({
-					root: './fixtures/with-subpath-no-trailing-slash/',
-					base: '/blog',
-					outDir: './dist-4004',
-					build: {
-						format: 'file',
-					},
-					trailingSlash: 'always',
-					server: {
-						port: 4005,
-					},
-				});
-				await fixture.build();
-				previewServer = await fixture.preview();
-			});
-
-			after(async () => {
-				await previewServer.stop();
-			});
-
-			it('404 when loading /', async () => {
-				const response = await fixture.fetch('/');
-				assert.equal(response.status, 404);
-			});
-
-			it('200 when loading subpath root with trailing slash', async () => {
-				const response = await fixture.fetch('/blog/');
-				assert.equal(response.status, 200);
-			});
-
-			it('404 when loading subpath root without trailing slash', async () => {
-				const response = await fixture.fetch('/blog');
-				assert.equal(response.status, 404);
-			});
-
-			it('200 when loading another page with subpath used', async () => {
-				const response = await fixture.fetch('/blog/another/');
-				assert.equal(response.status, 200);
-			});
-
-			it('404 when loading another page with subpath not used', async () => {
-				const response = await fixture.fetch('/blog/another');
-				assert.equal(response.status, 404);
-			});
-
-			it('200 when loading dynamic route', async () => {
-				const response = await fixture.fetch('/blog/1/');
-				assert.equal(response.status, 200);
-			});
-
-			it('404 when loading invalid dynamic route', async () => {
-				const response = await fixture.fetch('/blog/2/');
-				assert.equal(response.status, 404);
-			});
-		});
-
 		describe('Subpath without trailing slash and trailingSlash: ignore', () => {
 			/** @type {import('./test-utils').Fixture} */
 			let fixture;


### PR DESCRIPTION
## Changes

- No code changes

## Testing

We previously had tests that allowed you to use `build.format` of `'file'` and `trailingSlash: 'always'` which of course cannot work, /foo.html does not have a trailing slash, and web servers would not respect links with a trailing slash.

Previously this worked for static generation by accident, because did not construct params from the pathname, but instead just used the return value of getStaticPaths.

Because the refactor now uses the entire app infrastructure, these tests failed.

Remove because they are invalid tests.

## Docs

N/A