### PR TITLE
Fix `?raw` imports failing when used in both SSR and prerendered routes

### DIFF
--- a/.changeset/four-insects-tan.md
+++ b/.changeset/four-insects-tan.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `?raw` imports failing when used in both SSR and prerendered routes

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -13,6 +13,7 @@ import type { PageBuildData, StaticBuildOptions, StylesheetAsset } from '../type
 import { shouldInlineAsset } from './util.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../constants.js';
 import { CSS_LANGS_RE } from '../../viteUtils.js';
+import { specialQueriesRE } from '../../../vite-plugin-utils/index.js';
 import { normalizeEntryId } from './plugin-component-entry.js';
 
 /***** ASTRO PLUGIN *****/
@@ -57,7 +58,12 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 
 		transform: {
 			filter: {
-				id: CSS_LANGS_RE,
+				id: {
+					include: CSS_LANGS_RE,
+					// Exclude ?raw, ?url, ?direct imports - these need their actual content
+					// and should be handled by Vite's native asset handling, not emptied out.
+					exclude: specialQueriesRE,
+				},
 			},
 			handler(_code, id) {
 				// In prerender, don't rebundle CSS that was already bundled in SSR.

--- a/packages/astro/test/fixtures/ssr-prerender/src/pages/not-prerendered.astro
+++ b/packages/astro/test/fixtures/ssr-prerender/src/pages/not-prerendered.astro
@@ -1,8 +1,12 @@
+---
+import styles from '../styles.css?raw';
+---
 <html>
     <head>
         <title>Not prerendered</title>
     </head>
 	<body>
 		<h1 id="greeting">Hello world!</h1>
+		<div id="raw-styles">{styles}</div>
 	</body>
 </html>

--- a/packages/astro/test/fixtures/ssr-prerender/src/pages/static.astro
+++ b/packages/astro/test/fixtures/ssr-prerender/src/pages/static.astro
@@ -1,5 +1,6 @@
 ---
 export const prerender = true;
+import styles from '../styles.css?raw';
 
 const { searchParams } = Astro.url;
 ---
@@ -14,5 +15,6 @@ const { searchParams } = Astro.url;
 	<body>
 		<h1 id="greeting">Hello world!</h1>
 		<div id="searchparams">{searchParams.get('q')}</div>
+		<div id="raw-styles">{styles}</div>
 	</body>
 </html>

--- a/packages/astro/test/fixtures/ssr-prerender/src/styles.css
+++ b/packages/astro/test/fixtures/ssr-prerender/src/styles.css
@@ -1,0 +1,3 @@
+body {
+	background: blue;
+}

--- a/packages/astro/test/ssr-prerender.test.js
+++ b/packages/astro/test/ssr-prerender.test.js
@@ -36,6 +36,24 @@ describe('SSR: prerender', () => {
 		});
 	});
 
+	describe('?raw imports work in both SSR and prerendered routes', () => {
+		it('raw import works in SSR route', async () => {
+			const app = await fixture.loadTestAdapterApp();
+			const request = new Request('http://example.com/not-prerendered');
+			const response = await app.render(request);
+			assert.equal(response.status, 200);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#raw-styles').text().includes('background: blue'), true);
+		});
+
+		it('raw import works in prerendered route', async () => {
+			const html = await fixture.readFile('/client/static/index.html');
+			const $ = cheerio.load(html);
+			assert.equal($('#raw-styles').text().includes('background: blue'), true);
+		});
+	});
+
 	describe('Astro.params in SSR', () => {
 		it('Params are passed to component', async () => {
 			const app = await fixture.loadTestAdapterApp();


### PR DESCRIPTION
## Changes

- Excludes `?raw`, etc from our build CSS processing.
- Fixes case where `?raw` used in both prerender and ssr environments, causing the build to fail due to deduplication in that code.
- Fixes https://github.com/withastro/astro/issues/15316

## Testing

- New test case added.

## Docs

N/A, bug fix