### PR TITLE
node: skip ssr for pre-rendered pages

### DIFF
--- a/.changeset/ready-tigers-try.md
+++ b/.changeset/ready-tigers-try.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes an issue where the Node.js adapter could fail to serve a 404 page matching a pre-rendered dynamic route pattern.

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -50,7 +50,8 @@ export function createAppHandler(app: NodeApp, options: Options): RequestHandler
 		// Redirects are considered prerendered routes in static mode, but we want to
 		// handle them dynamically, so prerendered routes are included here.
 		const routeData = app.match(request, true);
-		if (routeData) {
+		// But we still want to skip prerendered pages.
+		if (routeData && !(routeData.type === 'page' && routeData.prerender)) {
 			const response = await als.run(request.url, () =>
 				app.render(request, {
 					addCookieHeader: true,

--- a/packages/integrations/node/test/fixtures/prerender/src/pages/dogs/[dog].astro
+++ b/packages/integrations/node/test/fixtures/prerender/src/pages/dogs/[dog].astro
@@ -1,0 +1,15 @@
+---
+export const prerender = true
+
+export function getStaticPaths() {
+  return [
+    { params: { dog: "clifford" }},
+    { params: { dog: "rover" }},
+    { params: { dog: "spot" }},
+  ];
+}
+
+const { dog } = Astro.params;
+---
+
+<h1>Good dog, {dog}!</h1>

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -84,6 +84,21 @@ describe('Prerendering', () => {
 			assert.equal(res.status, 200);
 			assert.equal($('h1').text(), 'Two');
 		});
+
+		it('Can render prerendered dynamic route', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/some-base/dogs/rover`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'Good dog, rover!');
+		});
+
+		it('Can render 404 matching a prerendered dynamic route pattern', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/some-base/dogs/unknown`);
+
+			assert.equal(res.status, 404);
+		});
 	});
 
 	describe('Without base', async () => {
@@ -145,6 +160,21 @@ describe('Prerendering', () => {
 
 			assert.equal(res.status, 200);
 			assert.equal($('h1').text(), 'Two');
+		});
+
+		it('Can render prerendered dynamic route', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/dogs/rover`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'Good dog, rover!');
+		});
+
+		it('Can render 404 matching a prerendered dynamic route pattern', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/dogs/unknown`);
+
+			assert.equal(res.status, 404);
 		});
 	});
 
@@ -318,6 +348,21 @@ describe('Hybrid rendering', () => {
 			assert.equal(res.status, 200);
 			assert.equal($('h1').text(), 'One');
 		});
+
+		it('Can render prerendered dynamic route', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/some-base/dogs/rover`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'Good dog, rover!');
+		});
+
+		it('Can render 404 matching a prerendered dynamic route pattern', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/some-base/dogs/unknown`);
+
+			assert.equal(res.status, 404);
+		});
 	});
 
 	describe('Without base', () => {
@@ -378,6 +423,21 @@ describe('Hybrid rendering', () => {
 
 			assert.equal(res.status, 200);
 			assert.equal($('h1').text(), 'One');
+		});
+
+		it('Can render prerendered dynamic route', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/dogs/rover`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'Good dog, rover!');
+		});
+
+		it('Can render 404 matching a prerendered dynamic route pattern', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/dogs/unknown`);
+
+			assert.equal(res.status, 404);
 		});
 	});
 


### PR DESCRIPTION
## Changes

Initially [reported on Discord](https://discord.com/channels/830184174198718474/1449132280432951398/1459163855686078534), this PR fixes an issue where visiting an unknown route matching the pattern of a pre-rendered dynamic route (e.g., `/dogs/unknown` when `/dogs/[dog]` is pre-rendered) would cause the Node.js adapter to fail to serve the expected 404 page.

- [Repro](https://github.com/HiDeoo/astro-6-node-ssr-prerender-404)
- Previously, pre-rendered routes were not part of the manifest due to [this condition](https://github.com/withastro/astro/blob/main/packages/astro/src/core/build/plugins/plugin-manifest.ts#L239). When [matching all routes](https://github.com/withastro/astro/blob/main/packages/integrations/node/src/serve-app.ts#L52) (including pre-rendered ones to include redirects), the Node.js adapter would now attempt to ssr pre-rendered pages matching the request.

## Testing

I added a pre-rendered dynamic route in an existing fixture and added tests to verify that visiting both the pre-rendered route and an unknown route matching its pattern behaves as expected.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->
This is a bug fix; no doc updates are needed.