### PR TITLE
chore(cloudflare): remove warning logs that no longer apply

### DIFF
--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -149,17 +149,11 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					logger.info(
 						`Enabling image processing with Cloudflare Images for production with the "${bindingName}" Images binding.`,
 					);
-					logger.info(
-						`If you see the error "Invalid binding \`${bindingName}\`" in your build output, you need to add the binding to your wrangler config file.`,
-					);
 				}
 
 				if (!session?.driver) {
 					logger.info(
 						`Enabling sessions with Cloudflare KV with the "${SESSION_KV_BINDING_NAME}" KV binding.`,
-					);
-					logger.info(
-						`If you see the error "Invalid binding \`${SESSION_KV_BINDING_NAME}\`" in your build output, you need to add the binding to your wrangler config file.`,
 					);
 
 					session = {


### PR DESCRIPTION
## Changes

Removes the warning about possible invalid bindings, because this won't happen anymore. We add the bindings for the user.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Just a log

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
