### PR TITLE
Extract minimal chunk data, release RollupOutput early

### DIFF
--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -1,11 +1,10 @@
 import { fileURLToPath } from 'node:url';
-import type { OutputChunk } from 'rollup';
 import { glob } from 'tinyglobby';
-import type * as vite from 'vite';
 import { getAssetsPrefix } from '../../../assets/utils/getAssetsPrefix.js';
 import { normalizeTheLocale } from '../../../i18n/index.js';
 import { runHookBuildSsr } from '../../../integrations/hooks.js';
 import { SERIALIZED_MANIFEST_RESOLVED_ID } from '../../../manifest/serialized.js';
+import type { ExtractedChunk } from '../static-build.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../../vite-plugin-scripts/index.js';
 import { toFallbackType } from '../../app/common.js';
 import { serializeRouteData, toRoutingStrategy } from '../../app/index.js';
@@ -69,40 +68,21 @@ export async function manifestBuildPostHook(
 	options: StaticBuildOptions,
 	internals: BuildInternals,
 	{
-		ssrOutputs,
-		prerenderOutputs,
+		chunks,
 		mutate,
 	}: {
-		ssrOutputs: vite.Rollup.RollupOutput[];
-		prerenderOutputs: vite.Rollup.RollupOutput[];
-		mutate: (chunk: OutputChunk, envs: ['server'], code: string) => void;
+		chunks: ExtractedChunk[];
+		mutate: (fileName: string, code: string, prerender: boolean) => void;
 	},
 ) {
 	const manifest = await createManifest(options, internals);
 
-	if (ssrOutputs.length > 0) {
-		let manifestEntryChunk: OutputChunk | undefined;
+	// Find SSR manifest chunk (prerender: false)
+	const ssrManifestChunk = chunks.find(
+		(c) => !c.prerender && c.moduleIds.includes(SERIALIZED_MANIFEST_RESOLVED_ID),
+	);
 
-		// Find the serialized manifest chunk in SSR outputs
-		for (const output of ssrOutputs) {
-			for (const chunk of output.output) {
-				if (chunk.type === 'asset') {
-					continue;
-				}
-				if (chunk.code && chunk.moduleIds.includes(SERIALIZED_MANIFEST_RESOLVED_ID)) {
-					manifestEntryChunk = chunk as OutputChunk;
-					break;
-				}
-			}
-			if (manifestEntryChunk) {
-				break;
-			}
-		}
-
-		if (!manifestEntryChunk) {
-			throw new Error(`Did not find serialized manifest chunk for SSR`);
-		}
-
+	if (ssrManifestChunk) {
 		const shouldPassMiddlewareEntryPoint =
 			options.settings.adapter?.adapterFeatures?.edgeMiddleware;
 		await runHookBuildSsr({
@@ -113,31 +93,18 @@ export async function manifestBuildPostHook(
 				? internals.middlewareEntryPoint
 				: undefined,
 		});
-		const code = injectManifest(manifest, manifestEntryChunk);
-		mutate(manifestEntryChunk, ['server'], code);
+		const code = injectManifest(manifest, ssrManifestChunk.code);
+		mutate(ssrManifestChunk.fileName, code, false);
 	}
 
-	// Also inject manifest into prerender outputs if available
-	if (prerenderOutputs?.length > 0) {
-		let prerenderManifestChunk: OutputChunk | undefined;
-		for (const output of prerenderOutputs) {
-			for (const chunk of output.output) {
-				if (chunk.type === 'asset') {
-					continue;
-				}
-				if (chunk.code && chunk.moduleIds.includes(SERIALIZED_MANIFEST_RESOLVED_ID)) {
-					prerenderManifestChunk = chunk as OutputChunk;
-					break;
-				}
-			}
-			if (prerenderManifestChunk) {
-				break;
-			}
-		}
-		if (prerenderManifestChunk) {
-			const prerenderCode = injectManifest(manifest, prerenderManifestChunk);
-			mutate(prerenderManifestChunk, ['server'], prerenderCode);
-		}
+	// Find prerender manifest chunk
+	const prerenderManifestChunk = chunks.find(
+		(c) => c.prerender && c.moduleIds.includes(SERIALIZED_MANIFEST_RESOLVED_ID),
+	);
+
+	if (prerenderManifestChunk) {
+		const code = injectManifest(manifest, prerenderManifestChunk.code);
+		mutate(prerenderManifestChunk.fileName, code, true);
 	}
 }
 
@@ -162,11 +129,9 @@ async function createManifest(
 }
 
 /**
- * It injects the manifest in the given output rollup chunk. It returns the new emitted code
+ * Injects the manifest into the given code string. Returns the new code.
  */
-function injectManifest(manifest: SerializedSSRManifest, chunk: Readonly<OutputChunk>) {
-	const code = chunk.code;
-
+function injectManifest(manifest: SerializedSSRManifest, code: string) {
 	return code.replace(replaceExp, () => {
 		return JSON.stringify(manifest);
 	});

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import colors from 'piccolore';
 import { glob } from 'tinyglobby';
 import * as vite from 'vite';
+import { LINKS_PLACEHOLDER } from '../../content/consts.js';
 import { contentAssetsBuildPostHook } from '../../content/vite-plugin-content-assets.js';
 import { type BuildInternals, createBuildInternals } from '../../core/build/internal.js';
 import { emptyDir, removeEmptyDirs } from '../../core/fs/index.js';
@@ -30,6 +31,48 @@ import { NOOP_MODULE_ID } from './plugins/plugin-noop.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../constants.js';
 
 const PRERENDER_ENTRY_FILENAME_PREFIX = 'prerender-entry';
+
+/**
+ * Minimal chunk data extracted from RollupOutput for deferred manifest/content injection.
+ * Allows releasing full RollupOutput objects early to reduce memory usage.
+ */
+export interface ExtractedChunk {
+	fileName: string;
+	code: string;
+	moduleIds: string[];
+	prerender: boolean;
+}
+
+/**
+ * Extracts only the chunks that need post-build injection from RollupOutput.
+ * This allows releasing the full RollupOutput to reduce memory usage.
+ */
+function extractRelevantChunks(
+	outputs: vite.Rollup.RollupOutput[],
+	prerender: boolean,
+): ExtractedChunk[] {
+	const extracted: ExtractedChunk[] = [];
+
+	for (const output of outputs) {
+		for (const chunk of output.output) {
+			if (chunk.type === 'asset') continue;
+
+			const needsContentInjection = chunk.code.includes(LINKS_PLACEHOLDER);
+			const needsManifestInjection = chunk.moduleIds.includes(SERIALIZED_MANIFEST_RESOLVED_ID);
+
+			if (needsContentInjection || needsManifestInjection) {
+				extracted.push({
+					fileName: chunk.fileName,
+					code: chunk.code,
+					moduleIds: [...chunk.moduleIds],
+					prerender,
+				});
+			}
+		}
+	}
+
+	return extracted;
+}
 
 export async function viteBuild(opts: StaticBuildOptions) {
 	const { allPages, settings } = opts;
@@ -65,7 +108,7 @@ export async function viteBuild(opts: StaticBuildOptions) {
 	// Build your project (SSR application code, assets, client JS, etc.)
 	const ssrTime = performance.now();
 	opts.logger.info('build', `Building ${settings.buildOutput} entrypoints...`);
-	const { ssrOutput, prerenderOutput, clientOutput } = await buildEnvironments(opts, internals);
+	const { extractedChunks } = await buildEnvironments(opts, internals);
 	opts.logger.info(
 		'build',
 		colors.green(`✓ Completed in ${getTimeStat(ssrTime, performance.now())}.`),
@@ -73,11 +116,8 @@ export async function viteBuild(opts: StaticBuildOptions) {
 
 	settings.timer.end('SSR build');
 
-	// Handle ssr output for post-build hooks
-	const ssrOutputs = viteBuildReturnToRollupOutputs(ssrOutput);
-	const clientOutputs = viteBuildReturnToRollupOutputs(clientOutput ?? []);
-	const prerenderOutputs = viteBuildReturnToRollupOutputs(prerenderOutput);
-	await runManifestInjection(opts, internals, ssrOutputs, clientOutputs, prerenderOutputs);
+	// Inject manifest and content placeholders into extracted chunks
+	await runManifestInjection(opts, internals, extractedChunks);
 
 	// Store prerender output directory for use in page generation
 	const prerenderOutputDir = new URL('./.prerender/', getServerOutputDirectory(settings));
@@ -287,16 +327,24 @@ async function buildEnvironments(opts: StaticBuildOptions, internals: BuildInter
 	const builder = await vite.createBuilder(updatedViteBuildConfig);
 
 	// Build ssr environment for server output
-	const ssrOutput =
+	let ssrOutput =
 		settings.buildOutput === 'static'
 			? []
 			: await builder.build(builder.environments[ASTRO_VITE_ENVIRONMENT_NAMES.ssr]);
+	// Extract chunks needing injection, then release output for GC
+	const ssrChunks = extractRelevantChunks(viteBuildReturnToRollupOutputs(ssrOutput), false);
+	ssrOutput = undefined as any;
 
 	// Build prerender environment for static generation
-	const prerenderOutput = await builder.build(builder.environments.prerender);
-
-	// Extract prerender entry filename and store in internals
+	let prerenderOutput = await builder.build(builder.environments.prerender);
+	// Extract prerender entry filename before releasing (only needs fileName)
 	extractPrerenderEntryFileName(internals, prerenderOutput);
+	// Extract chunks needing injection, then release output for GC
+	const prerenderChunks = extractRelevantChunks(
+		viteBuildReturnToRollupOutputs(prerenderOutput),
+		true,
+	);
+	prerenderOutput = undefined as any;
 
 	// Build client environment
 	// We must discover client inputs after SSR build because hydration/client-only directives
@@ -310,12 +358,11 @@ async function buildEnvironments(opts: StaticBuildOptions, internals: BuildInter
 		internals.clientInput.add(NOOP_MODULE_ID);
 	}
 	builder.environments.client.config.build.rollupOptions.input = Array.from(internals.clientInput);
-	const clientOutput = await builder.build(builder.environments.client);
+	// Build client but don't store - no injection needed, let GC reclaim immediately
+	await builder.build(builder.environments.client);
 
-	return { ssrOutput, prerenderOutput, clientOutput };
+	return { extractedChunks: [...ssrChunks, ...prerenderChunks] };
 }
-
-type MutateChunk = (chunk: vite.Rollup.OutputChunk, targets: string[], newCode: string) => void;
 
 /**
  * Finds and returns the prerender entry filename from the build output.
@@ -362,75 +409,40 @@ function extractPrerenderEntryFileName(
 async function runManifestInjection(
 	opts: StaticBuildOptions,
 	internals: BuildInternals,
-	ssrOutputs: vite.Rollup.RollupOutput[],
-	_clientOutputs: vite.Rollup.RollupOutput[],
-	prerenderOutputs: vite.Rollup.RollupOutput[],
+	chunks: ExtractedChunk[],
 ) {
-	const mutations = new Map<
-		string,
-		{
-			targets: string[];
-			code: string;
-		}
-	>();
+	const mutations = new Map<string, { code: string; prerender: boolean }>();
 
-	const mutate: MutateChunk = (chunk, targets, newCode) => {
-		chunk.code = newCode;
-		mutations.set(chunk.fileName, {
-			targets,
-			code: newCode,
-		});
+	const mutate = (fileName: string, newCode: string, prerender: boolean) => {
+		mutations.set(fileName, { code: newCode, prerender });
 	};
 
-	await manifestBuildPostHook(opts, internals, {
-		ssrOutputs,
-		prerenderOutputs,
-		mutate,
-	});
-
-	await contentAssetsBuildPostHook(opts.settings.config.base, internals, {
-		ssrOutputs,
-		prerenderOutputs,
-		mutate,
-	});
-
-	await writeMutatedChunks(opts, mutations, prerenderOutputs);
+	await manifestBuildPostHook(opts, internals, { chunks, mutate });
+	await contentAssetsBuildPostHook(opts.settings.config.base, internals, { chunks, mutate });
+	await writeMutatedChunks(opts, mutations);
 }
 
 /**
  * Writes chunks that were modified by post-build hooks (e.g., manifest injection).
  * Mutations are collected during the manifest hook and persisted here to the
- * appropriate output directories (server, client, or prerender).
+ * appropriate output directories (server or prerender).
  */
 async function writeMutatedChunks(
 	opts: StaticBuildOptions,
-	mutations: Map<
-		string,
-		{
-			targets: string[];
-			code: string;
-		}
-	>,
-	prerenderOutputs: vite.Rollup.RollupOutput[],
+	mutations: Map<string, { code: string; prerender: boolean }>,
 ) {
 	const { settings } = opts;
 	const config = settings.config;
-	const build = settings.config.build;
 	const serverOutputDir = getServerOutputDirectory(settings);
 
 	for (const [fileName, mutation] of mutations) {
 		let root: URL;
 
-		// Check if this is a prerender file by looking for it in prerender outputs
-		const isPrerender = prerenderOutputs.some((output) =>
-			output.output.some((chunk) => chunk.type !== 'asset' && (chunk as any).fileName === fileName),
-		);
-
-		if (isPrerender) {
+		if (mutation.prerender) {
 			// Write to prerender directory
 			root = new URL('./.prerender/', serverOutputDir);
 		} else if (settings.buildOutput === 'server') {
-			root = mutation.targets.includes('server') ? build.server : build.client;
+			root = config.build.server;
 		} else {
 			root = getOutDirWithinCwd(config.outDir);
 		}


### PR DESCRIPTION

## Changes

- Add ExtractedChunk interface + extractRelevantChunks helper
- Modify buildEnvironments to extract then release outputs
- Update hook signatures to use ExtractedChunk[]
- Remove dead targets code from mutations

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
