### PR TITLE
Add `appEntrypoint` to `@astrojs/react` to enable users to wrap every React island with a custom component

### DIFF
--- a/.changeset/jolly-pens-write.md
+++ b/.changeset/jolly-pens-write.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': minor
+---
+
+Adds a new `appEntrypoint` option. Specify a path to a file that contains a default-exported React component. The component will wrap every React island.

--- a/packages/integrations/react/env.d.ts
+++ b/packages/integrations/react/env.d.ts
@@ -6,3 +6,9 @@ declare module 'astro:react:opts' {
 	const options: Options;
 	export = options;
 }
+
+declare module 'virtual:astro:react-app' {
+	import type { ComponentType } from 'react';
+	import type { AppEntrypointProps } from './src/index.js';
+	export const AppEntrypoint: ComponentType<AppEntrypointProps> | undefined;
+}

--- a/packages/integrations/react/src/client-v17.ts
+++ b/packages/integrations/react/src/client-v17.ts
@@ -1,5 +1,6 @@
 import { createElement } from 'react';
 import { hydrate, render, unmountComponentAtNode } from 'react-dom';
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import StaticHtml from './static-html.js';
 
 export default (element: HTMLElement) =>
@@ -12,11 +13,14 @@ export default (element: HTMLElement) =>
 		for (const [key, value] of Object.entries(slotted)) {
 			props[key] = createElement(StaticHtml, { value, name: key });
 		}
-		const componentEl = createElement(
+		const baseComponentEl = createElement(
 			Component,
 			props,
 			children != null ? createElement(StaticHtml, { value: children }) : children,
 		);
+		const componentEl = AppEntrypoint
+			? createElement(AppEntrypoint, null, baseComponentEl)
+			: baseComponentEl;
 
 		const isHydrate = client !== 'only';
 		const bootstrap = isHydrate ? hydrate : render;

--- a/packages/integrations/react/src/client.ts
+++ b/packages/integrations/react/src/client.ts
@@ -1,5 +1,6 @@
 import { createElement, startTransition } from 'react';
 import { createRoot, hydrateRoot, type Root } from 'react-dom/client';
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import StaticHtml from './static-html.js';
 
 function isAlreadyHydrated(element: HTMLElement) {
@@ -90,11 +91,14 @@ export default (element: HTMLElement) =>
 			props[key] = createElement(StaticHtml, { value, name: key });
 		}
 
-		const componentEl = createElement(
+		const baseComponentEl = createElement(
 			Component,
 			props,
 			getChildren(children, element.hasAttribute('data-react-children')),
 		);
+		const componentEl = AppEntrypoint
+			? createElement(AppEntrypoint, null, baseComponentEl)
+			: baseComponentEl;
 		const rootKey = isAlreadyHydrated(element);
 		// HACK: delete internal react marker for nested components to suppress aggressive warnings
 		if (rootKey) {

--- a/packages/integrations/react/src/server-v17.ts
+++ b/packages/integrations/react/src/server-v17.ts
@@ -1,3 +1,4 @@
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
@@ -61,7 +62,10 @@ async function renderToStaticMarkup(
 			value: newChildren,
 		});
 	}
-	const vnode = React.createElement(Component, newProps);
+	const componentElement = React.createElement(Component, newProps);
+	const vnode = AppEntrypoint
+		? React.createElement(AppEntrypoint, null, componentElement)
+		: componentElement;
 	let html: string;
 	if (metadata?.hydrate) {
 		html = ReactDOM.renderToString(vnode);

--- a/packages/integrations/react/src/server.ts
+++ b/packages/integrations/react/src/server.ts
@@ -1,4 +1,5 @@
 import opts from 'astro:react:opts';
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
@@ -108,7 +109,10 @@ async function renderToStaticMarkup(
 		attrs['data-action-key'] = formState[1];
 		attrs['data-action-name'] = formState[2];
 	}
-	const vnode = React.createElement(Component, newProps);
+	const componentElement = React.createElement(Component, newProps);
+	const vnode = AppEntrypoint
+		? React.createElement(AppEntrypoint, null, componentElement)
+		: componentElement;
 	const renderOptions = {
 		identifierPrefix: prefix,
 		formState,

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/astro.config.mjs
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/astro.config.mjs
@@ -1,0 +1,11 @@
+import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [
+		react({
+			appEntrypoint: '/src/react-app.tsx',
+		}),
+	],
+});

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/package.json
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/react-app-entrypoint",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/react": "workspace:*",
+    "astro": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/components/Counter.tsx
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/components/Counter.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { useTheme } from '../react-app';
+
+export default function Counter() {
+	const [count, setCount] = useState(0);
+	const theme = useTheme();
+
+	return (
+		<div data-testid="counter" data-theme={theme}>
+			<p>Count: {count}</p>
+			<p>Theme: {theme}</p>
+			<button onClick={() => setCount((c) => c + 1)}>Increment</button>
+		</div>
+	);
+}

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/pages/index.astro
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import Counter from '../components/Counter';
+---
+<html>
+	<head>
+		<title>React App Entrypoint Test</title>
+	</head>
+	<body>
+		<h1>React App Entrypoint Test</h1>
+		<Counter client:load />
+	</body>
+</html>

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/react-app.tsx
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/react-app.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { AppEntrypointProps } from '@astrojs/react';
+
+const ThemeContext = createContext<string>('light');
+
+export function useTheme() {
+	return useContext(ThemeContext);
+}
+
+export default function Wrapper({ children }: AppEntrypointProps) {
+	return (
+		<ThemeContext.Provider value="dark">
+			<div data-testid="wrapper">
+				{children}
+			</div>
+		</ThemeContext.Provider>
+	);
+}

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/tsconfig.json
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "astro/tsconfigs/strict",
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "react"
+	},
+	"include": ["src/**/*", ".astro/types.d.ts"]
+}

--- a/packages/integrations/react/test/react-app-entrypoint.test.js
+++ b/packages/integrations/react/test/react-app-entrypoint.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { load as cheerioLoad } from 'cheerio';
+import { isWindows, loadFixture } from '../../../astro/test/test-utils.js';
+
+let fixture;
+
+describe('React App Entrypoint', () => {
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/react-app-entrypoint/', import.meta.url),
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('Wraps React islands with the wrapper component', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			// The wrapper component should wrap the counter
+			const wrapper = $('[data-testid="wrapper"]');
+			assert.equal(wrapper.length, 1);
+
+			// The counter should be inside the wrapper
+			const counter = wrapper.find('[data-testid="counter"]');
+			assert.equal(counter.length, 1);
+
+			// The counter should have access to the theme from context
+			assert.equal(counter.attr('data-theme'), 'dark');
+		});
+	});
+
+	if (isWindows) return;
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('Wraps React islands with the wrapper component in dev mode', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			// The wrapper component should wrap the counter
+			const wrapper = $('[data-testid="wrapper"]');
+			assert.equal(wrapper.length, 1);
+
+			// The counter should be inside the wrapper
+			const counter = wrapper.find('[data-testid="counter"]');
+			assert.equal(counter.length, 1);
+
+			// The counter should have access to the theme from context
+			assert.equal(counter.attr('data-theme'), 'dark');
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6103,6 +6103,21 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
 
+  packages/integrations/react/test/fixtures/react-app-entrypoint:
+    dependencies:
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+
   packages/integrations/react/test/fixtures/react-component:
     dependencies:
       '@astrojs/react':


### PR DESCRIPTION
## Changes

- I added a new option to `@astrojs/react`, **`appEntrypoint`**. It looks a whole lot like the Vue integration’s appEntrypoint option and it functions nearly identically. Specify a path to a file that has a default-exported component and that component will be used to wrap every React island.
- ~~I added `Astro.locals` to the render context and am passing `Astro.locals` through to `appEntrypoint`’s component as a prop called `locals`. The prop is only set in a server environment; clientside it’s just `undefined`.~~ Removed for now but you can see the change [here](https://github.com/meyer/astro/tree/meyer/add-locals-to-render-context) (it’s pretty minimal)

## Testing

New tests added that cover `appEntrypoint` in general ~~as well as the `locals` prop~~.

## Docs

PR with docs update is here: https://github.com/withastro/docs/pull/13208