### PR TITLE
chore: renovate language tools group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,6 +64,15 @@
         "packages/integrations/svelte/**",
         "packages/integrations/vue/**",
       ]
+    },
+    {
+      "groupName": "language tools",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "packages/language-tools/**"
+      ]
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## Changes

- Creates a renovate group for language tools packages. That should unblock updating deps for the rest of the monorepo, eg. #14707

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
