### PR TITLE
Remove virtual page module from importing renderers

### DIFF
--- a/packages/astro/src/container/pipeline.ts
+++ b/packages/astro/src/container/pipeline.ts
@@ -76,7 +76,6 @@ export class ContainerPipeline extends Pipeline {
 			page() {
 				return Promise.resolve(componentInstance);
 			},
-			renderers: this.manifest.renderers,
 			onRequest: this.resolvedMiddleware,
 		});
 	}

--- a/packages/astro/src/core/app/pipeline.ts
+++ b/packages/astro/src/core/app/pipeline.ts
@@ -85,7 +85,6 @@ export class AppPipeline extends Pipeline {
 			if (route.component === defaultRoute.component) {
 				return {
 					page: () => Promise.resolve(defaultRoute.instance),
-					renderers: [],
 				};
 			}
 		}

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -205,7 +205,6 @@ export abstract class Pipeline {
 			if (route.component === defaultRoute.component) {
 				return {
 					page: () => Promise.resolve(defaultRoute.instance),
-					renderers: [],
 				};
 			}
 		}

--- a/packages/astro/src/core/build/pipeline.ts
+++ b/packages/astro/src/core/build/pipeline.ts
@@ -206,7 +206,6 @@ export class BuildPipeline extends Pipeline {
 			if (route.component === defaultRoute.component) {
 				return {
 					page: () => Promise.resolve(defaultRoute.instance),
-					renderers: [],
 				};
 			}
 		}

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -3,7 +3,7 @@ import type { InlineConfig } from 'vite';
 import type { AstroSettings, ComponentInstance, RoutesList } from '../../types/astro.js';
 import type { MiddlewareHandler } from '../../types/public/common.js';
 import type { RuntimeMode } from '../../types/public/config.js';
-import type { RouteData, SSRLoadedRenderer } from '../../types/public/internal.js';
+import type { RouteData } from '../../types/public/internal.js';
 import type { Logger } from '../logger/core.js';
 
 type ComponentPath = string;
@@ -46,7 +46,6 @@ export interface SinglePageBuiltModule {
 	 * The `onRequest` hook exported by the middleware
 	 */
 	onRequest?: MiddlewareHandler;
-	renderers: SSRLoadedRenderer[];
 }
 
 export type ViteBuildReturn = Awaited<ReturnType<typeof vite.build>>;

--- a/packages/astro/src/core/redirects/component.ts
+++ b/packages/astro/src/core/redirects/component.ts
@@ -13,5 +13,4 @@ export const RedirectComponentInstance: ComponentInstance = {
 export const RedirectSinglePageBuiltModule: SinglePageBuiltModule = {
 	page: () => Promise.resolve(RedirectComponentInstance),
 	onRequest: (_, next) => next(),
-	renderers: [],
 };

--- a/packages/astro/src/vite-plugin-pages/page.ts
+++ b/packages/astro/src/vite-plugin-pages/page.ts
@@ -3,7 +3,6 @@ import { prependForwardSlash } from '../core/path.js';
 import { DEFAULT_COMPONENTS } from '../core/routing/default.js';
 import { routeIsRedirect } from '../core/routing/index.js';
 import type { RoutesList } from '../types/astro.js';
-import { ASTRO_RENDERERS_MODULE_ID } from '../vite-plugin-renderers/index.js';
 import { VIRTUAL_PAGE_MODULE_ID, VIRTUAL_PAGE_RESOLVED_MODULE_ID } from './const.js';
 
 interface PagePluginOptions {
@@ -47,9 +46,6 @@ export function pluginPage({ routesList }: PagePluginOptions): VitePlugin {
 
 					imports.push(`import * as _page from ${JSON.stringify(astroModuleId)};`);
 					exports.push(`export const page = () => _page`);
-
-					imports.push(`import { renderers } from "${ASTRO_RENDERERS_MODULE_ID}";`);
-					exports.push(`export { renderers };`);
 
 					return { code: `${imports.join('\n')}\n${exports.join('\n')}` };
 				}

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -61,9 +61,9 @@ function virtualAppEntrypoint(options?: Options): Plugin {
 			if (id === RESOLVED_VIRTUAL_MODULE_ID) {
 				if (appEntrypoint) {
 					return `\
-import * as mod from ${JSON.stringify(appEntrypoint)};
-
 export const setup = async (app) => {
+	const mod = await import(${JSON.stringify(appEntrypoint)});
+
 	if ('default' in mod) {
 		await mod.default(app);
 	} else {

--- a/packages/integrations/vue/test/app-entrypoint.test.js
+++ b/packages/integrations/vue/test/app-entrypoint.test.js
@@ -33,17 +33,6 @@ describe('App Entrypoint', () => {
 		assert.equal($('#generics-and-blocks').text(), '1 3!!!');
 	});
 
-	it('setup included in renderer bundle', async () => {
-		const data = await fixture.readFile('/index.html');
-		const { document } = parseHTML(data);
-		const island = document.querySelector('astro-island');
-		const client = island.getAttribute('renderer-url');
-		assert.notEqual(client, undefined);
-
-		const js = await fixture.readFile(client);
-		assert.match(js, /\w+\.component\("Bar"/g);
-	});
-
 	it('loads svg components without transforming them to assets', async () => {
 		const data = await fixture.readFile('/index.html');
 		const { document } = parseHTML(data);


### PR DESCRIPTION
## Changes

This had previously existed for reasons I can't even recall. I think it was related to pages being separate entrypoints but also needing the renderers array to pass to the App instance.

Since we no longer have this constraint this commit removes them. This also fixes a bug with Vue that was a circular reference between the Vue app entrypoint and renderers.

## Testing

- Removed one test that asserted that the app entrypoint was part of the renderers chunk. The renderers chunk no longer exists, so removed.

## Docs

N/A, bug fix