### PR TITLE
chore: remove unnecessary `--save-dev` in installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm create astro@latest
 You can also install Astro **manually** by running this command instead:
 
 ```bash
-npm install --save-dev astro
+npm install astro
 ```
 
 Looking for help? Start with our [Getting Started](https://docs.astro.build/en/getting-started/) guide.

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -15,7 +15,7 @@
 npm create astro@latest
 
 # Manual:
-npm install --save-dev astro
+npm install astro
 ```
 
 Looking for help? Start with our [Getting Started](https://docs.astro.build/en/getting-started/) guide.


### PR DESCRIPTION
## Changes
This PR fixes `npm install` astro command in the docs.

In case we install it as dev dependency, we have an issue when we try to run the project with production-only modules like `npm ci --omit=dev` 

```
  app-1  | Waiting for Node.js to bind to port 4321...                                                                                                                   
  app-1  | node:internal/modules/package_json_reader:316                                                                                                                 
  app-1  |   throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);                                                                                     
  app-1  |         ^                                                                                                                                                     
  app-1  |                                                                                                                                                               
  app-1  | Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'clsx' imported from /app/dist/server/chunks/astro/server_C_Kl7J8g.mjs                                      
 ...                                                                                                                             
  ```


I found related:
https://github.com/withastro/astro/issues/7247
https://github.com/withastro/roadmap/discussions/655
https://github.com/withastro/astro/issues/13991


I even checked how it is installed from the cli `npm create astro@latest` and in the template project, we do have `astro` in regular dependencies. 
<img width="1539" height="1050" alt="image" src="https://github.com/user-attachments/assets/23f1f384-6ac3-4e21-91f0-cee8d06913e9" />


## Testing
No testing required.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
Only the docs were updated. 
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
