### PR TITLE
chore: knip first in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:e2e:hosts": "turbo run test:hosted",
     "benchmark": "astro-benchmark",
     "lint": "biome lint && knip && eslint . --report-unused-disable-directives-severity=warn --concurrency=auto",
-    "lint:ci": "biome ci --formatter-enabled=false --enforce-assist=false --reporter=github && eslint . --concurrency=auto --report-unused-disable-directives-severity=warn && knip",
+    "lint:ci": "biome ci --formatter-enabled=false --enforce-assist=false --reporter=github && knip && eslint . --concurrency=auto --report-unused-disable-directives-severity=warn",
     "lint:fix": "biome lint --write --unsafe",
     "publint": "pnpm -r --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --no-bail exec publint",
     "version": "changeset version && node ./scripts/deps/update-example-versions.js && pnpm install --no-frozen-lockfile && pnpm run format",


### PR DESCRIPTION
## Changes

Moves `kinp` check in CI before ESLInt. ESLint is way slower, so we should move it last



## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
