### PR TITLE
chore: add developer agent skill

### DIFF
--- a/.agents/skills/astro-developer/SKILL.md
+++ b/.agents/skills/astro-developer/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: astro-developer
+description: Comprehensive guide for developing in the Astro monorepo. Covers architecture, debugging, testing, and critical constraints. Use when working on features, fixes, tests, or understanding the codebase structure.
+---
+
+# Astro Developer Skill
+
+Context-loading skill for AI agents and developers working in the Astro monorepo. Loads relevant documentation based on your task.
+
+## Quick Decision Matrix
+
+**What are you doing?** → **Read these files:**
+
+| Task                       | Primary Docs                                                         | Supporting Docs                    |
+| -------------------------- | -------------------------------------------------------------------- | ---------------------------------- |
+| Adding a core feature      | [architecture.md](architecture.md), [constraints.md](constraints.md) | [testing.md](testing.md)           |
+| Fixing a bug               | [debugging.md](debugging.md)                                         | [architecture.md](architecture.md) |
+| Writing/fixing tests       | [testing.md](testing.md)                                             | [constraints.md](constraints.md)   |
+| Creating an integration    | Explore `packages/integrations/` for examples                        | [testing.md](testing.md)           |
+| Understanding architecture | [architecture.md](architecture.md)                                   | -                                  |
+| Dealing with errors        | [debugging.md](debugging.md), [constraints.md](constraints.md)       | [testing.md](testing.md)           |
+| Understanding constraints  | [constraints.md](constraints.md)                                     | [architecture.md](architecture.md) |
+
+## Critical Warnings
+
+**Before you start, be aware of these common pitfalls:**
+
+1. **Prefer Unit Tests**: Write unit-testable code by default. Use integration tests only when necessary → [testing.md](testing.md)
+2. **Node.js API Restrictions**: Cannot use Node.js APIs in `runtime/` code → [constraints.md](constraints.md)
+3. **Test Isolation**: Must set unique `outDir` for each integration test → [testing.md](testing.md)
+4. **Runtime Boundaries**: Core vs Vite vs Browser execution contexts → [architecture.md](architecture.md)
+5. **Prerelease Mode**: Changesets target `origin/next` branch (check `.changeset/config.json`)
+
+## Quick Command Reference
+
+```bash
+# Development
+pnpm install                                    # Install (root only)
+pnpm run build                                  # Build all packages
+pnpm run dev                                    # Watch mode
+pnpm run lint                                   # Lint codebase
+
+# Testing
+pnpm -C packages/astro exec astro-scripts test "test/**/*.test.js"  # All tests
+pnpm -C packages/astro exec astro-scripts test -m "pattern"         # Filter tests
+pnpm run test:e2e                               # E2E tests
+node --test test/file.test.js                   # Single test
+
+# Examples
+pnpm --filter @example/minimal run dev          # Run example
+
+# Changesets
+pnpm exec changeset --empty                     # Create changeset, no interactive mode
+```
+
+## Key File Paths
+
+```
+packages/astro/src/
+├── core/              # Node.js execution context (build/dev commands)
+├── runtime/
+│   ├── server/        # Vite SSR execution context
+│   └── client/        # Browser execution context
+├── virtual-modules/   # Virtual module entry points
+├── content/           # Content layer system
+├── vite-plugin-*/     # Vite plugins
+└── types/             # Centralized TypeScript types
+
+packages/integrations/  # Official integrations
+examples/              # Test your changes here
+test/fixtures/         # Test fixtures
+```
+
+**Note**: Error stack traces in `node_modules/` map to source in `packages/`. See [architecture.md](architecture.md) for details.
+
+## Usage
+
+This skill loads relevant context—it doesn't orchestrate workflows. After loading appropriate docs:
+
+1. Read the recommended files for your task
+2. Apply the patterns and constraints described
+3. Use the commands and file paths provided
+4. Search docs for error messages if you encounter issues
+
+## Architecture Quick Summary
+
+**Three Execution Contexts:**
+
+- **core/** → Node.js, build/dev commands, avoid Node APIs except in Vite plugins
+- **runtime/server/** → Vite SSR, CANNOT use Node APIs
+- **runtime/client/** → Browser, CANNOT use Node APIs at all
+
+**Five Pipeline Types:**
+
+- **RunnablePipeline** → `astro dev` with Vite loader system
+- **NonRunnablePipeline** → `astro dev` without runtime module loading (Cloudflare adapter)
+- **BuildPipeline** → `astro build` + prerendering
+- **AppPipeline** → Production serverless/SSR
+- **ContainerPipeline** → Container API
+
+See [architecture.md](architecture.md) for complete details.
+
+## Testing Quick Summary
+
+**Philosophy**: Prefer unit tests over integration tests. Write unit-testable code by default.
+
+**Unit tests** (fast, preferred):
+
+- Test pure functions and business logic
+- Extract business logic from infrastructure
+- Use dependency injection
+
+**Integration tests** (slow, use sparingly):
+
+- Only for features that cannot be unit tested (virtual modules, full build pipeline)
+- Always set unique `outDir` to avoid cache pollution
+
+See [testing.md](testing.md) for complete patterns and examples.
+
+## When NOT to Use This Skill
+
+- **Bug triage**: Use the `triage` skill instead
+- **GitHub Actions analysis**: Use the `analyze-github-action-logs` skill
+- **Simple questions**: Just ask directly, don't load this skill
+
+## Related Documentation
+
+- Root: [/AGENTS.md](/Users/ema/www/withastro/astro/AGENTS.md)
+- Root: [/CONTRIBUTING.md](/Users/ema/www/withastro/astro/CONTRIBUTING.md)
+- Astro docs: https://docs.astro.build/llms.txt
+- Package: packages/astro/src/core/README.md
+- Build plugins: packages/astro/src/core/build/plugins/README.md

--- a/.agents/skills/astro-developer/architecture.md
+++ b/.agents/skills/astro-developer/architecture.md
@@ -1,0 +1,435 @@
+# Architecture Guide
+
+Understanding Astro's internal architecture is critical for effective development. This guide covers execution contexts, pipelines, virtual modules, and content layer architecture.
+
+## Three Execution Contexts
+
+Astro code runs in three distinct environments. Understanding which context your code executes in determines what APIs you can use and how to debug it.
+
+### Context 1: Node.js (Core)
+
+**Location**: `packages/astro/src/core/`
+
+**When it runs**: During `astro dev`, `astro build`, and CLI commands
+
+**Characteristics**:
+
+- Node.js environment (but contains mixed code)
+- Contains both build-time AND runtime code
+- Node.js API usage should be avoided except in Vite plugins
+- Powers build orchestration and dev server setup
+
+**Note**: `core/` is not purely build-time - avoid Node.js APIs unless in Vite plugin implementations
+
+**Examples**:
+
+- `packages/astro/src/core/build/` → Build orchestration (mixed)
+- `packages/astro/src/core/dev/` → Dev server setup (mixed)
+- `packages/astro/src/cli/` → CLI commands (pure Node.js)
+
+**Debug with**: Standard Node debugging, console.log, `node --inspect`
+
+### Context 2: Vite SSR (Runtime Server)
+
+**Location**: `packages/astro/src/runtime/server/`
+
+**When it runs**: Inside Vite's SSR environment during rendering
+
+**Characteristics**:
+
+- Node environment BUT isolated from core
+- **CANNOT use Node.js APIs** (`node:fs`, `node:path`, etc.)
+- Must work in non-Node runtimes (Cloudflare Workers, Deno)
+- Use `@astrojs/internal-helpers` for cross-platform utilities
+
+**Rule**: If the file path contains `/runtime/`, absolutely NO Node.js APIs
+
+**Examples**:
+
+- `packages/astro/src/runtime/server/render/` → Page rendering
+- Virtual modules loaded during SSR
+
+**Debug with**: `DEBUG=astro:*` environment variable
+
+### Context 3: Browser (Runtime Client)
+
+**Location**: `packages/astro/src/runtime/client/`
+
+**When it runs**: In the browser after page load
+
+**Characteristics**:
+
+- Browser-only environment
+- CANNOT use any Node.js APIs
+- Only browser-compatible code allowed
+- Handles partial hydration, client-side routing
+
+**Examples**:
+
+- `packages/astro/src/runtime/client/idle.ts` → Idle hydration
+- `packages/astro/src/runtime/client/visible.ts` → Visible hydration
+
+**Debug with**: Browser DevTools, console.log in browser
+
+## Pipeline Architecture
+
+Astro uses a base `Pipeline` class with multiple implementations for different environments.
+
+### Pipeline Hierarchy
+
+```
+Pipeline (abstract base class)
+├── RunnablePipeline       → Dev with RunnableDevEnvironment
+├── NonRunnablePipeline    → Dev with NonRunnableDevEnvironment
+├── BuildPipeline          → Build and prerendering
+├── AppPipeline            → Production SSR/serverless
+└── ContainerPipeline      → Container API
+```
+
+**Location**: `packages/astro/src/core/base-pipeline.ts`
+
+### Pipeline Types
+
+#### 1. RunnablePipeline
+
+**When**: During `astro dev` with Vite RunnableDevEnvironment
+**Purpose**: Handle dev server requests with runtime module loading
+**Location**: `packages/astro/src/vite-plugin-app/pipeline.ts`
+**Characteristics**:
+
+- Contains reference to Vite loader system
+- Can import modules at runtime via Vite environment APIs
+- Hot module reloading support
+- Standard dev workflow
+
+**Best practice**: Avoid runtime module imports when possible. Prefer Vite plugins and virtual modules instead.
+
+#### 2. NonRunnablePipeline
+
+**When**: During `astro dev` with Vite NonRunnableDevEnvironment
+**Purpose**: Handle dev server requests without runtime module loading
+**Location**: `packages/astro/src/core/app/dev/pipeline.ts`
+**Characteristics**:
+
+- Used by adapters like Cloudflare
+- No reference to Vite loader system
+- Cannot import modules at runtime
+- Must rely entirely on Vite plugins and virtual modules
+
+**Critical**: This is why code must avoid runtime module imports and use plugins/virtual modules instead
+
+#### 3. BuildPipeline
+
+**When**: During `astro build` and prerendering
+**Purpose**: Generate static HTML and handle prerendering
+**Location**: `packages/astro/src/core/build/pipeline.ts`
+**Characteristics**:
+
+- Optimized output
+- Static generation
+- Asset processing
+- Prerendering logic
+
+#### 4. AppPipeline
+
+**When**: Production runtime (serverless/SSR)
+**Purpose**: Serve dynamic requests in production
+**Location**: `packages/astro/src/core/app/pipeline.ts`
+**Characteristics**:
+
+- No build-time dependencies
+- Optimized for cold starts
+- Adapter integration
+- Production error handling
+
+#### 5. ContainerPipeline
+
+**When**: Using the Container API
+**Purpose**: Programmatic rendering outside of normal Astro contexts
+**Location**: `packages/astro/src/container/pipeline.ts`
+**Characteristics**:
+
+- Standalone rendering
+- Component interning cache
+- Used for testing and programmatic access
+
+### Base Pipeline
+
+**Pipeline** (abstract base class): Static parts that don't change between requests
+
+From `packages/astro/src/core/base-pipeline.ts`:
+
+- Configuration
+- Logger
+- Manifest
+- Runtime mode (development/production)
+- Middleware
+- Actions
+- Internal caches
+
+**All pipeline implementations extend this base class**
+
+### RenderContext vs Pipeline
+
+**Pipeline**: Constant per server/build session (static)
+
+- Created once at process start
+- Reused for every request
+- Contains configuration and settings
+
+**RenderContext**: Per-request data (dynamic)
+
+- Created for each request
+- Current URL
+- Matched route
+- Request locals
+- i18n context
+- Middleware execution
+
+## Virtual Modules System
+
+Virtual modules are a core pattern in Astro. They're "files" that don't exist on disk but are generated at build/dev time.
+
+### Virtual Module Conventions
+
+**Prefix**: `virtual:astro:*` for Astro-internal, `\0` prefix for Rollup-internal (Rollup convention)
+
+**Pattern**:
+
+1. Internal code imports `virtual:astro:something`
+2. Vite plugin `resolveId` hook returns `\0virtual:astro:something`
+3. Vite plugin `load` hook returns generated code
+
+### Core Virtual Modules Registry
+
+**File**: `packages/astro/src/virtual-modules/`
+
+| Module                     | Purpose                                      | Source                |
+| -------------------------- | -------------------------------------------- | --------------------- |
+| `virtual:astro:routes`     | Route definitions                            | Generated from pages/ |
+| `virtual:astro:manifest`   | Serialized manifest (single source of truth) | Build output          |
+| `virtual:astro:pages`      | Page collections                             | Generated from pages/ |
+| `virtual:astro:renderers`  | Framework renderers                          | Integration config    |
+| `virtual:astro:middleware` | Middleware module                            | src/middleware.ts     |
+| `virtual:astro:dev-css`    | Dev-mode CSS modules                         | Vite dev              |
+| `virtual:astro:app`        | App pipeline                                 | Production runtime    |
+| `virtual:image-service`    | Image service config                         | Config + integrations |
+
+**Actions Virtual Modules**:
+
+- `virtual:astro:actions/entrypoint` → Actions entry
+- `virtual:astro:actions/options` → Actions configuration
+
+**Adapter Virtual Modules**:
+
+- `virtual:astro:adapter-config` → Adapter configuration
+- `virtual:astro:adapter-entrypoint` → Adapter entry point
+
+### Internal Page Virtual Modules
+
+**Prefix**: `@astro-page:*` (legacy pattern, specific to pages)
+
+**Note**: This is an older pattern used specifically for page modules. New virtual modules should use `virtual:astro:*` instead unless there's a specific reason to deviate.
+
+**Example**: `@astro-page:src/pages/index.astro` → Virtual module for index page
+
+**Standard pattern for new plugins**: Use `virtual:astro:*` prefix
+
+### Virtual Module Implementation Pattern
+
+**Current pattern** (see `packages/astro/src/core/build/plugins/plugin-ssr.ts`):
+
+```typescript
+const VIRTUAL_MODULE_ID = 'virtual:astro:my-module';
+const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
+
+// In Vite plugin
+{
+  name: '@astrojs/vite-plugin-my-module',
+  resolveId: {
+    filter: {
+      id: new RegExp(`^${VIRTUAL_MODULE_ID}$`),
+    },
+    handler() {
+      return RESOLVED_VIRTUAL_MODULE_ID;
+    },
+  },
+  load: {
+    filter: {
+      id: new RegExp(`^${RESOLVED_VIRTUAL_MODULE_ID}$`),
+    },
+    handler() {
+      return {
+        code: `export default ${JSON.stringify(data)}`,
+      };
+    },
+  },
+}
+```
+
+**Pattern**: Use `filter/id/handler` structure for both `resolveId` and `load` hooks.
+
+## Content Layer Architecture
+
+The content layer handles content collections at build time and runtime.
+
+### Key Components
+
+**Location**: `packages/astro/src/content/`
+
+| Component          | File                           | Purpose                         |
+| ------------------ | ------------------------------ | ------------------------------- |
+| Content Layer      | `content-layer.ts` (479 lines) | Main orchestration              |
+| Data Store         | `data-store.ts`                | Read-only runtime store         |
+| Mutable Data Store | `mutable-data-store.ts`        | Build-time mutable store        |
+| Runtime API        | `runtime.ts`                   | `getCollection()`, `getEntry()` |
+| Types Generator    | `types-generator.ts`           | TypeScript type generation      |
+| Watcher            | `watcher.ts`                   | File system watching            |
+
+### Content Layer Flow
+
+```
+Build Time:
+┌─────────────┐    ┌──────────────┐    ┌────────────────┐
+│   Loaders   │───▶│MutableStore  │───▶│.astro/data-    │
+│(load data)  │    │(collect data)│    │store.json      │
+└─────────────┘    └──────────────┘    └────────────────┘
+                            │
+                            ▼
+                   ┌──────────────┐
+                   │Types Generator│
+                   └──────────────┘
+
+Runtime:
+┌────────────────┐    ┌──────────┐    ┌─────────────┐
+│.astro/data-    │───▶│DataStore │───▶│Runtime API  │
+│store.json      │    │(read-only)│    │(getCollection)│
+└────────────────┘    └──────────┘    └─────────────┘
+```
+
+### Content Constants
+
+**File**: `packages/astro/src/content/consts.ts`
+
+```typescript
+DATA_STORE_FILE = '.astro/data-store.json';
+COLLECTIONS_MANIFEST_FILE = 'collections-manifest.json';
+MODULES_IMPORTS_FILE = 'modules-imports.json';
+ASSET_IMPORTS_FILE = 'asset-imports.json';
+```
+
+### Live Collections (Astro 5+)
+
+**New pattern**: Fetch data at runtime rather than build time
+
+**Configuration**: Separate from build-time collections
+
+- Build-time: `src/content/config.ts`
+- Runtime: `src/live.config.ts`
+
+**Loader Protocol**: Loaders must implement standard interface
+
+## Vite Plugin Architecture
+
+**Location**: `packages/astro/src/vite-plugin-*/`
+
+Vite plugins execute within Vite's context (similar to runtime/server).
+
+### Build Plugins
+
+**Location**: `packages/astro/src/core/build/plugins/`
+
+**Documentation**: `packages/astro/src/core/build/plugins/README.md`
+
+**Plugin Responsibilities**:
+
+1. **plugin-middleware**: Emits `middleware.mjs` if present
+2. **plugin-renderers**: Collects renderers → `renderers.mjs`
+3. **plugin-pages**: Virtual modules for each page (static builds)
+4. **plugin-ssr**: Creates SSR entry points
+5. **plugin-manifest**: Creates `manifest.mjs` (single source of truth)
+
+### Plugin Execution Order
+
+Plugins work together in sequence:
+
+1. Middleware plugin runs first
+2. Renderers collected
+3. Pages processed
+4. SSR entries created
+5. Manifest generated (final step)
+
+## Package Structure
+
+### Monorepo Organization
+
+```
+packages/
+├── astro/                    # Core package
+│   ├── src/
+│   │   ├── core/            # Node.js build/dev
+│   │   ├── runtime/         # Vite SSR + browser
+│   │   ├── virtual-modules/ # Virtual module sources
+│   │   ├── content/         # Content layer
+│   │   ├── vite-plugin-*/   # Vite plugins
+│   │   └── types/           # Centralized types
+│   └── test/
+│       ├── fixtures/        # Test fixtures
+│       └── *.test.js        # Unit tests
+├── integrations/
+│   ├── react/
+│   ├── vue/
+│   ├── svelte/
+│   └── ...
+└── create-astro/            # CLI scaffolding tool
+
+examples/                     # Example projects
+├── blog/
+├── minimal/
+└── ...
+```
+
+### Node Modules Mapping
+
+When you see errors in `node_modules/`, map back to source:
+
+```
+ERROR in node_modules/astro/dist/core/build/index.js
+        ↓
+FIX in packages/astro/src/core/build/index.ts
+
+ERROR in node_modules/@astrojs/react/index.js
+        ↓
+FIX in packages/integrations/react/src/index.ts
+```
+
+**Rebuild required**: Edits to source files take effect after `pnpm run build`
+
+## Critical Constraints
+
+For detailed constraints including Node.js API restrictions, test isolation, virtual module conventions, and more, see [constraints.md](constraints.md).
+
+**Key points:**
+
+- Node.js APIs forbidden in `runtime/` folders
+- Tests must use unique `outDir`
+- Types centralized in `src/types/`
+- Virtual modules use `virtual:astro:*` prefix
+
+## Debugging
+
+For comprehensive debugging strategies, see [debugging.md](debugging.md).
+
+**Quick reference by context:**
+
+- **Core (Node.js)**: Use `DEBUG=astro:*` or `node --inspect`
+- **Runtime Server**: Check `DEBUG=astro:render,astro:server`
+- **Runtime Client**: Use browser DevTools
+- **Content Layer**: Inspect `.astro/data-store.json`
+
+## Further Reading
+
+- Core README: `packages/astro/src/core/README.md`
+- Build Plugins: `packages/astro/src/core/build/plugins/README.md`
+- Virtual Modules: `packages/astro/src/virtual-modules/README.md`
+- CONTRIBUTING.md sections on code structure

--- a/.agents/skills/astro-developer/constraints.md
+++ b/.agents/skills/astro-developer/constraints.md
@@ -1,0 +1,559 @@
+# Constraints & Gotchas
+
+Critical constraints and common pitfalls when developing in the Astro monorepo.
+
+## Node.js API Restrictions
+
+**MOST IMPORTANT CONSTRAINT**
+
+### The Rule (Conservative Approach)
+
+**Location**: `/CONTRIBUTING.md:84-98`
+
+Code in `packages/astro` has restricted Node.js API usage because Astro runs in multiple runtimes (Node.js, Cloudflare Workers, Deno, edge runtimes).
+
+**Safe decision rule:**
+
+```
+1. In Vite plugin implementations → Node.js APIs allowed
+2. In /runtime/ folders → Node.js APIs FORBIDDEN
+3. Everywhere else → Avoid Node.js APIs, use @astrojs/internal-helpers
+```
+
+**Reality**: The codebase is messy. Not all code follows clear boundaries. The safest approach is to avoid Node.js APIs unless you're in a Vite plugin.
+
+### Where Node.js APIs Are ABSOLUTELY FORBIDDEN
+
+**Pattern** (enforced by Biome linter):
+
+1. Any file in a `runtime/` folder: `**/packages/astro/src/**/runtime/**/*.ts`
+2. Any file with `runtime` in its name: `**/packages/astro/src/**/*runtime*.ts`
+
+**Examples of forbidden locations**:
+
+- `packages/astro/src/runtime/server/` → FORBIDDEN (runtime folder)
+- `packages/astro/src/runtime/client/` → FORBIDDEN (runtime folder)
+- `packages/astro/src/vite-plugin-astro/runtime.ts` → FORBIDDEN (runtime in name)
+- `packages/astro/src/core/render/runtime-utils.ts` → FORBIDDEN (runtime in name)
+
+**Forbidden APIs**:
+
+```typescript
+// FORBIDDEN in runtime/ folders or *runtime*.ts files
+import fs from 'node:fs';
+import path from 'node:path';
+import { Buffer } from 'node:buffer';
+import process from 'node:process';
+import crypto from 'node:crypto';
+// etc.
+```
+
+**Enforcement**: Biome linter rule `noNodejsModules` prevents this at lint time.
+
+### Where Node.js APIs Are SAFE
+
+**Vite Plugin Implementations**: Node.js APIs are safe in Vite plugins
+
+**Locations**:
+
+- `packages/astro/src/vite-plugin-*/` → Safe for Node.js APIs
+- `packages/astro/src/cli/` → Safe for Node.js APIs
+- Test files → Safe for Node.js APIs
+
+**Mixed/Unclear locations**:
+
+- `packages/astro/src/core/` → Mixed (contains both build-time and runtime code)
+
+**Safe approach for core/**:
+
+```typescript
+// AVOID in core/ unless in Vite plugin
+import fs from 'node:fs';
+
+// PREFER cross-platform utilities
+import { fileURLToPath } from '@astrojs/internal-helpers/path';
+```
+
+### Special Case: Vite Plugins
+
+**CAN use Node.js APIs**: In the plugin implementation itself
+
+```typescript
+// ALLOWED
+export function myVitePlugin() {
+  return {
+    name: 'my-plugin',
+    load: {
+      filter: {
+        id: /\.astro$/,
+      },
+      async handler(id) {
+        // Can use Node.js APIs here
+        const fs = await import('node:fs/promises');
+        const content = await fs.readFile(id, 'utf-8');
+        return { code: content };
+      },
+    },
+  };
+}
+```
+
+**CANNOT use Node.js APIs**: In virtual modules returned by plugins
+
+```typescript
+// FORBIDDEN
+export function myVitePlugin() {
+  return {
+    name: 'my-plugin',
+    load: {
+      filter: {
+        id: new RegExp(`^\\0virtual:my-module$`),
+      },
+      handler() {
+        // This code runs in runtime/server context
+        return {
+          code: `
+            import fs from 'node:fs';  // FORBIDDEN
+            export const data = fs.readFileSync('/data.json');
+          `,
+        };
+      },
+    },
+  };
+}
+```
+
+### Critical: NonRunnableDevEnvironment
+
+**Important**: Some adapters (like Cloudflare) set Vite's `NonRunnableDevEnvironment`, which imposes limitations on what Vite plugins can do.
+
+**Limitation**: Vite plugins execute, but certain operations are restricted. For example, you cannot use `runner.import()` in this environment.
+
+**Implication**: While Vite plugins still run their hooks (transform, load, etc.), they may not have access to all runtime capabilities. Code must work with these limitations.
+
+**Rule**: Write code that doesn't depend on full Vite runtime capabilities. This is why runtime-agnostic code is essential.
+
+### Why This Matters
+
+**Multi-runtime support**: Astro code must run in:
+
+- Node.js (traditional hosting)
+- Cloudflare Workers (V8 isolates)
+- Deno (alternative runtime)
+- Edge runtimes (limited APIs)
+
+**Implication**: Most code must be platform-agnostic.
+
+**Reality**: The codebase doesn't have perfect separation yet. When in doubt, avoid Node.js APIs and use cross-platform utilities from `@astrojs/internal-helpers`.
+
+### How to Handle This
+
+#### Pattern 1: Use Cross-Platform Utilities
+
+Use `@astrojs/internal-helpers` instead of Node.js APIs:
+
+```typescript
+// BAD: Direct Node.js API
+import { resolve } from 'node:path';
+const fullPath = resolve('./config.json');
+
+// GOOD: Cross-platform utility
+import { fileURLToPath } from '@astrojs/internal-helpers/path';
+const fullPath = fileURLToPath(new URL('./config.json', import.meta.url));
+```
+
+#### Pattern 2: Vite Plugin for File Operations
+
+If you need file operations, do them in a Vite plugin:
+
+```typescript
+// GOOD: In Vite plugin implementation
+export function myVitePlugin() {
+  return {
+    name: 'my-plugin',
+    load: {
+      filter: {
+        id: /\.config\.js$/,
+      },
+      async handler(id) {
+        // Safe to use Node.js APIs here
+        const fs = await import('node:fs/promises');
+        const content = await fs.readFile(id, 'utf-8');
+        return { code: content };
+      },
+    },
+  };
+}
+```
+
+#### Pattern 3: Build-Time Data Generation
+
+Generate data at build time via Vite plugin, embed in virtual module:
+
+```typescript
+// Vite plugin - safe to use Node.js APIs
+const VIRTUAL_MODULE_ID = 'virtual:my-config';
+const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
+
+export function myVitePlugin() {
+  return {
+    name: 'my-plugin',
+    resolveId: {
+      filter: {
+        id: new RegExp(`^${VIRTUAL_MODULE_ID}$`),
+      },
+      handler() {
+        return RESOLVED_VIRTUAL_MODULE_ID;
+      },
+    },
+    load: {
+      filter: {
+        id: new RegExp(`^${RESOLVED_VIRTUAL_MODULE_ID}$`),
+      },
+      async handler() {
+        // Read at build time (safe here)
+        const fs = await import('node:fs/promises');
+        const config = JSON.parse(await fs.readFile('./config.json', 'utf-8'));
+        // Embed in generated code (no Node.js APIs in output)
+        return {
+          code: `export default ${JSON.stringify(config)}`,
+        };
+      },
+    },
+  };
+}
+```
+
+### Detection
+
+**Error message**: If you violate this, you'll typically see:
+
+- `ReferenceError: fs is not defined`
+- `ReferenceError: process is not defined`
+- Build succeeds but runtime fails in edge environments
+
+**Prevention**: Code review, test in multiple environments
+
+## Test Isolation Requirements
+
+**Every test fixture MUST have a unique `outDir`** to avoid cache pollution between tests.
+
+**Why**: Build artifacts are cached and shared via ESM between test runs.
+
+**Reference**: See [testing.md](testing.md) for detailed explanation, examples, and detection strategies.
+
+## Circular Dependencies
+
+### The Problem
+
+TypeScript circular dependencies can cause:
+
+- Undefined exports at runtime
+- Type resolution issues
+- Build failures
+
+### Where It Happens
+
+Most commonly in type imports.
+
+### The Solution
+
+**Types are centralized**: `packages/astro/src/types/`
+
+```typescript
+// BAD: Import type from implementation
+import type { AstroConfig } from '../config/index.js';
+
+// GOOD: Import type from types/
+import type { AstroConfig } from '../types/public.js';
+```
+
+### Prevention
+
+- Import types from `types/` directory
+- Avoid importing implementation files for types
+- Use `import type` (not `import`) for type-only imports
+
+## Virtual Module Conventions
+
+**Constraint**: New virtual modules must use `virtual:astro:*` prefix (not `@astro-page:*` which is legacy).
+
+**Why**: Standard convention, avoids conflicts, follows Rollup/Vite patterns.
+
+**Reference**: See [architecture.md](architecture.md) for virtual module registry, implementation patterns, and detailed conventions.
+
+## Build vs Runtime Boundaries
+
+### The Separation
+
+Code must respect execution boundaries:
+
+| Context        | Location          | When Runs         | Node APIs |
+| -------------- | ----------------- | ----------------- | --------- |
+| Build          | `core/`           | `astro build`     | Yes       |
+| Dev            | `core/`           | `astro dev` setup | Yes       |
+| Runtime Server | `runtime/server/` | SSR rendering     | No        |
+| Runtime Client | `runtime/client/` | Browser           | No        |
+
+### Common Violation
+
+```typescript
+// BAD: Runtime code importing build code
+// In runtime/server/render.ts
+import { buildSomething } from '../../core/build/utils.js';
+```
+
+**Why bad**: Runtime shouldn't depend on build-time code. Creates coupling and increases bundle size.
+
+### Correct Pattern
+
+```typescript
+// GOOD: Data flows from build to runtime via manifest
+// Build time (core/build/)
+const manifest = {
+  routes: processedRoutes,
+  config: runtimeConfig,
+};
+
+// Runtime (runtime/server/)
+import { manifest } from 'virtual:astro:manifest';
+```
+
+## Package Boundaries
+
+### Workspace Dependencies
+
+Test fixtures and examples MUST use workspace dependencies:
+
+```json
+// GOOD: fixture package.json
+{
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/react": "workspace:*"
+  }
+}
+```
+
+```json
+// BAD: specific versions
+{
+  "dependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/react": "^3.0.0"
+  }
+}
+```
+
+### Why
+
+- Links to local packages during development
+- Automatically uses latest local code
+- Prevents version mismatches
+
+### Catalog Dependencies
+
+For external packages, use catalog when available:
+
+```json
+{
+  "dependencies": {
+    "astro": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}
+```
+
+**Catalog location**: Root `package.json`
+
+## Changeset Requirements
+
+### When Required
+
+**Required for**:
+
+- All packages in `packages/`
+- Any user-facing changes
+
+**NOT required for**:
+
+- Examples in `examples/`
+- Test fixtures
+- Documentation only changes
+- Internal refactors with no API changes
+
+### Prerelease Mode
+
+**Current state**: Repository in prerelease mode (check `.changeset/config.json`)
+
+```json
+{
+  "baseBranch": "origin/next"
+}
+```
+
+**Implication**: Changes go to `next` release, not `latest`
+
+### Creating Changeset
+
+```bash
+pnpm exec changeset
+```
+
+Select packages and describe changes.
+
+## Performance Constraints
+
+### Build Cache
+
+**Shared cache**: Build artifacts cached in `.astro/` and `dist/`
+
+**Implication**:
+
+- Tests must use unique `outDir`
+- Manual cache clear may be needed
+- Cache can speed up but also cause issues
+
+### Content Layer Concurrency
+
+**Location**: `packages/astro/src/content/content-layer.ts`
+
+**Pattern**: Uses PQueue with concurrency: 1
+
+```typescript
+const queue = new PQueue({ concurrency: 1 });
+```
+
+**Implication**: Loaders run sequentially, not in parallel
+
+**Reason**: Prevents race conditions in data store
+
+### Memory Constraints
+
+**Large sites**: May hit memory limits during build
+
+**Mitigation**:
+
+```bash
+node --max-old-space-size=4096 node_modules/.bin/astro build
+```
+
+## Debugging Constraints
+
+### Cannot Use Interactive Commands
+
+**Forbidden in CI**:
+
+```bash
+# BAD: Interactive
+git rebase -i
+git add -i
+```
+
+**Reason**: No TTY in CI environment
+
+### Log Levels
+
+**Production**: Don't log verbosely by default
+
+```typescript
+// BAD: Always logs
+console.log('Processing file:', file);
+
+// GOOD: Use logger with levels
+logger.debug('Processing file:', file);
+```
+
+## Common Gotchas
+
+### 1. File Paths in Tests
+
+```typescript
+// BAD: Relative to cwd
+const fixture = await loadFixture({
+  root: 'fixtures/my-test/',
+});
+
+// GOOD: Relative to test file
+const fixture = await loadFixture({
+  root: './fixtures/my-test/',
+});
+```
+
+### 2. Async/Await in Hooks
+
+```typescript
+// BAD: Forgetting await
+before(async () => {
+  fixture.build(); // Missing await
+});
+
+// GOOD: Proper await
+before(async () => {
+  await fixture.build();
+});
+```
+
+### 3. Server Cleanup
+
+```typescript
+// BAD: Server not stopped
+describe('dev', () => {
+  before(async () => {
+    devServer = await fixture.startDevServer();
+  });
+  // Missing after() hook
+});
+
+// GOOD: Always cleanup
+describe('dev', () => {
+  before(async () => {
+    devServer = await fixture.startDevServer();
+  });
+  after(async () => {
+    await devServer.stop();
+  });
+});
+```
+
+### 4. Type Imports
+
+```typescript
+// BAD: Runtime import for types
+import { AstroConfig } from 'astro';
+
+// GOOD: Type-only import
+import type { AstroConfig } from 'astro';
+```
+
+### 5. Module Resolution
+
+```typescript
+// BAD: May fail in different contexts
+import helper from '../utils';
+
+// GOOD: Explicit extension
+import helper from '../utils.js';
+```
+
+## Constraint Checklist
+
+Before submitting code, verify:
+
+- [ ] No Node.js APIs in `runtime/` code
+- [ ] Tests have unique `outDir`
+- [ ] No circular dependencies
+- [ ] Virtual modules follow naming conventions
+- [ ] Workspace dependencies in fixtures
+- [ ] Changeset created (if needed)
+- [ ] Servers cleaned up in tests
+- [ ] Type imports use `import type`
+- [ ] File extensions explicit (`.js`)
+
+## Further Reading
+
+- CONTRIBUTING.md: Node.js API restrictions (lines 84-98)
+- CONTRIBUTING.md: Test isolation (lines 203-214)
+- architecture.md: Execution contexts
+- testing.md: Test patterns

--- a/.agents/skills/astro-developer/debugging.md
+++ b/.agents/skills/astro-developer/debugging.md
@@ -1,0 +1,513 @@
+# Debugging Guide
+
+Practical debugging strategies for common issues in Astro development.
+
+## Quick Debugging Decision Tree
+
+**What's failing?** → **Debug with:**
+
+| Symptom          | First Check      | Debug Command                                | Section                                   |
+| ---------------- | ---------------- | -------------------------------------------- | ----------------------------------------- |
+| Build fails      | Astro build logs | `DEBUG=astro:* pnpm -C packages/astro build` | [Build Issues](#debugging-build-failures) |
+| Dev server crash | Core logs        | `DEBUG=astro:* astro dev`                    | [Core Issues](#debugging-core-nodejs)     |
+| HMR not working  | Browser network  | `agent-browser` (not curl)                   | [HMR Issues](#debugging-hmr)              |
+| SSR fails        | Runtime context  | `DEBUG=astro:* astro dev`                    | [SSR Issues](#debugging-ssr-issues)       |
+| Content missing  | Data store       | `cat .astro/data-store.json`                 | [Content](#debugging-content-collections) |
+| Tests failing    | Fixture setup    | Check `outDir` uniqueness                    | [Tests](testing.md)                       |
+
+## Debugging Approaches
+
+### 1. Use DEBUG Environment Variable (Recommended)
+
+**Most issues are in Astro's code, not Vite.** Use Astro-specific debugging first.
+
+```bash
+# Debug everything in Astro
+DEBUG=astro:* astro dev
+DEBUG=astro:* astro build
+
+# Debug specific subsystems
+DEBUG=astro:build astro build       # Build process
+DEBUG=astro:content astro dev       # Content collections
+DEBUG=astro:server astro dev        # Dev server
+DEBUG=astro:render astro dev        # Page rendering
+DEBUG=astro:config astro dev        # Configuration
+
+# Combine multiple namespaces
+DEBUG=astro:build,astro:config astro build
+DEBUG=astro:render,astro:server astro dev
+```
+
+### 2. Add Direct Logging
+
+**Fastest approach**: Add console.log directly in source files.
+
+```typescript
+// Pattern: Add logs with context prefix
+console.log('[CONTEXT] Message:', data);
+
+// Example
+console.log('[BUILD] Processing routes:', routes.length);
+console.log('[RENDER] Component:', component.name);
+console.log('[CONTENT] Collections:', collections);
+```
+
+**Workflow:**
+
+1. Add logs to relevant file (see [Strategic Logging Locations](#strategic-logging-locations))
+2. Run `pnpm -C packages/astro build` to rebuild
+3. Test your change
+
+**Use Astro's debug logger** (optional):
+
+```typescript
+import { debug } from '../logger/core.js';
+const logger = debug('astro:feature-name');
+logger('Operation starting', { data });
+```
+
+### 3. Node Inspector (Advanced)
+
+```bash
+# Start with debugger
+node --inspect node_modules/.bin/astro dev
+node --inspect node_modules/.bin/astro build
+
+# Connect with Chrome DevTools
+# Open chrome://inspect in Chrome
+# Click "inspect" on the Node.js process
+```
+
+**Set breakpoints** in Chrome DevTools, navigate to source files, click line numbers.
+
+## Strategic Logging Locations
+
+**Where to add logs based on issue type:**
+
+| Issue Type        | File Location                                        | Context     |
+| ----------------- | ---------------------------------------------------- | ----------- |
+| Build fails       | `packages/astro/src/core/build/index.ts`             | Core        |
+| Routes not found  | `packages/astro/src/core/routing/manifest/create.ts` | Core        |
+| Content missing   | `packages/astro/src/content/content-layer.ts`        | Core        |
+| Rendering errors  | `packages/astro/src/core/render/core.ts`             | Runtime     |
+| Config issues     | `packages/astro/src/core/config/config.ts`           | Core        |
+| Dev server issues | `packages/astro/src/core/dev/dev.ts`                 | Core        |
+| Component compile | `packages/astro/src/vite-plugin-astro/index.ts`      | Vite        |
+| Virtual modules   | `packages/astro/src/vite-plugin-*/`                  | Vite        |
+| Middleware issues | `packages/astro/src/core/middleware/`                | Core        |
+| Adapter issues    | Check specific adapter in `packages/integrations/`   | Integration |
+
+## Debugging Core (Node.js)
+
+Core code runs in Node.js context: `packages/astro/src/core/`
+
+**This is where most Astro bugs live.**
+
+### Build Pipeline Flow
+
+**Entry point**: `packages/astro/src/core/build/index.ts`
+
+**Flow:**
+
+1. `build()` → Main entry
+2. `staticBuild()` or `viteBuild()` → Build strategy
+3. Build plugins execute in order (see below)
+4. Assets emitted to `dist/`
+
+**Build plugin order** (`packages/astro/src/core/build/plugins/README.md`):
+
+1. middleware
+2. renderers
+3. pages
+4. ssr
+5. manifest
+
+**Add tracing logs** to understand flow:
+
+```typescript
+// In build/index.ts
+console.log('[1] build() entry');
+console.log('[2] Settings created');
+console.log('[3] Build complete');
+```
+
+### Component Identification
+
+**Astro Vite plugins**: `packages/astro/src/vite-plugin-*/`
+
+- `vite-plugin-astro` → `.astro` file compilation
+- `vite-plugin-astro-server` → Dev server integration
+- `vite-plugin-env` → Environment variables
+- `vite-plugin-html` → HTML injection
+
+**Build plugins**: `packages/astro/src/core/build/plugins/`
+
+- `plugin-middleware.ts` → Middleware emission
+- `plugin-renderers.ts` → Renderer collection
+- `plugin-pages.ts` → Page virtual modules
+- `plugin-ssr.ts` → SSR entry points
+- `plugin-manifest.ts` → Manifest generation
+
+## Debugging SSR Issues
+
+SSR issues span multiple contexts. Identify context first.
+
+### Context Identification
+
+**Determine which context the issue occurs in:**
+
+1. Does issue occur in `astro dev`? → Dev/render context
+2. Does issue occur after `astro build`? → Build context
+3. Does issue occur in `astro preview`? → Runtime/adapter context
+
+See [architecture.md](architecture.md) for pipeline details.
+
+### Debug by Context
+
+**Dev SSR:**
+
+- Location: `packages/astro/src/core/render/`
+- Command: `DEBUG=astro:render,astro:server astro dev`
+- Check: Components loading, middleware executing, virtual modules available
+
+**Build SSR:**
+
+- Location: `packages/astro/src/core/build/`
+- Command: `DEBUG=astro:build astro build`
+- Check: `dist/` structure, hashed chunks in `dist/server/chunks/`
+
+**Runtime SSR:**
+
+- Location: `packages/astro/src/core/app/`
+- Command: `astro preview`
+- Check: Adapter implementation, middleware presence, routing, environment variables
+
+### Inspect Build Output
+
+```bash
+# Inspect dist/ structure
+ls -laR dist/
+
+# SSR build structure (varies by adapter pattern):
+# dist/client/            → Client assets (hashed)
+# dist/server/chunks/     → All server code (hashed files)
+# dist/server/virtual_astro_middleware.mjs → Middleware
+# dist/server/[entrypoint] → Entry point (filename depends on adapter)
+
+# Legacy adapters: Use entry.mjs
+# Self adapters: Adapter decides filename (e.g., custom.mjs, _render.mjs)
+```
+
+**Adapter patterns:**
+
+- **Legacy** (`adapter.entrypointResolution = 'explicit'`): Always uses `entry.mjs`
+- **Self** (`adapter.entrypointResolution = 'self'`): Adapter controls entrypoint filename
+
+**Find entrypoint:**
+
+```bash
+# List server files (entrypoint is typically at top level)
+ls dist/server/*.mjs
+
+# Check entrypoint content (always a re-export to chunks)
+cat dist/server/entry.mjs  # or whatever the adapter named it
+```
+
+**Find actual code:**
+
+```bash
+# All server code is in hashed chunks
+ls dist/server/chunks/
+
+# Search for specific code in chunks
+grep -r "function.*render" dist/server/chunks/
+```
+
+## Debugging Virtual Modules
+
+Virtual modules use `virtual:astro:*` prefix.
+
+### Common Virtual Modules
+
+- `virtual:astro:manifest` → Manifest data
+- `virtual:astro:routes` → Route definitions
+- `virtual:astro:middleware` → Middleware module
+- `virtual:astro:renderers` → Framework renderers
+
+### Debug Virtual Module Generation
+
+Add logging to Vite plugin hooks:
+
+```typescript
+// In Vite plugin
+{
+  resolveId: {
+    handler(id) {
+      if (id.includes('virtual:astro')) {
+        console.log('[VIRTUAL] Resolving:', id);
+      }
+      // ...
+    }
+  },
+  load: {
+    handler(id) {
+      if (id.includes('\0virtual:astro')) {
+        console.log('[VIRTUAL] Loading:', id);
+        const code = generateCode();
+        console.log('[VIRTUAL] Generated code:', code);
+        return { code };
+      }
+    }
+  }
+}
+```
+
+### Inspect at Runtime
+
+```bash
+# See loaded virtual modules
+DEBUG=astro:* astro dev 2>&1 | grep "virtual:astro"
+```
+
+## Debugging Content Collections
+
+Content layer issues often relate to data store or type generation.
+
+### Inspect Data Store
+
+```bash
+# View entire data store
+cat .astro/data-store.json | jq
+
+# Check specific collection
+cat .astro/data-store.json | jq '.collections["blog"]'
+
+# Count entries per collection
+cat .astro/data-store.json | jq '.collections | to_entries | map({key: .key, count: .value.entries | length})'
+```
+
+### Debug Content Layer
+
+**Location**: `packages/astro/src/content/content-layer.ts`
+
+**Enable debugging:**
+
+```bash
+DEBUG=astro:content astro dev
+DEBUG=astro:content astro build
+```
+
+### Check Type Generation
+
+**Location**: `.astro/types.d.ts`
+
+```bash
+# View generated types
+cat .astro/types.d.ts | grep -A 20 "declare module 'astro:content'"
+```
+
+### Debug Loaders
+
+Add logging in your loader implementation:
+
+```typescript
+export function myLoader() {
+  return {
+    name: 'my-loader',
+    async load({ store, logger }) {
+      logger.info('Loading data...');
+      const data = await fetchData();
+      logger.info(`Loaded ${data.length} entries`);
+
+      for (const entry of data) {
+        console.log('[LOADER] Setting:', entry.id);
+        store.set({ id: entry.id, data: entry });
+      }
+    },
+  };
+}
+```
+
+## Debugging HMR
+
+HMR testing requires a browser. **Do not use `curl`** for HMR issues.
+
+### Use agent-browser
+
+```bash
+# Start dev server in background
+pnpm exec bgproc start -n devserver --wait-for-port 10 -- pnpm -C examples/minimal dev
+
+# Open browser
+agent-browser open http://localhost:4321
+
+# Get snapshot
+agent-browser snapshot -i
+
+# Make changes to source files
+# Verify HMR updates the page
+
+# View logs
+pnpm exec bgproc logs -n devserver
+
+# Cleanup
+pnpm exec bgproc stop -n devserver
+```
+
+### Check HMR Boundaries
+
+Vite maintains HMR boundaries. If HMR isn't working, check module boundaries.
+
+```bash
+DEBUG=vite:hmr astro dev
+```
+
+**Look for:**
+
+- "hmr update" messages
+- Module invalidation chains
+- Boundary violations
+
+### Common HMR Issues
+
+| Issue                  | Cause               | Fix                     |
+| ---------------------- | ------------------- | ----------------------- |
+| Full page reload       | No HMR boundary     | Add HMR accept          |
+| Styles not updating    | CSS module cache    | Check Vite CSS handling |
+| Component not updating | Module not in graph | Check import chain      |
+
+## Debugging Build Failures
+
+### Check Build Output
+
+```bash
+# Build with full output
+astro build
+
+# Inspect dist/ structure
+ls -laR dist/
+
+# SSR build structure:
+# dist/client/            → Client assets (hashed)
+# dist/server/[entrypoint] → Entry shim (filename varies by adapter)
+# dist/server/chunks/     → All server code (hashed files)
+
+# Find entrypoint (adapter-dependent filename)
+ls dist/server/*.mjs
+
+# Check entry point (always a re-export to chunks)
+cat dist/server/entry.mjs  # or whatever filename adapter uses
+
+# All actual code is in hashed chunks
+ls dist/server/chunks/
+```
+
+### Build Plugin Execution
+
+**Order matters.** Plugins execute sequentially.
+
+```bash
+# Check plugin execution
+DEBUG=vite:* astro build 2>&1 | grep "plugin-"
+```
+
+### Asset Processing
+
+**Check:**
+
+- `dist/client/` → Client assets
+- `dist/server/` → SSR code
+- Image optimization
+- CSS bundling
+
+```bash
+# Find asset references
+find dist/ -name "*.html" -exec grep -l "asset-file.jpg" {} \;
+```
+
+## Debugging Test Failures
+
+See [testing.md](testing.md) for comprehensive test debugging.
+
+**Quick checks:**
+
+1. **Unique outDir**: Each test must have unique output directory
+2. **Fixture structure**: Verify package.json has workspace dependencies
+3. **Build cache**: Clean `.astro/` and `dist/` in fixture
+4. **Parallel execution**: Check if `--parallel` is causing issues
+
+## Common Error Patterns
+
+### "Cannot find module 'node:fs'"
+
+**Cause**: Using Node.js API in `runtime/` code
+
+**Fix**: Move code to `core/` or use `@astrojs/internal-helpers`
+
+**See**: [constraints.md](constraints.md)
+
+### "Virtual module not found"
+
+**Cause**: Virtual module not registered or plugin not loaded
+
+**Fix:**
+
+1. Check plugin registration
+2. Verify `resolveId` and `load` hooks use filter/handler pattern
+3. Confirm virtual module prefix is `virtual:astro:*`
+
+### "Test fails intermittently"
+
+**Cause**: Shared `outDir` between tests causing cache pollution
+
+**Fix**: Set unique `outDir` for each test fixture
+
+**See**: [testing.md](testing.md)
+
+### "Port already in use"
+
+**Cause**: Previous dev server still running
+
+**Fix:**
+
+```bash
+# List running processes
+pnpm exec bgproc list
+
+# Stop specific server
+pnpm exec bgproc stop -n devserver
+
+# Kill all node processes (nuclear option)
+killall node
+```
+
+### "HMR not working"
+
+**Cause**: Module boundaries, full reload triggered, or browser cache
+
+**Fix:**
+
+1. Use `agent-browser` (not curl)
+2. Check HMR boundaries with `DEBUG=vite:hmr`
+3. Clear browser cache
+4. Check HMR accept statements in modules
+
+## Debugging Checklist
+
+Before asking for help or filing an issue:
+
+- [ ] Read error message completely
+- [ ] Identified execution context (core/runtime/client)
+- [ ] Enabled appropriate DEBUG flags
+- [ ] Verified with minimal reproduction
+- [ ] Checked if issue exists in `examples/`
+- [ ] Reviewed related documentation
+- [ ] Searched existing issues on GitHub
+- [ ] Isolated to specific component/plugin
+
+## Further Reading
+
+- Architecture: [architecture.md](architecture.md)
+- Constraints: [constraints.md](constraints.md)
+- Testing: [testing.md](testing.md)
+- Vite debugging: https://vitejs.dev/guide/troubleshooting.html

--- a/.agents/skills/astro-developer/testing.md
+++ b/.agents/skills/astro-developer/testing.md
@@ -1,0 +1,973 @@
+# Testing Guide
+
+Comprehensive guide to writing and debugging tests in the Astro monorepo.
+
+## Testing Philosophy
+
+**Prefer unit tests over integration tests.** The codebase is being refactored to be more unit-testable.
+
+**Guidelines:**
+
+- **Default to unit tests**: Test pure functions and business logic with unit tests
+- **Use integration tests sparingly**: Only for features that cannot be unit tested (e.g., virtual modules, full build pipeline)
+- **Write unit-testable code**: Extract business logic from infrastructure, avoid tight coupling, use dependency injection
+
+**When writing new code:**
+
+1. Design code to be unit-testable (pure functions, minimal side effects)
+2. Write unit tests first
+3. Only use integration tests when absolutely necessary
+
+## CRITICAL: Test Isolation Requirement
+
+**Every test fixture MUST have a unique `outDir`**. This is the #1 cause of mysterious test failures.
+
+```javascript
+// BAD - Will cause cache pollution
+await loadFixture({
+  root: './fixtures/my-test/',
+  // No outDir specified - uses default, shared with other tests
+});
+
+// GOOD - Isolated output
+await loadFixture({
+  root: './fixtures/my-test/',
+  outDir: './dist/my-test/', // Unique per test
+});
+```
+
+**Why**: Build artifacts are cached and shared via ESM between test runs. Without unique `outDir`, tests contaminate each other.
+
+**Reference**: `/CONTRIBUTING.md:203-214`
+
+## Test Types (Prefer Unit Tests)
+
+### Unit Tests (node:test) - PREFERRED
+
+**Location**: `packages/astro/test/*.test.js`
+
+**Runner**: `node:test` via `astro-scripts test`
+
+**When to use** (default for most code):
+
+- Testing pure functions and business logic
+- Testing utilities and helpers
+- Testing data transformations
+- Testing configuration parsing
+- Testing any code that can be isolated from infrastructure
+
+**Run**:
+
+```bash
+# All tests in package
+pnpm -C packages/astro exec astro-scripts test "test/**/*.test.js"
+
+# Single test file
+pnpm -C packages/astro exec astro-scripts test "test/actions.test.js"
+
+# Filter by pattern
+pnpm -C packages/astro exec astro-scripts test "test/**/*.test.js" --match "CSS"
+
+# Multiple files
+pnpm -C packages/astro exec astro-scripts test "test/{actions,css,middleware}.test.js"
+```
+
+**Flags**:
+
+- `--match` / `-m` → Filter tests by name pattern (regex)
+- `--only` / `-o` → Run only tests marked with `.only`
+- `--parallel` / `-p` → Run tests in parallel (default: sequential)
+- `--timeout` / `-t` → Set timeout in milliseconds
+- `--watch` / `-w` → Watch mode
+
+**Writing unit-testable code:**
+
+```typescript
+// BAD - tightly coupled, hard to test
+export function processConfig(configPath) {
+  const fs = require('node:fs');
+  const config = JSON.parse(fs.readFileSync(configPath));
+  const result = transformConfig(config);
+  fs.writeFileSync(configPath, JSON.stringify(result));
+}
+
+// GOOD - pure function, easy to test
+export function transformConfig(config) {
+  // Pure business logic, no side effects
+  return {
+    ...config,
+    transformed: true,
+  };
+}
+
+// Infrastructure layer (test with integration test if needed)
+export function processConfigFile(configPath) {
+  const fs = require('node:fs');
+  const config = JSON.parse(fs.readFileSync(configPath));
+  const result = transformConfig(config); // Unit-tested function
+  fs.writeFileSync(configPath, JSON.stringify(result));
+}
+```
+
+### Integration Tests - USE SPARINGLY
+
+**When to use** (only when unit tests are insufficient):
+
+- Testing virtual modules (cannot be unit tested)
+- Testing full build pipeline integration
+- Testing Vite plugin integration
+- Testing adapter integration
+- Testing features that require full Astro context
+
+**Location**: `packages/astro/test/*.test.js` (same location, different purpose)
+
+**Pattern**: Uses `loadFixture()` and builds full Astro projects
+
+**⚠️ Avoid when possible**: Integration tests are slower and harder to debug. Extract business logic into unit-testable functions.
+
+### E2E Tests (Playwright) - USE FOR BROWSER ONLY
+
+**Location**: `packages/astro/e2e/*.test.js`
+
+**When to use**:
+
+- Testing client-side hydration
+- Verifying HMR behavior
+- Browser-specific interactions
+- Testing dev server behavior in real browser
+
+**When NOT to use**:
+
+- Testing `astro build` output (use unit tests)
+- Testing server-side logic (use unit tests)
+- Static HTML validation (use unit tests)
+
+**Run**:
+
+```bash
+# All E2E tests
+pnpm run test:e2e
+
+# Filter by pattern
+pnpm run test:e2e:match "Tailwind CSS"
+```
+
+### Integration Package Tests
+
+**Location**: `packages/integrations/*/test/`
+
+**Pattern**: Each integration has its own test suite
+
+**Run**:
+
+```bash
+# Single integration
+pnpm -C packages/integrations/react run test
+
+# All integrations
+pnpm run test:integrations
+```
+
+## Writing Unit-Testable Code
+
+**Goal**: Make business logic testable without infrastructure dependencies.
+
+### Principles
+
+1. **Separate business logic from infrastructure**
+   - Business logic: Pure functions, data transformations, algorithms
+   - Infrastructure: File I/O, network calls, Vite plugins, Astro context
+
+2. **Use pure functions**
+   - Same input → same output
+   - No side effects
+   - Easy to test
+
+3. **Inject dependencies**
+   - Don't hardcode dependencies
+   - Pass them as parameters
+
+4. **Avoid tight coupling**
+   - Don't import concrete implementations
+   - Use interfaces/contracts
+
+### Patterns
+
+#### Pattern 1: Extract Business Logic
+
+```typescript
+// BAD - business logic mixed with infrastructure
+export async function processMarkdown(filePath: string) {
+  const fs = await import('node:fs/promises');
+  const content = await fs.readFile(filePath, 'utf-8');
+
+  // Business logic buried in infrastructure
+  const withFrontmatter = content.split('---')[2];
+  const processed = withFrontmatter.replace(/TODO:/g, 'NOTE:');
+
+  await fs.writeFile(filePath, processed);
+}
+
+// GOOD - business logic extracted (unit testable)
+export function transformMarkdownContent(content: string): string {
+  const withFrontmatter = content.split('---')[2];
+  return withFrontmatter.replace(/TODO:/g, 'NOTE:');
+}
+
+// Infrastructure layer (integration test if needed)
+export async function processMarkdownFile(filePath: string) {
+  const fs = await import('node:fs/promises');
+  const content = await fs.readFile(filePath, 'utf-8');
+  const processed = transformMarkdownContent(content);
+  await fs.writeFile(filePath, processed);
+}
+
+// Unit test (fast, no file I/O)
+it('transforms markdown content', () => {
+  const input = '---\ntitle: Test\n---\nTODO: Fix this';
+  const result = transformMarkdownContent(input);
+  assert.equal(result, 'NOTE: Fix this');
+});
+```
+
+#### Pattern 2: Dependency Injection
+
+```typescript
+// BAD - hardcoded dependency
+export function buildRoutes(config: AstroConfig) {
+  const pages = scanFilesystem('./src/pages'); // Hardcoded
+  return pages.map((page) => createRoute(page, config));
+}
+
+// GOOD - inject dependency (unit testable)
+export function buildRoutes(pages: string[], config: AstroConfig): Route[] {
+  return pages.map((page) => createRoute(page, config));
+}
+
+// Unit test (no filesystem access)
+it('builds routes from pages', () => {
+  const pages = ['index.astro', 'about.astro'];
+  const config = { base: '/' };
+  const routes = buildRoutes(pages, config);
+  assert.equal(routes.length, 2);
+});
+```
+
+#### Pattern 3: Use Interfaces
+
+```typescript
+// BAD - tight coupling to concrete type
+export function validateConfig(viteConfig: ViteUserConfig) {
+  // Requires full Vite config object
+}
+
+// GOOD - accept minimal interface
+interface ConfigLike {
+  build?: { outDir?: string };
+  server?: { port?: number };
+}
+
+export function validateConfig(config: ConfigLike) {
+  // Only needs what it uses, easy to mock
+}
+
+// Unit test (simple mock)
+it('validates config', () => {
+  const config = { build: { outDir: './dist' } };
+  const result = validateConfig(config);
+  assert.ok(result);
+});
+```
+
+#### Pattern 4: Return Data, Don't Mutate
+
+```typescript
+// BAD - mutation, side effects
+export function updateManifest(manifest: Manifest, route: Route) {
+  manifest.routes.push(route);
+  manifest.version++;
+}
+
+// GOOD - pure function returning new data
+export function addRouteToManifest(manifest: Manifest, route: Route): Manifest {
+  return {
+    ...manifest,
+    routes: [...manifest.routes, route],
+    version: manifest.version + 1,
+  };
+}
+
+// Unit test (predictable, no side effects)
+it('adds route to manifest', () => {
+  const manifest = { routes: [], version: 1 };
+  const route = { path: '/test' };
+  const result = addRouteToManifest(manifest, route);
+
+  assert.equal(result.routes.length, 1);
+  assert.equal(result.version, 2);
+  assert.equal(manifest.routes.length, 0); // Original unchanged
+});
+```
+
+### When Integration Tests Are Necessary
+
+Use integration tests only when unit tests are insufficient:
+
+1. **Virtual modules**: Cannot mock Vite's virtual module system
+2. **Full build pipeline**: Testing end-to-end build process
+3. **Vite plugin behavior**: Testing actual Vite plugin execution
+4. **Adapter integration**: Testing how adapters work with Astro
+
+**Even then**, extract as much business logic as possible into unit-testable functions.
+
+## Test Utilities
+
+**Location**: `packages/astro/test/test-utils.js`
+
+### loadFixture(config)
+
+Load a test fixture with configuration.
+
+```javascript
+import { loadFixture } from './test-utils.js';
+
+const fixture = await loadFixture({
+  root: './fixtures/my-test/',
+  outDir: './dist/my-test/', // REQUIRED
+  adapter: testAdapter(),
+  integrations: [react()],
+});
+```
+
+**Returns**: Fixture object with methods
+
+### Fixture Methods
+
+#### fixture.build()
+
+Build the fixture (runs `astro build`).
+
+```javascript
+await fixture.build();
+```
+
+#### fixture.startDevServer(options)
+
+Start dev server.
+
+```javascript
+const devServer = await fixture.startDevServer();
+// Use server
+await devServer.stop();
+```
+
+#### fixture.preview(options)
+
+Start preview server (serves build output).
+
+```javascript
+await fixture.build();
+const previewServer = await fixture.preview();
+// Use server
+await previewServer.stop();
+```
+
+#### fixture.fetch(url, init)
+
+Fetch from dev/preview server.
+
+```javascript
+const res = await fixture.fetch('/about');
+const html = await res.text();
+```
+
+#### fixture.readFile(path)
+
+Read file from build output.
+
+```javascript
+const html = await fixture.readFile('/index.html');
+```
+
+#### fixture.pathExists(path)
+
+Check if file exists in build output.
+
+```javascript
+const exists = await fixture.pathExists('/index.html');
+```
+
+### testAdapter()
+
+Test adapter for SSR testing.
+
+```javascript
+import testAdapter from './test-adapter.js';
+
+const fixture = await loadFixture({
+  adapter: testAdapter(),
+});
+```
+
+## Test Structure Pattern
+
+### Standard Test Structure
+
+```javascript
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadFixture } from './test-utils.js';
+
+describe('Feature Name', () => {
+  let fixture;
+
+  before(async () => {
+    fixture = await loadFixture({
+      root: './fixtures/feature-name/',
+      outDir: './dist/feature-name/', // Unique!
+    });
+  });
+
+  describe('dev', () => {
+    let devServer;
+
+    before(async () => {
+      devServer = await fixture.startDevServer();
+    });
+
+    after(async () => {
+      await devServer.stop();
+    });
+
+    it('should work in dev', async () => {
+      const res = await fixture.fetch('/');
+      assert.equal(res.status, 200);
+    });
+  });
+
+  describe('build', () => {
+    before(async () => {
+      await fixture.build();
+    });
+
+    it('should work in build', async () => {
+      const html = await fixture.readFile('/index.html');
+      assert.match(html, /expected content/);
+    });
+  });
+});
+```
+
+### Using .only for Focused Testing
+
+```javascript
+// Run only this test
+it.only('focused test', async () => {
+  // ...
+});
+
+// Run only this describe block
+describe.only('focused suite', () => {
+  // All tests here will run
+});
+```
+
+**Run with**:
+
+```bash
+node --test --test-only test/my-test.test.js
+```
+
+**Warning**:
+
+- All parent `describe` blocks must also have `.only`
+- `--test-only` flag must come before file path
+
+## Fixture Structure
+
+### Minimal Fixture
+
+```
+test/fixtures/my-test/
+├── package.json         # REQUIRED
+├── astro.config.mjs     # Optional
+└── src/
+    └── pages/
+        └── index.astro
+```
+
+### Fixture package.json
+
+**REQUIRED**: Use workspace dependencies
+
+```json
+{
+  "name": "@test/my-test",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/react": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}
+```
+
+**Pattern**:
+
+- `"astro": "workspace:*"` → Links to local astro package
+- `"@astrojs/*": "workspace:*"` → Links to local integrations
+- `"react": "catalog:"` → Uses version from catalog in root package.json
+
+### Fixture astro.config.mjs
+
+```javascript
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+export default defineConfig({
+  integrations: [react()],
+  outDir: './dist', // Can be overridden by test
+});
+```
+
+## Test Isolation Best Practices
+
+### 1. Unique Output Directories
+
+```javascript
+// Pattern: Use test name in outDir
+describe('Actions', () => {
+  const fixture = await loadFixture({
+    root: './fixtures/actions/',
+    outDir: './dist/actions/',  // Matches test name
+  });
+});
+
+describe('Actions with adapter', () => {
+  const fixture = await loadFixture({
+    root: './fixtures/actions/',
+    outDir: './dist/actions-adapter/',  // Different from above
+  });
+});
+```
+
+### 2. Clean Build Artifacts
+
+If tests still fail with unique outDir:
+
+```bash
+# Manual cleanup
+rm -rf test/fixtures/my-test/.astro
+rm -rf test/fixtures/my-test/dist
+```
+
+### 3. Avoid Parallel Execution for Flaky Tests
+
+```bash
+# Sequential execution (default)
+pnpm -C packages/astro exec astro-scripts test "test/**/*.test.js"
+
+# Parallel (faster but can cause issues)
+pnpm -C packages/astro exec astro-scripts test "test/**/*.test.js" --parallel
+```
+
+## Testing Patterns
+
+### Testing Vite Plugins
+
+```javascript
+describe('Vite Plugin', () => {
+  it('should transform .astro files', async () => {
+    const fixture = await loadFixture({
+      root: './fixtures/astro-components/',
+      outDir: './dist/astro-components/',
+    });
+
+    await fixture.build();
+    const html = await fixture.readFile('/index.html');
+    assert.match(html, /<h1>.*<\/h1>/);
+  });
+});
+```
+
+### Testing Virtual Modules
+
+```javascript
+describe('Virtual Modules', () => {
+  it('should load virtual:astro:middleware', async () => {
+    const fixture = await loadFixture({
+      root: './fixtures/middleware/',
+      outDir: './dist/middleware/',
+    });
+
+    const devServer = await fixture.startDevServer();
+    const res = await fixture.fetch('/');
+    assert.equal(res.headers.get('x-middleware'), 'true');
+    await devServer.stop();
+  });
+});
+```
+
+### Testing SSR
+
+```javascript
+import testAdapter from './test-adapter.js';
+
+describe('SSR', () => {
+  let fixture;
+
+  before(async () => {
+    fixture = await loadFixture({
+      root: './fixtures/ssr/',
+      outDir: './dist/ssr/',
+      output: 'server',
+      adapter: testAdapter(),
+    });
+    await fixture.build();
+  });
+
+  it('should render dynamically', async () => {
+    const app = await fixture.loadTestAdapterApp();
+    const request = new Request('http://example.com/');
+    const response = await app.render(request);
+    const html = await response.text();
+    assert.match(html, /dynamic content/);
+  });
+});
+```
+
+### Testing Content Collections
+
+```javascript
+describe('Content Collections', () => {
+  it('should generate types', async () => {
+    const fixture = await loadFixture({
+      root: './fixtures/content-collections/',
+      outDir: './dist/content-collections/',
+    });
+
+    await fixture.build();
+
+    // Check data store
+    const dataStore = await fixture.readFile('../.astro/data-store.json');
+    const parsed = JSON.parse(dataStore);
+    assert.ok(parsed.collections.blog);
+
+    // Check types
+    const types = await fixture.readFile('../.astro/types.d.ts');
+    assert.match(types, /declare module 'astro:content'/);
+  });
+});
+```
+
+### Testing Errors
+
+```javascript
+describe('Error Handling', () => {
+  it('should throw on invalid config', async () => {
+    await assert.rejects(async () => {
+      await loadFixture({
+        root: './fixtures/invalid-config/',
+        outDir: './dist/invalid-config/',
+      });
+    }, /Expected configuration error/);
+  });
+});
+```
+
+## Business Logic vs Infrastructure
+
+**Pattern**: Separate pure logic from side effects for testability
+
+### Bad: Hard to Test
+
+```typescript
+// create-key.ts
+import { logger } from '../utils.js';
+
+export async function createKey() {
+  const key = await crypto.subtle.generateKey(/* ... */);
+  logger.info(`Key: ${key}`);
+  return key;
+}
+```
+
+**Issues**:
+
+- Global logger dependency
+- Crypto API hardcoded
+- Can't easily mock
+
+### Good: Testable
+
+```typescript
+// create-key.ts
+import type { Logger, KeyGenerator } from './types.js';
+
+interface Options {
+  logger: Logger;
+  keyGenerator: KeyGenerator;
+}
+
+export async function createKey({ logger, keyGenerator }: Options) {
+  const key = await keyGenerator.generate();
+  logger.info(`Key: ${key}`);
+  return key;
+}
+
+// test/create-key.test.js
+import { SpyLogger } from './test-utils.js';
+import { FakeKeyGenerator } from './test-utils.js';
+
+it('logs the generated key', async () => {
+  const logger = new SpyLogger();
+  const keyGenerator = new FakeKeyGenerator('test-key');
+
+  await createKey({ logger, keyGenerator });
+
+  assert.equal(logger.logs[0].message, 'Key: test-key');
+});
+```
+
+### Test-Specific Abstractions
+
+```javascript
+// test/test-utils.js
+
+export class SpyLogger {
+  logs = [];
+
+  info(message) {
+    this.logs.push({ level: 'info', message });
+  }
+
+  error(message) {
+    this.logs.push({ level: 'error', message });
+  }
+}
+
+export class FakeKeyGenerator {
+  constructor(key) {
+    this.key = key;
+  }
+
+  async generate() {
+    return this.key;
+  }
+}
+```
+
+## Debugging Test Failures
+
+### 1. Run Test in Isolation
+
+```bash
+# Single test file
+node --test test/my-test.test.js
+
+# With focused test
+node --test --test-only test/my-test.test.js
+```
+
+### 2. Check Fixture Setup
+
+```javascript
+// Add logging
+before(async () => {
+  console.log('Loading fixture:', fixturePath);
+  fixture = await loadFixture({
+    root: fixturePath,
+    outDir: './dist/unique/',
+  });
+  console.log('Fixture loaded');
+});
+```
+
+### 3. Inspect Build Output
+
+```javascript
+// After build, inspect files
+await fixture.build();
+const files = await fs.readdir(fixture.config.outDir);
+console.log('Built files:', files);
+```
+
+### 4. Check for Cache Issues
+
+```bash
+# Clean fixture manually
+rm -rf test/fixtures/my-test/.astro
+rm -rf test/fixtures/my-test/dist
+rm -rf test/fixtures/my-test/node_modules/.vite
+```
+
+### 5. Verify outDir Uniqueness
+
+```javascript
+// Check if another test uses same outDir
+grep -r "outDir.*dist/my-test" test/**/*.test.js
+```
+
+### 6. Debug Timeouts in CI
+
+**Symptom**: Tests pass locally but timeout in CI
+
+**Fix**: Add `--parallel` to see which file times out
+
+```json
+// package.json
+{
+  "test": "astro-scripts test --parallel \"test/**/*.test.js\""
+}
+```
+
+**After identifying problematic file**, remove `--parallel` and fix the test.
+
+## Running Tests
+
+### Local Development
+
+```bash
+# Fast iteration
+pnpm -C packages/astro exec astro-scripts test "test/my-feature.test.js" --watch
+
+# Filter by pattern
+pnpm -C packages/astro exec astro-scripts test -m "should handle errors"
+```
+
+### Full Test Suite
+
+```bash
+# All tests (slow)
+pnpm run test
+
+# Just astro package
+pnpm run test:astro
+
+# Just integrations
+pnpm run test:integrations
+
+# E2E tests
+pnpm run test:e2e
+```
+
+### CI Testing
+
+```bash
+# Run in CI mode (no cache)
+pnpm run build:ci:no-cache
+pnpm run test
+```
+
+## Common Test Failures
+
+### "Test timeout exceeded"
+
+**Cause**: Test takes too long (default: 30s)
+
+**Fix**:
+
+```bash
+# Increase timeout
+pnpm -C packages/astro exec astro-scripts test --timeout 60000 "test/slow.test.js"
+```
+
+### "Port already in use"
+
+**Cause**: Previous dev server not stopped
+
+**Fix**:
+
+```javascript
+// Always stop servers in after() hook
+after(async () => {
+  await devServer?.stop();
+});
+```
+
+### "ENOENT: no such file"
+
+**Cause**: File path wrong or build didn't complete
+
+**Fix**:
+
+1. Check file path relative to outDir
+2. Verify `await fixture.build()` completed
+3. Check if file should exist
+
+### "Fixture contamination"
+
+**Cause**: Shared outDir between tests
+
+**Fix**: Ensure unique outDir per test (see top of this guide)
+
+## Test Organization
+
+### Group Related Tests
+
+```javascript
+describe('Feature', () => {
+  describe('dev mode', () => {
+    // Dev-specific tests
+  });
+
+  describe('build mode', () => {
+    // Build-specific tests
+  });
+
+  describe('SSR mode', () => {
+    // SSR-specific tests
+  });
+});
+```
+
+### Share Setup Between Tests
+
+```javascript
+describe('Feature', () => {
+  let fixture;
+
+  // Shared setup
+  before(async () => {
+    fixture = await loadFixture({
+      root: './fixtures/shared/',
+      outDir: './dist/shared/',
+    });
+    await fixture.build();
+  });
+
+  // Multiple tests use same fixture
+  it('test 1', async () => {
+    const html = await fixture.readFile('/page1.html');
+    // ...
+  });
+
+  it('test 2', async () => {
+    const html = await fixture.readFile('/page2.html');
+    // ...
+  });
+});
+```
+
+## Testing Checklist
+
+Before considering a feature complete:
+
+- [ ] Unit tests cover happy path
+- [ ] Unit tests cover error cases
+- [ ] E2E tests if browser interaction needed
+- [ ] Tests use unique outDir
+- [ ] Tests clean up servers/resources
+- [ ] Tests pass locally
+- [ ] Tests pass with `--parallel` (if applicable)
+- [ ] Fixture has proper package.json
+- [ ] Business logic separated from infrastructure
+
+## Further Reading
+
+- CONTRIBUTING.md: Testing section
+- CONTRIBUTING.md: Making code testable (lines 347-531)
+- Fixtures: `packages/astro/test/fixtures/`
+- Test utils: `packages/astro/test/test-utils.js`


### PR DESCRIPTION
## Changes

This PR adds a new `astro-developer` skill, which is a comprehensive set of instructions that should give proper context on how an agent should move in the Astro code base:
- constraints: what to do, what cannot be done, etc.
- testing: how to test stuff, what kind of tests we have, preferences of testing
- architecture: how to navigate the code, the roles of each entity, etc.
- debugging: how to debug Astro when there's an issue that needs fixing
- SKILL and README: small entrypoints that provide initial context, and then redirect the agent to a more comprehensive document

## Testing

Proof reading

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
