### PR TITLE
fix(cli): add .vercel to .gitignore when using astro add vercel

### DIFF
--- a/.changeset/vercel-gitignore.md
+++ b/.changeset/vercel-gitignore.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add `.vercel` to `.gitignore` when adding the Vercel adapter via `astro add vercel`

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -325,6 +325,43 @@ export async function add(names: string[], { flags }: AddOptions) {
 					defaultConfigContent: STUBS.LIT_NPMRC,
 				});
 			}
+			// The Vercel adapter outputs to .vercel/output which should be gitignored
+			if (integrations.find((integration) => integration.id === 'vercel')) {
+				const gitignorePath = new URL('./.gitignore', root);
+				const gitignoreEntry = '.vercel';
+
+				if (existsSync(gitignorePath)) {
+					const content = await fs.readFile(fileURLToPath(gitignorePath), { encoding: 'utf-8' });
+					if (!content.includes(gitignoreEntry)) {
+						logger.info(
+							'SKIP_FORMAT',
+							`\n  ${magenta(`Astro will add ${green('.vercel')} to ${green('.gitignore')}.`)}\n`,
+						);
+
+						if (await askToContinue({ flags, logger })) {
+							const newContent = content.endsWith('\n')
+								? `${content}${gitignoreEntry}\n`
+								: `${content}\n${gitignoreEntry}\n`;
+							await fs.writeFile(fileURLToPath(gitignorePath), newContent, { encoding: 'utf-8' });
+							logger.debug('add', 'Updated .gitignore with .vercel');
+						}
+					} else {
+						logger.debug('add', '.vercel already in .gitignore');
+					}
+				} else {
+					logger.info(
+						'SKIP_FORMAT',
+						`\n  ${magenta(`Astro will create ${green('.gitignore')} with ${green('.vercel')}.`)}\n`,
+					);
+
+					if (await askToContinue({ flags, logger })) {
+						await fs.writeFile(fileURLToPath(gitignorePath), `${gitignoreEntry}\n`, {
+							encoding: 'utf-8',
+						});
+						logger.debug('add', 'Created .gitignore with .vercel');
+					}
+				}
+			}
 			break;
 		}
 		case UpdateResult.cancelled: {


### PR DESCRIPTION
## Summary

When running `astro add vercel`, the Vercel adapter creates build artifacts in `.vercel/output/`. This directory should be gitignored to avoid committing build artifacts.

This PR adds automatic `.gitignore` handling for the Vercel adapter, following the same pattern already used for Cloudflare, Tailwind, Svelte, and other integrations:
- If `.gitignore` exists but doesn't contain `.vercel`, prompts to add it
- If `.gitignore` doesn't exist, prompts to create it with `.vercel`
- If `.vercel` is already in `.gitignore`, skips silently

Closes #15058

## Test plan

1. Run `astro add vercel` in a project without `.gitignore` - should prompt to create one
2. Run `astro add vercel` in a project with `.gitignore` without `.vercel` - should prompt to add it
3. Run `astro add vercel` in a project with `.gitignore` containing `.vercel` - should skip silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)