### PR TITLE
fix(hmr): invalidate SSR dependency cache

### DIFF
--- a/.changeset/fix-ssr-hmr-deps.md
+++ b/.changeset/fix-ssr-hmr-deps.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix SSR HMR to invalidate dependency modules so server-only updates reflect changes without restarting the dev server.

--- a/packages/astro/e2e/fixtures/hmr/src/pages/ssr-dep.astro
+++ b/packages/astro/e2e/fixtures/hmr/src/pages/ssr-dep.astro
@@ -1,0 +1,12 @@
+---
+import { testValue } from '../store/teststore';
+---
+
+<html>
+	<head>
+		<title>SSR Dependency Test</title>
+	</head>
+	<body>
+		<h1 id="ssr-output">{testValue}</h1>
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/hmr/src/store/registry.ts
+++ b/packages/astro/e2e/fixtures/hmr/src/store/registry.ts
@@ -1,0 +1,9 @@
+const storeCache = new Map();
+
+export function defineStore(name, value) {
+	const cached = storeCache.get(name);
+	if (cached) return cached;
+	const store = { value };
+	storeCache.set(name, store);
+	return store;
+}

--- a/packages/astro/e2e/fixtures/hmr/src/store/teststore.ts
+++ b/packages/astro/e2e/fixtures/hmr/src/store/teststore.ts
@@ -1,0 +1,4 @@
+import { defineStore } from './registry';
+
+export const store = defineStore('test', 'initial value');
+export const testValue = store.value;

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -1,4 +1,9 @@
-import type { EnvironmentModuleNode, Plugin } from 'vite';
+import {
+	isRunnableDevEnvironment,
+	normalizePath,
+	type EnvironmentModuleNode,
+	type Plugin,
+} from 'vite';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
 import { VIRTUAL_PAGE_RESOLVED_MODULE_ID } from '../vite-plugin-pages/const.js';
 import { getDevCssModuleNameFromPageVirtualModuleName } from '../vite-plugin-css/util.js';
@@ -20,13 +25,72 @@ export default function hmrReload(): Plugin {
 				let hasSsrOnlyModules = false;
 
 				const invalidatedModules = new Set<EnvironmentModuleNode>();
+				// Track SSR-only modules we invalidate for targeted runner cache cleanup.
+				const ssrOnlyModules = new Set<EnvironmentModuleNode>();
 				for (const mod of modules) {
 					if (mod.id == null) continue;
 					const clientModule = server.environments.client.moduleGraph.getModuleById(mod.id);
 					if (clientModule != null) continue;
 
+					// Invalidate SSR module + importers in the SSR module graph.
 					this.environment.moduleGraph.invalidateModule(mod, invalidatedModules, timestamp, true);
+					// Keep a list of SSR-only modules for runner cache invalidation.
+					ssrOnlyModules.add(mod);
 					hasSsrOnlyModules = true;
+				}
+
+				if (hasSsrOnlyModules && isRunnableDevEnvironment(this.environment)) {
+					// Access the SSR runner cache to invalidate evaluated module state.
+					const evaluatedModules = this.environment.runner.evaluatedModules;
+
+					const invalidateRunnerModule = (mod: EnvironmentModuleNode) => {
+						// Invalidate by module id when available.
+						if (mod.id) {
+							const runnerMod = evaluatedModules.getModuleById(mod.id);
+							if (runnerMod) evaluatedModules.invalidateModule(runnerMod);
+						}
+
+						// Invalidate by module url when available.
+						if (mod.url) {
+							const runnerMod = evaluatedModules.getModuleByUrl(mod.url);
+							if (runnerMod) evaluatedModules.invalidateModule(runnerMod);
+						}
+
+						// Invalidate by file path (normalized) when available.
+						if (mod.file) {
+							const normalizedFile = normalizePath(mod.file);
+							const runnerMods =
+								evaluatedModules.getModulesByFile(mod.file) ??
+								evaluatedModules.getModulesByFile(normalizedFile);
+							if (runnerMods) {
+								for (const runnerMod of runnerMods) {
+									evaluatedModules.invalidateModule(runnerMod);
+								}
+							}
+						}
+					};
+
+					// Collect the dependency subtree for SSR-only modules so dependencies re-evaluate.
+					const dependenciesToInvalidate = new Set<EnvironmentModuleNode>();
+					const collectDependencies = (mod: EnvironmentModuleNode) => {
+						if (dependenciesToInvalidate.has(mod)) return;
+						dependenciesToInvalidate.add(mod);
+						// Walk down the import graph to cover dependency modules.
+						for (const importedModule of mod.importedModules) {
+							if (!importedModule) continue;
+							collectDependencies(importedModule);
+						}
+					};
+
+					// Seed traversal from the SSR-only changed modules.
+					for (const mod of ssrOnlyModules) {
+						collectDependencies(mod);
+					}
+
+					// Invalidate runner cache entries for all dependencies we collected.
+					for (const mod of dependenciesToInvalidate) {
+						invalidateRunnerModule(mod);
+					}
 				}
 
 				// If any invalidated modules are virtual modules for pages, also invalidate their


### PR DESCRIPTION
## Changes
- invalidate SSR runner cache entries for dependency modules when SSR-only updates occur
- Fixes https://github.com/withastro/astro/issues/15021

## Testing
- new e2e test: SSR dependency invalidation in `packages/astro/e2e/hmr.test.js`

## Docs
N/A, bug fix