### PR TITLE
fix: renderError fallback 

### DIFF
--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -91,7 +91,7 @@ export interface RenderErrorOptions {
 	 */
 	error?: unknown;
 	clientAddress: string | undefined;
-	prerenderedErrorPageFetch: (url: ErrorPagePath) => Promise<Response>;
+	prerenderedErrorPageFetch: ((url: ErrorPagePath) => Promise<Response>) | undefined;
 }
 
 type ErrorPagePath =
@@ -500,7 +500,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 			if (errorRouteData.prerender) {
 				const maybeDotHtml = errorRouteData.route.endsWith(`/${status}`) ? '.html' : '';
 				const statusURL = new URL(`${this.baseWithoutTrailingSlash}/${status}${maybeDotHtml}`, url);
-				if (statusURL.toString() !== request.url) {
+				if (statusURL.toString() !== request.url && prerenderedErrorPageFetch) {
 					const response = await prerenderedErrorPageFetch(statusURL.toString() as ErrorPagePath);
 
 					// In order for the response of the remote to be usable as a response

--- a/packages/astro/src/core/build/app.ts
+++ b/packages/astro/src/core/build/app.ts
@@ -31,7 +31,10 @@ export class BuildApp extends BaseApp<BuildPipeline> {
 		if (options.status === 500) {
 			throw options.error;
 		} else {
-			return super.renderError(request, options);
+			return super.renderError(request, {
+				...options,
+				prerenderedErrorPageFetch: undefined
+			});
 		}
 	}
 }


### PR DESCRIPTION
## Changes

During the build, `prerenderedErrorPageFetch` is useless, so I marked it as possibly `undefined`.

This allows static pages to return `404` responses and **render them**, which is handled within the `i18n` middleware. 

## Testing

Tests in `i18n-manual-routing.test.js` pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
