### PR TITLE
Update JSDoc entry with missing `@docs` tag

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -549,7 +549,7 @@ export interface AstroUserConfig<
 	scopedStyleStrategy?: 'where' | 'class' | 'attribute';
 
 	/**
-	 *
+	 * @docs
 	 * @name prerenderConflictBehavior
 	 * @type {'error' | 'warn' | 'ignore'}
 	 * @default `'warn'`


### PR DESCRIPTION
## Changes

Fixes an issue where one of our entries wasn't displaying in config reference docs because it was missing the `@docs` keyword.

## Testing

No tests

## Docs

Only for docs.
