### PR TITLE
fix(dev): prevent extraneous file requests

### DIFF
--- a/.changeset/fix-serve-files-outside-srcdir.md
+++ b/.changeset/fix-serve-files-outside-srcdir.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the dev server would serve files like `/README.md` from the project root when they shouldn't be accessible. A new route guard middleware now blocks direct URL access to files that exist outside of `srcDir` and `publicDir`, returning a 404 instead.

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -29,6 +29,7 @@ import { baseMiddleware } from './base.js';
 import { createController } from './controller.js';
 import { recordServerError } from './error.js';
 import { setRouteError } from './server-state.js';
+import { routeGuardMiddleware } from './route-guard.js';
 import { trailingSlashMiddleware } from './trailing-slash.js';
 import { sessionConfigToManifest } from '../core/session/utils.js';
 
@@ -97,6 +98,11 @@ export default function createVitePluginAstroServer({
 				viteServer.middlewares.stack.unshift({
 					route: '',
 					handle: trailingSlashMiddleware(settings),
+				});
+				// Prevent serving files outside srcDir/publicDir (e.g., /README.md at project root)
+				viteServer.middlewares.stack.unshift({
+					route: '',
+					handle: routeGuardMiddleware(settings),
 				});
 
 				// Note that this function has a name so other middleware can find it.

--- a/packages/astro/src/vite-plugin-astro-server/route-guard.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route-guard.ts
@@ -1,0 +1,82 @@
+import * as fs from 'node:fs';
+import type * as vite from 'vite';
+import type { AstroSettings } from '../types/astro.js';
+import { notFoundTemplate } from '../template/4xx.js';
+import { writeHtmlResponse } from './response.js';
+
+// Vite internal prefixes that should always be allowed through
+const VITE_INTERNAL_PREFIXES = [
+	'/@vite/',
+	'/@fs/',
+	'/@id/',
+	'/__vite',
+	'/@react-refresh',
+	'/node_modules/',
+	'/.astro/',
+];
+
+/**
+ * Middleware that prevents Vite from serving files that exist outside
+ * of srcDir and publicDir when accessed via direct URL navigation.
+ *
+ * This fixes the issue where files like /README.md are served
+ * when they exist at the project root but aren't part of Astro's routing.
+ */
+export function routeGuardMiddleware(settings: AstroSettings): vite.Connect.NextHandleFunction {
+	const { config } = settings;
+
+	return function devRouteGuard(req, res, next) {
+		const url = req.url;
+		if (!url) {
+			return next();
+		}
+
+		// Only intercept requests that look like browser navigation (HTML requests)
+		// Let all other requests through (JS modules, assets, Vite transforms, etc.)
+		const accept = req.headers.accept || '';
+		if (!accept.includes('text/html')) {
+			return next();
+		}
+
+		let pathname: string;
+		try {
+			pathname = decodeURI(new URL(url, 'http://localhost').pathname);
+		} catch {
+			// Malformed URI, let other middleware handle it
+			return next();
+		}
+
+		// Always allow Vite internal paths through
+		if (VITE_INTERNAL_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+			return next();
+		}
+
+		// Always allow requests with query params (Vite transform requests like ?url, ?raw)
+		if (url.includes('?')) {
+			return next();
+		}
+
+		// Check if the file exists in publicDir - allow if so
+		const publicFilePath = new URL('.' + pathname, config.publicDir);
+		if (fs.existsSync(publicFilePath)) {
+			return next();
+		}
+
+		// Check if the file exists in srcDir - allow if so (potential route)
+		const srcFilePath = new URL('.' + pathname, config.srcDir);
+		if (fs.existsSync(srcFilePath)) {
+			return next();
+		}
+
+		// Check if the file exists at project root (outside srcDir/publicDir)
+		const rootFilePath = new URL('.' + pathname, config.root);
+		if (fs.existsSync(rootFilePath)) {
+			// File exists at root but not in srcDir or publicDir - block it
+			const html = notFoundTemplate(pathname);
+			return writeHtmlResponse(res, 404, html);
+		}
+
+		// File doesn't exist anywhere, let other middleware handle it
+		return next();
+	};
+}

--- a/packages/astro/test/fixtures/route-guard/LICENSE
+++ b/packages/astro/test/fixtures/route-guard/LICENSE
@@ -1,0 +1,1 @@
+MIT License - This file should NOT be accessible via /LICENSE

--- a/packages/astro/test/fixtures/route-guard/README.md
+++ b/packages/astro/test/fixtures/route-guard/README.md
@@ -1,0 +1,3 @@
+# Test README
+
+This file should NOT be accessible via /README.md

--- a/packages/astro/test/fixtures/route-guard/config.json
+++ b/packages/astro/test/fixtures/route-guard/config.json
@@ -1,0 +1,3 @@
+{
+  "secret": "this-should-not-be-served"
+}

--- a/packages/astro/test/fixtures/route-guard/package.json
+++ b/packages/astro/test/fixtures/route-guard/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/route-guard",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/route-guard/public/robots.txt
+++ b/packages/astro/test/fixtures/route-guard/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/packages/astro/test/fixtures/route-guard/src/pages/about.md
+++ b/packages/astro/test/fixtures/route-guard/src/pages/about.md
@@ -1,0 +1,5 @@
+---
+---
+# About Page
+
+This is a valid markdown page.

--- a/packages/astro/test/fixtures/route-guard/src/pages/index.astro
+++ b/packages/astro/test/fixtures/route-guard/src/pages/index.astro
@@ -1,0 +1,6 @@
+---
+---
+<html>
+  <head><title>Home</title></head>
+  <body><h1>Home Page</h1></body>
+</html>

--- a/packages/astro/test/route-guard.test.js
+++ b/packages/astro/test/route-guard.test.js
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+describe('Route Guard - Dev Server', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	/** @type {import('./test-utils').DevServer} */
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/route-guard/' });
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	describe('Files at project root should return 404 for browser requests', () => {
+		// Browser navigation sends Accept: text/html - these should be blocked
+		const browserHeaders = { headers: { Accept: 'text/html' } };
+
+		it('404 when loading /README.md (file exists at project root)', async () => {
+			const response = await fixture.fetch('/README.md', browserHeaders);
+			assert.equal(response.status, 404);
+		});
+
+		it('404 when loading /LICENSE (file exists at project root)', async () => {
+			const response = await fixture.fetch('/LICENSE', browserHeaders);
+			assert.equal(response.status, 404);
+		});
+
+		it('404 when loading /config.json (file exists at project root)', async () => {
+			const response = await fixture.fetch('/config.json', browserHeaders);
+			assert.equal(response.status, 404);
+		});
+
+		it('404 when loading /package.json (file exists at project root)', async () => {
+			const response = await fixture.fetch('/package.json', browserHeaders);
+			assert.equal(response.status, 404);
+		});
+	});
+
+	describe('Valid routes should work', () => {
+		it('200 when loading / (index page)', async () => {
+			const response = await fixture.fetch('/');
+			assert.equal(response.status, 200);
+		});
+
+		it('200 when loading /about (markdown page in src/pages)', async () => {
+			const response = await fixture.fetch('/about');
+			assert.equal(response.status, 200);
+		});
+	});
+
+	describe('Public directory files should be served', () => {
+		it('200 when loading /robots.txt (file in public directory)', async () => {
+			const response = await fixture.fetch('/robots.txt');
+			assert.equal(response.status, 200);
+			const text = await response.text();
+			assert.match(text, /User-agent/);
+		});
+	});
+
+	describe('Non-existent files should 404 normally', () => {
+		it('404 when loading /nonexistent.md (file does not exist)', async () => {
+			const response = await fixture.fetch('/nonexistent.md');
+			assert.equal(response.status, 404);
+		});
+
+		it('404 when loading /does-not-exist (no file, no route)', async () => {
+			const response = await fixture.fetch('/does-not-exist');
+			assert.equal(response.status, 404);
+		});
+	});
+
+	describe('Vite internal paths should still work', () => {
+		it('allows /@vite/ prefixed requests', async () => {
+			// This tests that we don't block Vite internals
+			// The actual response may vary, but it shouldn't be our custom 404
+			const response = await fixture.fetch('/@vite/client');
+			// Vite client should return 200 or handle it appropriately
+			assert.notEqual(response.status, 404);
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4011,6 +4011,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/route-guard:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/route-manifest:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/15273

> [!IMPORTANT]
> I vibe coded this PR using Claude Code.

This PR creates a new vite middleware that prevents the exposure of requests of files that are outside of `publicDir` and `srcDir`

I reviewed the code, and it seems fine. 

## Testing

Added new tests. CI should stay green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
