### PR TITLE
simplify gif image detection in sharp service

### DIFF
--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -71,6 +71,9 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 		// always call rotate to adjust for EXIF data orientation
 		result.rotate();
 
+		// get some information about the input
+		const { format } = await result.metadata();
+
 		// If `fit` isn't set then use old behavior:
 		// - Do not use both width and height for resizing, and prioritize width over height
 		// - Allow enlarging images
@@ -108,15 +111,7 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 				}
 			}
 
-			const isGifInput =
-				inputBuffer[0] === 0x47 && // 'G'
-				inputBuffer[1] === 0x49 && // 'I'
-				inputBuffer[2] === 0x46 && // 'F'
-				inputBuffer[3] === 0x38 && // '8'
-				(inputBuffer[4] === 0x39 || inputBuffer[4] === 0x37) && // '9' or '7'
-				inputBuffer[5] === 0x61; // 'a'
-
-			if (transform.format === 'webp' && isGifInput) {
+			if (transform.format === 'webp' && format === 'gif') {
 				// Convert animated GIF to animated WebP with loop=0 (infinite)
 				result.webp({ quality: typeof quality === 'number' ? quality : undefined, loop: 0 });
 			} else {


### PR DESCRIPTION
## Changes

This replaces some bytes parsing with metadata obtained from sharp.

## Testing

Existing unit tests passing.

## Docs

No doc update needed, since this has no impact.