### PR TITLE
fix: Remove Vitest workaround for client-side Astro component rendering

### DIFF
--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -231,14 +231,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 
 			// If an Astro component is imported in code used on the client, we return an empty
 			// module so that Vite doesn’t bundle the server-side Astro code for the client.
-			if (
-				!options?.ssr &&
-				// Workaround to allow tests run with Vitest in a “client” environment to still render
-				// Astro components. See https://github.com/withastro/astro/issues/14883
-				// TODO: In a future major we should remove this and require people test Astro rendering in
-				// an SSR test environment, which more closely matches the real-world Vite environment.
-				!process.env.VITEST
-			) {
+if (!options?.ssr) {
 				return {
 					code: `export default import.meta.env.DEV
 									? () => {


### PR DESCRIPTION
Fixes #14895

## Changes

- Removed the temporary workaround (`!process.env.VITEST`) that allowed Vitest tests to render Astro components in a "client" environment
- Simplified the condition to only check `!options?.ssr`

## Testing

This is a breaking change. Users who were testing Astro component rendering with the container API in Vitest using client environments like `happy-dom` or `jsdom` will need to switch to using an SSR test environment (e.g., `node`).

## Notes

As mentioned in the issue, most of the work here will be documentation:
- Clear docs for what changed and who is impacted
- Guidance for how to update tests if affected