### PR TITLE
wip: consider tsconfig aliases when resolving content layer image paths

### DIFF
--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -284,6 +284,8 @@ class ContentLayer {
 						false,
 						// FUTURE: Remove in this in v6
 						id.endsWith('.svg'),
+						undefined,
+						this.#settings,
 					);
 
 					return parsedData;

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -9,7 +9,6 @@ import { AstroError } from '../core/errors/errors.js';
 import { AstroErrorData } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
 import type { AstroSettings } from '../types/astro.js';
-import type { AstroConfig } from '../types/public/config.js';
 import type {
 	ContentEntryModule,
 	ContentEntryType,
@@ -105,7 +104,7 @@ export function astroContentImportPlugin({
 						fileId,
 						entryConfigByExt: dataEntryConfigByExt,
 						contentDir,
-						config: settings.config,
+						settings,
 						fs,
 						pluginContext: this,
 						shouldEmitFile,
@@ -128,7 +127,7 @@ export const _internal = {
 						fileId,
 						entryConfigByExt: contentEntryConfigByExt,
 						contentDir,
-						config: settings.config,
+						settings,
 						fs,
 						pluginContext: this,
 						shouldEmitFile,
@@ -210,7 +209,7 @@ type GetEntryModuleParams<TEntryType extends ContentEntryType | DataEntryType> =
 	contentDir: URL;
 	pluginContext: PluginContext;
 	entryConfigByExt: Map<string, TEntryType>;
-	config: AstroConfig;
+	settings: AstroSettings;
 	shouldEmitFile: boolean;
 };
 
@@ -248,6 +247,7 @@ async function getContentEntryModule(
 				// FUTURE: Remove in this in v6
 				id.endsWith('.svg'),
 				pluginContext,
+				params.settings,
 			)
 		: unvalidatedData;
 
@@ -285,6 +285,7 @@ async function getDataEntryModule(
 				// FUTURE: Remove in this in v6
 				id.endsWith('.svg'),
 				pluginContext,
+				params.settings,
 			)
 		: unvalidatedData;
 

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -9,7 +9,7 @@ type Alias = {
 };
 
 /** Returns a list of compiled aliases. */
-const getConfigAlias = (settings: AstroSettings): Alias[] | null => {
+export const getConfigAlias = (settings: AstroSettings): Alias[] | null => {
 	const { tsConfig, tsConfigPath } = settings;
 	if (!tsConfig || !tsConfigPath || !tsConfig.compilerOptions) return null;
 

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -291,6 +291,11 @@ describe('Content Layer', () => {
 			assert.equal(json.rockets[1].data.image.format, 'jpg');
 		});
 
+		it('loads images with tsconfig aliases in JSON', async () => {
+			assert.ok(json.rockets[2].data.image.src.startsWith('/_astro'));
+			assert.equal(json.rockets[2].data.image.format, 'jpg');
+		});
+
 		it('renders images from frontmatter', async () => {
 			assert.ok($('img[alt="Lunar Module"]').attr('src').startsWith('/_astro'));
 		});

--- a/packages/astro/test/fixtures/content-layer/src/data/rockets.json
+++ b/packages/astro/test/fixtures/content-layer/src/data/rockets.json
@@ -10,5 +10,11 @@
     "name": "Saturn V",
     "manufacturer": "NASA",
     "image": "./shuttle.jpg"
+  },
+  {
+    "id": "apollo-11",
+    "name": "Apollo 11",
+    "manufacturer": "NASA",
+    "image": "$images/shuttle.jpg"
   }
 ]

--- a/packages/astro/test/fixtures/content-layer/tsconfig.json
+++ b/packages/astro/test/fixtures/content-layer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "paths": {
+      "$images/*": ["./images/*"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2782,6 +2782,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/content-layer-tsconfig-alias:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/content-ssr-integration:
     dependencies:
       '@astrojs/mdx':


### PR DESCRIPTION
## Changes

Tries to potentially address #14766 by using the aliases from tsconfig.

I personally had an issue with #14590 because I use an alias with `$` rather than the astro convention of `@`. I figured that one option to fix this is to utilise the resolution from the `astro:tsconfig-alias` plugin.

Now this does work currently, IF you're using this alias feature (i.e. not using vite replacements) AND you don't include a `baseUrl` in your tsconfig. Since the base url changes how relative paths are resolved, it would actually circumvent the changes made in #14766 since `foo.png`, for example, would match the base url regex.

I need a break, but will look into this a little more later and hopefully figure out why the markdown resolution is working fine. Putting this up now though in case anyone else has any insight.

## Testing

Tests have been added and need some further work

## Docs

n/a
