### PR TITLE
Fix @astrojs/db tests

### DIFF
--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -9,6 +9,7 @@ import {
 	type HotPayload,
 	loadEnv,
 	mergeConfig,
+	type RunnableDevEnvironment,
 	type UserConfig,
 	type ViteDevServer,
 } from 'vite';
@@ -150,8 +151,9 @@ function astroDBIntegration(options?: AstroDBConfig): AstroIntegration {
 				});
 			},
 			'astro:server:setup': async ({ server, logger }) => {
+				const environment = server.environments.ssr as RunnableDevEnvironment;
 				seedHandler.execute = async (fileUrl) => {
-					await executeSeedFile({ fileUrl, viteServer: server });
+					await executeSeedFile({ fileUrl, environment });
 				};
 				const filesToWatch = [
 					...CONFIG_FILE_NAMES.map((c) => new URL(c, getDbDirectoryUrl(root))),
@@ -164,22 +166,20 @@ function astroDBIntegration(options?: AstroDBConfig): AstroIntegration {
 					}
 				});
 				// Wait for dev server log before showing "connected".
-				setTimeout(() => {
-					logger.info(
-						connectToRemote ? 'Connected to remote database.' : 'New local database created.',
-					);
-					if (connectToRemote) return;
+				logger.info(
+					connectToRemote ? 'Connected to remote database.' : 'New local database created.',
+				);
+				if (connectToRemote) return;
 
-					const localSeedPaths = SEED_DEV_FILE_NAME.map(
-						(name) => new URL(name, getDbDirectoryUrl(root)),
-					);
-					// Eager load astro:db module on startup
-					if (seedFiles.get().length || localSeedPaths.find((path) => existsSync(path))) {
-						server.ssrLoadModule(VIRTUAL_MODULE_ID).catch((e) => {
-							logger.error(e instanceof Error ? e.message : String(e));
-						});
-					}
-				}, 100);
+				const localSeedPaths = SEED_DEV_FILE_NAME.map(
+					(name) => new URL(name, getDbDirectoryUrl(root)),
+				);
+				// Eager load astro:db module on startup
+				if (seedFiles.get().length || localSeedPaths.find((path) => existsSync(path))) {
+					await environment.runner.import(VIRTUAL_MODULE_ID).catch((e) => {
+						logger.error(e instanceof Error ? e.message : String(e));
+					});
+				}
 			},
 			'astro:build:start': async ({ logger }) => {
 				if (!connectToRemote && !databaseFileEnvDefined() && finalBuildOutput === 'server') {
@@ -196,8 +196,9 @@ function astroDBIntegration(options?: AstroDBConfig): AstroIntegration {
 			},
 			'astro:build:setup': async ({ vite }) => {
 				tempViteServer = await getTempViteServer({ viteConfig: vite });
+				const environment = tempViteServer.environments.ssr as RunnableDevEnvironment;
 				seedHandler.execute = async (fileUrl) => {
-					await executeSeedFile({ fileUrl, viteServer: tempViteServer! });
+					await executeSeedFile({ fileUrl, environment });
 				};
 			},
 			'astro:build:done': async ({}) => {
@@ -218,15 +219,15 @@ export function integration(options?: AstroDBConfig): AstroIntegration[] {
 
 async function executeSeedFile({
 	fileUrl,
-	viteServer,
+	environment,
 }: {
 	fileUrl: URL;
-	viteServer: ViteDevServer;
+	environment: RunnableDevEnvironment;
 }) {
 	// Use decodeURIComponent to handle paths with spaces correctly
 	// This ensures that %20 in the pathname is properly handled
 	const pathname = decodeURIComponent(fileUrl.pathname);
-	const mod = await viteServer.ssrLoadModule(pathname);
+	const mod = await environment.runner.import(pathname);
 	if (typeof mod.default !== 'function') {
 		throw new AstroDbError(EXEC_DEFAULT_EXPORT_ERROR(fileURLToPath(fileUrl)));
 	}

--- a/packages/db/test/libsql-remote.test.js
+++ b/packages/db/test/libsql-remote.test.js
@@ -8,16 +8,8 @@ import { loadFixture } from '../../astro/test/test-utils.js';
 import { clearEnvironment, initializeRemoteDb } from './test-utils.js';
 
 describe('astro:db local database', () => {
-	let fixture;
-	before(async () => {
-		fixture = await loadFixture({
-			root: new URL('./fixtures/libsql-remote/', import.meta.url),
-			output: 'server',
-			adapter: testAdapter(),
-		});
-	});
-
 	describe('build --remote with local libSQL file (absolute path)', () => {
+		let fixture;
 		before(async () => {
 			clearEnvironment();
 
@@ -27,6 +19,15 @@ describe('astro:db local database', () => {
 
 			process.env.ASTRO_INTERNAL_TEST_REMOTE = true;
 			process.env.ASTRO_DB_REMOTE_URL = absoluteFileUrl.toString();
+
+			const root = new URL('./fixtures/libsql-remote/', import.meta.url);
+			fixture = await loadFixture({
+				root,
+				outDir: fileURLToPath(new URL('./dist/absolute/', root)),
+				output: 'server',
+				adapter: testAdapter(),
+			});
+
 			await fixture.build();
 			await initializeRemoteDb(fixture.config);
 		});
@@ -45,6 +46,7 @@ describe('astro:db local database', () => {
 	});
 
 	describe('build --remote with local libSQL file (relative path)', () => {
+		let fixture;
 		before(async () => {
 			clearEnvironment();
 
@@ -56,6 +58,15 @@ describe('astro:db local database', () => {
 
 			process.env.ASTRO_INTERNAL_TEST_REMOTE = true;
 			process.env.ASTRO_DB_REMOTE_URL = `file:${prodDbPath}`;
+
+			const root = new URL('./fixtures/libsql-remote/', import.meta.url);
+			fixture = await loadFixture({
+				root,
+				outDir: fileURLToPath(new URL('./dist/relative/', root)),
+				output: 'server',
+				adapter: testAdapter(),
+			});
+
 			await fixture.build();
 			await initializeRemoteDb(fixture.config);
 		});

--- a/packages/db/test/local-prod.test.js
+++ b/packages/db/test/local-prod.test.js
@@ -6,19 +6,18 @@ import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
 describe('astro:db local database', () => {
-	let fixture;
-	before(async () => {
-		fixture = await loadFixture({
-			root: new URL('./fixtures/local-prod/', import.meta.url),
-			output: 'server',
-			adapter: testAdapter(),
-		});
-	});
-
 	describe('build (not remote) with DATABASE_FILE env (file URL)', () => {
+		let fixture;
 		const prodDbPath = new URL('./fixtures/basics/dist/astro.db', import.meta.url).toString();
 		before(async () => {
 			process.env.ASTRO_DATABASE_FILE = prodDbPath;
+			const root = new URL('./fixtures/local-prod/', import.meta.url);
+			fixture = await loadFixture({
+				root,
+				outDir: fileURLToPath(new URL('./dist/file-url/', root)),
+				output: 'server',
+				adapter: testAdapter(),
+			});
 			await fixture.build();
 		});
 
@@ -35,11 +34,19 @@ describe('astro:db local database', () => {
 	});
 
 	describe('build (not remote) with DATABASE_FILE env (relative file path)', () => {
+		let fixture;
 		const absoluteFileUrl = new URL('./fixtures/basics/dist/astro.db', import.meta.url);
 		const prodDbPath = relative(process.cwd(), fileURLToPath(absoluteFileUrl));
 
 		before(async () => {
 			process.env.ASTRO_DATABASE_FILE = prodDbPath;
+			const root = new URL('./fixtures/local-prod/', import.meta.url);
+			fixture = await loadFixture({
+				root,
+				outDir: fileURLToPath(new URL('./dist/relative/', root)),
+				output: 'server',
+				adapter: testAdapter(),
+			});
 			await fixture.build();
 		});
 
@@ -58,6 +65,13 @@ describe('astro:db local database', () => {
 	describe('build (not remote)', () => {
 		it('should throw during the build for server output', async () => {
 			delete process.env.ASTRO_DATABASE_FILE;
+			const root = new URL('./fixtures/local-prod/', import.meta.url);
+			const fixture = await loadFixture({
+				root,
+				outDir: fileURLToPath(new URL('./dist/not-remote/', root)),
+				output: 'server',
+				adapter: testAdapter(),
+			});
 			let buildError = null;
 			try {
 				await fixture.build();
@@ -69,8 +83,10 @@ describe('astro:db local database', () => {
 		});
 
 		it('should throw during the build for hybrid output', async () => {
-			let fixture2 = await loadFixture({
-				root: new URL('./fixtures/local-prod/', import.meta.url),
+			let root = new URL('./fixtures/local-prod/', import.meta.url);
+			const fixture2 = await loadFixture({
+				root,
+				outDir: fileURLToPath(new URL('./dist/hybrid-output/', root)),
 				output: 'static',
 				adapter: testAdapter(),
 			});


### PR DESCRIPTION

## Changes
This fixes the Astro DB tests. there were two issues:

1. Previously there was a race condition that never failed. The new code path must apparently be faster in development mode, as in these tests we are able to render a page before the seed file runs. Removed the setTimeout to make it guaranteed to run. This sacrifices dev server performance.
2. Some tests reused the same fixture. Previously Astro always changed the bundle hashes so this was safe to do, but now its not, so updated the tests to build to different build directories

## Testing

- Updated some of the tests to use a different `outDir` so they would not reuse the same built code.
- No tests removed.

## Docs

N/A, bug fix