### PR TITLE
chore(cli): speedup test

### DIFF
--- a/packages/astro/e2e/fixtures/actions-blog/package.json
+++ b/packages/astro/e2e/fixtures/actions-blog/package.json
@@ -10,7 +10,7 @@
 		"astro": "astro"
 	},
 	"dependencies": {
-		"@astrojs/check": "^0.9.6",
+		"@astrojs/check": "workspace:*",
 		"@astrojs/db": "workspace:*",
 		"@astrojs/node": "workspace:*",
 		"@astrojs/react": "workspace:*",

--- a/packages/astro/e2e/fixtures/actions-react-19/package.json
+++ b/packages/astro/e2e/fixtures/actions-react-19/package.json
@@ -10,7 +10,7 @@
 		"astro": "astro"
 	},
 	"dependencies": {
-		"@astrojs/check": "^0.9.6",
+		"@astrojs/check": "workspace:*",
 		"@astrojs/db": "workspace:*",
     "@astrojs/node": "workspace:*",
 		"@astrojs/react": "workspace:*",

--- a/packages/astro/src/cli/definitions.ts
+++ b/packages/astro/src/cli/definitions.ts
@@ -14,6 +14,7 @@ export interface TextStyler {
 	green: (msg: string) => string;
 	bold: (msg: string) => string;
 	bgGreen: (msg: string) => string;
+	cyan: (msg: string) => string;
 }
 
 export interface AstroVersionProvider {

--- a/packages/astro/src/cli/infra/passthrough-text-styler.ts
+++ b/packages/astro/src/cli/infra/passthrough-text-styler.ts
@@ -19,4 +19,7 @@ export class PassthroughTextStyler implements TextStyler {
 	bgGreen(msg: string): string {
 		return msg;
 	}
+	cyan(msg: string): string {
+		return msg;
+	}
 }

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -21,6 +21,8 @@ import {
 	MAX_PATCH_DISTANCE,
 	shouldCheckForUpdates,
 } from './update-check.js';
+import { BuildTimeAstroVersionProvider } from '../../cli/infra/build-time-astro-version-provider.js';
+import { piccoloreTextStyler } from '../../cli/infra/piccolore-text-styler.js';
 
 export interface DevServer {
 	address: AddressInfo;
@@ -125,6 +127,8 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 			resolvedUrls: restart.container.viteServer.resolvedUrls || { local: [], network: [] },
 			host: restart.container.settings.config.server.host,
 			base: restart.container.settings.config.base,
+			astroVersionProvider: new BuildTimeAstroVersionProvider(),
+			textStyler: piccoloreTextStyler,
 		}),
 	);
 

--- a/packages/astro/src/core/messages/runtime.ts
+++ b/packages/astro/src/core/messages/runtime.ts
@@ -9,6 +9,7 @@ import {
 	type ErrorWithMetadata,
 } from '../errors/index.js';
 import { padMultilineString } from '../util-runtime.js';
+import type { AstroVersionProvider, TextStyler } from '../../cli/definitions.js';
 
 const {
 	bgGreen,
@@ -62,45 +63,49 @@ export function serverStart({
 	resolvedUrls,
 	host,
 	base,
+	astroVersionProvider,
+	textStyler,
 }: {
 	startupTime: number;
 	resolvedUrls: ResolvedServerUrls;
 	host: string | boolean;
 	base: string;
+	astroVersionProvider: AstroVersionProvider;
+	textStyler: TextStyler;
 }): string {
-	// PACKAGE_VERSION is injected at build-time
-	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
-	const localPrefix = `${dim('┃')} Local    `;
-	const networkPrefix = `${dim('┃')} Network  `;
+	const localPrefix = `${textStyler.dim('┃')} Local    `;
+	const networkPrefix = `${textStyler.dim('┃')} Network  `;
 	const emptyPrefix = ' '.repeat(11);
 
 	const localUrlMessages = resolvedUrls.local.map((url, i) => {
-		return `${i === 0 ? localPrefix : emptyPrefix}${cyan(new URL(url).origin + base)}`;
+		return `${i === 0 ? localPrefix : emptyPrefix}${textStyler.cyan(new URL(url).origin + base)}`;
 	});
 	const networkUrlMessages = resolvedUrls.network.map((url, i) => {
-		return `${i === 0 ? networkPrefix : emptyPrefix}${cyan(new URL(url).origin + base)}`;
+		return `${i === 0 ? networkPrefix : emptyPrefix}${textStyler.cyan(new URL(url).origin + base)}`;
 	});
 
 	if (networkUrlMessages.length === 0) {
 		const networkLogging = getNetworkLogging(host);
 		if (networkLogging === 'host-to-expose') {
-			networkUrlMessages.push(`${networkPrefix}${dim('use --host to expose')}`);
+			networkUrlMessages.push(`${networkPrefix}${textStyler.dim('use --host to expose')}`);
 		} else if (networkLogging === 'visible') {
-			networkUrlMessages.push(`${networkPrefix}${dim('unable to find network to expose')}`);
+			networkUrlMessages.push(
+				`${networkPrefix}${textStyler.dim('unable to find network to expose')}`,
+			);
 		}
 	}
 
 	const messages = [
 		'',
-		`${bgGreen(bold(` astro `))} ${green(`v${version}`)} ${dim(`ready in`)} ${Math.round(
+		`${textStyler.bgGreen(textStyler.bold(` astro `))} ${textStyler.green(`v${astroVersionProvider.version}`)} ${textStyler.dim(`ready in`)} ${Math.round(
 			startupTime,
-		)} ${dim('ms')}`,
+		)} ${textStyler.dim('ms')}`,
 		'',
 		...localUrlMessages,
 		...networkUrlMessages,
 		'',
 	];
-	return messages.filter((msg) => typeof msg === 'string').join('\n');
+	return messages.filter(Boolean).join('\n');
 }
 
 /** Display custom dev server shortcuts */

--- a/packages/astro/src/core/preview/static-preview-server.ts
+++ b/packages/astro/src/core/preview/static-preview-server.ts
@@ -8,6 +8,8 @@ import type { Logger } from '../logger/core.js';
 import * as msg from '../messages/runtime.js';
 import { getResolvedHostForHttpServer } from './util.js';
 import { vitePluginAstroPreview } from './vite-plugin-astro-preview.js';
+import { BuildTimeAstroVersionProvider } from '../../cli/infra/build-time-astro-version-provider.js';
+import { piccoloreTextStyler } from '../../cli/infra/piccolore-text-styler.js';
 
 interface PreviewServer {
 	host?: string;
@@ -71,6 +73,8 @@ export default async function createStaticPreviewServer(
 			resolvedUrls: previewServer.resolvedUrls ?? { local: [], network: [] },
 			host: settings.config.server.host,
 			base: settings.config.base,
+			astroVersionProvider: new BuildTimeAstroVersionProvider(),
+			textStyler: piccoloreTextStyler,
 		}),
 	);
 

--- a/packages/astro/test/fixtures/astro-check-errors/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-check-errors/astro.config.mjs
@@ -1,6 +1,0 @@
-import { defineConfig } from 'astro/config';
-
-// https://astro.build/config
-export default defineConfig({
-	integrations: [],
-});

--- a/packages/astro/test/fixtures/astro-check-errors/package.json
+++ b/packages/astro/test/fixtures/astro-check-errors/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "astro": "workspace:*",
-    "@astrojs/check": "^0.9.6",
+    "@astrojs/check": "workspace:*",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
@@ -1,15 +1,3 @@
 ---
 console.log(doesntExist)
 ---
-
-<html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Document</title>
-</head>
-<body>
-	<div>Hello, Astro!</div>
-</body>
-</html>

--- a/packages/astro/test/fixtures/astro-check-no-errors/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-check-no-errors/astro.config.mjs
@@ -1,6 +1,0 @@
-import { defineConfig } from 'astro/config';
-
-// https://astro.build/config
-export default defineConfig({
-	integrations: [],
-});

--- a/packages/astro/test/fixtures/astro-check-no-errors/package.json
+++ b/packages/astro/test/fixtures/astro-check-no-errors/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "astro": "workspace:*",
-    "@astrojs/check": "^0.9.6",
+    "@astrojs/check": "workspace:*",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
@@ -1,11 +1,4 @@
-<html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Document</title>
-</head>
-<body>
-	<div>Hello, Astro!</div>
-</body>
-</html>
+---
+const foo = 'bar'
+---
+

--- a/packages/astro/test/units/cli/misc.test.js
+++ b/packages/astro/test/units/cli/misc.test.js
@@ -1,0 +1,133 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { serverStart } from '../../../dist/core/messages/runtime.js';
+import { PassthroughTextStyler } from '../../../dist/cli/infra/passthrough-text-styler.js';
+import { FakeAstroVersionProvider } from './utils.js';
+
+const textStyler = new PassthroughTextStyler();
+const astroVersionProvider = new FakeAstroVersionProvider('1.2.3');
+
+describe('CLI misc', () => {
+	it('serverStart()', () => {
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: true,
+				base: '/',
+				resolvedUrls: {
+					local: ['http://localhost:4321'],
+					network: ['http://192.168.1.15:4321'],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/\n┃ Network  http://192.168.1.15:4321/',
+		);
+
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: true,
+				base: '/',
+				resolvedUrls: {
+					local: ['http://localhost:4321', 'http://localhost:4322'],
+					network: ['http://192.168.1.15:4321', 'http://192.168.1.15:4322'],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/\n           http://localhost:4322/\n┃ Network  http://192.168.1.15:4321/\n           http://192.168.1.15:4322/',
+		);
+
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: true,
+				base: '/foo',
+				resolvedUrls: {
+					local: ['http://localhost:4321'],
+					network: ['http://192.168.1.15:4321'],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/foo\n┃ Network  http://192.168.1.15:4321/foo',
+		);
+
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: false,
+				base: '/',
+				resolvedUrls: {
+					local: ['http://localhost:4321'],
+					network: [],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/\n┃ Network  use --host to expose',
+		);
+
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: 'localhost',
+				base: '/',
+				resolvedUrls: {
+					local: ['http://localhost:4321'],
+					network: [],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/',
+		);
+
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: '127.0.0.1',
+				base: '/',
+				resolvedUrls: {
+					local: ['http://localhost:4321'],
+					network: [],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/',
+		);
+
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: '127.0.0.2',
+				base: '/',
+				resolvedUrls: {
+					local: ['http://localhost:4321'],
+					network: [],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/\n┃ Network  unable to find network to expose',
+		);
+
+		assert.equal(
+			serverStart({
+				textStyler,
+				astroVersionProvider,
+				startupTime: 300,
+				host: true,
+				base: '/',
+				resolvedUrls: {
+					local: ['http://localhost:4321'],
+					network: [],
+				},
+			}),
+			' astro  v1.2.3 ready in 300 ms\n┃ Local    http://localhost:4321/\n┃ Network  unable to find network to expose',
+		);
+	});
+});

--- a/packages/db/test/fixtures/ticketing-example/package.json
+++ b/packages/db/test/fixtures/ticketing-example/package.json
@@ -9,7 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.6",
+    "@astrojs/check": "workspace:*",
     "@astrojs/db": "workspace:*",
     "@astrojs/node": "workspace:*",
     "@astrojs/react": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,8 +816,8 @@ importers:
   packages/astro/e2e/fixtures/actions-blog:
     dependencies:
       '@astrojs/check':
-        specifier: ^0.9.6
-        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../../../language-tools/astro-check
       '@astrojs/db':
         specifier: workspace:*
         version: link:../../../../db
@@ -849,8 +849,8 @@ importers:
   packages/astro/e2e/fixtures/actions-react-19:
     dependencies:
       '@astrojs/check':
-        specifier: ^0.9.6
-        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../../../language-tools/astro-check
       '@astrojs/db':
         specifier: workspace:*
         version: link:../../../../db
@@ -2019,8 +2019,8 @@ importers:
   packages/astro/test/fixtures/astro-check-errors:
     dependencies:
       '@astrojs/check':
-        specifier: ^0.9.6
-        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../../../language-tools/astro-check
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -2031,8 +2031,8 @@ importers:
   packages/astro/test/fixtures/astro-check-no-errors:
     dependencies:
       '@astrojs/check':
-        specifier: ^0.9.6
-        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../../../language-tools/astro-check
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -4803,8 +4803,8 @@ importers:
   packages/db/test/fixtures/ticketing-example:
     dependencies:
       '@astrojs/check':
-        specifier: ^0.9.6
-        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../../../language-tools/astro-check
       '@astrojs/db':
         specifier: workspace:*
         version: link:../../..


### PR DESCRIPTION
## Changes

- Updates `@astrojs/check` to always use the workspace version
- Updates the `astro check` related fixtures to be faster by keeping the absolute minimum
- Removes some integrated CLI tests
- Adds new CLI unit tests that hopefully cover the same behaviors as before? If not, advices welcome!

## Testing

Updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Internal change

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
