### PR TITLE
fix(svelte): server_context_required error

### DIFF
--- a/packages/integrations/svelte/test/fixtures/async-rendering/package.json
+++ b/packages/integrations/svelte/test/fixtures/async-rendering/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@astrojs/svelte": "^7.2.2",
     "astro": "^5.16.0",
-    "svelte": "^5.43.14"
+    "svelte": "5.44.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -319,7 +319,7 @@ importers:
         version: link:../../packages/astro
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   examples/framework-vue:
     dependencies:
@@ -373,7 +373,7 @@ importers:
         version: link:../../packages/astro
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   examples/starlog:
     dependencies:
@@ -936,7 +936,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1081,7 +1081,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1138,7 +1138,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1194,7 +1194,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1234,7 +1234,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1274,7 +1274,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1314,7 +1314,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1354,7 +1354,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1394,7 +1394,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1590,7 +1590,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/e2e/fixtures/tailwindcss:
     dependencies:
@@ -1650,7 +1650,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1794,7 +1794,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -1815,7 +1815,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/alias-tsconfig:
     dependencies:
@@ -1830,7 +1830,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/alias-tsconfig-baseurl-only:
     dependencies:
@@ -1842,7 +1842,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/alias-tsconfig-no-baseurl:
     dependencies:
@@ -1985,7 +1985,7 @@ importers:
         version: 10.27.2
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -2018,7 +2018,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/astro-client-only/pkg: {}
 
@@ -2110,7 +2110,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/astro-env:
     dependencies:
@@ -2485,7 +2485,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -2575,7 +2575,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/component-library-shared:
     dependencies:
@@ -2956,7 +2956,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/css-import-as-inline:
     dependencies:
@@ -3244,7 +3244,7 @@ importers:
         version: 10.27.2
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -3493,7 +3493,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -3717,7 +3717,7 @@ importers:
         version: 1.9.10
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -3962,7 +3962,7 @@ importers:
         version: link:../../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/server-islands/ssr:
     dependencies:
@@ -3977,7 +3977,7 @@ importers:
         version: link:../../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/sessions:
     dependencies:
@@ -4052,7 +4052,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/slots-vue:
     dependencies:
@@ -4398,7 +4398,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/astro/test/fixtures/svg-deduplication:
     dependencies:
@@ -4521,7 +4521,7 @@ importers:
         version: link:../../..
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
       vue:
         specifier: ^3.5.24
         version: 3.5.24(typescript@5.9.3)
@@ -4994,7 +4994,7 @@ importers:
         version: link:../../../../../astro
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/integrations/cloudflare/test/fixtures/with-vue:
     dependencies:
@@ -5991,10 +5991,10 @@ importers:
     dependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.1
-        version: 5.1.1(svelte@5.43.14)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.1.1(svelte@5.44.0)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))
       svelte2tsx:
         specifier: ^0.7.45
-        version: 0.7.45(svelte@5.43.14)(typescript@5.9.3)
+        version: 0.7.45(svelte@5.44.0)(typescript@5.9.3)
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1)
@@ -6010,7 +6010,7 @@ importers:
         version: 1.1.2
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/integrations/svelte/test/fixtures/async-rendering:
     dependencies:
@@ -6021,8 +6021,8 @@ importers:
         specifier: ^5.16.0
         version: link:../../../../../astro
       svelte:
-        specifier: ^5.43.14
-        version: 5.43.14
+        specifier: 5.44.0
+        version: 5.44.0
 
   packages/integrations/svelte/test/fixtures/prop-types:
     dependencies:
@@ -6034,7 +6034,7 @@ importers:
         version: link:../../../../../astro
       svelte:
         specifier: ^5.43.14
-        version: 5.43.14
+        version: 5.44.0
 
   packages/integrations/vercel:
     dependencies:
@@ -6043,7 +6043,7 @@ importers:
         version: link:../../internal-helpers
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(react@19.2.0)(svelte@5.43.14)(vue@3.5.24(typescript@5.9.3))
+        version: 1.5.0(react@19.2.0)(svelte@5.44.0)(vue@3.5.24(typescript@5.9.3))
       '@vercel/functions':
         specifier: ^2.2.13
         version: 2.2.13
@@ -14730,8 +14730,8 @@ packages:
     resolution: {integrity: sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==}
     engines: {node: '>=16'}
 
-  svelte@5.43.14:
-    resolution: {integrity: sha512-pHeUrp1A5S6RGaXhJB7PtYjL1VVjbVrJ2EfuAoPu9/1LeoMaJa/pcdCsCSb0gS4eUHAHnhCbUDxORZyvGK6kOQ==}
+  svelte@5.44.0:
+    resolution: {integrity: sha512-R7387No2zEGw4CtYtI2rgsui6BqjFARzoZFGLiLN5OPla0Pq4Ra2WwcP/zBomP3MYalhSNvF1fzDMuU0P0zPJw==}
     engines: {node: '>=18'}
 
   svgo@3.3.2:
@@ -18446,23 +18446,23 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.14)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.43.14)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.44.0)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.44.0)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.43.14)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.44.0)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))
       debug: 4.4.3(supports-color@8.1.1)
-      svelte: 5.43.14
+      svelte: 5.44.0
       vite: 6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.14)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.44.0)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.14)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.43.14)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.44.0)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.44.0)(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))
       debug: 4.4.3(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
-      svelte: 5.43.14
+      svelte: 5.44.0
       vite: 6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1)
       vitefu: 1.1.1(vite@6.4.1(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(tsx@4.20.6)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -18914,10 +18914,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@1.5.0(react@19.2.0)(svelte@5.43.14)(vue@3.5.24(typescript@5.9.3))':
+  '@vercel/analytics@1.5.0(react@19.2.0)(svelte@5.44.0)(vue@3.5.24(typescript@5.9.3))':
     optionalDependencies:
       react: 19.2.0
-      svelte: 5.43.14
+      svelte: 5.44.0
       vue: 3.5.24(typescript@5.9.3)
 
   '@vercel/functions@2.2.13':
@@ -24547,11 +24547,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte2tsx@0.7.45(svelte@5.43.14)(typescript@5.9.3):
+  svelte2tsx@0.7.45(svelte@5.44.0)(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.43.14
+      svelte: 5.44.0
       typescript: 5.9.3
 
   svelte@4.2.20:
@@ -24571,7 +24571,7 @@ snapshots:
       magic-string: 0.30.21
       periscopic: 3.1.0
 
-  svelte@5.43.14:
+  svelte@5.44.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -24581,6 +24581,7 @@ snapshots:
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
+      devalue: 5.5.0
       esm-env: 1.2.2
       esrap: 2.1.0
       is-reference: 3.0.3


### PR DESCRIPTION
## Changes

- Spotted in #14977
- https://github.com/sveltejs/svelte/pull/17154 breaks async rendering svelte components (throws https://svelte.dev/docs/svelte/runtime-errors#Server-errors-server_context_required)

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Needs changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
