### PR TITLE
fix(cloudflare): externalize node built-ins in dev mode

### DIFF
--- a/.changeset/whole-dancers-enter.md
+++ b/.changeset/whole-dancers-enter.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Correctly externalize Node.js builti-ins in dev mode to fix image optimization endpoint


### PR DESCRIPTION
## Changes

- Dynamically detect and externalize all Node.js built-ins (`fs`, `os`, `path`, etc.) only during `dev` mode.

- Added these modules to `optimizeDeps.exclude` and `ssr.external` within the Cloudflare adapter configuration.

- Updated the `vite:cf-imports` plugin to resolve `node:` prefixed imports as external.

- **Why?** Astro's image optimization endpoint (`astro/assets/endpoint/dev.js`) relies on Node.js APIs to serve local images during development. Since the adapter sets a `workerd` target, Vite was attempting to bundle these modules and failing. This change ensures the Vite SSR runner treats them as external in the dev environment while keeping the production bundle strict.

Fixes #15319 

## Testing

- Tested locally with a reproduction project using the `<Image />` component.

- Verified that the "Failed to load url node:fs/promises" error is gone and images render correctly in `pnpm dev` after linking the modified adapter.

## Docs

- No documentation changes needed.