### PR TITLE
fix: improperly escaped code block in MDXError message

### DIFF
--- a/.changeset/fix-mdx-error-message-escaping.md
+++ b/.changeset/fix-mdx-error-message-escaping.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes greedy regex in error message markdown rendering that caused link syntax examples to capture extra characters

--- a/packages/astro/src/core/errors/dev/utils.ts
+++ b/packages/astro/src/core/errors/dev/utils.ts
@@ -241,7 +241,7 @@ export function getDocsForError(err: ErrorWithMetadata): string | undefined {
 	}
 }
 
-const linkRegex = /\[([^[]+)\]\((.*)\)/g;
+const linkRegex = /\[([^[]+)\]\(([^)]*)\)/g;
 const boldRegex = /\*\*(.+)\*\*/g;
 const urlRegex = / ((?:https?|ftp):\/\/[-\w+&@#\\/%?=~|!:,.;]*[-\w+&@#\\/%=~|])/gi;
 const codeRegex = /`([^`]+)`/g;

--- a/packages/astro/test/units/errors/dev-utils.test.js
+++ b/packages/astro/test/units/errors/dev-utils.test.js
@@ -1,0 +1,107 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { renderErrorMarkdown } from '../../../dist/core/errors/dev/utils.js';
+
+describe('renderErrorMarkdown', () => {
+	describe('html target', () => {
+		it('converts markdown links to HTML anchor tags', () => {
+			const input = 'Check the [documentation](https://docs.astro.build)';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.equal(
+				result,
+				'Check the <a href="https://docs.astro.build" target="_blank">documentation</a>',
+			);
+		});
+
+		it('converts bold text to HTML b tags', () => {
+			const input = 'This is **important** text';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.equal(result, 'This is <b>important</b> text');
+		});
+
+		it('converts inline code to HTML code tags', () => {
+			const input = 'Use the `console.log` function';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.equal(result, 'Use the <code>console.log</code> function');
+		});
+
+		it('converts bare URLs to HTML anchor tags', () => {
+			const input = 'Visit https://astro.build for more info';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.equal(
+				result,
+				'Visit <a href="https://astro.build" target="_blank">https://astro.build</a> for more info',
+			);
+		});
+
+		it('escapes HTML entities in the input', () => {
+			const input = 'Use <script> tags carefully';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.ok(result.includes('&lt;script&gt;'));
+		});
+
+		it('handles multiple markdown elements', () => {
+			const input = 'Check **bold** and `code` and [link](https://example.com)';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.ok(result.includes('<b>bold</b>'));
+			assert.ok(result.includes('<code>code</code>'));
+			assert.ok(result.includes('<a href="https://example.com" target="_blank">link</a>'));
+		});
+
+		it('handles link with parentheses followed by more content', () => {
+			// This is the bug case from issue #15068
+			// The link [text](url) should not consume content after it
+			const input = 'use [text](url) for links';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.equal(result, 'use <a href="url" target="_blank">text</a> for links');
+		});
+
+		it('handles link followed by closing parenthesis', () => {
+			// Edge case: link inside parentheses like "(use [text](url))"
+			const input = '(use [text](url))';
+			const result = renderErrorMarkdown(input, 'html');
+			// The link should only capture 'url', not 'url)'
+			assert.equal(result, '(use <a href="url" target="_blank">text</a>)');
+		});
+
+		it('handles escaped HTML followed by link syntax', () => {
+			// This simulates the MDX error message case
+			const input = 'use <code>[text](url)</code>';
+			const result = renderErrorMarkdown(input, 'html');
+			// After HTML escaping, <code> becomes &lt;code&gt;
+			// The link should still be parsed correctly without consuming &gt;)
+			assert.ok(result.includes('<a href="url" target="_blank">text</a>'));
+			assert.ok(result.includes('&lt;code&gt;'));
+			assert.ok(result.includes('&lt;/code&gt;'));
+		});
+
+		it('handles multiple links in the same message', () => {
+			const input = 'See [docs](https://docs.astro.build) and [guide](https://guide.astro.build)';
+			const result = renderErrorMarkdown(input, 'html');
+			assert.ok(result.includes('<a href="https://docs.astro.build" target="_blank">docs</a>'));
+			assert.ok(result.includes('<a href="https://guide.astro.build" target="_blank">guide</a>'));
+		});
+	});
+
+	describe('cli target', () => {
+		it('formats markdown links for CLI output', () => {
+			const input = 'Check the [documentation](https://docs.astro.build)';
+			const result = renderErrorMarkdown(input, 'cli');
+			// CLI output should contain the link text and URL
+			assert.ok(result.includes('documentation'));
+			assert.ok(result.includes('https://docs.astro.build'));
+		});
+
+		it('formats bold text for CLI output', () => {
+			const input = 'This is **important** text';
+			const result = renderErrorMarkdown(input, 'cli');
+			assert.ok(result.includes('important'));
+		});
+
+		it('formats bare URLs for CLI output', () => {
+			const input = 'Visit https://astro.build for more info';
+			const result = renderErrorMarkdown(input, 'cli');
+			assert.ok(result.includes('https://astro.build'));
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- Fixed greedy regex in `renderErrorMarkdown` that caused markdown link examples in error messages to capture extra characters
- Changed `linkRegex` from `/\[([^[]+)\]\((.*)\)/g` to `/\[([^[]+)\]\(([^)]*)\)/g`
- The `(.*)` was capturing everything up to the **last** `)` in the string instead of the first one after the URL

### Root Cause

When an error message contained `[text](url)</code>)`, the greedy `(.*)` incorrectly captured `url)</code>` as the URL, causing the rendered output to include escaped HTML in the href attribute (appearing as `%3C/code%3E`).

### Process

1. Wrote tests first to verify the hypothesis - tests for `renderErrorMarkdown` covering link parsing edge cases
2. Ran tests to confirm they failed with the buggy regex
3. Applied the fix: changed `(.*)` to `([^)]*)` to stop at the first `)`
4. Ran tests again - all passing

Closes #15068

## Testing

Added 13 new unit tests for `renderErrorMarkdown` in `packages/astro/test/units/errors/dev-utils.test.js`:
- Basic markdown rendering (links, bold, code, URLs)
- Edge cases for links followed by other content
- Links inside parentheses
- Multiple links in same message
- Escaped HTML followed by link syntax

All 52 error unit tests pass.

## Docs

No documentation changes needed - this is a bug fix for error message display.