### PR TITLE
fix: suppress empty chunk warning for noop entrypoint

### DIFF
--- a/packages/astro/src/core/build/plugins/plugin-noop.ts
+++ b/packages/astro/src/core/build/plugins/plugin-noop.ts
@@ -17,7 +17,7 @@ export function pluginNoop(): vite.Plugin {
 		},
 		load(id) {
 			if(id === RESOLVED_NOOP_MODULE_ID) {
-				return '';
+				return 'export const noop = {};';
 			}
 		},
 		generateBundle(_options, bundle) {

--- a/packages/astro/test/astro-public.test.js
+++ b/packages/astro/test/astro-public.test.js
@@ -1,13 +1,30 @@
 import assert from 'node:assert/strict';
+import { Writable } from 'node:stream';
 import { before, describe, it } from 'node:test';
+import { Logger } from '../dist/core/logger/core.js';
 import { loadFixture } from './test-utils.js';
 
 describe('Public', () => {
 	let fixture;
+	let buildLogs = [];
 
 	before(async () => {
 		fixture = await loadFixture({ root: './fixtures/astro-public/' });
-		await fixture.build();
+		await fixture.build({
+			vite: {
+				logLevel: 'info',
+			},
+			logger: new Logger({
+				level: 'info',
+				dest: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						buildLogs.push(event);
+						callback();
+					},
+				}),
+			}),
+		});
 	});
 
 	it('css and js files do not get bundled', async () => {
@@ -15,5 +32,16 @@ describe('Public', () => {
 		assert.equal(indexHtml.includes('<script src="/example.js"></script>'), true);
 		assert.equal(indexHtml.includes('<link href="/example.css" rel="stylesheet">'), true);
 		assert.equal(indexHtml.includes('<img src="/images/twitter.png">'), true);
+	});
+
+	it('should not produce empty chunk warning when building with no client JS', () => {
+		// Check for empty chunk warnings in the build logs
+		const emptyChunkWarning = buildLogs.find((log) =>
+			log.message && (log.message.includes('empty chunk') || (log.message.includes('empty') && log.message.includes('chunk')))
+		);
+
+		if (emptyChunkWarning) {
+			assert.fail(`Should not have empty chunk warning, but got: ${emptyChunkWarning.message}`);
+		}
 	});
 });


### PR DESCRIPTION
## Changes

- export const noop from noop module instead of empty string
- suppresses vite empty chunk warning when no client JS
- bundle still deleted in generateBundle hook so no code ships


## Testing

- add test to verify no empty chunk warning is produced

## Docs

N/A, bug fix