### PR TITLE
fix(ci): Delete root package info to avoid vsce picking it up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,11 @@ jobs:
         if: steps.vscode-published.outputs.published == 'true'
         working-directory: ./packages/language-tools/vscode
         run: |
-          sleep 60s # wait for npm registry to update
           rm -rf node_modules
+          # Also delete root package.json and node_modules to avoid vsce picking up monorepo info
+          rm ../../package.json
+          rm -rf ../../node_modules
+          sleep 60s # wait for npm registry to update
           npm i --workspaces=false # vsce does not support pnpm, so we need to pretend this is not a monorepo and use npm
           npm run build
           npm run build:grammar


### PR DESCRIPTION
## Changes

Unlike the language-tools monorepo, the main monorepo is actually both a pnpm and a npm workspace (the latter because of changesets historically). Even though we install dependencies using `--workspaces false`, `vsce` runs `npm ls` which picks up dependencies in the root folder, since they're extraneous from npm's perspective, this creates an error

## Testing

hahaha github actions

## Docs

N/A
