### PR TITLE
fix: externalize `css-tree` to resolve build errors when using `exper…

### DIFF
--- a/.changeset/fonts-db-ssr-fix.md
+++ b/.changeset/fonts-db-ssr-fix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Fixes a build error when using `experimental.fonts` alongside `@astrojs/db` with the Cloudflare adapter. The error occurred because `css-tree` (a dependency of the fonts feature) was being bundled in SSR mode, which breaks in Cloudflare workers. This fix externalizes `css-tree` from the temporary Vite server used during builds.

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -248,7 +248,7 @@ async function getTempViteServer({ viteConfig }: { viteConfig: UserConfig }) {
 		mergeConfig(viteConfig, {
 			server: { middlewareMode: true, hmr: false, watch: null, ws: false },
 			optimizeDeps: { noDiscovery: true },
-			ssr: { external: [] },
+			ssr: { external: ['css-tree'] },
 			logLevel: 'silent',
 		}),
 	);


### PR DESCRIPTION
## Changes

Fixes #14933

- Externalize `css-tree` in the temporary Vite server created by `@astrojs/db` during builds
- `css-tree` (a dependency of the fonts feature) was being bundled in SSR mode, which breaks in Cloudflare workers
- Added `css-tree` to ssr.external array in `getTempViteServer()`

## Testing

- Tested with Cloudflare adapter + `experimental.fonts` + `@astrojs/db`
- Build now completes without the "Expected URL scheme to be http or https" error

## Docs

No docs changes needed - this is a bug fix with no API changes.