### PR TITLE
fix: normalize path case for style matching on case-insensitive systems

### DIFF
--- a/.changeset/fix-style-path-case.md
+++ b/.changeset/fix-style-path-case.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fix styles missing when the working directory path case differs from the filesystem on case-insensitive systems (e.g. Windows)
+
+When running `astro dev` from a directory with different casing than the actual filesystem path (e.g. `d:\dev` vs `D:\dev`), styles would not be applied because Astro treated the differently-cased paths as different files. The root path is now normalized using `fs.realpathSync` to ensure consistent casing.

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -21,7 +21,16 @@ export function resolveRoot(cwd?: string | URL): string {
 	if (cwd instanceof URL) {
 		cwd = fileURLToPath(cwd);
 	}
-	return cwd ? path.resolve(cwd) : process.cwd();
+	const resolved = cwd ? path.resolve(cwd) : process.cwd();
+	// Normalize to the real filesystem path to ensure consistent casing on
+	// case-insensitive systems (e.g. Windows). Without this, running from a
+	// directory typed with different casing (e.g. `d:\dev` vs `D:\dev`) causes
+	// Astro to treat paths as different files, which breaks style association.
+	try {
+		return fs.realpathSync(resolved);
+	} catch {
+		return resolved;
+	}
 }
 
 // Config paths to search for.

--- a/packages/astro/test/units/config/config-resolve.test.js
+++ b/packages/astro/test/units/config/config-resolve.test.js
@@ -1,8 +1,27 @@
 import * as assert from 'node:assert/strict';
+import fs from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { resolveConfig } from '../../../dist/core/config/index.js';
+import { resolveConfig, resolveRoot } from '../../../dist/core/config/index.js';
+
+describe('resolveRoot', () => {
+	it('returns the real filesystem path (normalizes case)', () => {
+		// resolveRoot should return fs.realpathSync result, which normalizes
+		// path casing on case-insensitive file systems (e.g. Windows).
+		const root = resolveRoot();
+		const expected = fs.realpathSync(process.cwd());
+		assert.equal(root, expected);
+	});
+
+	it('resolves a URL to a real path', () => {
+		const url = new URL('file:///tmp');
+		const root = resolveRoot(url);
+		// Should be a string, resolved via realpathSync
+		assert.equal(typeof root, 'string');
+		assert.ok(path.isAbsolute(root));
+	});
+});
 
 describe('resolveConfig', () => {
 	it('resolves relative inline root correctly', async () => {


### PR DESCRIPTION
## Description

Fixes #14013

On Windows, when the working directory path case differs from the actual filesystem path (e.g. `d:\dev` vs `D:\dev`), styles are missing because Astro treats them as different files. The route component paths are computed relative to the root, so if the root has wrong casing, the paths won't match what Vite's module graph uses.

## Changes

- **`packages/astro/src/core/config/config.ts`**: `resolveRoot()` now normalizes the resolved path using `fs.realpathSync()` to ensure the path casing matches the actual filesystem. Falls back to the original resolved path if `realpathSync` fails.

- **`packages/astro/test/units/config/config-resolve.test.js`**: Added unit tests for `resolveRoot()` verifying it returns the real filesystem path.

## Testing

The fix ensures that `resolveRoot()` returns the canonical filesystem path regardless of how the user typed the directory name. This is transparent on case-sensitive systems (Linux/macOS) and fixes the style mismatch on case-insensitive systems (Windows).