### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'withastro'
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
## Changes

- Updated `actions/labeler` from `v4` to `v6` in `.github/workflows/label.yml`
- Added changeset: `pnpm changeset` (details to be provided)
- Improved version compatibility for better stability and features

## Testing

- The change will be tested in the CI pipeline of the pull request
- Tests will verify the functionality of the updated action in the specified workflow

## Docs

- No changes to user behavior, so no documentation updates required
- The change is internal and affects only the GitHub Action versioning mechanism