### PR TITLE
fix broken proxy policy

### DIFF
--- a/.flue/workflows/issue-triage/WORKFLOW.ts
+++ b/.flue/workflows/issue-triage/WORKFLOW.ts
@@ -20,9 +20,9 @@ export const proxies = {
 				// Allow read-only access to the GraphQL endpoint
 				{ method: 'POST', path: '/graphql', body: githubBody.graphql() },
 				// Allow git clone, fetch, and push over smart HTTP transport
-				{ method: 'GET', path: '/*/info/refs' },
-				{ method: 'POST', path: '/*/git-upload-pack' },
-				{ method: 'POST', path: '/*/git-receive-pack' },
+				{ method: 'GET', path: '/*/*/info/refs' },
+				{ method: 'POST', path: '/*/*/git-upload-pack' },
+				{ method: 'POST', path: '/*/*/git-receive-pack' },
 			],
 		},
 	}),


### PR DESCRIPTION
## Changes

From the most recent CI run, after #15545 was merged:
https://github.com/withastro/astro/actions/runs/22320279718/job/64576369787

```
[opencode] (skill("triage/reproduce.md")) tool:pending  bash — bash
[opencode] (skill("triage/reproduce.md")) > The StackBlitz URL `[https://stackblitz.com/~/github.com/jwoyo/astro-server-island-bug`](https://stackblitz.com/~/github.com/jwoyo/astro-server-island-bug%60) points to a GitHub repo. Let me clone it.
[opencode] (skill("triage/reproduce.md")) tool:running  bash — mkdir -p triage/gh-15622 && git clone https://github.com/jwoyo/astro-server-island-bug.git triage/gh-15622 && rm -rf triage/gh-15622/.git
[proxy:github-git] DENIED: POST /jwoyo/astro-server-island-bug.git/git-upload-pack
  Reason: not allowed by allow-read policy
  To allow: add a policy.allow rule for POST to this path, or use policy: 'allow-all'
CLONE_FAILED
```

## Testing

- N/A

## Docs

- N/A