### PR TITLE
Fixed the TypeScript error about the implicit

### DIFF
--- a/benchmark/packages/adapter/src/index.ts
+++ b/benchmark/packages/adapter/src/index.ts
@@ -1,10 +1,10 @@
-import type { AstroIntegration } from 'astro';
+import type { AstroIntegration, HookParameters } from 'astro';
 
 export default function createIntegration(): AstroIntegration {
 	return {
 		name: '@benchmark/timer',
 		hooks: {
-			'astro:config:setup': ({ updateConfig }) => {
+			'astro:config:setup': ({ updateConfig }: HookParameters<'astro:config:setup'>) => {
 				updateConfig({
 					vite: {
 						ssr: {
@@ -13,7 +13,7 @@ export default function createIntegration(): AstroIntegration {
 					},
 				});
 			},
-			'astro:config:done': ({ setAdapter }) => {
+			'astro:config:done': ({ setAdapter }: HookParameters<'astro:config:done'>) => {
 				setAdapter({
 					name: '@benchmark/adapter',
 					serverEntrypoint: '@benchmark/adapter/server.js',


### PR DESCRIPTION

The Problem:
The destructured parameters { updateConfig } and { setAdapter } in the integration hooks had implicit 'any' types because they weren't explicitly typed.
The Solution:
I imported and applied the HookParameters utility type from Astro, which properly types the hook parameters:

import type { AstroIntegration, HookParameters } from 'astro';
'astro:config:setup': ({ updateConfig }: HookParameters<'astro:config:setup'>) => {

'astro:config:done': ({ setAdapter }: HookParameters<'astro:config:done'>) => {
