### PR TITLE
chore: optimise the use of `opts.ssr`

### DIFF
--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -20,6 +20,7 @@ import {
 import { hasContentFlag } from './utils.js';
 import { joinPaths, prependForwardSlash, slash } from '@astrojs/internal-helpers/path';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
+import { isAstroServerEnvironment } from '../environments.js';
 
 export function astroContentAssetPropagationPlugin({
 	settings,
@@ -74,14 +75,14 @@ export function astroContentAssetPropagationPlugin({
 				server.environments[ASTRO_VITE_ENVIRONMENT_NAMES.ssr] as RunnableDevEnvironment,
 			);
 		},
-		async transform(_, id, options) {
+		async transform(_, id) {
 			if (hasContentFlag(id, PROPAGATED_ASSET_FLAG)) {
 				const basePath = id.split('?')[0];
 				let stringifiedLinks: string, stringifiedStyles: string;
 
 				// We can access the server in dev,
 				// so resolve collected styles and scripts here.
-				if (options?.ssr && devModuleLoader) {
+				if (isAstroServerEnvironment(this.environment) && devModuleLoader) {
 					if (!devModuleLoader.getModuleById(basePath)?.ssrModule) {
 						await devModuleLoader.import(basePath);
 					}

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -23,6 +23,7 @@ import {
 } from './consts.js';
 import { getDataStoreFile } from './content-layer.js';
 import { getContentPaths, isDeferredModule } from './utils.js';
+import { isAstroClientEnvironment } from '../environments.js';
 
 interface AstroContentVirtualModPluginParams {
 	settings: AstroSettings;
@@ -111,9 +112,9 @@ export function astroContentVirtualModPlugin({
 				return ASSET_IMPORTS_RESOLVED_STUB_ID;
 			}
 		},
-		async load(id, args) {
+		async load(id) {
 			if (id === RESOLVED_VIRTUAL_MODULE_ID) {
-				const isClient = !args?.ssr;
+				const isClient = isAstroClientEnvironment(this.environment);
 				const code = await generateContentEntryFile({
 					settings,
 					fs,

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -15,6 +15,7 @@ import type { EnvLoader } from './env-loader.js';
 import { type InvalidVariable, invalidVariablesToError } from './errors.js';
 import type { EnvSchema } from './schema.js';
 import { getEnvFieldType, validateEnvVariable } from './validators.js';
+import { isAstroClientEnvironment } from '../environments.js';
 
 interface AstroEnvPluginParams {
 	settings: AstroSettings;
@@ -60,12 +61,12 @@ export function astroEnv({ settings, sync, envLoader }: AstroEnvPluginParams): P
 				return RESOLVED_INTERNAL_VIRTUAL_MODULE_ID;
 			}
 		},
-		load(id, options) {
+		load(id) {
 			if (id === RESOLVED_INTERNAL_VIRTUAL_MODULE_ID) {
 				return { code: `export const schema = ${JSON.stringify(schema)};` };
 			}
 
-			if (id === RESOLVED_SERVER_VIRTUAL_MODULE_ID && !options?.ssr) {
+			if (id === RESOLVED_SERVER_VIRTUAL_MODULE_ID && isAstroClientEnvironment(this.environment)) {
 				throw new AstroError({
 					...AstroErrorData.ServerOnlyModule,
 					message: AstroErrorData.ServerOnlyModule.message(SERVER_VIRTUAL_MODULE_ID),

--- a/packages/astro/src/env/vite-plugin-import-meta-env.ts
+++ b/packages/astro/src/env/vite-plugin-import-meta-env.ts
@@ -3,6 +3,7 @@ import MagicString from 'magic-string';
 import type * as vite from 'vite';
 import { createFilter, isCSSRequest } from 'vite';
 import type { EnvLoader } from './env-loader.js';
+import { isAstroClientEnvironment } from '../environments.js';
 
 interface EnvPluginOptions {
 	envLoader: EnvLoader;
@@ -99,9 +100,9 @@ export function importMetaEnv({ envLoader }: EnvPluginOptions): vite.Plugin {
 			}
 		},
 
-		transform(source, id, options) {
+		transform(source, id) {
 			if (
-				!options?.ssr ||
+				isAstroClientEnvironment(this.environment) ||
 				!source.includes('import.meta.env') ||
 				!filter(id) ||
 				isCSSRequest(id) ||

--- a/packages/astro/src/environments.ts
+++ b/packages/astro/src/environments.ts
@@ -1,0 +1,13 @@
+import type { Environment } from 'vite';
+import { ASTRO_VITE_ENVIRONMENT_NAMES } from './core/constants.js';
+
+export function isAstroServerEnvironment(environment: Environment) {
+	return (
+		environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr ||
+		environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.prerender
+	);
+}
+
+export function isAstroClientEnvironment(environment: Environment) {
+	return environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.client;
+}

--- a/packages/astro/src/vite-plugin-adapter-config/index.ts
+++ b/packages/astro/src/vite-plugin-adapter-config/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin as VitePlugin } from 'vite';
 import type { AstroSettings } from '../types/astro.js';
+import { isAstroServerEnvironment } from '../environments.js';
 
 const VIRTUAL_CLIENT_ID = 'virtual:astro:adapter-config/client';
 const RESOLVED_VIRTUAL_CLIENT_ID = '\0' + VIRTUAL_CLIENT_ID;
@@ -12,10 +13,10 @@ export function vitePluginAdapterConfig(settings: AstroSettings): VitePlugin {
 				return RESOLVED_VIRTUAL_CLIENT_ID;
 			}
 		},
-		load(id, options) {
+		load(id) {
 			if (id === RESOLVED_VIRTUAL_CLIENT_ID) {
 				// During SSR, return empty headers to avoid any runtime issues
-				if (options?.ssr) {
+				if (isAstroServerEnvironment(this.environment)) {
 					return {
 						code: `export const internalFetchHeaders = {};`,
 					};

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -12,6 +12,7 @@ import { handleHotUpdate } from './hmr.js';
 import { parseAstroRequest } from './query.js';
 import type { PluginMetadata as AstroPluginMetadata, CompileMetadata } from './types.js';
 import { loadId } from './utils.js';
+import { isAstroServerEnvironment } from '../environments.js';
 
 export { getAstroMetadata } from './metadata.js';
 export type { AstroPluginMetadata };
@@ -91,7 +92,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 				astroFileToCompileMetadataWeakMap.set(config, astroFileToCompileMetadata);
 			}
 		},
-		async load(id, opts) {
+		async load(id) {
 			const parsedId = parseAstroRequest(id);
 			const query = parsedId.query;
 			if (!query.astro) {
@@ -155,7 +156,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 						throw new Error(`Requests for scripts must include an index`);
 					}
 					// SSR script only exists to make them appear in the module graph.
-					if (opts?.ssr) {
+					if (isAstroServerEnvironment(this.environment)) {
 						return {
 							code: `/* client script, empty in SSR: ${id} */`,
 						};

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -15,6 +15,7 @@ import type { AstroSettings, RoutesList } from '../types/astro.js';
 import { createDefaultAstroMetadata } from '../vite-plugin-astro/metadata.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
+import { isAstroServerEnvironment } from '../environments.js';
 
 type Payload = {
 	settings: AstroSettings;
@@ -135,8 +136,8 @@ export default async function astroPluginRoutes({
 			}
 		},
 
-		async transform(this, code, id, options) {
-			if (!options?.ssr) return;
+		async transform(this, code, id) {
+			if (!isAstroServerEnvironment(this.environment)) return;
 
 			const filename = normalizePath(id);
 			let fileURL: URL;

--- a/packages/astro/src/vite-plugin-scripts/page-ssr.ts
+++ b/packages/astro/src/vite-plugin-scripts/page-ssr.ts
@@ -3,6 +3,7 @@ import { normalizePath, type Plugin as VitePlugin } from 'vite';
 import { isPage } from '../core/util.js';
 import type { AstroSettings } from '../types/astro.js';
 import { PAGE_SSR_SCRIPT_ID } from './index.js';
+import { isAstroServerEnvironment } from '../environments.js';
 
 export default function astroScriptsPostPlugin({
 	settings,
@@ -12,8 +13,8 @@ export default function astroScriptsPostPlugin({
 	return {
 		name: 'astro:scripts:page-ssr',
 		enforce: 'post',
-		transform(this, code, id, options) {
-			if (!options?.ssr) return;
+		transform(this, code, id) {
+			if (!isAstroServerEnvironment(this.environment)) return;
 
 			const hasInjectedScript = settings.scripts.some((s) => s.stage === 'page-ssr');
 			if (!hasInjectedScript) return;

--- a/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
+++ b/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
@@ -15,7 +15,7 @@ const astroTagComponentImportRegex = /[\s,{]__astro_tag_component__[\s,}]/;
 export function vitePluginMdxPostprocess(astroConfig: AstroConfig): Plugin {
 	return {
 		name: '@astrojs/mdx-postprocess',
-		transform(code, id, opts) {
+		transform(code, id) {
 			if (!id.endsWith('.mdx')) return;
 
 			const fileInfo = getFileInfo(id, astroConfig);
@@ -25,7 +25,12 @@ export function vitePluginMdxPostprocess(astroConfig: AstroConfig): Plugin {
 			code = injectUnderscoreFragmentImport(code, imports);
 			code = injectMetadataExports(code, exports, fileInfo);
 			code = transformContentExport(code, exports);
-			code = annotateContentExport(code, id, !!opts?.ssr, imports);
+			code = annotateContentExport(
+				code,
+				id,
+				this.environment.name === 'ssr' || this.environment.name === 'prerender',
+				imports,
+			);
 
 			// The code transformations above are append-only, so the line/column mappings are the same
 			// and we can omit the sourcemap for performance.


### PR DESCRIPTION
## Changes

Removes the checks of `opts?.ssr` in favour of environment checks.

Added two new utilities for avoid code duplication 

## Testing

CI should still pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
