### PR TITLE
chore: disable engines in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,11 @@
       "matchManagers": ["github-actions"]
     },
     {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    },
+    {
       "groupName": "astro dependencies",
       "matchManagers": ["npm"],
       "matchFileNames": [
@@ -67,6 +72,7 @@
     "@biomejs/biome",
     "knip",
     "@types/node",
+    "@types/vscode",
 
     // TODO: investigate upgrade (zod import issues with atproto)
     "astro-embed",
@@ -74,14 +80,10 @@
     // TODO: investigate upgrade (has type issues)
     "drizzle-orm",
     "sharp",
+
     // manually bumping workflow actions
     "actions/labeler",
-    // ignore "engines" update
-    "node",
-    "npm",
-    "pnpm",
-    "vscode",
-    "@types/vscode",
+
     // follow vite deps version
     "postcss-load-config",
     "esbuild"


### PR DESCRIPTION
## Changes

- Before, we disabled updating node/yarn/pnpm because it would cause `engines` to be updated.
- After, we specifically disable `engines` which still allows eg. `pnpm` to be updated in the monorepo

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
