### PR TITLE
fix(astro): resolve non-ASCII target paths in Astro.rewrite

### DIFF
--- a/.changeset/fix-rewrite-non-ascii-paths.md
+++ b/.changeset/fix-rewrite-non-ascii-paths.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.rewrite` returning 404 when rewriting to a URL with non-ASCII characters
+
+When rewriting to a path containing non-ASCII characters (e.g., `/redirected/héllo`), the route lookup compared encoded `distURL` hrefs against decoded pathnames, causing the comparison to always fail and resulting in a 404. This fix compares against the encoded pathname instead.

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -111,12 +111,13 @@ export function findRouteToRewrite({
 				route.distURL.length !== 0
 			) {
 				// Remove outDir from beginning of distURL
-				// Remove /index.html or .html from end of distURL and compare with decodedPathname
+				// Remove /index.html or .html from end of distURL and compare with pathname
+				// Use pathname (encoded) instead of decodedPathname because url.href is encoded
 				if (
 					!route.distURL.find(
 						(url) =>
 							url.href.replace(outDir.toString(), '').replace(/(?:\/index\.html|\.html)$/, '') ==
-							trimSlashes(decodedPathname),
+							trimSlashes(pathname),
 					)
 				) {
 					continue;

--- a/packages/astro/test/fixtures/reroute/src/pages/redirected/[slug].astro
+++ b/packages/astro/test/fixtures/reroute/src/pages/redirected/[slug].astro
@@ -1,0 +1,19 @@
+---
+export function getStaticPaths() {
+	return [
+		{ params: { slug: 'héllo' } },
+	];
+}
+
+return Astro.rewrite("/")
+
+---
+
+<html>
+<head>
+	<title>Redirected [slug].astro</title>
+</head>
+<body>
+<h1>/redirected/[slug].astro</h1>
+</body>
+</html>

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -56,6 +56,13 @@ describe('Dev reroute', () => {
 		assert.equal($('h1').text(), 'Index');
 	});
 
+	it('should render the index page when rewriting from a non-ASCII path /redirected/héllo ', async () => {
+		const html = await fixture.fetch('/redirected/h%C3%A9llo').then((res) => res.text());
+		const $ = cheerioLoad(html);
+
+		assert.equal($('h1').text(), 'Index');
+	});
+
 	it('should return a 404', async () => {
 		const response = await fixture.fetch('/blog/oops');
 
@@ -346,6 +353,13 @@ describe('Build reroute', () => {
 		assert.equal($('h1').text(), 'Index');
 	});
 
+	it('should create the index page when rewriting from a non-ASCII path /redirected/héllo ', async () => {
+		const html = await fixture.readFile('/redirected/héllo/index.html');
+		const $ = cheerioLoad(html);
+
+		assert.equal($('h1').text(), 'Index');
+	});
+
 	it('should create the 404 built-in page', async () => {
 		try {
 			await fixture.readFile('/spread/oops/index.html');
@@ -425,6 +439,15 @@ describe('SSR reroute', () => {
 
 	it('should render the index page when navigating spread route /spread/[...spread] ', async () => {
 		const request = new Request('http://example.com/spread/hello');
+		const response = await app.render(request);
+		const html = await response.text();
+		const $ = cheerioLoad(html);
+
+		assert.equal($('h1').text(), 'Index');
+	});
+
+	it('should render the index page when rewriting from a non-ASCII path /redirected/héllo ', async () => {
+		const request = new Request('http://example.com/redirected/h%C3%A9llo');
 		const response = await app.render(request);
 		const html = await response.text();
 		const $ = cheerioLoad(html);


### PR DESCRIPTION
Closes #14464

## Changes

Fixes `Astro.rewrite` returning 404 when rewriting to a URL with non-ASCII characters (e.g., `/redirected/héllo`).

- In `findRouteToRewrite`, the `distURL` href comparison now uses the encoded `pathname` instead of `decodedPathname`, since `url.href` values are always percent-encoded
- Added a dynamic route fixture with non-ASCII characters (`/redirected/[slug]` with `héllo` param)

## Testing

Added tests for all three modes:
- **Dev**: fetching `/redirected/h%C3%A9llo` renders the index page
- **Build (SSG)**: `/redirected/héllo/index.html` is generated correctly
- **SSR**: request to `/redirected/h%C3%A9llo` renders the index page

All 63 rewrite-related tests pass, including the 3 new ones.

## Docs

No docs changes needed — this is a bug fix for existing `Astro.rewrite` behavior.