### PR TITLE
fix: Allow node: prefix for Node builtins for Vercel middleware

### DIFF
--- a/.changeset/wide-falcons-double.md
+++ b/.changeset/wide-falcons-double.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+fix: Allow "node:" prefix for Node builtins

--- a/packages/integrations/vercel/src/serverless/middleware.ts
+++ b/packages/integrations/vercel/src/serverless/middleware.ts
@@ -9,6 +9,8 @@ import {
 	NODE_PATH,
 } from '../index.js';
 
+const NODE_BUILTINS_FILTER = new RegExp(builtinModules.map((mod) => `(^${mod}$|^node:${mod}$)`).join('|'));
+
 /**
  * It generates the Vercel Edge Middleware file.
  *
@@ -64,10 +66,9 @@ export async function generateEdgeMiddleware(
 			{
 				name: 'esbuild-namespace-node-built-in-modules',
 				setup(build) {
-					const filter = new RegExp(builtinModules.map((mod) => `(^${mod}$)`).join('|'));
 					build.onResolve(
 						{
-							filter,
+							filter: NODE_BUILTINS_FILTER,
 						},
 						(args) => ({
 							path: 'node:' + args.path,


### PR DESCRIPTION
## Changes

Fixes #14838. Allows `node:` prefix for Node builtins on Vercel adapter. Allows middleware to build even if Node builtins are referenced

## Testing

- Tested this change in the original source of the error, and it runs perfectly

## Docs

This should be an invisible change