### PR TITLE
fix(create-astro): validate integration names to prevent shell injection

### DIFF
--- a/.changeset/fix-add-shell-injection.md
+++ b/.changeset/fix-add-shell-injection.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes shell command injection via `--add` flag by validating integration names against npm package name pattern before passing to shell

--- a/packages/create-astro/test/dependencies.test.js
+++ b/packages/create-astro/test/dependencies.test.js
@@ -6,6 +6,54 @@ import { setup } from './utils.js';
 describe('dependencies', () => {
 	const fixture = setup();
 
+	it('rejects integration names with shell metacharacters', async () => {
+		const context = {
+			cwd: '',
+			yes: true,
+			packageManager: 'npm',
+			dryRun: true,
+			prompt: () => ({ deps: true }),
+			add: ['react; open -a Calculator.app;'],
+		};
+
+		await dependencies(context);
+
+		assert.ok(fixture.hasMessage('Invalid integration name(s)'));
+		assert.deepEqual(context.add, []);
+	});
+
+	it('accepts valid integration names', async () => {
+		const context = {
+			cwd: '',
+			yes: true,
+			packageManager: 'npm',
+			dryRun: true,
+			prompt: () => ({ deps: true }),
+			add: ['react', '@astrojs/tailwind', 'vue'],
+		};
+
+		await dependencies(context);
+
+		assert.ok(!fixture.hasMessage('Invalid integration name(s)'));
+		assert.deepEqual(context.add, ['react', '@astrojs/tailwind', 'vue']);
+	});
+
+	it('filters out only invalid integration names', async () => {
+		const context = {
+			cwd: '',
+			yes: true,
+			packageManager: 'npm',
+			dryRun: true,
+			prompt: () => ({ deps: true }),
+			add: ['react', 'vue; rm -rf /', 'svelte'],
+		};
+
+		await dependencies(context);
+
+		assert.ok(fixture.hasMessage('Invalid integration name(s)'));
+		assert.deepEqual(context.add, ['react', 'svelte']);
+	});
+
 	it('--yes', async () => {
 		const context = {
 			cwd: '',


### PR DESCRIPTION
## Description

Fixes #15420

The `--add` flag was passing user input directly to shell commands, allowing shell metacharacters to be interpreted as shell syntax. For example:

```bash
npm create --yes astro poc -- --add "react; open -a Calculator.app;" --install --yes
```

Would result in `open -a Calculator.app` being executed.

## Changes

- Added `VALID_INTEGRATION_NAME` regex pattern that matches valid npm package names (lowercase letters, numbers, hyphens, underscores, dots, and scoped packages)
- Added `isValidIntegrationName()` validation function  
- Invalid integration names are now filtered out with a clear error message
- Added 3 tests for validation behavior:
  - Rejects integration names with shell metacharacters
  - Accepts valid integration names
  - Filters out only invalid names (keeps valid ones)

## Testing

All 73 tests pass, including the 3 new tests:
- `rejects integration names with shell metacharacters` ✔
- `accepts valid integration names` ✔  
- `filters out only invalid integration names` ✔
