### PR TITLE
fix: remove useless tests

### DIFF
--- a/packages/astro/test/astro-pageDirectoryUrl.test.js
+++ b/packages/astro/test/astro-pageDirectoryUrl.test.js
@@ -1,14 +1,11 @@
 import assert from 'node:assert/strict';
-import { Writable } from 'node:stream';
 import { before, describe, it } from 'node:test';
-import { Logger } from '../dist/core/logger/core.js';
 import { loadFixture } from './test-utils.js';
 
 describe('build format', () => {
 	describe('build.format: file', () => {
 		/** @type {import('./test-utils.js').Fixture} */
 		let fixture;
-		const logs = [];
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -17,18 +14,7 @@ describe('build format', () => {
 					format: 'file',
 				},
 			});
-			await fixture.build({
-				logger: new Logger({
-					level: 'info',
-					dest: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
-				}),
-			});
+			await fixture.build();
 		});
 
 		it('outputs', async () => {
@@ -36,22 +22,11 @@ describe('build format', () => {
 			assert.ok(await fixture.readFile('/nested-md.html'));
 			assert.ok(await fixture.readFile('/nested-astro.html'));
 		});
-
-		it('logs correct output paths', () => {
-			assert.ok(logs.find((log) => log.level === 'info' && log.message.includes('/client.html')));
-			assert.ok(
-				logs.find((log) => log.level === 'info' && log.message.includes('/nested-md.html')),
-			);
-			assert.ok(
-				logs.find((log) => log.level === 'info' && log.message.includes('/nested-astro.html')),
-			);
-		});
 	});
 
 	describe('build.format: preserve', () => {
 		/** @type {import('./test-utils.js').Fixture} */
 		let fixture;
-		const logs = [];
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -60,36 +35,13 @@ describe('build format', () => {
 					format: 'preserve',
 				},
 			});
-			await fixture.build({
-				logger: new Logger({
-					level: 'info',
-					dest: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
-				}),
-			});
+			await fixture.build();
 		});
 
 		it('outputs', async () => {
 			assert.ok(await fixture.readFile('/client.html'));
 			assert.ok(await fixture.readFile('/nested-md/index.html'));
 			assert.ok(await fixture.readFile('/nested-astro/index.html'));
-		});
-
-		it('logs correct output paths', () => {
-			assert.ok(logs.find((log) => log.level === 'info' && log.message.includes('/client.html')));
-			assert.ok(
-				logs.find((log) => log.level === 'info' && log.message.includes('/nested-md/index.html')),
-			);
-			assert.ok(
-				logs.find(
-					(log) => log.level === 'info' && log.message.includes('/nested-astro/index.html'),
-				),
-			);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

Removes a couple of tests that fail because they check the logs.

I deemed them useless, since the tests already check if the physical files exist. 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
