### PR TITLE
ClientRouter: Preserve hash fragment during redirects

### DIFF
--- a/.changeset/sixty-deer-fold.md
+++ b/.changeset/sixty-deer-fold.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Enables the ClientRouter to preserve the original hash part of the target URL during server side redirects.

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -11,6 +11,7 @@ import Layout from '../components/Layout.astro';
 	<a id="click-longpage" href="/long-page">go to long page</a>
 	<a id="click-self" href="">go to top</a>
 	<a id="click-redirect-two" href="/redirect-two">go to redirect 2</a>
+	<a id="click-redirect-two-hash" href="/redirect-two#bottom">go to redirect 2 with hash</a>
 	<a id="click-redirect-external" href="/redirect-external">go to a redirect external</a>
 	<a id="click-redirect" href="/redirect">redirect cross-origin</a>
 	<a id="click-404" href="/undefined-page">go to undefined page</a>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/two.astro
@@ -5,6 +5,8 @@ import Layout from '../components/Layout.astro';
 	<p id="two">Page 2</p>
 	<article id="twoarticle"></article>
 	<a id="click-longpage" data-astro-history="replace" href="/long-page">go to long page</a>
+	<div style="height:100vh"></div>
+	<div id="bottom">bottom</div>
 </Layout>
 <script>
 	document.addEventListener('astro:page-load', () => {

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -884,6 +884,24 @@ test.describe('View Transitions', () => {
 		).toEqual(1);
 	});
 
+	test('Hash part of the target URL is preserved during server redirect', async ({
+		page,
+		astro,
+	}) => {
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/one'));
+		let p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// go to page 2
+		await page.click('#click-redirect-two-hash');
+		p = page.locator('#two');
+		await expect(p, 'should have content').toHaveText('Page 2');
+
+		const Y = await page.evaluate(() => window.scrollY);
+		expect(Y, 'The target is further down the page').toBeGreaterThan(0);
+	});
+
 	// Skip: flaky
 	test.skip('Redirect to external site causes page load', async ({ page, astro }) => {
 		const loads = collectLoads(page);

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -443,7 +443,10 @@ async function transition(
 				preparationEvent.preventDefault();
 				return;
 			}
+			// preserve fragment
+			const fragment = preparationEvent.to.hash;
 			preparationEvent.to = redirectedTo;
+			preparationEvent.to.hash = fragment;
 		}
 
 		parser ??= new DOMParser();


### PR DESCRIPTION
## Changes

Fetching the new doc from the server might redirect to a different URL. We replace the target URL of the navigation with the target URL from the redirection, and that way lose the original fragment identifier.

The hash fragment is a client concept which is not sent to the server and therefore not included in the redirection response. This patch adds the original fragment identifier to the new target URL after a redirect.   

Fixes #15086

## Testing

Added a e2e test that redirects with a hash fragment.

## Docs

n.a. / bug fix
