### PR TITLE
chore: update docs references of csp

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -559,7 +559,7 @@ export interface AstroUserConfig<
 	 */
 	prerenderConflictBehavior?: 'error' | 'warn' | 'ignore';
 
-		/**
+	/**
 	 * @docs
 	 * @name vite
 	 * @typeraw {ViteUserConfig}
@@ -592,7 +592,7 @@ export interface AstroUserConfig<
 	 * ```
 	 */
 	vite?: ViteUserConfig;
-	
+
 	/**
 	 * @docs
 	 * @name security
@@ -693,7 +693,7 @@ export interface AstroUserConfig<
 		 * Enabling this feature adds additional security to Astro's handling of processed and bundled scripts and styles by default, and allows you to further configure these, and additional, content types.
 		 *
 		 * This feature comes with some limitations:
-		 * - External scripts and external styles are not supported out of the box, but you can [provide your own hashes](https://v6.docs.astro.build/en/reference/configuration-reference/#hashes). 
+		 * - External scripts and external styles are not supported out of the box, but you can [provide your own hashes](https://v6.docs.astro.build/en/reference/configuration-reference/#hashes).
 		 * - [Astro's view transitions](https://v6.docs.astro.build/en/guides/view-transitions/) using the `<ClientRouter />` are not supported, but you can [consider migrating to the browser native View Transition API](https://events-3bg.pages.dev/jotter/astro-view-transitions/) instead if you are not using Astro's enhancements to the native View Transitions and Navigation APIs.
 		 * - Shiki isn't currently supported. By design, Shiki functions using inline styles.
 		 *
@@ -745,7 +745,7 @@ export interface AstroUserConfig<
 					 */
 					algorithm?: CspAlgorithm;
 
-				 /**
+					/**
 					 * @name security.csp.directives
 					 * @type {string[]}
 					 * @default `[]`
@@ -783,7 +783,6 @@ export interface AstroUserConfig<
 					 * ```
 					 */
 					directives?: CspDirective[];
-			  };
 
 					/**
 					 * @name security.csp.styleDirective
@@ -999,6 +998,7 @@ export interface AstroUserConfig<
 						 */
 						strictDynamic?: boolean;
 					};
+			  };
 	};
 
 	/**


### PR DESCRIPTION
## Changes

Updates the JS docs for all CSP fields.

@sarah11918 FYI in the website we decided to "merge" `hashes` and `resources`, but here we can't do that, so I used the same content for both occurrences and updated the copy to include only the relevant information e.g. `styleDirectives.hashes` -> `style-src`

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
