### PR TITLE
chore(sitemap): migrate to astro:routes:resolved

### DIFF
--- a/.changeset/icy-pigs-smile.md
+++ b/.changeset/icy-pigs-smile.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Updates how routes are retrieved to avoid relying on a deprecated API


### PR DESCRIPTION
## Changes

- Partial backport of #14446
- The sitemap integration has been relying on a deprecated API. This has been causing a few issues on next for some fixtures

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
