### PR TITLE
fix(astro): render island styles in head instead of body

### DIFF
--- a/.changeset/fix-island-styles-in-head.md
+++ b/.changeset/fix-island-styles-in-head.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Moves `astro-island` styles (`display:contents`) from `<body>` to `<head>`
+
+The `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>` tag was previously rendered inline in the `<body>` alongside hydration scripts, causing HTML validation errors. It is now included in the `<head>` via `result.styles` when framework renderers are configured.

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -36,6 +36,7 @@ import { renderRedirect } from './redirects/render.js';
 import { getParams, getProps, type Pipeline, Slots } from './render/index.js';
 import { isRoute404or500, isRouteExternalRedirect, isRouteServerIsland } from './routing/match.js';
 import { copyRequest, getOriginPathname, setOriginPathname } from './routing/rewrite.js';
+import { ISLAND_STYLES } from '../runtime/server/astro-island-styles.js';
 import { AstroSession } from './session/runtime.js';
 import { validateAndDecodePathname } from './util/pathname.js';
 
@@ -521,6 +522,17 @@ export class RenderContext {
 			pipeline;
 		const { links, scripts, styles } = await pipeline.headElements(routeData);
 
+		// Check if the pipeline already added island styles to head (e.g. BuildPipeline
+		// adds them for pages with hydrated components). This flag tells getPrescripts()
+		// to skip inlining island styles in the body, avoiding duplication.
+		let islandStylesInHead = false;
+		for (const style of styles) {
+			if (style.children === ISLAND_STYLES) {
+				islandStylesInHead = true;
+				break;
+			}
+		}
+
 		const extraStyleHashes = [];
 		const extraScriptHashes = [];
 		const shouldInjectCspMetaTags = this.shouldInjectCspMetaTags;
@@ -589,6 +601,7 @@ export class RenderContext {
 				renderedScripts: new Set(),
 				hasDirectives: new Set(),
 				hasRenderedServerIslandRuntime: false,
+				islandStylesInHead,
 				headInTree: false,
 				extraHead: [],
 				extraStyleHashes,

--- a/packages/astro/src/runtime/server/scripts.ts
+++ b/packages/astro/src/runtime/server/scripts.ts
@@ -35,10 +35,16 @@ export function getPrescripts(result: SSRResult, type: PrescriptType, directive:
 	// an astro-island element, the callbacks will fire immediately, causing the JS
 	// deps to be loaded immediately.
 	switch (type) {
-		case 'both':
-			return `<style>${ISLAND_STYLES}</style><script>${getDirectiveScriptText(result, directive)}</script><script>${
+		case 'both': {
+			// If the pipeline already placed island styles in <head>, skip inlining them
+			// in <body>. Otherwise fall back to the inline <style> (e.g. dev / SSR).
+			const styles = result._metadata.islandStylesInHead
+				? ''
+				: `<style>${ISLAND_STYLES}</style>`;
+			return `${styles}<script>${getDirectiveScriptText(result, directive)}</script><script>${
 				process.env.NODE_ENV === 'development' ? islandScriptDev : islandScript
 			}</script>`;
+		}
 		case 'directive':
 			return `<script>${getDirectiveScriptText(result, directive)}</script>`;
 	}

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -292,6 +292,11 @@ export interface SSRMetadata {
 	hasRenderedHead: boolean;
 	hasRenderedServerIslandRuntime: boolean;
 	/**
+	 * Whether island styles (astro-island { display: contents }) were already added
+	 * to the page's <head> by the pipeline, so they don't need to be inlined in the body.
+	 */
+	islandStylesInHead: boolean;
+	/**
 	 * Used to signal the rendering engine if the current route (page) contains the
 	 * <head> element.
 	 */

--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -84,9 +84,9 @@ describe('CSS', function () {
 				}
 			});
 
-			it('Using hydrated components adds astro-island styles', async () => {
-				const inline = $('style').html();
-				assert.equal(inline.includes('display:contents'), true);
+			it('Using hydrated components adds astro-island styles in head', async () => {
+				const headStyles = $('head style').toArray().map((el) => $(el).html());
+				assert.equal(headStyles.some((s) => s.includes('display:contents')), true);
 			});
 
 			it('<style lang="sass">', async () => {


### PR DESCRIPTION
## Changes

Fixes #13832

The `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>` tag was rendered inline in the `<body>` alongside hydration scripts when the first hydrated component was encountered. This caused HTML validation errors since `<style>` tags should be in the `<head>`.

### Approach

**Build (SSG):** Island styles are added to `<head>` via `BuildPipeline.headElements()` only for pages that actually use hydrated components, using the `pagesByHydratedComponent` map populated during the build analysis phase. This is precise — pages without islands get no extra styles.

**Dev / SSR:** Island styles continue to be inlined in `<body>` by `getPrescripts()` as a fallback, since the dev pipeline does not have per-page hydration information at head-render time.

A new `islandStylesInHead` flag on `SSRMetadata` prevents duplication when both mechanisms would otherwise apply.

### Files changed
- `packages/astro/src/core/build/pipeline.ts` — Add island styles to `headElements()` for pages with hydrated components
- `packages/astro/src/core/render-context.ts` — Detect if pipeline already added island styles, set metadata flag
- `packages/astro/src/runtime/server/scripts.ts` — Skip inline `<style>` when island styles are already in head; keep inline fallback for dev/SSR
- `packages/astro/src/types/public/internal.ts` — Add `islandStylesInHead` to `SSRMetadata`
- `packages/astro/test/0-css.test.js` — Update test to verify island styles are in `<head>`

## Testing

- All 5 previously failing CI tests now pass (Vue, astro-basic, astro-partial-html, content-collections-render, 0-css)
- Build passes cleanly
- CodSpeed reports +10.31% performance improvement on hybrid build benchmark

## Docs

No documentation changes needed — this is a rendering behavior fix.