### PR TITLE
skip flaky view transitions redirect test

### DIFF
--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -884,7 +884,8 @@ test.describe('View Transitions', () => {
 		).toEqual(1);
 	});
 
-	test('Redirect to external site causes page load', async ({ page, astro }) => {
+	// Skip: flaky
+	test.skip('Redirect to external site causes page load', async ({ page, astro }) => {
 		const loads = collectLoads(page);
 
 		// Go to page 1


### PR DESCRIPTION
## Testing

Skipping this test which fails 50+% of the time, causing us to need to rerun tests to get clean PRs.

This is particularly bad for outside contributors who don't know that tests can be flakey.

Will re-enable when the flakiness can be dealt with.