### PR TITLE
fixes syntax highlighting on lower case component usage

### DIFF
--- a/.changeset/lowercase-style-tags.md
+++ b/.changeset/lowercase-style-tags.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fix syntax highlighting for lowercase component tags that start with "style" or "script".

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "Astro",
   "scopeName": "source.astro",
-  "fileTypes": ["astro"],
+  "fileTypes": [
+    "astro"
+  ],
   "injections": {
     "L:(meta.script.astro) (meta.lang.json) - (meta source)": {
       "patterns": [
@@ -750,7 +752,7 @@
       ]
     },
     "tags-lang": {
-      "begin": "<(script|style)",
+      "begin": "<(script|style)(?=\\s|/?>)",
       "end": "</\\1\\s*>|/>",
       "beginCaptures": {
         "0": {

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -490,7 +490,7 @@ repository:
 
   # Language tags - they are handled differently for the purposes of language injection.
   tags-lang:
-    begin: <(script|style)
+    begin: <(script|style)(?=\s|/?>)
     end: </\1\s*>|/>
     beginCaptures: { 0: { patterns: [include: '#tags-start-node'] } }
     endCaptures: { 0: { patterns: [include: '#tags-end-node'] } }

--- a/packages/language-tools/vscode/test/grammar/fixtures/components/lowercase-style-prefix.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/components/lowercase-style-prefix.astro
@@ -1,0 +1,6 @@
+---
+const label = "Click Me";
+---
+
+<styled.button>{label}</styled.button>
+<div>After</div>

--- a/packages/language-tools/vscode/test/grammar/fixtures/components/lowercase-style-prefix.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/components/lowercase-style-prefix.astro.snap
@@ -1,0 +1,30 @@
+>---
+#^^^ source.astro comment
+>const label = "Click Me";
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.embedded.block.astro source.ts
+>---
+#^^^ source.astro comment
+>
+><styled.button>{label}</styled.button>
+#^ source.astro meta.scope.tag.styled.button.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.styled.button.astro meta.tag.start.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.styled.button.astro meta.tag.start.astro
+#        ^^^^^^ source.astro meta.scope.tag.styled.button.astro meta.tag.start.astro entity.name.tag.astro
+#              ^ source.astro meta.scope.tag.styled.button.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+#               ^ source.astro punctuation.section.embedded.begin.astro
+#                ^^^^^ source.astro meta.embedded.expression.astro source.tsx
+#                     ^ source.astro punctuation.section.embedded.end.astro
+#                      ^^ source.astro meta.scope.tag.styled.button.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#                        ^^^^^^ source.astro meta.scope.tag.styled.button.astro meta.tag.end.astro entity.name.tag.astro
+#                              ^ source.astro meta.scope.tag.styled.button.astro meta.tag.end.astro
+#                               ^^^^^^ source.astro meta.scope.tag.styled.button.astro meta.tag.end.astro entity.name.tag.astro
+#                                     ^ source.astro meta.scope.tag.styled.button.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+><div>After</div>
+#^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
+#    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+#     ^^^^^ source.astro text.astro
+#          ^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#            ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
+#               ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>


### PR DESCRIPTION
## Summary
- tighten the TextMate grammar so only exact `style`/`script` tags open language scopes
- add a snapshot fixture covering lowercase component tags like `<styled.button>`

Fixes #14680.

## Tests

- New snapshot test.

## Docs

N/A, bug fix