### PR TITLE
[cloudflare] Fix deploy failure when using base path

### DIFF
--- a/.changeset/fix-cloudflare-basepath-assetsignore.md
+++ b/.changeset/fix-cloudflare-basepath-assetsignore.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes deploy failure when using Astro base path with Cloudflare adapter
+
+When deploying to Cloudflare Workers with a `base` path configured, wrangler would fail with an error about uploading `_worker.js` directory as an asset. The adapter now automatically generates a `.assetsignore` file that excludes `_worker.js` from being treated as a static asset when a base path is configured.

--- a/packages/integrations/cloudflare/test/assets-ignore.test.js
+++ b/packages/integrations/cloudflare/test/assets-ignore.test.js
@@ -1,0 +1,48 @@
+import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import cloudflare from '../dist/index.js';
+import { loadFixture } from './_test-utils.js';
+
+describe('.assetsignore generation', () => {
+	describe('with base path', () => {
+		/** @type {import('../../../astro/test/test-utils').Fixture} */
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: new URL('./fixtures/with-base/', import.meta.url).toString(),
+				adapter: cloudflare({}),
+			});
+			await fixture.build();
+		});
+
+		it('creates .assetsignore file with _worker.js entry', async () => {
+			const assetsIgnore = await fixture.readFile('/.assetsignore');
+			assert.ok(assetsIgnore.includes('_worker.js'), '.assetsignore should contain _worker.js');
+		});
+	});
+
+	describe('without base path', () => {
+		/** @type {import('../../../astro/test/test-utils').Fixture} */
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: new URL('./fixtures/routes-json/', import.meta.url).toString(),
+				srcDir: './src/mixed',
+				adapter: cloudflare({}),
+			});
+			await fixture.build();
+		});
+
+		it('does not create .assetsignore file', async () => {
+			try {
+				await fixture.readFile('/.assetsignore');
+				assert.fail('.assetsignore file should not exist');
+			} catch (error) {
+				// Expected: file should not exist
+				assert.ok(error.message.includes('ENOENT') || error.code === 'ENOENT');
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes deploy failure when using Astro base path with Cloudflare adapter
- When a base path is configured (e.g., base: '/blog'), wrangler would fail with an error about uploading _worker.js directory as an asset
- The adapter now automatically generates a .assetsignore file containing _worker.js when a base path is configured
- If the user has an existing .assetsignore in their public directory, _worker.js is appended to it (if not already present)
- Changeset added

Fixes #15134

## Testing
Added new test file packages/integrations/cloudflare/test/assets-ignore.test.js with two tests:
- Verifies .assetsignore is created with _worker.js entry when base path is configured
- Verifies .assetsignore is NOT created when no base path is configured (default behavior unchanged)
▶ .assetsignore generation
  ▶ with base path
    ✔ creates .assetsignore file with _worker.js entry
  ✔ with base path
  ▶ without base path
    ✔ does not create .assetsignore file
  ✔ without base path
✔ .assetsignore generation

## Docs
No docs changes needed. This is a bug fix that makes the existing base configuration work correctly with Cloudflare deployments. Users who were previously working around this issue by manually adding .assetsignore files can now remove that workaround.