### PR TITLE
fix(svelte): improve Svelte children prop type checking

### DIFF
--- a/.changeset/every-carpets-grin.md
+++ b/.changeset/every-carpets-grin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Improve Svelte `children` prop type checking

--- a/packages/integrations/svelte/svelte-shims.d.ts
+++ b/packages/integrations/svelte/svelte-shims.d.ts
@@ -4,10 +4,18 @@ import type { JSX } from 'astro/jsx-runtime';
 
 export type AstroClientDirectives = JSX.AstroComponentDirectives;
 
+type Snippet = import('svelte').Snippet;
+
 /**
- * Helper to detect index-signature-like keys (string or number).
+ * Helper to detect index-signature-like keys.
  */
-type IsIndexSignatureKey<K> = string extends K ? true : number extends K ? true : false;
+type IsIndexSignatureKey<K> = string extends K
+	? true
+	: number extends K
+		? true
+		: symbol extends K
+			? true
+			: false;
 
 /**
  * Removes index signatures whose value type is `never`.
@@ -15,14 +23,43 @@ type IsIndexSignatureKey<K> = string extends K ? true : number extends K ? true 
  */
 export type StripNeverIndexSignatures<T> = {
 	[K in keyof T as IsIndexSignatureKey<K> extends true
-		? T[K] extends never
+		? [T[K]] extends [never]
 			? never
 			: K
 		: K]: T[K];
 };
 
 /**
- * Svelte component props plus Astro's client directives,
- * with `never` index signatures stripped out.
+ * If `children` exists and is `never`, make it `{ children?: undefined }`
+ * (works even when it was required).
+ * If `children` doesn't exist, add `{ children?: undefined }`.
  */
-export type PropsWithClientDirectives<T> = StripNeverIndexSignatures<T> & AstroClientDirectives;
+type NormalizeNeverChildren<T> = 'children' extends keyof T
+	? [T['children']] extends [never]
+		? Omit<T, 'children'> & { children?: undefined }
+		: T
+	: T & { children?: undefined };
+
+/**
+ * If `children` includes `Snippet` (even as part of a union), widen to `any`
+ * to allow arbitrary content.
+ */
+type WidenChildrenIfSnippet<T> = {
+	[K in keyof T]: K extends 'children'
+		? Extract<NonNullable<T[K]>, Snippet> extends never
+			? T[K]
+			: any
+		: T[K];
+};
+
+/**
+ * `T` (Svelte props) made safe for Astro:
+ * - Normalize `children` (avoid `never`/missing cases)
+ * - Widen snippet-based `children` to `any` (Astro slot/content compatibility)
+ * - Strip useless `never` index signatures (allow extra keys like `client:*`)
+ * - Add Astro client directives
+ */
+export type PropsWithClientDirectives<T> = StripNeverIndexSignatures<
+	WidenChildrenIfSnippet<NormalizeNeverChildren<T>>
+> &
+	AstroClientDirectives;

--- a/packages/integrations/svelte/test/check.test.js
+++ b/packages/integrations/svelte/test/check.test.js
@@ -33,4 +33,49 @@ describe('Svelte Check', () => {
 		}
 		assert.equal(exitCode, 0, 'Expected check to pass (exit code 0)');
 	});
+
+	it('should pass check on valid children usage', async () => {
+		const root = fileURLToPath(new URL('./fixtures/prop-types/types/children', import.meta.url));
+		const tsConfigPath = fileURLToPath(
+			new URL('./fixtures/prop-types/tsconfig.children-pass.json', import.meta.url),
+		);
+		const { getResult } = cli('check', '--tsconfig', tsConfigPath, '--root', root);
+		const { exitCode, stdout, stderr } = await getResult();
+
+		if (exitCode !== 0) {
+			console.error(stdout);
+			console.error(stderr);
+		}
+		assert.equal(exitCode, 0, 'Expected check to pass (exit code 0)');
+	});
+
+	it('should fail check on invalid text children', async () => {
+		const root = fileURLToPath(new URL('./fixtures/prop-types/types/children', import.meta.url));
+		const tsConfigPath = fileURLToPath(
+			new URL('./fixtures/prop-types/tsconfig.children-fail.json', import.meta.url),
+		);
+		const { getResult } = cli('check', '--tsconfig', tsConfigPath, '--root', root);
+		const { exitCode, stdout } = await getResult();
+
+		assert.equal(exitCode, 1, 'Expected check to fail (exit code 1)');
+		assert.ok(
+			stdout.includes(`'Empty' components don't accept text`),
+			'Expected Empty component error',
+		);
+		assert.ok(
+			stdout.includes(`'EmptyV5' components don't accept text`),
+			'Expected EmptyV5 component error',
+		);
+	});
+
+	it('should fail check on invalid element children', { skip: true }, async () => {
+		const root = fileURLToPath(new URL('./fixtures/prop-types/types/children', import.meta.url));
+		const tsConfigPath = fileURLToPath(
+			new URL('./fixtures/prop-types/tsconfig.children-fail-element.json', import.meta.url),
+		);
+		const { getResult } = cli('check', '--tsconfig', tsConfigPath, '--root', root);
+		const { exitCode } = await getResult();
+
+		assert.equal(exitCode, 1, 'Expected check to fail (exit code 1)');
+	});
 });

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.children-fail-element.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.children-fail-element.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["types/children/FailElement.astro"]
+}

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.children-fail.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.children-fail.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["types/children/Fail.astro"]
+}

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.children-pass.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.children-pass.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["types/children/Pass.astro"]
+}

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Arbitrary.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Arbitrary.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+
+  interface Props {
+    children: number;
+  }
+
+  const { children }: Props = $props();
+</script>
+
+<p>{children}</p>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Empty.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Empty.svelte
@@ -1,0 +1,1 @@
+<p>hello world</p>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/EmptyV5.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/EmptyV5.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  const value = $state();
+</script>
+
+<p>hello world</p>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Explicit.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Explicit.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    children: Snippet;
+  }
+
+  const { children }: Props = $props();
+</script>
+
+{@render children()}

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Fail.astro
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Fail.astro
@@ -1,0 +1,7 @@
+---
+import Empty from './Empty.svelte';
+import EmptyV5 from './EmptyV5.svelte';
+---
+
+<EmptyV5>Hello</EmptyV5>
+<Empty>Hello</Empty>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/FailElement.astro
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/FailElement.astro
@@ -1,0 +1,7 @@
+---
+import Empty from './Empty.svelte';
+import EmptyV5 from './EmptyV5.svelte';
+---
+
+<EmptyV5><p>Hello</p></EmptyV5>
+<Empty><p>Hello</p></Empty>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Implicit.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Implicit.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  const { children } = $props();
+</script>
+
+{@render children?.()}

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Multiple.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Multiple.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  interface Props {
+    children: Snippet;
+  }
+  let { children }: Props = $props();
+</script>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Optional.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Optional.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    children?: Snippet;
+  }
+
+  const { children }: Props = $props();
+</script>
+
+{@render children?.()}

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/children/Pass.astro
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/children/Pass.astro
@@ -1,0 +1,17 @@
+---
+import Arbitrary from './Arbitrary.svelte';
+import Explicit from './Explicit.svelte';
+import Implicit from './Implicit.svelte';
+import Optional from './Optional.svelte';
+import Multiple from './Multiple.svelte';
+---
+
+<Explicit> Hello World </Explicit>
+<Implicit> Hello World </Implicit>
+<Arbitrary children={123}></Arbitrary>
+<Optional />
+<Optional>Hello</Optional>
+<Multiple>
+    <p>First Child</p>
+    <p>Second Child</p>
+</Multiple>


### PR DESCRIPTION
## Changes

When a Svelte component types its `children` prop as `Snippet`, Astro may still type passed children as `any` when using elements or `string` for text. Which can produce false-positive TypeScript errors (e.g. `string` is not assignable to `Snippet`) even though Svelte treats passed children as snippets.

With these changes, Astro respects the `children` type declared by the Svelte component. Additionally, if a component references `children` but doesn’t explicitly type it, we default `children` to `Snippet` to mirror [Svelte’s implicit prop behavior](https://svelte.dev/docs/svelte/snippet#Passing-snippets-to-components-Implicit-props).

Known limitation: we still can’t reliably error when a component *doesn’t accept* children but is used with element/multiple children. Astro’s element-children typing currently becomes `any`, which prevents TypeScript from catching those cases. Text-only children are typed as `string`, so TypeScript can still flag that scenario. This could be improved in the future by tightening the type Astro uses for one or multiple element children. 

For example, given:

```svelte
<script lang="ts">
  const value = $state();
</script>

<p>hello world</p>
```

The Svelte component above should error if it’s used with children. With current limitations, we do error for text children:
```svelte
<Empty>Hello</Empty>
```

but not for this:
```svelte
<Empty><p>Hello</p></Empty>
<!-- or -->
<Empty>
  <p>Hello</p>
  <p>Hello</p>
</Empty>
```

Other than the example above, it should respect the type defined in the Svelte component.

Overall, this should improve the Svelte integration’s type-checking and catch more cases than before.

Fixes #15040

## Testing

Added a new test to check the children prop.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
