### PR TITLE
Upgrade the turbo package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prettier-plugin-astro": "^0.14.1",
     "publint": "^0.3.16",
     "tinyglobby": "^0.2.15",
-    "turbo": "^2.7.2",
+    "turbo": "^2.7.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.51.0"
   }


### PR DESCRIPTION
I upgraded the turbo package to improve performance and speed up builds.
The newer version also includes bug fixes that make the build process more reliable.
It helps ensure compatibility with newer versions of Node.js and other tooling.
Upgrading reduces the risk of running into issues that are already fixed in older releases.
Overall, it keeps the project modern, stable, and easier to maintain.