### PR TITLE
Fix server-islands data being used across tests

### DIFF
--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -10,13 +10,12 @@ const RESOLVED_SERVER_ISLAND_MANIFEST = '\0' + SERVER_ISLAND_MANIFEST;
 const serverIslandPlaceholderMap = "'$$server-islands-map$$'";
 const serverIslandPlaceholderNameMap = "'$$server-islands-name-map$$'";
 
-const serverIslandMap = new Map();
-const serverIslandNameMap = new Map();
-
 export function vitePluginServerIslands({ settings }: AstroPluginOptions): VitePlugin {
 	let command: ConfigEnv['command'] = 'serve';
 	let ssrEnvironment: DevEnvironment | null = null;
 	const referenceIdMap = new Map<string, string>();
+	const serverIslandMap = new Map();
+	const serverIslandNameMap = new Map();
 	return {
 		name: 'astro:server-islands',
 		enforce: 'post',


### PR DESCRIPTION
## Changes

- Move the map to within the vite plugin closure, so its not shared between tests.

## Testing

- Should fix a bunch, will post the result when the test is done.

## Docs

N/A, bug fix