### PR TITLE
fix(docs): update config types to reflect changes made in docs

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2293,7 +2293,10 @@ export interface AstroUserConfig<
 		 * @version 5.0.0
 		 * @description
 		 *
-		 * An object that uses `envField` to define the data type and properties of your environment variables: `context` (client or server), `access` (public or secret), a `default` value to use, and whether or not this environment variable is `optional` (defaults to `false`).
+		 * Defines environment variables to be enforced by Zod validation and for which TypeScript support (e.g. autocompletion, type-safety) is available. Each key corresponds to the variable name and the value to the data type and validations [defined with `envField`](https://v6.docs.astro.build/en/reference/modules/astro-config/#envfield).
+		 *
+		 * Four data types are supported: string, number, enumeration, and boolean. Each type requires a `context` (client or server), an `access` level (public or secret), and additional validations, such as a `default` value and an indication of whether the variable is `optional` (defaults to `false`).
+		 *
 		 * ```js
 		 * // astro.config.mjs
 		 * import { defineConfig, envField } from "astro/config"
@@ -2306,46 +2309,6 @@ export interface AstroUserConfig<
 		 *       API_SECRET: envField.string({ context: "server", access: "secret" }),
 		 *     }
 		 *   }
-		 * })
-		 * ```
-		 *
-		 * `envField` supports four data types: string, number, enum, and boolean. `context` and `access` are required properties for all data types. The following shows the complete list of properties available for each data type:
-		 *
-		 * ```js
-		 * import { envField } from "astro/config"
-		 *
-		 * envField.string({
-		 *    // context & access
-		 *    optional: true,
-		 *    default: "foo",
-		 *    max: 20,
-		 *    min: 1,
-		 *    length: 13,
-		 *    url: true,
-		 *    includes: "oo",
-		 *    startsWith: "f",
-		 *    endsWith: "o",
-		 * })
-		 * envField.number({
-		 *    // context & access
-		 *    optional: true,
-		 *    default: 15,
-		 *    gt: 2,
-		 *    min: 1,
-		 *    lt: 3,
-		 *    max: 4,
-		 *    int: true,
-		 * })
-		 * envField.boolean({
-		 *    // context & access
-		 *    optional: true,
-		 *    default: true,
-		 * })
-		 * envField.enum({
-		 *    // context & access
-		 *    values: ['foo', 'bar', 'baz'], // required
-		 *    optional: true,
-		 *    default: 'baz',
 		 * })
 		 * ```
 		 */


### PR DESCRIPTION
## Changes

Updates `types/public/config.ts` to reflect docs changes made in https://github.com/withastro/docs/pull/13222

We decided to:
* move `envField` documentation to the [`astro:config` module page](https://v6.docs.astro.build/en/reference/modules/astro-config/#envfield)
* reword the `env.schema` description to reflect this change

The docs PR has been approved and merged, but we still need to make those changes here!

## Testing

N/A

## Docs

This is docs! No changeset added because this doesn't fix anything, this is only some docs reorganization.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
