### PR TITLE
fix(internal-helpers): remove unused exports

### DIFF
--- a/.changeset/true-dingos-attack.md
+++ b/.changeset/true-dingos-attack.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/internal-helpers': minor
+---
+
+**BREAKING CHANGE**
+
+Removes `collapseDuplicateSlashes()`, `startsWithForwardSlash()`, `startsWithDotDotSlash()`, `startsWithDotSlash()` and `isAbsolutePath()` from the `/path` export

--- a/packages/internal-helpers/src/path.ts
+++ b/packages/internal-helpers/src/path.ts
@@ -15,10 +15,6 @@ export function prependForwardSlash(path: string) {
 	return path[0] === '/' ? path : '/' + path;
 }
 
-export function collapseDuplicateSlashes(path: string) {
-	return path.replace(/(?<!:)\/{2,}/g, '/');
-}
-
 export const MANY_TRAILING_SLASHES = /\/{2,}$/g;
 
 export function collapseDuplicateTrailingSlashes(path: string, trailingSlash: boolean) {
@@ -44,18 +40,14 @@ export function trimSlashes(path: string) {
 	return path.replace(/^\/|\/$/g, '');
 }
 
-export function startsWithForwardSlash(path: string) {
-	return path[0] === '/';
-}
-
-export function startsWithDotDotSlash(path: string) {
+function startsWithDotDotSlash(path: string) {
 	const c1 = path[0];
 	const c2 = path[1];
 	const c3 = path[2];
 	return c1 === '.' && c2 === '.' && c3 === '/';
 }
 
-export function startsWithDotSlash(path: string) {
+function startsWithDotSlash(path: string) {
 	const c1 = path[0];
 	const c2 = path[1];
 	return c1 === '.' && c2 === '/';
@@ -63,12 +55,6 @@ export function startsWithDotSlash(path: string) {
 
 export function isRelativePath(path: string) {
 	return startsWithDotDotSlash(path) || startsWithDotSlash(path);
-}
-
-export function isAbsolutePath(path: string) {
-	// Unix absolute paths start with /
-	// Windows absolute paths start with drive letter (C:, D:, etc)
-	return startsWithForwardSlash(path) || /^[a-zA-Z]:/.test(path);
 }
 
 function isString(path: unknown): path is string {


### PR DESCRIPTION
## Changes

- Closes #15311
- I was looking at writing tests then updating the implementation of `collapseDuplicateSlashes()` when I realized...we don't even use this function anymore!
- So I went through all the exports of the `path` submodule and removed any unused one

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
