### PR TITLE
examples: add main landmark to minimal example

### DIFF
--- a/examples/minimal/src/pages/index.astro
+++ b/examples/minimal/src/pages/index.astro
@@ -12,6 +12,8 @@
 		<title>Astro</title>
 	</head>
 	<body>
-		<h1>Astro</h1>
+		<main>
+			<h1>Astro</h1>
+		</main>
 	</body>
 </html>


### PR DESCRIPTION
Adds a `<main>` landmark to the minimal example page to improve semantic HTML and accessibility. The visual output remains unchanged.
