### PR TITLE
Add an option to specify default image output format

### DIFF
--- a/.changeset/dull-baths-end.md
+++ b/.changeset/dull-baths-end.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add an option to specify default image output format

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -2,7 +2,7 @@ import { isRemoteAllowed } from '@astrojs/internal-helpers/remote';
 import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import { isRemotePath, joinPaths } from '../../core/path.js';
 import type { AstroConfig } from '../../types/public/config.js';
-import { DEFAULT_HASH_PROPS, DEFAULT_OUTPUT_FORMAT, VALID_SUPPORTED_FORMATS } from '../consts.js';
+import { DEFAULT_HASH_PROPS, VALID_SUPPORTED_FORMATS } from '../consts.js';
 import type {
 	ImageFit,
 	ImageOutputFormat,
@@ -215,7 +215,7 @@ export function verifyOptions(options: ImageTransform): void {
  */
 export const baseService: Omit<LocalImageService, 'transform'> = {
 	propertiesToHash: DEFAULT_HASH_PROPS,
-	validateOptions(options) {
+	validateOptions(options, imageConfig) {
 		// We currently do not support processing SVGs, so whenever the input format is a SVG, force the output to also be one
 		if (isESMImportedImage(options.src) && options.src.format === 'svg') {
 			options.format = 'svg';
@@ -226,7 +226,7 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 
 		// Apply defaults and normalization separate from verification
 		if (!options.format) {
-			options.format = DEFAULT_OUTPUT_FORMAT;
+			options.format = imageConfig.outputFormat;
 		}
 		if (options.width) options.width = Math.round(options.width);
 		if (options.height) options.height = Math.round(options.height);
@@ -264,11 +264,11 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			decoding: attributes.decoding ?? 'async',
 		};
 	},
-	getSrcSet(options): Array<UnresolvedSrcSetValue> {
+	getSrcSet(options, imageConfig): Array<UnresolvedSrcSetValue> {
 		const { targetWidth, targetHeight } = getTargetDimensions(options);
 		const aspectRatio = targetWidth / targetHeight;
 		const { widths, densities } = options;
-		const targetFormat = options.format ?? DEFAULT_OUTPUT_FORMAT;
+		const targetFormat = options.format ?? imageConfig.outputFormat;
 
 		let transformedWidths = (widths ?? []).sort(sortNumeric);
 

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -9,6 +9,7 @@ import { markdownConfigDefaults, syntaxHighlightDefaults } from '@astrojs/markdo
 import { type BuiltinTheme, bundledThemes } from 'shiki';
 import type { Config as SvgoConfig } from 'svgo';
 import { z } from 'zod';
+import { DEFAULT_OUTPUT_FORMAT, VALID_OUTPUT_FORMATS } from '../../../assets/consts.js';
 import { localFontFamilySchema, remoteFontFamilySchema } from '../../../assets/fonts/config.js';
 import { EnvSchema } from '../../../env/schema.js';
 import type { AstroUserConfig, ViteUserConfig } from '../../../types/public/config.js';
@@ -68,6 +69,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 	},
 	image: {
 		endpoint: { entrypoint: undefined, route: '/_image' },
+		outputFormat: DEFAULT_OUTPUT_FORMAT,
 		service: { entrypoint: 'astro/assets/services/sharp', config: {} },
 		responsiveStyles: false,
 	},
@@ -264,6 +266,7 @@ export const AstroConfigSchema = z.object({
 					entrypoint: z.string().optional(),
 				})
 				.default(ASTRO_CONFIG_DEFAULTS.image.endpoint),
+			outputFormat: z.enum(VALID_OUTPUT_FORMATS).default(ASTRO_CONFIG_DEFAULTS.image.outputFormat),
 			service: z
 				.object({
 					entrypoint: z

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -11,7 +11,7 @@ import type { Config as SvgoConfig } from 'svgo';
 import type { BuiltinDriverName, BuiltinDriverOptions, Driver, Storage } from 'unstorage';
 import type { UserConfig as OriginalViteUserConfig, SSROptions as ViteSSROptions } from 'vite';
 import type { FontFamily, FontProvider } from '../../assets/fonts/types.js';
-import type { ImageFit, ImageLayout } from '../../assets/types.js';
+import type { ImageFit, ImageLayout, ImageOutputFormat } from '../../assets/types.js';
 import type { AssetsPrefix } from '../../core/app/types.js';
 import type { AstroConfigType } from '../../core/config/schemas/index.js';
 import type { REDIRECT_STATUS_CODES } from '../../core/constants.js';
@@ -1270,6 +1270,25 @@ export interface AstroUserConfig<
 			route: '/_image' | (string & {});
 			entrypoint: undefined | string;
 		};
+
+		/**
+		 * @docs
+		 * @name image.outputFormat
+		 * @type {ImageOutputFormat}
+		 * @default `webp`
+		 * @description
+		 * The default output format for images.
+		 *
+		 * ```js
+		 * {
+		 *   image: {
+		 *     // Example: Output `avif` files by default
+		 *     outputFormat: 'avif',
+		 *   },
+		 * }
+		 * ```
+		 */
+		outputFormat?: ImageOutputFormat;
 
 		/**
 		 * @docs


### PR DESCRIPTION
## Changes

- Add an option to override the default output format `webp`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

[Image component](https://github.com/withastro/docs/blob/68ff22ec26d2b3d381cb8587930ad384e8e80c8e/src/content/docs/en/reference/modules/astro-assets.mdx#format) might need an update to state that the default value can be overridden.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
