### PR TITLE
fix(sitemap): add .html extension to URLs when build.format is file

### DIFF
--- a/.changeset/sitemap-file-format.md
+++ b/.changeset/sitemap-file-format.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Fix sitemap URLs missing `.html` extension when `build.format` is set to `file`

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -125,7 +125,15 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 								finalSiteUrl.pathname += '/';
 							if (p.pathname.startsWith('/')) p.pathname = p.pathname.slice(1);
 							const fullPath = finalSiteUrl.pathname + p.pathname;
-							return new URL(fullPath, finalSiteUrl).href;
+							const newUrl = new URL(fullPath, finalSiteUrl).href;
+
+							if (config.build.format === 'file') {
+								const path = new URL(newUrl).pathname;
+								if (path !== '/' && path !== '' && !path.endsWith('/')) {
+									return newUrl + '.html';
+								}
+							}
+							return newUrl;
 						});
 
 					const routeUrls = _routes.reduce<string[]>((urls, r) => {
@@ -146,10 +154,15 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 
 							const newUrl = new URL(fullPath, finalSiteUrl).href;
 
-							if (config.build.format === 'file' && !newUrl.endsWith('/')) {
-								// When build.format is 'file', output files have .html extension
-								// (e.g., /about → /about.html), so sitemap URLs should match
-								urls.push(newUrl + '.html');
+							if (config.build.format === 'file') {
+								const path = new URL(newUrl).pathname;
+								if (path !== '/' && path !== '' && !path.endsWith('/')) {
+									// When build.format is 'file', output files have .html extension
+									// (e.g., /about → /about.html), so sitemap URLs should match
+									urls.push(newUrl + '.html');
+								} else {
+									urls.push(newUrl);
+								}
 							} else if (config.trailingSlash === 'never') {
 								urls.push(newUrl);
 							} else if (config.build.format === 'directory' && !newUrl.endsWith('/')) {

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -146,7 +146,11 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 
 							const newUrl = new URL(fullPath, finalSiteUrl).href;
 
-							if (config.trailingSlash === 'never') {
+							if (config.build.format === 'file' && !newUrl.endsWith('/')) {
+								// When build.format is 'file', output files have .html extension
+								// (e.g., /about → /about.html), so sitemap URLs should match
+								urls.push(newUrl + '.html');
+							} else if (config.trailingSlash === 'never') {
 								urls.push(newUrl);
 							} else if (config.build.format === 'directory' && !newUrl.endsWith('/')) {
 								urls.push(newUrl + '/');

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -128,8 +128,8 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							const newUrl = new URL(fullPath, finalSiteUrl).href;
 
 							if (config.build.format === 'file') {
-								const path = new URL(newUrl).pathname;
-								if (path !== '/' && path !== '' && !path.endsWith('/')) {
+								const urlPath = new URL(newUrl).pathname;
+								if (urlPath !== '/' && urlPath !== '' && !urlPath.endsWith('/')) {
 									return newUrl + '.html';
 								}
 							}
@@ -155,8 +155,8 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							const newUrl = new URL(fullPath, finalSiteUrl).href;
 
 							if (config.build.format === 'file') {
-								const path = new URL(newUrl).pathname;
-								if (path !== '/' && path !== '' && !path.endsWith('/')) {
+								const urlPath = new URL(newUrl).pathname;
+								if (urlPath !== '/' && urlPath !== '' && !urlPath.endsWith('/')) {
 									// When build.format is 'file', output files have .html extension
 									// (e.g., /about → /about.html), so sitemap URLs should match
 									urls.push(newUrl + '.html');

--- a/packages/integrations/sitemap/test/trailing-slash.test.js
+++ b/packages/integrations/sitemap/test/trailing-slash.test.js
@@ -41,13 +41,13 @@ describe('Trailing slash', () => {
 				await fixture.build();
 			});
 
-			it('URLs do not end with trailing slash', async () => {
+			it('URLs have .html extension', async () => {
 				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 				const urls = data.urlset.url;
 
 				assert.equal(urls[0].loc[0], 'http://example.com');
-				assert.equal(urls[1].loc[0], 'http://example.com/one');
-				assert.equal(urls[2].loc[0], 'http://example.com/two');
+				assert.equal(urls[1].loc[0], 'http://example.com/one.html');
+				assert.equal(urls[2].loc[0], 'http://example.com/two.html');
 			});
 		});
 	});


### PR DESCRIPTION
## Description

When `build.format` is set to `'file'`, Astro outputs pages with `.html` extensions (e.g., `about.html`). However, the sitemap integration was generating URLs without extensions (e.g., `/about` instead of `/about.html`), leading to incorrect sitemap entries.

## Changes

- Added a check in the sitemap URL generation to append `.html` when `build.format === 'file'`
- Updated the corresponding test to expect `.html` extensions
- Added changeset

Fixes #15526