### PR TITLE
fix(node): prevent infinite loop in resolveClientDir

### DIFF
--- a/.changeset/large-things-dress.md
+++ b/.changeset/large-things-dress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes infinite loop in `resolveClientDir()` when server folder is not found.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -130,7 +130,18 @@ function resolveClientDir(options: Options) {
 	// walk up the parent folders until you find the one that is the root of the server entry folder. This is how we find the client folder relatively.
 	const serverFolder = path.basename(options.server);
 	let serverEntryFolderURL = path.dirname(import.meta.url);
+	let previousPath = '';
+
 	while (!serverEntryFolderURL.endsWith(serverFolder)) {
+		// Prevent infinite loop when reaching filesystem root
+		if (serverEntryFolderURL === previousPath) {
+			throw new Error(
+				`Could not find server folder "${serverFolder}" when resolving client directory. ` +
+					`The directory structure may not be as expected. ` +
+					`Expected to find a folder ending with "${serverFolder}" in the path from ${import.meta.url}`
+			);
+		}
+		previousPath = serverEntryFolderURL;
 		serverEntryFolderURL = path.dirname(serverEntryFolderURL);
 	}
 	const serverEntryURL = serverEntryFolderURL + '/entry.mjs';


### PR DESCRIPTION
## Changes

- Fixes #14353
- Prevents infinite loop in `resolveClientDir()` when server folder is not found
- Throws a descriptive error instead of hanging indefinitely

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests pass.


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

N/A, bug fix
