### PR TITLE
fix(sitemap): handle undefined _routes in server mode

### DIFF
--- a/.changeset/fix-sitemap-undefined-routes.md
+++ b/.changeset/fix-sitemap-undefined-routes.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Fixes "Cannot read properties of undefined (reading 'reduce')" error when using sitemap integration with `output: 'server'` mode. The `_routes` variable could be undefined if the `astro:routes:resolved` hook did not fire before `astro:build:done`.

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -117,7 +117,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							return new URL(fullPath, finalSiteUrl).href;
 						});
 
-					const routeUrls = _routes.reduce<string[]>((urls, r) => {
+					const routeUrls = (_routes ?? []).reduce<string[]>((urls, r) => {
 						// Only expose pages, not endpoints or redirects
 						if (r.type !== 'page') return urls;
 


### PR DESCRIPTION
## Summary

Fixes a crash when using `@astrojs/sitemap` with `output: 'server'` mode that results in:

```
Cannot read properties of undefined (reading 'reduce')
```

## Problem

When using `output: 'server'` in Astro config, the `astro:routes:resolved` hook may not fire before `astro:build:done`, leaving the `_routes` variable undefined. When the sitemap integration tries to call `_routes.reduce()`, it crashes.

## Solution

Added a nullish coalescing operator to default `_routes` to an empty array:

```typescript
// Before
const routeUrls = _routes.reduce<string[]>((urls, r) => {

// After  
const routeUrls = (_routes ?? []).reduce<string[]>((urls, r) => {
```

This prevents the crash while maintaining existing behavior - if routes aren't available, the sitemap will simply not include route-based URLs (falling back to pages and customPages).

## Testing

Tested with an Astro project using:
- `output: 'server'`
- `@astrojs/node` adapter
- Build previously crashed, now completes successfully

## Related Issues

- #3682 - Sitemap Generation Does Not Work with SSR
- #12437 - Sitemap not included in static output with SSR

## Changeset

Included a patch changeset for `@astrojs/sitemap`.