### PR TITLE
fix: avoid hard-coded file URLs in SSR output

### DIFF
--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -1,9 +1,13 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Plugin as VitePlugin } from 'vite';
 import { ENTRYPOINT_VIRTUAL_MODULE_ID } from '../../../actions/consts.js';
 import type { AstroAdapter } from '../../../types/public/integrations.js';
 import { MIDDLEWARE_MODULE_ID } from '../../middleware/vite-plugin.js';
+import { appendForwardSlash } from '../../path.js';
 import { routeIsRedirect } from '../../redirects/index.js';
 import { VIRTUAL_ISLAND_MAP_ID } from '../../server-islands/vite-plugin-server-islands.js';
+import { normalizePath } from '../../viteUtils.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import type { BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
@@ -102,7 +106,11 @@ function vitePluginSSR(
 				contents.push(`const pageMap = new Map([\n    ${pageMap.join(',\n    ')}\n]);`);
 				exports.push(`export { pageMap }`);
 				const middleware = await this.resolve(MIDDLEWARE_MODULE_ID);
-				const ssrCode = generateSSRCode(adapter, middleware!.id);
+				const entryUrl = new URL(
+					options.settings.config.build.serverEntry,
+					options.settings.config.build.server,
+				);
+				const ssrCode = generateSSRCode(adapter, middleware!.id, entryUrl);
 				imports.push(...ssrCode.imports);
 				contents.push(...ssrCode.contents);
 				return { code: [...imports, ...contents, ...exports].join('\n') };
@@ -164,7 +172,7 @@ export function pluginSSR(
 	};
 }
 
-function generateSSRCode(adapter: AstroAdapter, middlewareId: string) {
+function generateSSRCode(adapter: AstroAdapter, middlewareId: string, entryUrl: URL) {
 	const edgeMiddleware = adapter?.adapterFeatures?.edgeMiddleware ?? false;
 
 	const imports = [
@@ -183,7 +191,7 @@ function generateSSRCode(adapter: AstroAdapter, middlewareId: string) {
 		`    actions: () => import("${ENTRYPOINT_VIRTUAL_MODULE_ID}"),`,
 		`    middleware: ${edgeMiddleware ? 'undefined' : `() => import("${middlewareId}")`}`,
 		`});`,
-		`const _args = ${adapter.args ? JSON.stringify(adapter.args, null, 4) : 'undefined'};`,
+		`const _args = ${adapter.args ? serializeArgs(adapter.args, entryUrl) : 'undefined'};`,
 		adapter.exports
 			? `const _exports = serverEntrypointModule.createExports(_manifest, _args);`
 			: '',
@@ -208,4 +216,102 @@ if (Object.prototype.hasOwnProperty.call(serverEntrypointModule, _start)) {
 		imports,
 		contents,
 	};
+}
+
+function serializeArgs(args: unknown, entryUrl: URL): string {
+	const entryDir = fileURLToPath(new URL('./', entryUrl));
+	const result = serializeValue(args, entryDir, new Set());
+	return result === undefined ? 'undefined' : result;
+}
+
+function serializeValue(value: unknown, entryDir: string, seen: Set<unknown>): string | undefined {
+	if (
+		value &&
+		typeof value === 'object' &&
+		'toJSON' in value &&
+		typeof (value as { toJSON?: () => unknown }).toJSON === 'function'
+	) {
+		return serializeValue((value as { toJSON: () => unknown }).toJSON(), entryDir, seen);
+	}
+
+	if (value === null) {
+		return 'null';
+	}
+
+	switch (typeof value) {
+		case 'string': {
+			const fileUrl = serializeFileUrl(value, entryDir);
+			return fileUrl ?? JSON.stringify(value);
+		}
+		case 'number':
+		case 'boolean':
+			return JSON.stringify(value);
+		case 'bigint':
+			throw new TypeError('Do not know how to serialize a BigInt');
+		case 'undefined':
+		case 'function':
+		case 'symbol':
+			return undefined;
+		case 'object': {
+			if (seen.has(value)) {
+				throw new TypeError('Converting circular structure to JSON');
+			}
+
+			seen.add(value);
+
+			if (Array.isArray(value)) {
+				const serializedItems = value.map((item) => {
+					const serialized = serializeValue(item, entryDir, seen);
+					return serialized === undefined ? 'null' : serialized;
+				});
+				seen.delete(value);
+				return `[${serializedItems.join(',')}]`;
+			}
+
+			const entries: string[] = [];
+			for (const [key, item] of Object.entries(value)) {
+				const serialized = serializeValue(item, entryDir, seen);
+				if (serialized !== undefined) {
+					entries.push(`${JSON.stringify(key)}:${serialized}`);
+				}
+			}
+			seen.delete(value);
+			return `{${entries.join(',')}}`;
+		}
+	}
+}
+
+function serializeFileUrl(value: string, entryDir: string): string | undefined {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return undefined;
+	}
+
+	if (url.protocol !== 'file:') {
+		return undefined;
+	}
+
+	const targetPath = fileURLToPath(url);
+	let relative = path.relative(entryDir, targetPath);
+	const needsTrailingSlash = url.pathname.endsWith('/');
+
+	if (path.isAbsolute(relative)) {
+		return JSON.stringify(value);
+	}
+
+	if (relative === '' && needsTrailingSlash) {
+		relative = '.';
+	}
+
+	if (relative !== '') {
+		relative = normalizePath(relative);
+	}
+
+	if (needsTrailingSlash) {
+		relative = appendForwardSlash(relative === '' ? '.' : relative);
+	}
+
+	return `new URL(${JSON.stringify(relative)}, import.meta.url).href`;
 }


### PR DESCRIPTION
Fixes #15087

## Summary
- Avoid hard-coded file URLs in SSR output by making manifest paths and astro:config/server paths relative to runtime module location.
- Keep SSR output portable after moving build artifacts.
