### PR TITLE
feat(cloudflare): throw on stackblitz

### DIFF
--- a/.changeset/ten-numbers-rush.md
+++ b/.changeset/ten-numbers-rush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Adds an error when running on Stackblitz, since `workerd` doesn't support it

--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -42,7 +42,7 @@ body:
     id: bug-reproduction
     attributes:
       label: Link to Minimal Reproducible Example
-      description: 'Use [StackBlitz](https://astro.new/repro) to create a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed. Not sure how to create a minimal example? [Read our guide](https://docs.astro.build/en/guides/troubleshooting/#creating-minimal-reproductions)'
+      description: 'Use [StackBlitz](https://astro.new/repro) (does not support `@astrojs/cloudflare`) or [GitHub](https://astro.new/minimal?on=github) to create a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed. Not sure how to create a minimal example? [Read our guide](https://docs.astro.build/en/guides/troubleshooting/#creating-minimal-reproductions).'
       placeholder: 'https://stackblitz.com/abcd1234'
     validations:
       required: true

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -60,6 +60,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
 		name: '@astrojs/cloudflare',
 		hooks: {
 			'astro:config:setup': ({ command, config, updateConfig, logger, addWatchFile }) => {
+				if (!!process.versions.webcontainer) {
+					throw new Error('`workerd` does not run on Stackblitz.')
+				}
+
 				let session = config.session;
 
 				if (args?.imageService === 'cloudflare-binding') {


### PR DESCRIPTION
## Changes

- Addresses https://github.com/orgs/withastro/projects/21/views/1?pane=issue&itemId=159371241
- `workerd` doesn't work on Stackblitz, which causes weird errors. We now throw a clean error when running in a webcontainer
- Updates the issue template to mention github for repros

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset + issue template

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
