### PR TITLE
Update markdoc integration changeset

### DIFF
--- a/.changeset/markdoc-emit-image-metadata.md
+++ b/.changeset/markdoc-emit-image-metadata.md
@@ -1,5 +1,7 @@
 ---
-'@astrojs/markdoc': major
+'@astrojs/markdoc': minor
 ---
 
-Updates internal image processing to use `emitImageMetadata()` instead of the removed `emitESMImage()` function
+Updates internal image processing to be compatible with Astro 6. This change is internal-only and does not affect the public API.
+
+The integration now uses Astro's new `emitImageMetadata()` function instead of the removed `emitESMImage()` function for processing images referenced in Markdoc content during build time. This ensures continued compatibility with Astro's asset processing pipeline while maintaining the same behavior for users.


### PR DESCRIPTION
Updates the changeset to `minor` as well as explain a little more the reasoning.