### PR TITLE
Refactoring the main index file

### DIFF
--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -13,61 +13,78 @@ export type ReactIntegrationOptions = Pick<
 	'include' | 'exclude' | 'babel'
 > & {
 	experimentalReactChildren?: boolean;
-	/**
-	 * Disable streaming in React components
-	 */
 	experimentalDisableStreaming?: boolean;
 };
 
+const INTEGRATION_NAME = '@astrojs/react';
+const VIRTUAL_MODULE_ID = 'astro:react:opts';
+const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
 const FAST_REFRESH_PREAMBLE = react.preambleCode;
+const KNOWN_JSX_RENDERERS = ['@astrojs/react', '@astrojs/preact', '@astrojs/solid-js'];
+const SSR_NO_EXTERNAL_PACKAGES = [
+	'@mui/material',
+	'@mui/base',
+	'@babel/runtime',
+	'use-immer',
+	'@material-tailwind/react',
+];
 
-function getRenderer(reactConfig: ReactVersionConfig) {
+function validateReactVersion() {
+	const majorVersion = getReactMajorVersion();
+	if (!isSupportedReactVersion(majorVersion)) {
+		throw new Error(`Unsupported React version: ${majorVersion}.`);
+	}
+	return versionsConfig[majorVersion];
+}
+
+function createRenderer(reactConfig: ReactVersionConfig): AstroRenderer {
 	return {
-		name: '@astrojs/react',
+		name: INTEGRATION_NAME,
 		clientEntrypoint: reactConfig.client,
 		serverEntrypoint: reactConfig.server,
 	};
 }
 
-function optionsPlugin({
-	experimentalReactChildren = false,
-	experimentalDisableStreaming = false,
-}: {
+interface OptionsPluginParams {
 	experimentalReactChildren: boolean;
 	experimentalDisableStreaming: boolean;
-}): vite.Plugin {
-	const virtualModule = 'astro:react:opts';
-	const virtualModuleId = '\0' + virtualModule;
+}
+
+function createVirtualModuleCode(options: OptionsPluginParams): string {
+	return `export default {
+		experimentalReactChildren: ${JSON.stringify(options.experimentalReactChildren)},
+		experimentalDisableStreaming: ${JSON.stringify(options.experimentalDisableStreaming)}
+	}`;
+}
+
+function createOptionsPlugin(options: OptionsPluginParams): vite.Plugin {
 	return {
-		name: '@astrojs/react:opts',
+		name: `${INTEGRATION_NAME}:opts`,
 		resolveId(id) {
-			if (id === virtualModule) {
-				return virtualModuleId;
+			if (id === VIRTUAL_MODULE_ID) {
+				return RESOLVED_VIRTUAL_MODULE_ID;
 			}
 		},
 		load(id) {
-			if (id === virtualModuleId) {
-				return {
-					code: `export default {
-						experimentalReactChildren: ${JSON.stringify(experimentalReactChildren)},
-						experimentalDisableStreaming: ${JSON.stringify(experimentalDisableStreaming)}
-					}`,
-				};
+			if (id === RESOLVED_VIRTUAL_MODULE_ID) {
+				return { code: createVirtualModuleCode(options) };
 			}
 		},
 	};
 }
 
-function getViteConfiguration(
-	{
+function createViteConfiguration(
+	options: ReactIntegrationOptions,
+	reactConfig: ReactVersionConfig,
+) {
+	const {
 		include,
 		exclude,
 		babel,
-		experimentalReactChildren,
-		experimentalDisableStreaming,
-	}: ReactIntegrationOptions = {},
-	reactConfig: ReactVersionConfig,
-) {
+		experimentalReactChildren = false,
+		experimentalDisableStreaming = false,
+	} = options;
+
 	return {
 		optimizeDeps: {
 			include: [reactConfig.client],
@@ -75,73 +92,61 @@ function getViteConfiguration(
 		},
 		plugins: [
 			react({ include, exclude, babel }),
-			optionsPlugin({
+			createOptionsPlugin({
 				experimentalReactChildren: !!experimentalReactChildren,
 				experimentalDisableStreaming: !!experimentalDisableStreaming,
 			}),
 		],
 		ssr: {
-			noExternal: [
-				// These are all needed to get mui to work.
-				'@mui/material',
-				'@mui/base',
-				'@babel/runtime',
-				'use-immer',
-				'@material-tailwind/react',
-			],
+			noExternal: SSR_NO_EXTERNAL_PACKAGES,
 		},
 	};
 }
 
-export default function ({
-	include,
-	exclude,
-	babel,
-	experimentalReactChildren,
-	experimentalDisableStreaming,
-}: ReactIntegrationOptions = {}): AstroIntegration {
-	const majorVersion = getReactMajorVersion();
-	if (!isSupportedReactVersion(majorVersion)) {
-		throw new Error(`Unsupported React version: ${majorVersion}.`);
+function setupConfigHook(
+	options: ReactIntegrationOptions,
+	versionConfig: ReactVersionConfig,
+	{ command, addRenderer, updateConfig, injectScript }: any,
+) {
+	addRenderer(createRenderer(versionConfig));
+	updateConfig({
+		vite: createViteConfiguration(options, versionConfig),
+	});
+
+	if (command === 'dev') {
+		const preamble = FAST_REFRESH_PREAMBLE.replace('__BASE__', '/');
+		injectScript('before-hydration', preamble);
 	}
-	const versionConfig = versionsConfig[majorVersion];
+}
+
+function configDoneHook(
+	options: ReactIntegrationOptions,
+	{ logger, config }: any,
+) {
+	const { include, exclude } = options;
+	const enabledJsxRenderers = config.integrations.filter((integration: any) =>
+		KNOWN_JSX_RENDERERS.includes(integration.name),
+	);
+
+	if (enabledJsxRenderers.length > 1 && !include && !exclude) {
+		logger.warn(
+			'More than one JSX renderer is enabled. This will lead to unexpected behavior unless you set the `include` or `exclude` option. See https://docs.astro.build/en/guides/integrations-guide/react/#combining-multiple-jsx-frameworks for more information.',
+		);
+	}
+}
+
+export default function (options: ReactIntegrationOptions = {}): AstroIntegration {
+	const versionConfig = validateReactVersion();
 
 	return {
-		name: '@astrojs/react',
+		name: INTEGRATION_NAME,
 		hooks: {
-			'astro:config:setup': ({ command, addRenderer, updateConfig, injectScript }) => {
-				addRenderer(getRenderer(versionConfig));
-				updateConfig({
-					vite: getViteConfiguration(
-						{ include, exclude, babel, experimentalReactChildren, experimentalDisableStreaming },
-						versionConfig,
-					),
-				});
-				if (command === 'dev') {
-					const preamble = FAST_REFRESH_PREAMBLE.replace(`__BASE__`, '/');
-					injectScript('before-hydration', preamble);
-				}
-			},
-			'astro:config:done': ({ logger, config }) => {
-				const knownJsxRenderers = ['@astrojs/react', '@astrojs/preact', '@astrojs/solid-js'];
-				const enabledKnownJsxRenderers = config.integrations.filter((renderer) =>
-					knownJsxRenderers.includes(renderer.name),
-				);
-
-				if (enabledKnownJsxRenderers.length > 1 && !include && !exclude) {
-					logger.warn(
-						'More than one JSX renderer is enabled. This will lead to unexpected behavior unless you set the `include` or `exclude` option. See https://docs.astro.build/en/guides/integrations-guide/react/#combining-multiple-jsx-frameworks for more information.',
-					);
-				}
-			},
+			'astro:config:setup': (params) => setupConfigHook(options, versionConfig, params),
+			'astro:config:done': (params) => configDoneHook(options, params),
 		},
 	};
 }
 
 export function getContainerRenderer(): AstroRenderer {
-	const majorVersion = getReactMajorVersion();
-	if (!isSupportedReactVersion(majorVersion)) {
-		throw new Error(`Unsupported React version: ${majorVersion}.`);
-	}
-	return getRenderer(versionsConfig[majorVersion]);
+	return createRenderer(validateReactVersion());
 }


### PR DESCRIPTION
1. Extracted constants - Moved all magic strings and arrays to named constants at the top (INTEGRATION_NAME, KNOWN_JSX_RENDERERS, SSR_NO_EXTERNAL_PACKAGES, etc.)

2. Eliminated duplicate code - Created validateReactVersion() helper that's reused in both the main integration and getContainerRenderer()

3.  Better function naming - Renamed functions to be more descriptive:

    -    getRenderer → createRenderer
    - optionsPlugin → createOptionsPlugin
    - getViteConfiguration → createViteConfiguration
4. Modular design - Extracted complex logic into focused functions: