### PR TITLE
fix: content layer loaders can use dynamic imports

### DIFF
--- a/.changeset/fix-vite-runner-closed.md
+++ b/.changeset/fix-vite-runner-closed.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes content layer loaders that use dynamic imports
+
+Content collection loaders can now use `await import()` and `import.meta.glob()` to dynamically import modules during build. Previously, these would fail with "Vite module runner has been closed."

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -278,6 +278,16 @@ describe('Content Layer', () => {
 			});
 		});
 
+		// Regression test for https://github.com/withastro/astro/issues/12689
+		it('returns a collection from a loader that uses dynamic import', async () => {
+			assert.ok(json.hasOwnProperty('dynamicImportLoader'));
+			assert.ok(Array.isArray(json.dynamicImportLoader));
+			// Should have loaded cats.json via dynamic import
+			const ids = json.dynamicImportLoader.map((item) => item.data.id);
+			assert.ok(ids.includes('siamese'), 'Should include siamese cat');
+			assert.ok(ids.includes('tabby'), 'Should include tabby cat');
+		});
+
 		it('transforms a reference id to a reference object', async () => {
 			assert.ok(json.hasOwnProperty('entryWithReference'));
 			assert.deepEqual(json.entryWithReference.data.cat, { collection: 'cats', id: 'tabby' });

--- a/packages/astro/test/fixtures/content-layer/src/content.config.ts
+++ b/packages/astro/test/fixtures/content-layer/src/content.config.ts
@@ -365,6 +365,23 @@ const renderMarkdownTest = defineCollection({
 	}),
 });
 
+// Collection that uses dynamic import in loader - tests fix for #12689
+const dynamicImport = defineCollection({
+	loader: async () => {
+		// This dynamic import would fail with "Vite module runner has been closed" before the fix
+		const data = await import('./data/cats.json');
+		return data.default;
+	},
+	schema: z.object({
+		breed: z.string(),
+		id: z.string(),
+		size: z.string(),
+		origin: z.string(),
+		lifespan: z.string(),
+		temperament: z.array(z.string()),
+	}),
+});
+
 export const collections = {
 	blog,
 	dogs,
@@ -386,6 +403,7 @@ export const collections = {
 	rodents,
 	rockets,
 	renderMarkdownTest,
+	dynamicImport,
 	notADirectory,
 	nothingMatches
 };

--- a/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
@@ -48,6 +48,9 @@ export async function GET() {
 
 	const renderMarkdownTest = await getEntry('renderMarkdownTest', 'with-frontmatter');
 	const renderMarkdownWithImage = await getEntry('renderMarkdownTest', 'with-image');
+
+	// Test for #12689 - dynamic import in loader
+	const dynamicImportLoader = await getCollection('dynamicImport');
 	
 	return new Response(
 		devalue.stringify({
@@ -77,6 +80,7 @@ export async function GET() {
 			spacecraftNoBody: spacecraftNoBody.map(({id, body}) => ({id, body})),
 			renderMarkdownTest,
 			renderMarkdownWithImage,
+			dynamicImportLoader,
 		})
 	);
 }


### PR DESCRIPTION
## Changes

- Fixes content collection loaders that use dynamic imports (`await import()`, `import.meta.glob()`) failing during build with "Vite module runner has been closed"
- Refactors sync to keep the Vite server alive through both content config loading and content layer sync phases
- Adds regression test for dynamic imports in loaders

Fixes #12689

## Testing

Added a test case to `content-layer.test.js` that creates a collection loader using `await import()` to load data. This test failed before the fix and passes after.

## Docs

N/A, bug fix