### PR TITLE
fix(vite): import mergeConfig from direct file to avoid dynamic import being processed by Vite

### DIFF
--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -12,7 +12,7 @@ import { globalContentConfigObserver } from '../content/utils.js';
 import type { SerializedSSRManifest } from '../core/app/types.js';
 import type { PageBuildData } from '../core/build/types.js';
 import { buildClientDirectiveEntrypoint } from '../core/client-directive/index.js';
-import { mergeConfig } from '../core/config/index.js';
+import { mergeConfig } from '../core/config/merge.js';
 import { validateConfigRefined } from '../core/config/validate.js';
 import { validateSetAdapter } from '../core/dev/adapter-validation.js';
 import type { AstroIntegrationLogger, Logger } from '../core/logger/core.js';


### PR DESCRIPTION
## Changes

That barrel file has an import to vite-load which has a dynamic import, Vite tries to resolve said dynamic import but we don't want that.

## Testing

Tested manually

## Docs

N/A
