### PR TITLE
fix: update devalue to the latest

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -127,7 +127,7 @@
     "cssesc": "^3.0.0",
     "debug": "^4.4.3",
     "deterministic-object-hash": "^2.0.2",
-    "devalue": "^5.6.1",
+    "devalue": "^5.6.2",
     "diff": "^8.0.3",
     "dlv": "^1.1.3",
     "dset": "^3.1.4",

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -50,7 +50,7 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.1.2",
-    "devalue": "^5.6.1",
+    "devalue": "^5.6.2",
     "rollup": "^4.55.1"
   },
   "publishConfig": {

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -77,7 +77,7 @@
     "@types/markdown-it": "^14.1.2",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "devalue": "^5.6.1",
+    "devalue": "^5.6.2",
     "linkedom": "^0.18.12",
     "vite": "^6.4.1"
   },

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -57,7 +57,7 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.1.2",
-    "devalue": "^5.6.1",
+    "devalue": "^5.6.2",
     "typescript": "^5.9.3"
   },
   "astro": {

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -47,7 +47,7 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.1.2",
-    "devalue": "^5.6.1",
+    "devalue": "^5.6.2",
     "express": "^4.22.1",
     "fastify": "^5.6.2",
     "@fastify/middie": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,8 +552,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       devalue:
-        specifier: ^5.6.1
-        version: 5.6.1
+        specifier: ^5.6.2
+        version: 5.6.2
       diff:
         specifier: ^8.0.3
         version: 8.0.3
@@ -4888,8 +4888,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       devalue:
-        specifier: ^5.6.1
-        version: 5.6.1
+        specifier: ^5.6.2
+        version: 5.6.2
       rollup:
         specifier: ^4.55.1
         version: 4.55.1
@@ -5084,8 +5084,8 @@ importers:
         specifier: workspace:*
         version: link:../../../scripts
       devalue:
-        specifier: ^5.6.1
-        version: 5.6.1
+        specifier: ^5.6.2
+        version: 5.6.2
       linkedom:
         specifier: ^0.18.12
         version: 0.18.12
@@ -5548,8 +5548,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       devalue:
-        specifier: ^5.6.1
-        version: 5.6.1
+        specifier: ^5.6.2
+        version: 5.6.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5673,8 +5673,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       devalue:
-        specifier: ^5.6.1
-        version: 5.6.1
+        specifier: ^5.6.2
+        version: 5.6.2
       express:
         specifier: ^4.22.1
         version: 4.22.1
@@ -11440,6 +11440,9 @@ packages:
 
   devalue@5.6.1:
     resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
+
+  devalue@5.6.2:
+    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -20613,6 +20616,8 @@ snapshots:
   dettle@1.0.5: {}
 
   devalue@5.6.1: {}
+
+  devalue@5.6.2: {}
 
   devlop@1.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,8 @@ overrides:
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@biomejs/*'
+  # TODO: remove in a few days
+  - 'devalue'
   # Temporary, so we can install new lightweight updates
   - 'fontace'
   - '@capsizecss/unpack'


### PR DESCRIPTION
## Changes

Updates `devalue` to the latest

I commented `minimumReleaseAge`, installed the library, and uncommented it `minimumReleaseAge`

## Testing

I believe I needed to add `devalue` to `minimumReleaseAgeExclude` so that it will be installed in fresh installs too, but I might be wrong.

CI should stay green.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
