### PR TITLE
Fix file import using alias matching directory name

### DIFF
--- a/.changeset/tired-eels-cough.md
+++ b/.changeset/tired-eels-cough.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue when importing using an import alias a file with a name matching a directory name.

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -90,7 +90,8 @@ const getViteResolveAlias = (settings: AstroSettings) => {
 				// resolvedValues still have the * in them, so replace * with id
 				for (const resolvedValue of resolvedValues) {
 					const resolved = resolvedValue.replace('*', id);
-					if (fs.existsSync(resolved)) {
+					const stats = fs.statSync(resolved, { throwIfNoEntry: false });
+					if (stats && stats.isFile()) {
 						return normalizePath(resolved);
 					}
 				}

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages.ts
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages.ts
@@ -1,0 +1,5 @@
+// This function does nothing but is used to test that importing using an import alias a file name
+// that matches a directory name works correctly.
+export function doNothing() {
+  // …
+}

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
@@ -9,8 +9,12 @@ import Bar from "@short/Bar"
 import Baz from "@short/Baz"
 import StyleComp from 'src/components/Style.astro';
 import { foo, index } from 'src/utils/constants';
+import { doNothing } from '@pages';
 
 const globResult = Object.keys(import.meta.glob('@components/glob/*.js')).join(', ')
+
+// Call a function imported using an import alias from a file name matching a directory.
+doNothing()
 ---
 <html lang="en">
   <head>


### PR DESCRIPTION
## Changes

Initially [reported on Discord](https://discord.com/channels/830184174198718474/1449132280432951398/1460268936695119954), this PR fixes an issue when importing using an [import alias](https://docs.astro.build/en/guides/typescript/#import-aliases) a file with a name matching a directory name.

- [Repro](https://github.com/HiDeoo/astro-6-import-alias-matching-directory)
- The custom resolver used in the vite plugin to alias paths now checks if a match is a file instead of only relying on `fs.existsSync()`, which returns `true` for both files and directories.

## Testing

<!-- How was this change tested? -->
- Added a new `src/pages.ts` file in the existing `alias-tsconfig` fixture, matching the name of the `src/pages/` directory, and imported it using an alias.
  - The associated test fails before the fix.
  - The test succeeds after the fix.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

This is a bug fix; no doc updates are needed.