### PR TITLE
chore: add missing changeset for vue integration

### DIFF
--- a/.changeset/vite-plugin-vue-v6.md
+++ b/.changeset/vite-plugin-vue-v6.md
@@ -2,6 +2,4 @@
 '@astrojs/vue': minor
 ---
 
-Updates `@vitejs/plugin-vue` to v6, `@vitejs/plugin-vue-jsx` to v5, and `vite-plugin-vue-devtools` to v8
-
-Some options may now differ, refer to these packages changelogs to learn more
+Updates `@vitejs/plugin-vue` to v6, `@vitejs/plugin-vue-jsx` to v5, and `vite-plugin-vue-devtools` to v8. No changes are needed from users.


### PR DESCRIPTION
## Changes

<!-- 
- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.
-->

Add a changeset to trigger a new beta version of `@astrojs/vue`. The following dependencies have been updated to new major versions.

| Dependency | Published ([6.0.0-beta.0](https://unpkg.com/@astrojs/vue@6.0.0-beta.0/package.json)) | Local |
|---|---|---|
| `@vitejs/plugin-vue` | v5 | v6 |
| `@vitejs/plugin-vue-jsx` | v4 | v5 |
| `vite-plugin-vue-devtools` | v7 | v8 |


## Testing

No code change.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Only new changeset.


<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
