### PR TITLE
Validate Host header against allowedDomains

### DIFF
--- a/.changeset/calm-birds-fly.md
+++ b/.changeset/calm-birds-fly.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Improves error page loading to read from disk first before falling back to configured host

--- a/.changeset/strong-wolves-march.md
+++ b/.changeset/strong-wolves-march.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves Host header handling for SSR deployments behind proxies

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -1,6 +1,39 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { createReadStream } from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
 import { NodeApp } from 'astro/app/node';
+import { resolveClientDir } from './shared.js';
 import type { Options, RequestHandler } from './types.js';
+
+/**
+ * Read a prerendered error page from disk and return it as a Response.
+ * Returns undefined if the file doesn't exist or can't be read.
+ */
+async function readErrorPageFromDisk(client: string, status: number): Promise<Response | undefined> {
+	// Try both /404.html and /404/index.html patterns
+	const filePaths = [`${status}.html`, `${status}/index.html`];
+
+	for (const filePath of filePaths) {
+		const fullPath = path.join(client, filePath);
+		try {
+			const stream = createReadStream(fullPath);
+			// Wait for the stream to open successfully or error
+			await new Promise<void>((resolve, reject) => {
+				stream.once('open', () => resolve());
+				stream.once('error', reject);
+			});
+			const webStream = Readable.toWeb(stream) as ReadableStream;
+			return new Response(webStream, {
+				headers: { 'Content-Type': 'text/html; charset=utf-8' },
+			});
+		} catch {
+			// File doesn't exist or can't be read, try next pattern
+		}
+	}
+
+	return undefined;
+}
 
 /**
  * Creates a Node.js http listener for on-demand rendered pages, compatible with http.createServer and Connect middleware.
@@ -20,18 +53,30 @@ export function createAppHandler(app: NodeApp, options: Options): RequestHandler
 		console.error(reason);
 	});
 
-	const originUrl = options.experimentalErrorPageHost
-		? new URL(options.experimentalErrorPageHost)
-		: undefined;
+	const client = resolveClientDir(options);
 
-	const prerenderedErrorPageFetch = originUrl
-		? (url: string) => {
-				const errorPageUrl = new URL(url);
-				errorPageUrl.protocol = originUrl.protocol;
-				errorPageUrl.host = originUrl.host;
-				return fetch(errorPageUrl);
-			}
-		: undefined;
+	// Read prerendered error pages directly from disk instead of fetching over HTTP.
+	// This avoids SSRF risks and is more efficient.
+	const prerenderedErrorPageFetch = async (url: string): Promise<Response> => {
+		if (url.includes('/404')) {
+			const response = await readErrorPageFromDisk(client, 404);
+			if (response) return response;
+		}
+		if (url.includes('/500')) {
+			const response = await readErrorPageFromDisk(client, 500);
+			if (response) return response;
+		}
+		// Fallback: if experimentalErrorPageHost is configured, fetch from there
+		if (options.experimentalErrorPageHost) {
+			const originUrl = new URL(options.experimentalErrorPageHost);
+			const errorPageUrl = new URL(url);
+			errorPageUrl.protocol = originUrl.protocol;
+			errorPageUrl.host = originUrl.host;
+			return fetch(errorPageUrl);
+		}
+		// No file found and no fallback configured - return empty response
+		return new Response(null, { status: 404 });
+	};
 
 	return async (req, res, next, locals) => {
 		let request: Request;

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -1,10 +1,10 @@
 import fs from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import path from 'node:path';
-import url from 'node:url';
 import { hasFileExtension, isInternalPath } from '@astrojs/internal-helpers/path';
 import type { NodeApp } from 'astro/app/node';
 import send from 'send';
+import { resolveClientDir } from './shared.js';
 import type { Options } from './types.js';
 
 /**
@@ -122,27 +122,6 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 	};
 }
 
-function resolveClientDir(options: Options) {
-	const clientURLRaw = new URL(options.client);
-	const serverURLRaw = new URL(options.server);
-	const rel = path.relative(url.fileURLToPath(serverURLRaw), url.fileURLToPath(clientURLRaw));
-
-	// walk up the parent folders until you find the one that is the root of the server entry folder. This is how we find the client folder relatively.
-	const serverFolder = path.basename(options.server);
-	let serverEntryFolderURL = path.dirname(import.meta.url);
-	while (!serverEntryFolderURL.endsWith(serverFolder)) {
-		serverEntryFolderURL = path.dirname(serverEntryFolderURL);
-	}
-	const serverEntryURL = serverEntryFolderURL + '/entry.mjs';
-	const clientURL = new URL(appendForwardSlash(rel), serverEntryURL);
-	const client = url.fileURLToPath(clientURL);
-	return client;
-}
-
 function prependForwardSlash(pth: string) {
 	return pth.startsWith('/') ? pth : '/' + pth;
-}
-
-function appendForwardSlash(pth: string) {
-	return pth.endsWith('/') ? pth : pth + '/';
 }

--- a/packages/integrations/node/src/shared.ts
+++ b/packages/integrations/node/src/shared.ts
@@ -1,1 +1,36 @@
+import path from 'node:path';
+import url from 'node:url';
+import { appendForwardSlash } from '@astrojs/internal-helpers/path';
+import type { Options } from './types.js';
+
 export const STATIC_HEADERS_FILE = '_headers.json';
+
+/**
+ * Resolves the client directory path at runtime.
+ *
+ * At build time, we know the relative path between server and client directories.
+ * At runtime, we need to find the actual location based on where the server entry is running.
+ */
+export function resolveClientDir(options: Options) {
+	// options.client and options.server are file:// URLs set at build time
+	// e.g., "file:///project/dist/client/" and "file:///project/dist/server/"
+	const clientURLRaw = new URL(options.client);
+	const serverURLRaw = new URL(options.server);
+
+	// Calculate relative path from server to client (e.g., "../client")
+	// This relative path is stable regardless of where the build output is deployed
+	const rel = path.relative(url.fileURLToPath(serverURLRaw), url.fileURLToPath(clientURLRaw));
+
+	// Find the server entry folder by walking up from this file's location
+	// We need to find the actual runtime location, not the build-time paths
+	const serverFolder = path.basename(options.server);
+	let serverEntryFolderURL = path.dirname(import.meta.url);
+	while (!serverEntryFolderURL.endsWith(serverFolder)) {
+		serverEntryFolderURL = path.dirname(serverEntryFolderURL);
+	}
+
+	// Resolve the client directory by applying the relative path to the runtime server location
+	const serverEntryURL = serverEntryFolderURL + '/entry.mjs';
+	const clientURL = new URL(appendForwardSlash(rel), serverEntryURL);
+	return url.fileURLToPath(clientURL);
+}

--- a/packages/integrations/node/test/error-page-host.test.js
+++ b/packages/integrations/node/test/error-page-host.test.js
@@ -1,8 +1,26 @@
 import * as assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { after, before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
+
+/**
+ * Integration that removes prerendered error pages after build.
+ * This forces the fallback to experimentalErrorPageHost.
+ */
+function removeErrorPages() {
+	return {
+		name: 'remove-error-pages',
+		hooks: {
+			'astro:build:done': async ({ dir }) => {
+				// dir already points to the client output directory
+				await fs.unlink(new URL('404.html', dir));
+				await fs.unlink(new URL('500.html', dir));
+			},
+		},
+	};
+}
 
 describe('Prerendered error page host', () => {
 	/** @type {import('./test-utils').Fixture} */
@@ -38,6 +56,7 @@ describe('Prerendered error page host', () => {
 		fixture = await loadFixture({
 			root: './fixtures/prerender-error-page/',
 			adapter: nodejs({ mode: 'standalone', experimentalErrorPageHost: 'http://localhost:3030' }),
+			integrations: [removeErrorPages()],
 		});
 		await fixture.build();
 		devPreview = await fixture.preview();

--- a/packages/integrations/node/test/fixtures/api-route/astro.config.mjs
+++ b/packages/integrations/node/test/fixtures/api-route/astro.config.mjs
@@ -2,6 +2,12 @@ import { defineConfig} from "astro/config";
 
 export default defineConfig({
     security: {
-        checkOrigin: false
+        checkOrigin: false,
+        allowedDomains: [
+            {
+                hostname: 'localhost',
+                port: '4321'
+            }
+        ]
     }
 })

--- a/packages/integrations/node/test/fixtures/url/astro.config.mjs
+++ b/packages/integrations/node/test/fixtures/url/astro.config.mjs
@@ -9,6 +9,13 @@ export default defineConfig({
 			{
 				hostname: 'abc.xyz',
 				port: '444'
+			},
+			{
+				hostname: 'legitimate.example.com'
+			},
+			{
+				hostname: 'localhost',
+				port: '3000'
 			}
 		]
 	}


### PR DESCRIPTION

## Changes

- Add Host header validation against configured allowedDomains
- Rename rewrite-forwarded-headers.ts to validate-headers.ts since it does host validation now too.
- In Node adapter, read error page from disk to prevent going to network.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, bug fix