### PR TITLE
use matchProtocol when parsing the protocol in validate-headers.ts

### DIFF
--- a/.changeset/silent-dragons-jam.md
+++ b/.changeset/silent-dragons-jam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update validate-headers to use matchProtocol when parsing protocol

--- a/packages/astro/src/core/app/validate-headers.ts
+++ b/packages/astro/src/core/app/validate-headers.ts
@@ -1,4 +1,4 @@
-import { matchPattern, type RemotePattern } from '@astrojs/internal-helpers/remote';
+import { matchPattern, matchProtocol, type RemotePattern } from '@astrojs/internal-helpers/remote';
 
 /**
  * Sanitize a hostname by rejecting any with path separators.
@@ -93,7 +93,7 @@ export function validateForwardedHeaders(
 				// Validate against allowedDomains patterns
 				try {
 					const testUrl = new URL(`${forwardedProtocol}://example.com`);
-					const isAllowed = allowedDomains.some((pattern) => matchPattern(testUrl, pattern));
+					const isAllowed = allowedDomains.some((pattern) => matchProtocol(testUrl, pattern.protocol));
 					if (isAllowed) {
 						result.protocol = forwardedProtocol;
 					}


### PR DESCRIPTION
## Changes

When parsing the protocol, use matchProtocol instead of matchPattern.

note: this is the smaller version of #15534

## Testing

No tests was changed.

## Docs

No docs was or needs to be changed.
