### PR TITLE
fix(audit): use textContent instead of innerText

### DIFF
--- a/.changeset/loud-items-watch.md
+++ b/.changeset/loud-items-watch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a false positive triggered by the Astro Toolbar, which flagged content hidden by the `<details>` element as non-a11y complaint.

--- a/packages/astro/e2e/dev-toolbar-audits.test.js
+++ b/packages/astro/e2e/dev-toolbar-audits.test.js
@@ -259,4 +259,26 @@ test.describe('Dev Toolbar - Audits', () => {
 		const count = await auditHighlights.count();
 		expect(count).toEqual(0);
 	});
+
+	test('does not warn about content inside closed details elements', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/a11y-details'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
+		await appButton.click();
+
+		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
+		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
+
+		// Should only flag the 2 empty elements (empty h2 and empty anchor)
+		// Should NOT flag the headings and anchors inside closed details elements
+		const count = await auditHighlights.count();
+		expect(count).toEqual(2);
+
+		// Verify that both flagged elements have the a11y-missing-content code
+		for (const auditHighlight of await auditHighlights.all()) {
+			const auditCode = await auditHighlight.getAttribute('data-audit-code');
+			expect(auditCode).toBe('a11y-missing-content');
+		}
+	});
 });

--- a/packages/astro/e2e/dev-toolbar-audits.test.js
+++ b/packages/astro/e2e/dev-toolbar-audits.test.js
@@ -246,6 +246,23 @@ test.describe('Dev Toolbar - Audits', () => {
 		expect(count).toEqual(0);
 	});
 
+	test('does not warn about headings and anchors inside closed details elements', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/a11y-details'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
+		await appButton.click();
+
+		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
+		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
+
+		const count = await auditHighlights.count();
+		expect(count).toEqual(0);
+	});
+
 	test('does not warn about label with valid labelable elements', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/a11y-labelable'));
 

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-details.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-details.astro
@@ -1,0 +1,42 @@
+---
+// Test fixture for issue #15558
+// Content inside closed details elements should not be flagged as missing content
+---
+
+<h1>Testing Details Element</h1>
+
+<!-- Closed details with heading - should NOT be flagged -->
+<details>
+	<summary>Click to expand</summary>
+	<h2>Hidden Heading Inside Details</h2>
+	<p>This heading has content but is hidden inside a closed details element.</p>
+</details>
+
+<!-- Closed details with anchor - should NOT be flagged -->
+<details>
+	<summary>More information</summary>
+	<a href="#test">Hidden Link Inside Details</a>
+	<p>This link has content but is hidden inside a closed details element.</p>
+</details>
+
+<!-- Open details with heading - should NOT be flagged -->
+<details open>
+	<summary>Already expanded</summary>
+	<h2>Visible Heading Inside Open Details</h2>
+	<p>This is visible content.</p>
+</details>
+
+<!-- Multiple nested elements in closed details - should NOT be flagged -->
+<details>
+	<summary>Complex content</summary>
+	<div>
+		<h3>Nested Heading</h3>
+		<a href="#nested">Nested Link</a>
+	</div>
+</details>
+
+<!-- Empty heading - SHOULD be flagged -->
+<h2></h2>
+
+<!-- Empty link - SHOULD be flagged -->
+<a href="#empty"></a>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-details.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-details.astro
@@ -1,42 +1,27 @@
 ---
-// Test fixture for issue #15558
-// Content inside closed details elements should not be flagged as missing content
+
 ---
 
-<h1>Testing Details Element</h1>
-
-<!-- Closed details with heading - should NOT be flagged -->
+<!-- Closed <details> with heading and anchor that have valid text content -->
+<!-- These should NOT trigger a11y-missing-content -->
 <details>
-	<summary>Click to expand</summary>
-	<h2>Hidden Heading Inside Details</h2>
-	<p>This heading has content but is hidden inside a closed details element.</p>
+	<summary>Toggle section</summary>
+	<h2>Heading inside closed details</h2>
+	<a href="/">Link inside closed details</a>
 </details>
 
-<!-- Closed details with anchor - should NOT be flagged -->
-<details>
-	<summary>More information</summary>
-	<a href="#test">Hidden Link Inside Details</a>
-	<p>This link has content but is hidden inside a closed details element.</p>
-</details>
-
-<!-- Open details with heading - should NOT be flagged -->
+<!-- Open <details> with heading and anchor -->
+<!-- These should NOT trigger a11y-missing-content -->
 <details open>
-	<summary>Already expanded</summary>
-	<h2>Visible Heading Inside Open Details</h2>
-	<p>This is visible content.</p>
+	<summary>Open section</summary>
+	<h2>Heading inside open details</h2>
+	<a href="/">Link inside open details</a>
 </details>
 
-<!-- Multiple nested elements in closed details - should NOT be flagged -->
+<!-- Closed <details> with elements that have aria-label -->
+<!-- These should NOT trigger a11y-missing-content -->
 <details>
-	<summary>Complex content</summary>
-	<div>
-		<h3>Nested Heading</h3>
-		<a href="#nested">Nested Link</a>
-	</div>
+	<summary>Another section</summary>
+	<h3 aria-label="Accessible heading"></h3>
+	<a href="/" aria-label="Accessible link"></a>
 </details>
-
-<!-- Empty heading - SHOULD be flagged -->
-<h2></h2>
-
-<!-- Empty link - SHOULD be flagged -->
-<a href="#empty"></a>

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -301,9 +301,9 @@ export const a11y: AuditRuleWithSelector[] = [
 			const nestedLabelableElement = element.querySelector(`${labelableElements.join(', ')}`);
 			if (!hasFor && !nestedLabelableElement) return true;
 
-			// Label must have text content, using innerText to ignore hidden text
-			const innerText = element.innerText.trim();
-			if (innerText === '') return true;
+			// Label must have text content
+			const textContent = element.textContent?.trim() ?? '';
+			if (textContent === '') return true;
 		},
 	},
 	{
@@ -367,9 +367,10 @@ export const a11y: AuditRuleWithSelector[] = [
 			'Headings and anchors must have an accessible name, which can come from: inner text, aria-label, aria-labelledby, an img with alt property, or an svg with a tag <title></title>.',
 		selector: a11y_required_content.join(','),
 		match(element: HTMLElement) {
-			// innerText is used to ignore hidden text
-			const innerText = element.innerText?.trim();
-			if (innerText && innerText !== '') return false;
+			// textContent is used instead of innerText so that content inside
+			// closed <details> elements is not falsely reported as missing
+			const textContent = element.textContent?.trim();
+			if (textContent && textContent !== '') return false;
 
 			// Check for aria-label
 			const ariaLabel = element.getAttribute('aria-label')?.trim();
@@ -381,7 +382,8 @@ export const a11y: AuditRuleWithSelector[] = [
 				const ids = ariaLabelledby.split(' ');
 				for (const id of ids) {
 					const referencedElement = document.getElementById(id);
-					if (referencedElement && referencedElement.innerText.trim() !== '') return false;
+					if (referencedElement && (referencedElement.textContent?.trim() ?? '') !== '')
+						return false;
 				}
 			}
 
@@ -417,7 +419,8 @@ export const a11y: AuditRuleWithSelector[] = [
 					const ids = inputAriaLabelledby.split(' ');
 					for (const id of ids) {
 						const referencedElement = document.getElementById(id);
-						if (referencedElement && referencedElement.innerText.trim() !== '') return false;
+						if (referencedElement && (referencedElement.textContent?.trim() ?? '') !== '')
+							return false;
 					}
 				}
 

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -302,8 +302,7 @@ export const a11y: AuditRuleWithSelector[] = [
 			if (!hasFor && !nestedLabelableElement) return true;
 
 			// Label must have text content
-			const textContent = element.textContent?.trim() ?? '';
-			if (textContent === '') return true;
+			if (getAccessibleText(element) === '') return true;
 		},
 	},
 	{
@@ -367,10 +366,8 @@ export const a11y: AuditRuleWithSelector[] = [
 			'Headings and anchors must have an accessible name, which can come from: inner text, aria-label, aria-labelledby, an img with alt property, or an svg with a tag <title></title>.',
 		selector: a11y_required_content.join(','),
 		match(element: HTMLElement) {
-			// textContent is used instead of innerText so that content inside
-			// closed <details> elements is not falsely reported as missing
-			const textContent = element.textContent?.trim();
-			if (textContent && textContent !== '') return false;
+			// Check for text content using rendering-aware helper
+			if (getAccessibleText(element) !== '') return false;
 
 			// Check for aria-label
 			const ariaLabel = element.getAttribute('aria-label')?.trim();
@@ -382,7 +379,7 @@ export const a11y: AuditRuleWithSelector[] = [
 				const ids = ariaLabelledby.split(' ');
 				for (const id of ids) {
 					const referencedElement = document.getElementById(id);
-					if (referencedElement && (referencedElement.textContent?.trim() ?? '') !== '')
+					if (referencedElement && getAccessibleText(referencedElement as HTMLElement) !== '')
 						return false;
 				}
 			}
@@ -419,7 +416,7 @@ export const a11y: AuditRuleWithSelector[] = [
 					const ids = inputAriaLabelledby.split(' ');
 					for (const id of ids) {
 						const referencedElement = document.getElementById(id);
-						if (referencedElement && (referencedElement.textContent?.trim() ?? '') !== '')
+						if (referencedElement && getAccessibleText(referencedElement as HTMLElement) !== '')
 							return false;
 					}
 				}
@@ -709,4 +706,29 @@ function is_semantic_role_element(
 		}
 	}
 	return false;
+}
+
+/**
+ * Gets text content relevant for accessibility checks.
+ *
+ * Uses `innerText` by default because it is rendering-aware: text hidden via CSS
+ * (`display: none`, `visibility: hidden`, etc.) is excluded, which matches the
+ * accessibility tree behavior.
+ *
+ * Falls back to `textContent` when the element is inside a closed `<details>`,
+ * because `innerText` returns `""` for non-rendered content even though
+ * closed `<details>` content is still part of the accessibility tree.
+ */
+function getAccessibleText(element: HTMLElement): string {
+	const text = element.innerText?.trim() ?? '';
+	if (text !== '') return text;
+
+	// innerText returned empty — check if the element is inside a closed <details>.
+	// Content inside closed <details> is part of the accessibility tree even though
+	// the browser does not render it, so innerText incorrectly returns "".
+	if (element.closest('details:not([open])')) {
+		return element.textContent?.trim() ?? '';
+	}
+
+	return '';
 }


### PR DESCRIPTION
## Changes

Closes #15558 

Did some research and `textContent` is generally safer than `innerText`, so it's safe to use.

## Testing

Added a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
