### PR TITLE
feat(astro): pass collection name to live content loaders

### DIFF
--- a/.changeset/slimy-fans-sing.md
+++ b/.changeset/slimy-fans-sing.md
@@ -1,0 +1,24 @@
+---
+'astro': minor
+---
+
+Passes collection name to live content loaders
+
+Live content collection loaders now receive the collection name as part of their parameters. This is helpful for loaders that manage multiple collections or need to differentiate behavior based on the collection being accessed.
+
+```ts
+export function storeLoader({
+  field,
+  key,
+}) {
+  return {
+    name: "store-loader",
+    loadCollection: async ({ filter, collection }) => {
+      // ...
+    },
+    loadEntry: async ({ filter, collection }) => {
+      // ...
+    },
+  };
+}
+```

--- a/packages/astro/src/content/loaders/types.ts
+++ b/packages/astro/src/content/loaders/types.ts
@@ -75,10 +75,12 @@ export type Loader = {
 
 export interface LoadEntryContext<TEntryFilter = never> {
 	filter: TEntryFilter extends never ? { id: string } : TEntryFilter;
+	collection: string;
 }
 
 export interface LoadCollectionContext<TCollectionFilter = unknown> {
 	filter?: TCollectionFilter;
+	collection: string;
 }
 
 export interface LiveLoader<

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -278,6 +278,7 @@ export function createGetLiveCollection({
 		try {
 			const context = {
 				filter,
+				collection,
 			};
 
 			const response = await (
@@ -392,6 +393,7 @@ export function createGetLiveEntry({
 		try {
 			const lookupObject = {
 				filter: typeof lookup === 'string' ? { id: lookup } : lookup,
+				collection,
 			};
 
 			let entry = await (

--- a/packages/astro/test/fixtures/live-loaders/src/live.config.ts
+++ b/packages/astro/test/fixtures/live-loaders/src/live.config.ts
@@ -36,7 +36,7 @@ class CustomError extends Error {
 
 const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 	name: 'test-loader',
-	loadEntry: async ({ filter }) => {
+	loadEntry: async ({ filter, collection }) => {
 		const entry = entries[filter.id];
 		if (!entry) {
 			return {
@@ -47,6 +47,7 @@ const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 			...entry,
 			data: {
 				title: entry.data.title,
+				collection,
 				age: filter?.addToAge
 					? entry.data.age
 						? entry.data.age + filter.addToAge
@@ -59,7 +60,7 @@ const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 			},
 		};
 	},
-	loadCollection: async ({filter}) => {
+	loadCollection: async ({ filter, collection }) => {
 		return {
 			entries: filter?.addToAge
 				? Object.values(entries).map((entry) => ({
@@ -67,6 +68,7 @@ const loader: LiveLoader<Entry, EntryFilter, CollectionFilter, CustomError> = {
 						data: {
 							title: filter.returnInvalid ? 99 as any : entry.data.title,
 							age: entry.data.age ? entry.data.age + filter!.addToAge! : undefined,
+							collection
 						},
 					}))
 				: Object.values(entries),
@@ -83,6 +85,7 @@ const liveStuff = defineLiveCollection({
 	schema: z.object({
 		title: z.string(),
 		age: z.number().optional(),
+		collection: z.string().optional(),
 	}),
 });
 

--- a/packages/astro/test/live-loaders.test.js
+++ b/packages/astro/test/live-loaders.test.js
@@ -44,7 +44,7 @@ describe('Live content collections', () => {
 			assert.deepEqual(data.entryByString, {
 				entry: {
 					id: '123',
-					data: { title: 'Page 123', age: 10 },
+					data: { title: 'Page 123', age: 10, collection: 'liveStuff' },
 					rendered: { html: '<h1>Page 123</h1><p>This is rendered content.</p>' },
 					cacheHint: {
 						tags: [`page:123`],
@@ -59,7 +59,7 @@ describe('Live content collections', () => {
 			assert.deepEqual(data.entryByObject, {
 				entry: {
 					id: '456',
-					data: { title: 'Page 456', age: 20 },
+					data: { title: 'Page 456', age: 20, collection: 'liveStuff' },
 					cacheHint: {
 						tags: [`page:456`],
 						lastModified: '2025-01-01T00:00:00.000Z',
@@ -76,6 +76,7 @@ describe('Live content collections', () => {
 						id: '123',
 						data: { title: 'Page 123', age: 10 },
 						rendered: { html: '<h1>Page 123</h1><p>This is rendered content.</p>' },
+						
 					},
 					{
 						id: '456',
@@ -102,7 +103,7 @@ describe('Live content collections', () => {
 				{
 					entry: {
 						id: '456',
-						data: { title: 'Page 456', age: 25 },
+						data: { title: 'Page 456', age: 25, collection: 'liveStuff' },
 						cacheHint: {
 							lastModified: '2025-01-01T00:00:00.000Z',
 							tags: [`page:456`],
@@ -120,16 +121,16 @@ describe('Live content collections', () => {
 				[
 					{
 						id: '123',
-						data: { title: 'Page 123', age: 15 },
+						data: { title: 'Page 123', age: 15, collection: 'liveStuff' },
 						rendered: { html: '<h1>Page 123</h1><p>This is rendered content.</p>' },
 					},
 					{
 						id: '456',
-						data: { title: 'Page 456', age: 25 },
+						data: { title: 'Page 456', age: 25, collection: 'liveStuff' },
 					},
 					{
 						id: '789',
-						data: { title: 'Page 789', age: 35 },
+						data: { title: 'Page 789', age: 35, collection: 'liveStuff' },
 					},
 				],
 				'passes dynamic filter to getCollection',
@@ -177,7 +178,7 @@ describe('Live content collections', () => {
 			assert.deepEqual(data.entryByString, {
 				entry: {
 					id: '123',
-					data: { title: 'Page 123', age: 10 },
+					data: { title: 'Page 123', age: 10, collection: 'liveStuff' },
 					rendered: { html: '<h1>Page 123</h1><p>This is rendered content.</p>' },
 					cacheHint: {
 						lastModified: '2025-01-01T00:00:00.000Z',
@@ -201,7 +202,7 @@ describe('Live content collections', () => {
 				{
 					entry: {
 						id: '456',
-						data: { title: 'Page 456', age: 25 },
+						data: { title: 'Page 456', age: 25, collection: 'liveStuff' },
 						cacheHint: {
 							lastModified: '2025-01-01T00:00:00.000Z',
 							tags: [`page:456`],


### PR DESCRIPTION
## Changes

Live content collection loaders now receive the collection name as part of their parameters. This is helpful for loaders that manage multiple collections or need to differentiate behavior based on the collection being accessed.

```ts
export function storeLoader({
  field,
  key,
}) {
  return {
    name: "store-loader",
    loadCollection: async ({ filter, collection }) => {
      // ...
    },
    loadEntry: async ({ filter, collection }) => {
      // ...
    },
  };
}
```

## Testing

Added tests

## Docs

Need updating

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
