### PR TITLE
ci: use docker/login-action for GHCR auth in issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -84,10 +84,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull sandbox image
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker pull $IMAGE:latest
+        run: docker pull $IMAGE:latest
 
       - name: Verify sandbox image
         run: |


### PR DESCRIPTION
## Changes

- Replace manual `docker login` with the official `docker/login-action@v3.7.0` in the issue triage workflow. 
- This silences the "credentials stored unencrypted" Docker warning that was appearing in CI logs and causing confusion.

## Testing

Verified by reviewing the `docker/login-action` docs — it performs the same GHCR authentication but uses a credential store instead of writing plaintext credentials. Will be validated on the next issue triage run.

## Docs

No docs needed — this is an internal CI workflow change with no user-facing impact.