### PR TITLE
chore(cloudflare): enable more tests

### DIFF
--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -91,7 +91,7 @@ export async function loadFixture(inlineConfig) {
 	if (!inlineConfig?.root) throw new Error("Must provide { root: './fixtures/...' }");
 
 	// Silent by default during tests to not pollute the console output
-	inlineConfig.logLevel = 'silent';
+	inlineConfig.logLevel ??= 'silent';
 	inlineConfig.vite ??= {};
 	inlineConfig.vite.logLevel = 'silent';
 

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -250,7 +250,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 												exclude: [
 													'unstorage/drivers/cloudflare-kv-binding',
 													'astro:toolbar:internal',
-													'virtual:astro:middleware'
+													'virtual:astro:middleware',
 												],
 											},
 										};

--- a/packages/integrations/cloudflare/test/astro-dev-platform.test.js
+++ b/packages/integrations/cloudflare/test/astro-dev-platform.test.js
@@ -9,7 +9,6 @@ describe('AstroDevPlatform', () => {
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/astro-dev-platform/',
-			logLevel: 'debug',
 		});
 		devServer = await fixture.startDevServer();
 		// Do an initial request to prime preloading
@@ -34,7 +33,7 @@ describe('AstroDevPlatform', () => {
 		assert.equal($('#hasCACHE').text(), 'true');
 	});
 
-	it('adds D1 mocking', {skip: "mocking currently broken", todo: "must restore D1 mocking"},async () => {
+	it('adds D1 mocking', async () => {
 		const res = await fixture.fetch('/d1');
 		const html = await res.text();
 		const $ = cheerio.load(html);
@@ -43,7 +42,7 @@ describe('AstroDevPlatform', () => {
 		assert.equal($('#hasACCESS').text(), 'true');
 	});
 
-	it('adds R2 mocking', {skip: "mocking currently broken", todo: "must restore R2 mocking"},async () => {
+	it('adds R2 mocking', async () => {
 		const res = await fixture.fetch('/r2');
 		const html = await res.text();
 		const $ = cheerio.load(html);
@@ -52,7 +51,7 @@ describe('AstroDevPlatform', () => {
 		assert.equal($('#hasACCESS').text(), 'true');
 	});
 
-	it('adds KV mocking', {skip: "mocking currently broken", todo: "must restore kv mocking"}, async () => {
+	it('adds KV mocking', async () => {
 		const res = await fixture.fetch('/kv');
 		const html = await res.text();
 		const $ = cheerio.load(html);

--- a/packages/integrations/cloudflare/test/custom-entryfile.test.js
+++ b/packages/integrations/cloudflare/test/custom-entryfile.test.js
@@ -1,26 +1,16 @@
 import * as assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { after, before, describe, it } from 'node:test';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { loadFixture } from './_test-utils.js';
 
-const root = new URL('./fixtures/custom-entryfile/', import.meta.url);
-
-describe('Custom entry file', { skip: "This test hangs when is run, even with node", todo: "Resolve test hanging"}, () => {
-	let fixture;
-
-	before(async () => {
-		fixture = await loadFixture({
+describe('Custom entry file', () => {
+	it('filters out duplicate "default" export and builds', async () => {
+		const fixture = await loadFixture({
 			root: './fixtures/custom-entryfile/',
 		});
 		await fixture.build();
-	});
-	
-	after(async () => {
-		await fixture.clean();
-	})
-
-	it('filters out duplicate "default" export and builds', async () => {
+		const root = new URL('./fixtures/custom-entryfile/', import.meta.url);
 		const filePath = fileURLToPath(new URL('dist/_worker.js', root));
 		const hasBuilt = existsSync(filePath);
 		assert.equal(hasBuilt, true, `Expected ${filePath} to exist after build`);

--- a/packages/integrations/cloudflare/test/fixtures/custom-entryfile/src/worker.ts
+++ b/packages/integrations/cloudflare/test/fixtures/custom-entryfile/src/worker.ts
@@ -1,31 +1,22 @@
-import type { SSRManifest } from 'astro';
-
-import { App } from 'astro/app';
 import { handle } from '@astrojs/cloudflare/handler'
 import { DurableObject } from 'cloudflare:workers';
 
-class MyDurableObject extends DurableObject<Env> {
+export class MyDurableObject extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
     // Required, as we're extending the base class.
     super(ctx, env)
   }
 }
 
-export function createExports(manifest: SSRManifest) {
-	const app = new App(manifest);
-	return {
-		default: {
-			async fetch(request, env, ctx) {
-				console.log("env", env)
-				await env.MY_QUEUE.send("log");
-				// @ts-expect-error - The types are identical, I don't get why this is an error.
-				return handle(manifest, app, request, env, ctx);
-			},
-			async queue(batch, _env) {
-				let messages = JSON.stringify(batch.messages);
-    		console.log(`consumed from our queue: ${messages}`);
-			}
-		} satisfies ExportedHandler<Env>,
-		MyDurableObject: MyDurableObject,
+export default {
+	async fetch(request, env, ctx) {
+		console.log("env", env)
+		await env.MY_QUEUE.send("log");
+		return handle(request, env, ctx);
+	},
+
+	async queue(batch, _env) {
+		let messages = JSON.stringify(batch.messages);
+		console.log(`consumed from our queue: ${messages}`);
 	}
 }

--- a/packages/integrations/cloudflare/test/fixtures/custom-entryfile/wrangler.jsonc
+++ b/packages/integrations/cloudflare/test/fixtures/custom-entryfile/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "compatibility_date": "2025-05-21",
-  "main": "@astrojs/cloudflare/entrypoints/server",
+  "main": "./src/worker.ts",
   "name": "astro-cloudflare-custom-entryfile",
   "assets": {
     "directory": "./dist",

--- a/packages/integrations/cloudflare/test/fixtures/module-loader/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/module-loader/astro.config.mjs
@@ -2,6 +2,8 @@ import cloudflare from '@astrojs/cloudflare';
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-	adapter: cloudflare({}),
+	adapter: cloudflare({
+		cloudflareModules: true
+	}),
 	output: 'static'
 });

--- a/packages/integrations/cloudflare/test/fixtures/module-loader/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/module-loader/package.json
@@ -2,6 +2,7 @@
   "name": "@test/astro-cloudflare-wasm",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@astrojs/cloudflare": "workspace:*",
     "astro": "workspace:*"

--- a/packages/integrations/cloudflare/test/fixtures/wrangler-preview-platform/wrangler.toml
+++ b/packages/integrations/cloudflare/test/fixtures/wrangler-preview-platform/wrangler.toml
@@ -1,5 +1,6 @@
 name = "test"
-main = "@astrojs/cloudflare/entrypoint/server"
+main = "@astrojs/cloudflare/entrypoints/server"
+compatibility_date = "2025-10-30"
 
 [vars]
 COOL = "ME"

--- a/packages/integrations/cloudflare/test/sessions.test.js
+++ b/packages/integrations/cloudflare/test/sessions.test.js
@@ -4,89 +4,85 @@ import * as devalue from 'devalue';
 import cloudflare from '../dist/index.js';
 import { loadFixture } from './_test-utils.js';
 
-describe.skip(
-	'sessions',
-	{ skip: 'Requires the preview server', todo: 'Enable once the preview server is supported' },
-	() => {
-		let fixture;
-		let previewServer;
+describe('sessions', () => {
+	let fixture;
+	let previewServer;
 
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/sessions/',
-			});
-			await fixture.build();
-			previewServer = await fixture.preview();
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/sessions/',
+		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
+
+	after(async () => {
+		await previewServer.stop();
+	});
+
+	it('can regenerate session cookies upon request', async () => {
+		const firstResponse = await fixture.fetch('/regenerate', { method: 'GET' });
+		const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
+		const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
+
+		const secondResponse = await fixture.fetch('/regenerate', {
+			method: 'GET',
+			headers: {
+				cookie: `astro-session=${firstSessionId}`,
+			},
+		});
+		const secondHeaders = secondResponse.headers.get('set-cookie').split(',');
+		const secondSessionId = secondHeaders[0].split(';')[0].split('=')[1];
+		assert.notEqual(firstSessionId, secondSessionId);
+	});
+
+	it('can save session data by value', async () => {
+		const firstResponse = await fixture.fetch('/update', { method: 'GET' });
+		const firstValue = await firstResponse.json();
+		assert.equal(firstValue.previousValue, 'none');
+
+		const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
+		const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
+		const secondResponse = await fixture.fetch('/update', {
+			method: 'GET',
+			headers: {
+				cookie: `astro-session=${firstSessionId}`,
+			},
+		});
+		const secondValue = await secondResponse.json();
+		assert.equal(secondValue.previousValue, 'expected');
+	});
+
+	it('can save and restore URLs in session data', async () => {
+		const firstResponse = await fixture.fetch('/_actions/addUrl', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ favoriteUrl: 'https://domain.invalid' }),
 		});
 
-		after(async () => {
-			await previewServer.stop();
+		assert.equal(firstResponse.ok, true);
+		const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
+		const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
+
+		const data = devalue.parse(await firstResponse.text());
+		assert.equal(data.message, 'Favorite URL set to https://domain.invalid/ from nothing');
+		const secondResponse = await fixture.fetch('/_actions/addUrl', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				cookie: `astro-session=${firstSessionId}`,
+			},
+			body: JSON.stringify({ favoriteUrl: 'https://example.com' }),
 		});
-
-		it('can regenerate session cookies upon request', async () => {
-			const firstResponse = await fixture.fetch('/regenerate', { method: 'GET' });
-			const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
-			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
-
-			const secondResponse = await fixture.fetch('/regenerate', {
-				method: 'GET',
-				headers: {
-					cookie: `astro-session=${firstSessionId}`,
-				},
-			});
-			const secondHeaders = secondResponse.headers.get('set-cookie').split(',');
-			const secondSessionId = secondHeaders[0].split(';')[0].split('=')[1];
-			assert.notEqual(firstSessionId, secondSessionId);
-		});
-
-		it('can save session data by value', async () => {
-			const firstResponse = await fixture.fetch('/update', { method: 'GET' });
-			const firstValue = await firstResponse.json();
-			assert.equal(firstValue.previousValue, 'none');
-
-			const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
-			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
-			const secondResponse = await fixture.fetch('/update', {
-				method: 'GET',
-				headers: {
-					cookie: `astro-session=${firstSessionId}`,
-				},
-			});
-			const secondValue = await secondResponse.json();
-			assert.equal(secondValue.previousValue, 'expected');
-		});
-
-		it('can save and restore URLs in session data', async () => {
-			const firstResponse = await fixture.fetch('/_actions/addUrl', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({ favoriteUrl: 'https://domain.invalid' }),
-			});
-
-			assert.equal(firstResponse.ok, true);
-			const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
-			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
-
-			const data = devalue.parse(await firstResponse.text());
-			assert.equal(data.message, 'Favorite URL set to https://domain.invalid/ from nothing');
-			const secondResponse = await fixture.fetch('/_actions/addUrl', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					cookie: `astro-session=${firstSessionId}`,
-				},
-				body: JSON.stringify({ favoriteUrl: 'https://example.com' }),
-			});
-			const secondData = devalue.parse(await secondResponse.text());
-			assert.equal(
-				secondData.message,
-				'Favorite URL set to https://example.com/ from https://domain.invalid/',
-			);
-		});
-	},
-);
+		const secondData = devalue.parse(await secondResponse.text());
+		assert.equal(
+			secondData.message,
+			'Favorite URL set to https://example.com/ from https://domain.invalid/',
+		);
+	});
+});
 
 describe.skip('sessions with custom options', () => {
 	it('can build with custom options', async () => {

--- a/packages/integrations/cloudflare/test/with-solid-js.test.js
+++ b/packages/integrations/cloudflare/test/with-solid-js.test.js
@@ -3,32 +3,28 @@ import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './_test-utils.js';
 
-describe(
-	'SolidJS',
-	{ skip: 'Incorrect rendering', todo: 'There are some caching issues? It renders svelte content' },
-	() => {
-		let fixture;
-		let previewServer;
+describe('SolidJS', () => {
+	let fixture;
+	let previewServer;
 
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/with-svelte/',
-			});
-			await fixture.build();
-			previewServer = await fixture.preview();
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/with-solid-js/',
 		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
 
-		after(async () => {
-			await previewServer.stop();
-			await fixture.clean();
-		});
+	after(async () => {
+		await previewServer.stop();
+		await fixture.clean();
+	});
 
-		it('renders the solid component', async () => {
-			const res = await fixture.fetch('/');
-			assert.equal(res.status, 200);
-			const html = await res.text();
-			const $ = cheerio.load(html);
-			assert.equal($('.solid').text(), 'Solid Content');
-		});
-	},
-);
+	it('renders the solid component', async () => {
+		const res = await fixture.fetch('/');
+		assert.equal(res.status, 200);
+		const html = await res.text();
+		const $ = cheerio.load(html);
+		assert.equal($('.solid').text(), 'Solid Content');
+	});
+});

--- a/packages/integrations/cloudflare/test/with-vue.test.js
+++ b/packages/integrations/cloudflare/test/with-vue.test.js
@@ -5,7 +5,10 @@ import { loadFixture } from './_test-utils.js';
 
 describe(
 	'Vue',
-	{ skip: 'Error with virtual:@astrojs/vue/app', todo: 'Enable once the module is resolved by cloudflare' },
+	{
+		skip: 'Error with virtual:@astrojs/vue/app',
+		todo: 'Enable once the module is resolved by cloudflare',
+	},
 	() => {
 		let fixture;
 		let previewServer;

--- a/packages/integrations/cloudflare/test/wrangler-preview-platform.test.js
+++ b/packages/integrations/cloudflare/test/wrangler-preview-platform.test.js
@@ -3,50 +3,46 @@ import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './_test-utils.js';
 
-describe(
-	'WranglerPreviewPlatform',
-	{ skip: 'Requires the preview server', todo: 'Enable once the preview server is supported' },
-	() => {
-		let fixture;
-		let previewServer;
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/wrangler-preview-platform/',
-			});
-			await fixture.build();
-			previewServer = await fixture.preview();
+describe('WranglerPreviewPlatform', () => {
+	let fixture;
+	let previewServer;
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/wrangler-preview-platform/',
 		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
 
-		after(async () => {
-			previewServer.stop();
-		});
+	after(async () => {
+		previewServer.stop();
+	});
 
-		it('exists', async () => {
-			const res = await fixture.fetch('/');
-			const html = await res.text();
-			const $ = cheerio.load(html);
-			assert.equal($('#hasRuntime').text().includes('true'), true);
-		});
+	it('exists', async () => {
+		const res = await fixture.fetch('/');
+		const html = await res.text();
+		const $ = cheerio.load(html);
+		assert.equal($('#hasRuntime').text().includes('true'), true);
+	});
 
-		it('has environment variables', async () => {
-			const res = await fixture.fetch('/');
-			const html = await res.text();
-			const $ = cheerio.load(html);
-			assert.equal($('#hasENV').text().includes('true'), true);
-		});
+	it('has environment variables', async () => {
+		const res = await fixture.fetch('/');
+		const html = await res.text();
+		const $ = cheerio.load(html);
+		assert.equal($('#hasENV').text().includes('true'), true);
+	});
 
-		it('has Cloudflare request object', async () => {
-			const res = await fixture.fetch('/');
-			const html = await res.text();
-			const $ = cheerio.load(html);
-			assert.equal($('#hasCF').text().includes('true'), true);
-		});
+	it('has Cloudflare request object', async () => {
+		const res = await fixture.fetch('/');
+		const html = await res.text();
+		const $ = cheerio.load(html);
+		assert.equal($('#hasCF').text().includes('true'), true);
+	});
 
-		it('has Cloudflare cache', async () => {
-			const res = await fixture.fetch('/');
-			const html = await res.text();
-			const $ = cheerio.load(html);
-			assert.equal($('#hasCACHES').text().includes('true'), true);
-		});
-	},
-);
+	it('has Cloudflare cache', async () => {
+		const res = await fixture.fetch('/');
+		const html = await res.text();
+		const $ = cheerio.load(html);
+		assert.equal($('#hasCACHES').text().includes('true'), true);
+	});
+});


### PR DESCRIPTION
## Changes

Enabeld more tests inside the Cloudflare test suite.

There are still two tests that are skipped:
- the vue one, error with `virtual:@astrojs/vue/app`
- the module loader, we can't seem to properly load WASM modules

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
