### PR TITLE
ci: fix test and update contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,17 @@ When creating new tests, it's best to reference other existing test files and re
 
 - When re-using a fixture multiple times with different configurations, you should also configure unique `outDir`, `build.client`, and `build.server` values so the build output runtime isn't cached and shared by ESM between test runs.
 
+> [!IMPORTANT]
+> If tests start to fail for no apparent reason, the first thing to look at the `outDir` configuration. As build cache artifacts between runs, different tests might end up sharing some of the emitted modules.
+> To avoid this possible overlap, **make sure to add a custom `outDir` to your test case**
+> 
+> ```js
+> await loadFixture({
+>   root: "./fixtures/some-fixture",
+>   outDir: "./dist/some-folder"
+> })
+> ```
+
 ### Other useful commands
 
 ```shell

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -187,6 +187,7 @@ describe('CSP', () => {
 	it('allows injecting custom script resources and hashes based on pages, deduplicated', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
+			outDir: './dist/inject-scripts/',
 			experimental: {
 				csp: {
 					directives: ["img-src 'self'"],
@@ -220,6 +221,7 @@ describe('CSP', () => {
 	it('allows injecting custom styles resources and hashes based on pages', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/csp/',
+			outDir: './dist/inject-styles/',
 			experimental: {
 				csp: {
 					directives: ["img-src 'self'"],


### PR DESCRIPTION
## Changes

Fixes current tests and updates the contribution guide to help triage possible issues when triaging/creating tests


## Testing


CI should stay green 
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
