### PR TITLE
Fix windows build issue with import alias

### DIFF
--- a/.changeset/spicy-beds-boil.md
+++ b/.changeset/spicy-beds-boil.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a Windows-specific build issue when importing an Astro component with a `<script>` tag using an import alias.

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -91,7 +91,7 @@ const getViteResolveAlias = (settings: AstroSettings) => {
 				for (const resolvedValue of resolvedValues) {
 					const resolved = resolvedValue.replace('*', id);
 					if (fs.existsSync(resolved)) {
-						return resolved;
+						return normalizePath(resolved);
 					}
 				}
 				return null;

--- a/packages/astro/test/fixtures/alias-tsconfig/src/components/Qux.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/components/Qux.astro
@@ -1,0 +1,5 @@
+<p>qux</p>
+
+<script>
+  console.log('Hello from Qux');
+</script>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Alias from '@components/Alias.svelte';
 import Client from '@components/Client.svelte'
+import Qux from '@components/Qux.astro'
 import '@styles/main.css';
 import { namespace } from '@test/namespace-package'
 import Foo from 'src/components/Foo.astro';
@@ -23,6 +24,7 @@ const globResult = Object.keys(import.meta.glob('@components/glob/*.js')).join('
       <Foo />
 			<Bar />
       <Baz />
+      <Qux />
       <StyleComp />
       <Alias client:load />
       <p id="namespace">{namespace}</p>


### PR DESCRIPTION
## Changes

Initially [reported on Discord](https://discord.com/channels/830184174198718474/1449132280432951398/1456959433853632717), this PR fixes a Windows-specific build issue when importing an Astro component with a `<script>` tag using an [import alias](https://docs.astro.build/en/guides/typescript/#import-aliases).

- [Repro](https://github.com/HiDeoo/astro-6-mdx-import-alias-windows-repro) (the repro includes MDX, but turns out the issue is not MDX-related)
- The custom resolver used in the vite plugin to alias paths needs to return normalized paths.

## Testing

<!-- How was this change tested? -->
- Added a new component `Qux.astro` with a `<script>` tag to the existing `alias-tsconfig` fixture, imported it using an alias.
  - The associated test fails to build the fixture on Windows before the fix.
  - The build succeeds after the fix.
- Also tested the fix with a local patch on the Starlight repo where the issue was [originally reported](https://github.com/withastro/starlight/pull/3644).
  - The build succeeds on Windows after applying the fix.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

This is a bug fix; no doc updates are needed.