### PR TITLE
Exclude virtual modules from client optimizeDeps

### DIFF
--- a/.changeset/warm-dots-glow.md
+++ b/.changeset/warm-dots-glow.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/cloudflare': patch
+---
+
+Excludes `astro:*` and `virtual:astro:*` from client optimizeDeps in core. Needed for prefetch users since virtual modules are now in the dependency graph.

--- a/packages/astro/src/vite-plugin-environment/index.ts
+++ b/packages/astro/src/vite-plugin-environment/index.ts
@@ -92,6 +92,7 @@ export function vitePluginEnvironment({
 						// For the dev toolbar
 						'astro > html-escaper',
 					],
+					exclude: ['astro:*', 'virtual:astro:*'],
 					// Astro files can't be rendered on the client
 					entries: [`${srcDirPattern}**/*.{jsx,tsx,vue,svelte,html}`],
 				};

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -234,7 +234,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 										return {
 											optimizeDeps: {
 												include: ['astro/runtime/client/dev-toolbar/entrypoint.js'],
-												exclude: ['astro:*'],
 											},
 										};
 									}


### PR DESCRIPTION


## Changes

- Moves astro:* and virtual:astro:* exclusion to core.
- This is needed because prefetch gets optimized for the client and `virtual:astro:adapter-config/client` is part of the dep graph.

## Testing

- Verified this fixes astro.build

## Docs

N/A