### PR TITLE
fix(fonts): font providers as class instances

### DIFF
--- a/.changeset/violet-terms-post.md
+++ b/.changeset/violet-terms-post.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where font providers provided as class instances may not work when using the experimental Fonts API. It affected the local provider

--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -26,7 +26,7 @@ const requiredFamilyAttributesSchema = z.object({
 	cssVariable: z.string(),
 });
 
-export const fontProviderSchema = z
+const _fontProviderSchema = z
 	.object({
 		name: z.string(),
 		config: z.record(z.string(), z.any()).optional(),
@@ -35,6 +35,13 @@ export const fontProviderSchema = z
 		listFonts: z.custom<FontProvider['listFonts']>((v) => typeof v === 'function').optional(),
 	})
 	.strict();
+
+// Using z.object directly makes zod remap the input, preventing
+// the usage of class instances. Instead, we check if it matches
+// the right shape and pass the original
+export const fontProviderSchema = z.custom<FontProvider>((v) => {
+	return _fontProviderSchema.safeParse(v).success;
+}, 'Invalid FontProvider object');
 
 export const fontFamilySchema = z
 	.object({

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { stripVTControlCharacters } from 'node:util';
 import { z } from 'zod';
 import { fontProviders } from '../../../dist/assets/fonts/providers/index.js';
+import { LocalFontProvider } from '../../../dist/assets/fonts/providers/local.js';
 import { validateConfig as _validateConfig } from '../../../dist/core/config/validate.js';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
 import { envField } from '../../../dist/env/config.js';
@@ -533,6 +534,22 @@ describe('Config Validation', () => {
 					},
 				}),
 			);
+		});
+
+		it('should preserve FontProvider as a class instance', async () => {
+			const config = await validateConfig({
+				experimental: {
+					fonts: [
+						{
+							provider: fontProviders.local(),
+							name: 'Roboto',
+							cssVariable: '--font-roboto',
+							options: {},
+						},
+					],
+				},
+			});
+			assert.equal(config.experimental.fonts?.[0].provider instanceof LocalFontProvider, true);
 		});
 	});
 


### PR DESCRIPTION
## Changes

- Reported by a user on Discord: `TypeError: Cannot write private member #root to an object whose class did not declare it`
- Zod remaps object but we want to keep the initial value instead, so that `this` remains valid

## Testing

Manually + unit test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
