### PR TITLE
 chore: remove devEntrypoint 

### DIFF
--- a/packages/astro/src/types/public/integrations.ts
+++ b/packages/astro/src/types/public/integrations.ts
@@ -124,7 +124,6 @@ export interface AstroAdapter {
 	name: string;
 	serverEntrypoint?: string | URL;
 	previewEntrypoint?: string | URL;
-	devEntrypoint?: string | URL;
 	exports?: string[];
 	args?: any;
 	adapterFeatures?: AstroAdapterFeatures;


### PR DESCRIPTION
## Changes

I added the property during the environment API work.

It's no longer needed (for now)

## Testing

CI should stay green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
