### PR TITLE
fix: adjust page warning to only show up in more relevant times

### DIFF
--- a/.changeset/proud-singers-smoke.md
+++ b/.changeset/proud-singers-smoke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates "Unsupported page types found" error to only appear in more realistic cases

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -178,7 +178,7 @@ export class Logger {
 	error(label: LoggerLabel | null, message: string, newLine = true) {
 		error(this.options, label, message, newLine);
 	}
-	debug(label: LoggerLabel | null, ...messages: any[]) {
+	debug(label: LoggerLabel, ...messages: any[]) {
 		debug(label, ...messages);
 	}
 


### PR DESCRIPTION
## Changes

Realistically there's no point in showing this warning all the time, no one is confusing a .png to be a page. As such, I think it's better to only show the warning whenever it'd be possible for users to be confused

Fixes https://github.com/withastro/astro/issues/14321

## Testing

N/A

## Docs

N/A