### PR TITLE
fix: container and routing tests

### DIFF
--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -149,7 +149,7 @@ function createManifest(
 		buildFormat: manifest?.buildFormat ?? ASTRO_CONFIG_DEFAULTS.build.format,
 		compressHTML: manifest?.compressHTML ?? ASTRO_CONFIG_DEFAULTS.compressHTML,
 		assetsDir: manifest?.assetsDir ?? ASTRO_CONFIG_DEFAULTS.build.assets,
-		serverLike: manifest?.serverLike ?? false,
+		serverLike: manifest?.serverLike ?? true,
 		assets: manifest?.assets ?? new Set(),
 		assetsPrefix: manifest?.assetsPrefix ?? undefined,
 		entryModules: manifest?.entryModules ?? {},

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -405,8 +405,8 @@ describe('Development Routing', () => {
 			assert.equal((await response.text()).includes('none: 1'), true);
 		});
 
-		it('200 when loading /html-ext/1.html', async () => {
-			const response = await fixture.fetch('/html-ext/1.html');
+		it('200 when loading /html-ext/1.html.html', async () => {
+			const response = await fixture.fetch('/html-ext/1.html.html');
 			assert.equal(response.status, 200);
 			assert.equal((await response.text()).includes('html: 1'), true);
 		});


### PR DESCRIPTION
## Changes

- fixes the container tests by switching the harder value of `serverLike` to `false`
- fixes a test in `dev-routing.test.js`

The test was testing that `[slug].html.astro` would render as `/1.html`, but I don't think that's true? 

If that's true, then we would need to fix the build too, because at the moment we the build emits `1.html.html`

## Testing

Fixes tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
