### PR TITLE
Ignore duplicates in e18e action

### DIFF
--- a/.github/workflows/diff-dependencies.yml
+++ b/.github/workflows/diff-dependencies.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Create Diff
         uses: e18e/action-dependency-diff@d8853a053c2a8a2a428eee0edbaa4f8934f55cdb # v1.4.1
+        with:
+          # We’re using this package primarily to track size changes, not as worried about duplicates
+          duplicate-threshold: 100


### PR DESCRIPTION
## Changes

- Updates the config for the e18e dependency diffing action to basically ignore dependency duplicates
- Defaults produce a lot of not very helpful noise. See e.g. https://github.com/withastro/astro/pull/14541#issuecomment-3571055512

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
