### PR TITLE
chore: enable lockfile maintenance

### DIFF
--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -15,6 +15,9 @@
   "postUpdateOptions": [
     "pnpmDedupe"
   ],
+  "lockfileMaintenance": {
+    "enabled": true
+  },
   "ignorePaths": [
     "**/node_modules/**",
     // This fixture depends on the versions in its package.json not being modified by


### PR DESCRIPTION
## Changes

- Enable renovate's lockfile maintenance
- Renames renovate from json5 to jsonc so it can be better understood by tooling (eg. formatted)

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
