### PR TITLE
fix(docs): update fonts heading level in config reference

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2382,6 +2382,7 @@ export interface AstroUserConfig<
 
 	/**
 	 * @docs
+	 * @kind heading
 	 * @name fonts
 	 * @type {Array<FontFamily>}
 	 * @default `[]`


### PR DESCRIPTION
## Changes

Updates the JSDoc for `fonts` config to include `@kind heading`. We got the auto-generated PR in docs https://github.com/withastro/docs/pull/13191 but the [heading level is wrong](https://deploy-preview-13191--astro-docs-2.netlify.app/en/reference/configuration-reference/#fonts). Looking at the other entries, I think all we miss is `@kind heading`...

## Testing

N/A

## Docs

This is docs, and I don't think we need a changeset for this.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
