### PR TITLE
Improve error messages for invalid unions

### DIFF
--- a/.changeset/bright-pens-dance.md
+++ b/.changeset/bright-pens-dance.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves zod union type error messages to show expected vs received types instead of generic "Invalid input"

--- a/packages/astro/src/core/errors/zod-error-map.ts
+++ b/packages/astro/src/core/errors/zod-error-map.ts
@@ -4,6 +4,7 @@ type TypeOrLiteralErrByPathEntry = {
 	code: 'invalid_type' | 'invalid_literal';
 	received: unknown;
 	expected: unknown[];
+	message: string | undefined;
 };
 
 export const errorMap: $ZodErrorMap = (issue) => {
@@ -25,6 +26,7 @@ export const errorMap: $ZodErrorMap = (issue) => {
 						code: unionError.code,
 						received: (unionError as any).received,
 						expected: [unionError.expected],
+						message: unionError.message
 					});
 				}
 			}
@@ -90,6 +92,7 @@ export const errorMap: $ZodErrorMap = (issue) => {
 					code: issue.code,
 					received: typeof issue.input,
 					expected: [issue.expected],
+					message: issue.message
 				}),
 			),
 		};
@@ -100,7 +103,7 @@ export const errorMap: $ZodErrorMap = (issue) => {
 
 const getTypeOrLiteralMsg = (error: TypeOrLiteralErrByPathEntry): string => {
 	// received could be `undefined` or the string `'undefined'`
-	if (typeof error.received === 'undefined' || error.received === 'undefined') return 'Required';
+	if (typeof error.received === 'undefined' || error.received === 'undefined') return error.message ?? 'Required';
 	const expectedDeduped = new Set(error.expected);
 	switch (error.code) {
 		case 'invalid_type':

--- a/packages/astro/test/error-map.test.js
+++ b/packages/astro/test/error-map.test.js
@@ -12,7 +12,7 @@ describe('Content Collections - error map', () => {
 			}),
 			{ foo: 1 },
 		);
-		assert.deepEqual(messages(error), ['Invalid input: expected string, received number']);
+		assert.deepEqual(messages(error), ['**foo**: Expected type `"string"`, received `"number"`']);
 	});
 	it('Returns formatted error for literal mismatch', () => {
 		const error = getParseError(
@@ -31,14 +31,14 @@ describe('Content Collections - error map', () => {
 			}),
 			{ foo: 'foo' },
 		);
-		assert.deepEqual(messages(error), ['Invalid input: expected string, received undefined']);
+		assert.deepEqual(messages(error), ['**bar**: Required']);
 	});
 	it('Returns formatted error for basic union mismatch', () => {
 		const error = getParseError(
 			z.union([z.boolean(), z.number()]),
 			'not a boolean or a number, oops!',
 		);
-		assert.deepEqual(messages(error), [fixLineEndings('Invalid input')]);
+		assert.deepEqual(messages(error), [fixLineEndings('Did not match union.\n> Expected type `"boolean"`, received `"string"`')]);
 	});
 	it('Returns formatted error for union mismatch on nested object properties', () => {
 		const error = getParseError(
@@ -52,7 +52,9 @@ describe('Content Collections - error map', () => {
 			]),
 			{ type: 'integration-guide' },
 		);
-		assert.deepEqual(messages(error), [fixLineEndings('Invalid input')]);
+		assert.deepEqual(messages(error), [fixLineEndings('Did not match union.\n' +
+    '> Expected type `"tutorial" | "article"`\n' +
+    '> Received `{ "type": "integration-guide" }`')]);
 	});
 	it('Lets unhandled errors fall through', () => {
 		const error = getParseError(
@@ -73,7 +75,7 @@ function messages(error) {
 	return error.issues.map((e) => e.message);
 }
 
-function getParseError(schema, entry, parseOpts = { errorMap }) {
+function getParseError(schema, entry, parseOpts = { error: errorMap }) {
 	const res = schema.safeParse(entry, parseOpts);
 	assert.equal(res.success, false, 'Schema should raise error');
 	return res.error;


### PR DESCRIPTION
## Changes

- Zod issues have an optional `message` that is a good message in case of unions. Use it.

## Testing

- Updated existing tests with more descriptive messages.

## Docs

N/A, bug fix.