### PR TITLE
fix(environment): Prevent Vite from interpreting injected sourcemap comments as actual sourcemaps

### DIFF
--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -293,7 +293,9 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 
 function appendSourceMap(content: string, map?: string) {
 	if (!map) return content;
-	return `${content}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
+	// The \n here is on purpose inside a template literal because otherwise, in the final built version of this file, the comment would
+	// start on its own line, and some tools will think it's actually the sourcemap of this file, not of generated code.
+	return `${content}${'\n'}//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
 		map,
 	).toString('base64')}`;
 }


### PR DESCRIPTION
## Changes

Not sure what changed, might just be the Vite update, but Vite seems to get confused by the comment appearing in the file. I'm guessing it's a regex on their side.

## Testing

Ran dev manually

## Docs

N/A
