### PR TITLE
fix(create-astro): error when --add and --no-install are used together

### DIFF
--- a/.changeset/friendly-knives-rest.md
+++ b/.changeset/friendly-knives-rest.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Errors when `--add` and `--no-install` flags are used together, as `--add` requires dependencies to be installed

--- a/packages/create-astro/src/actions/context.ts
+++ b/packages/create-astro/src/actions/context.ts
@@ -91,6 +91,14 @@ export async function getContext(argv: string[]): Promise<Context> {
 		'--ref': ref,
 		'--add': add,
 	} = flags;
+
+	if (add?.length && noInstall) {
+		console.error(
+			'The --add flag requires dependencies to be installed. Remove --no-install or run `astro add` manually after installation.',
+		);
+		process.exit(1);
+	}
+
 	let projectName = cwd;
 
 	if (no) {

--- a/packages/create-astro/test/context.test.js
+++ b/packages/create-astro/test/context.test.js
@@ -71,4 +71,16 @@ describe('context', () => {
 		const ctx = await getContext(['--no-git']);
 		assert.deepEqual(ctx.git, false);
 	});
+
+	it('--add with --no-install conflicts', async () => {
+		const exitCode = await new Promise((resolve) => {
+			const originalExit = process.exit;
+			process.exit = (code) => {
+				process.exit = originalExit;
+				resolve(code);
+			};
+			getContext(['--add', 'cloudflare', '--no-install']);
+		});
+		assert.equal(exitCode, 1);
+	});
 });


### PR DESCRIPTION
## Changes

- Adds validation that errors early when `--add` and `--no-install` flags are used together
- Previously, `--add` was silently ignored when `--no-install` was set, leading to confusing behavior (e.g., `--add cloudflare` wouldn't create `wrangler.jsonc`)
- Now users get a clear error message: "The --add flag requires dependencies to be installed. Remove --no-install or run \`astro add\` manually after installation."

## Testing

Added a test case in `packages/create-astro/test/context.test.js` that verifies the process exits with code 1 when both flags are used together.

## Docs

No docs changes needed - this is a bug fix that adds a clear error message for an invalid flag combination that was previously silently failing.