### PR TITLE
chore(renovate): group lockfile maintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,10 @@
   "rangeStrategy": "bump",
   "postUpdateOptions": ["pnpmDedupe"],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "packageRules": [{
+      "groupName": null
+    }]
   },
   "ignorePaths": [
     "**/node_modules/**",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
     "source.fixAll.biome": "explicit"
+  },
+  "files.associations": {
+    "*.json5": "jsonc"
   }
 }


### PR DESCRIPTION
## Changes

- Currently, lockfile maintenance occurs per group which is not useful. This PR attempts to group lockfile maintenance in one PR

<img width="2327" height="455" alt="image" src="https://github.com/user-attachments/assets/3c30fd79-c9c1-45a3-bf63-74822be50de9" />


## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
