### PR TITLE
fix: components imports paths

### DIFF
--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -3,8 +3,8 @@ import type { ThemePresets } from '@astrojs/markdown-remark';
 import type { ShikiTransformer, ThemeRegistration, ThemeRegistrationRaw } from 'shiki';
 import { bundledLanguages } from 'shiki/langs';
 import { getCachedHighlighter } from '../dist/core/shiki.js';
-import type { CodeLanguage } from '../dist/types/public';
-import type { HTMLAttributes } from '../types';
+import type { CodeLanguage } from '../dist/types/public/index.js';
+import type { HTMLAttributes } from '../types.js';
 
 interface Props extends Omit<HTMLAttributes<'pre'>, 'lang'> {
 	/** The code to highlight. Required. */

--- a/packages/astro/components/Image.astro
+++ b/packages/astro/components/Image.astro
@@ -1,8 +1,8 @@
 ---
 import { getImage, imageConfig, type LocalImageProps, type RemoteImageProps } from 'astro:assets';
-import type { UnresolvedImageTransform } from '../dist/assets/types';
+import type { UnresolvedImageTransform } from '../dist/assets/types.js';
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
-import type { HTMLAttributes } from '../types';
+import type { HTMLAttributes } from '../types.js';
 
 // The TypeScript diagnostic for JSX props uses the last member of the union to suggest props, so it would be better for
 // LocalImageProps to be last. Unfortunately, when we do this the error messages that remote images get are complete nonsense

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -8,7 +8,7 @@ import type {
 	ImageOutputFormat,
 	UnresolvedImageTransform,
 } from '../dist/types/public/index.js';
-import type { HTMLAttributes } from '../types';
+import type { HTMLAttributes } from '../types.js';
 
 export type Props = (LocalImageProps | RemoteImageProps) & {
 	formats?: ImageOutputFormat[];


### PR DESCRIPTION
## Changes

- Found in #15104
- Updates the imports paths to use a file extension, otherwise it may fail with `astro check`. Doing it here and not on the renovate PR directly will allow renovate to push updates to said PR

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
