### PR TITLE
Ensure that the astro:page-load event gets dispatched on initial page loads

### DIFF
--- a/.changeset/tangy-years-grin.md
+++ b/.changeset/tangy-years-grin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the `astro:page-load` event did not fire on initial page loads.

--- a/packages/astro/src/transitions/events.ts
+++ b/packages/astro/src/transitions/events.ts
@@ -1,4 +1,4 @@
-import { updateScrollPosition } from './router.js';
+
 import { swap } from './swap-functions.js';
 import type { Direction, NavigationTypeString } from './types.js';
 
@@ -183,6 +183,15 @@ export async function doPreparation(
 	}
 	return event;
 }
+
+// only update history entries that are managed by us
+// leave other entries alone and do not accidentally add state.
+export const updateScrollPosition = (positions: { scrollX: number; scrollY: number }) => {
+	if (history.state) {
+		history.scrollRestoration = 'manual';
+		history.replaceState({ ...history.state, ...positions }, '');
+	}
+};
 
 export async function doSwap(
 	afterPreparation: BeforeEvent,

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -6,6 +6,7 @@ import {
 	TRANSITION_AFTER_SWAP,
 	onPageLoad,
 	triggerEvent,
+	updateScrollPosition
 } from './events.js';
 import { detectScriptExecuted } from './swap-functions.js';
 import type { Direction, Fallback, Options } from './types.js';
@@ -27,14 +28,7 @@ type Transition = {
 
 const inBrowser = import.meta.env.SSR === false;
 
-// only update history entries that are managed by us
-// leave other entries alone and do not accidentally add state.
-export const updateScrollPosition = (positions: { scrollX: number; scrollY: number }) => {
-	if (history.state) {
-		history.scrollRestoration = 'manual';
-		history.replaceState({ ...history.state, ...positions }, '');
-	}
-};
+
 
 export const supportsViewTransitions = inBrowser && !!document.startViewTransition;
 


### PR DESCRIPTION
## Changes

Removed a cyclic module dependency between router.js and event.js, which could explain the behavior observed in #15191.

While investigating why our existing end to end tests did not fail, I found that I could reproduce the issue with 6.0.0-beta.1, but not with the current tip of next.

Breaking the cycle seems still the right thing to do.

Closes #15191

## Testing

We already have an e2e test for that case.

## Docs
n.a.