### PR TITLE
Add major changeset for markdoc based on emitImageMetadata change

### DIFF
--- a/.changeset/markdoc-emit-image-metadata.md
+++ b/.changeset/markdoc-emit-image-metadata.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': major
+---
+
+Updates internal image processing to use `emitImageMetadata()` instead of the removed `emitESMImage()` function


### PR DESCRIPTION
Adding a changeset that was missing.