### PR TITLE
fix: replace regex with removeTrailingForwardSlash for iOS 15-16 compatibility

### DIFF
--- a/packages/astro/src/actions/runtime/virtual.ts
+++ b/packages/astro/src/actions/runtime/virtual.ts
@@ -2,6 +2,7 @@ import { shouldAppendTrailingSlash } from 'virtual:astro:actions/options';
 import { internalFetchHeaders } from 'virtual:astro:adapter-config/client';
 import type { APIContext } from '../../types/public/context.js';
 import type { ActionClient, SafeResult } from './server.js';
+import { removeTrailingForwardSlash } from '../../core/path.js';
 import {
 	ACTION_QUERY_PARAMS,
 	ActionError,
@@ -65,7 +66,7 @@ function toActionProxy(actionCallback: Record<string | symbol, any> = {}, aggreg
 }
 
 function _getActionPath(toString: () => string) {
-	let path = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/_actions/${new URLSearchParams(toString()).get(ACTION_QUERY_PARAMS.actionName)}`;
+	let path = `${removeTrailingForwardSlash(import.meta.env.BASE_URL)}/_actions/${new URLSearchParams(toString()).get(ACTION_QUERY_PARAMS.actionName)}`;
 	if (shouldAppendTrailingSlash) {
 		path = appendForwardSlash(path);
 	}


### PR DESCRIPTION
Fixes #15311

Replace the regex pattern `/\/$/` with `removeTrailingForwardSlash` utility function to fix SyntaxError on iOS 15-16 Safari which doesn't support named capture groups in regular expressions.

This change makes astro:actions compatible with iOS Safari 15-16 by using a utility function instead of a regex pattern that requires named capture group support (available from Safari 16.4+).