### PR TITLE
fix(routing): improve error for invalid dynamic redirect destinations

### DIFF
--- a/.changeset/better-redirect-error.md
+++ b/.changeset/better-redirect-error.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Improves error message when a dynamic redirect destination does not match any existing route.
+
+Previously, configuring a redirect like `/categories/[category]` → `/categories/[category]/1` in static output mode would fail with a misleading "getStaticPaths required" error. Now, Astro detects this early and provides a clear error explaining that the destination does not match any existing route.

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1004,6 +1004,23 @@ export const UnsupportedExternalRedirect = {
 /**
  * @docs
  * @see
+ * - [Configured redirects](https://docs.astro.build/en/guides/routing/#configured-redirects)
+ * @description
+ * A dynamic redirect destination must match an existing route pattern.
+ * This error occurs when a redirect with dynamic parameters points to a destination
+ * that doesn't correspond to any page in your project.
+ */
+export const InvalidRedirectDestination = {
+	name: 'InvalidRedirectDestination',
+	title: 'Invalid redirect destination.',
+	message: (from: string, to: string) =>
+		`The redirect from "${from}" to "${to}" is invalid. The destination "${to}" does not match any existing route in your project.`,
+	hint: 'If you are redirecting to a specific page of a dynamic route (e.g., "/posts/[slug]/1"), this is not supported. The destination must be either a static path or a route pattern that matches an existing page (e.g., "/posts/[slug]/[page]").',
+} satisfies ErrorData;
+
+/**
+ * @docs
+ * @see
  * - [Dynamic routes](https://docs.astro.build/en/guides/routing/#dynamic-routes)
  * @description
  * A dynamic route param is invalid. This is often caused by an `undefined` parameter or a missing [rest parameter](https://docs.astro.build/en/guides/routing/#rest-parameters).

--- a/packages/astro/test/fixtures/redirects/src/pages/categories/[category]/[page].astro
+++ b/packages/astro/test/fixtures/redirects/src/pages/categories/[category]/[page].astro
@@ -1,0 +1,20 @@
+---
+export function getStaticPaths() {
+	return [
+		{ params: { category: 'food', page: '1' } },
+		{ params: { category: 'food', page: '2' } },
+		{ params: { category: 'technology', page: '1' } },
+	];
+}
+
+const { category, page } = Astro.params;
+---
+<html>
+	<head>
+		<title>{category} - Page {page}</title>
+	</head>
+	<body>
+		<h1>{category}</h1>
+		<p>Page {page}</p>
+	</body>
+</html>


### PR DESCRIPTION
## Changes

- Adds early validation in `createRedirectRoutes()` to detect when a dynamic redirect destination doesn't match any existing route
- Throws a new `InvalidRedirectDestination` error with a clear message instead of the misleading "getStaticPaths required" error
- Only applies to static output mode (server mode handles dynamic redirects at runtime)

Closes #12036. Supersedes #14161 which was closed due to inactivity.

## Testing

Added test case in `packages/astro/test/redirects.test.js` that reproduces the issue and verifies the new error message.

## Docs

N/A, bug fix