### PR TITLE
fix(ci): Try building package before deleting dependencies for vscode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,14 +73,13 @@ jobs:
         if: steps.vscode-published.outputs.published == 'true'
         working-directory: ./packages/language-tools/vscode
         run: |
+          npm run build:grammar
           rm -rf node_modules
           # Also delete root package.json and node_modules to avoid vsce picking up any monorepo info
           rm ../../../package.json
           rm -rf ../../../node_modules
           sleep 60s # wait for npm registry to update
           npm i --workspaces=false # vsce does not support pnpm, so we need to pretend this is not a monorepo and use npm
-          npm run build:ci # this ci task does not prebuild the ts-plugin, as it is already built in the root build step and building it after deleting node_modules would fail
-          npm run build:grammar
 
       - name: Publish to VSCode Marketplace
         if: steps.vscode-published.outputs.published == 'true'

--- a/packages/language-tools/vscode/package.json
+++ b/packages/language-tools/vscode/package.json
@@ -237,9 +237,8 @@
   "scripts": {
     "prebuild": "cd ../ts-plugin && pnpm build",
     "build": "tsc && pnpm prebuild && node scripts/build.mjs -- --minify",
-    "build:ci": "tsc && node scripts/build.mjs -- --minify --sourcemap",
-    "build:grammar": "node scripts/build-grammar.mjs",
     "dev": "node scripts/build.mjs -- --watch",
+    "build:grammar": "node scripts/build-grammar.mjs",
     "dev:grammar": "node scripts/build-grammar.mjs -- --watch",
     "test": "pnpm test:vscode && pnpm test:grammar",
     "test:vscode": "vscode-test",


### PR DESCRIPTION
## Changes

Building the ts-plugin after deleting node_modules obviously doesn't work, but it doesn't matter because it's already been built!

## Testing

We hope!

## Docs

N/A