### PR TITLE
fix: X-Forwarded-Proto rejected when allowedDomains includes protocol field

### DIFF
--- a/.changeset/fix-forwarded-proto-allowed-domains.md
+++ b/.changeset/fix-forwarded-proto-allowed-domains.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix X-Forwarded-Proto validation when allowedDomains includes both protocol and hostname fields. The protocol check no longer fails due to hostname mismatch against the hardcoded test URL.

--- a/packages/astro/src/core/app/validate-headers.ts
+++ b/packages/astro/src/core/app/validate-headers.ts
@@ -90,10 +90,12 @@ export function validateForwardedHeaders(
 		if (allowedDomains && allowedDomains.length > 0) {
 			const hasProtocolPatterns = allowedDomains.some((pattern) => pattern.protocol !== undefined);
 			if (hasProtocolPatterns) {
-				// Validate against allowedDomains patterns
+				// Only validate the protocol here; host+proto combination is checked in the host block below
 				try {
 					const testUrl = new URL(`${forwardedProtocol}://example.com`);
-					const isAllowed = allowedDomains.some((pattern) => matchPattern(testUrl, pattern));
+					const isAllowed = allowedDomains.some((pattern) =>
+						matchPattern(testUrl, { protocol: pattern.protocol }),
+					);
 					if (isAllowed) {
 						result.protocol = forwardedProtocol;
 					}


### PR DESCRIPTION
The protocol validation in `validateForwardedHeaders()` passed the full pattern object to `matchPattern()`, which also checked hostname against the hardcoded test URL (`example.com`). Pass only `{ protocol }` to `matchPattern()` so that only the protocol field is validated; the host+proto combination is already checked in the host validation block below.

Fixes withastro/astro#15559

## Changes

- Pass `{ protocol: pattern.protocol }` instead of the full pattern to `matchPattern()` in the protocol validation block
- Changeset included

## Testing

Added 4 unit tests in `node.test.js` covering the reverse proxy case (`socket.encrypted: false`):
- Accepts forwarded `https` when `allowedDomains` has protocol + hostname
- Rejects forwarded `http` when only `https` is allowed
- Accepts forwarded `https` with wildcard hostname pattern
- Constructs correct URL behind reverse proxy with all forwarded headers

## Docs

No docs changes needed — this restores the documented behavior of `security.allowedDomains`.
