### PR TITLE
fix(astro): ensure `req.url` has a starting `/` when modifying it in the internal base middleware

### DIFF
--- a/.changeset/purple-steaks-begin.md
+++ b/.changeset/purple-steaks-begin.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Avoid generating `req.url` without the starting `/` by the internal base middleware.
+Fixes a bug where some requests to the dev server didn't start with the leading `/`.

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
-import { appendForwardSlash } from '@astrojs/internal-helpers/path';
+import { appendForwardSlash, prependForwardSlash } from '@astrojs/internal-helpers/path';
 import colors from 'piccolore';
 import type * as vite from 'vite';
 import type { Logger } from '../core/logger/core.js';
@@ -32,7 +32,7 @@ export function baseMiddleware(
 
 		if (pathname.startsWith(devRoot)) {
 			req.url = url.replace(devRoot, devRootReplacement);
-			if (!req.url.startsWith('/')) req.url = '/' + req.url;
+			if (!req.url.startsWith('/')) req.url = prependForwardSlash(req.url);
 			return next();
 		}
 


### PR DESCRIPTION
## Changes

This PR fixes the following error found in ecosystem-ci:

> [ERROR] [vite] Internal server error: The specifiers must be a non-empty string. Received ""
> https://github.com/vitejs/vite-ecosystem-ci/actions/runs/21699933912/job/62578172408#step:7:1774

This error was happening because astro's internal base middleware was assigning a string without the starting `/` to `req.url`.

## Testing

Tested on ecosystem-ci: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/21707585317/job/62602560591

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No user facing change

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
