### PR TITLE
feat(cloudflare): refactor image service config

### DIFF
--- a/.changeset/cloudflare-image-service-config.md
+++ b/.changeset/cloudflare-image-service-config.md
@@ -2,30 +2,27 @@
 '@astrojs/cloudflare': minor
 ---
 
-Adds flexible `imageService` configuration for the Cloudflare adapter, with named presets and support for custom image services that need to run in Node at build time.
+Adds flexible `imageService` configuration for the Cloudflare adapter, with named presets, a Vite dev middleware that uses `jiti` to dynamically import custom image services in Node, and support for per-phase service configuration.
 
 The `imageService` option now accepts named presets, a bare entrypoint, a shorthand object, or a full per-phase triple:
 
 ```js
-// astro.config.mjs
-import { defineConfig } from 'astro/config';
-import cloudflare from '@astrojs/cloudflare';
+// Named preset (recommended)
+imageService: 'compile'
 
-export default defineConfig({
-  adapter: cloudflare({
-    // Named preset (recommended)
-    imageService: 'compile',
+// Bare entrypoint — unknown entrypoints default to transformsAtBuild: true
+imageService: './src/my-image-service.ts'
 
-    // Bare entrypoint — auto-detects whether Node is needed at build time
-    imageService: './src/my-image-service.ts',
+// Shorthand with config
+imageService: { entrypoint: './src/my-image-service.ts', config: { quality: 80 } }
 
-    // Shorthand with config
-    imageService: { entrypoint: './src/my-image-service.ts', config: { quality: 80 } },
-
-    // Full control over each phase
-    imageService: { build: 'compile', dev: './src/my-image-service.ts', runtime: 'passthrough' },
-  }),
-});
+// Full control over each phase
+imageService: {
+  build: './src/my-build-service.ts',
+  dev: './src/my-dev-service.ts',
+  runtime: './src/my-runtime-service.ts',
+  transformAtBuild: false,
+}
 ```
 
 **Available presets:**
@@ -34,7 +31,6 @@ export default defineConfig({
 - `cloudflare` — uses Cloudflare's CDN (`cdn-cgi/image`) for URL-based transforms
 - `compile` — Sharp at build time and in dev, passthrough at runtime (pre-optimized assets served as-is)
 - `passthrough` — no transforms anywhere
+- `custom` (deprecated) — workerd stub for build, Sharp in dev, user's `config.image.service` at runtime
 
-**Custom services** that can't run in workerd (e.g. anything using native Node modules) are automatically detected and compiled as a Node-side bundle for build-time transforms. The `compile` preset also picks up any image service set by another integration in its `config:setup` hook.
-
-`imageService: 'sharp'` now throws with guidance to use `'compile'` instead. `imageService: 'custom'` is deprecated and maps to `'compile'` with a warning.
+`imageService: 'custom'` is deprecated. It uses the workerd stub for build, Sharp for dev, and preserves the user's existing `config.image.service` at runtime.

--- a/.changeset/cloudflare-image-service-config.md
+++ b/.changeset/cloudflare-image-service-config.md
@@ -1,0 +1,40 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Adds flexible `imageService` configuration for the Cloudflare adapter, with named presets and support for custom image services that need to run in Node at build time.
+
+The `imageService` option now accepts named presets, a bare entrypoint, a shorthand object, or a full per-phase triple:
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  adapter: cloudflare({
+    // Named preset (recommended)
+    imageService: 'compile',
+
+    // Bare entrypoint — auto-detects whether Node is needed at build time
+    imageService: './src/my-image-service.ts',
+
+    // Shorthand with config
+    imageService: { entrypoint: './src/my-image-service.ts', config: { quality: 80 } },
+
+    // Full control over each phase
+    imageService: { build: 'compile', dev: './src/my-image-service.ts', runtime: 'passthrough' },
+  }),
+});
+```
+
+**Available presets:**
+
+- `cloudflare-binding` (default) — uses the Cloudflare Images binding (`IMAGES`) for transforms
+- `cloudflare` — uses Cloudflare's CDN (`cdn-cgi/image`) for URL-based transforms
+- `compile` — Sharp at build time and in dev, passthrough at runtime (pre-optimized assets served as-is)
+- `passthrough` — no transforms anywhere
+
+**Custom services** that can't run in workerd (e.g. anything using native Node modules) are automatically detected and compiled as a Node-side bundle for build-time transforms. The `compile` preset also picks up any image service set by another integration in its `config:setup` hook.
+
+`imageService: 'sharp'` now throws with guidance to use `'compile'` instead. `imageService: 'custom'` is deprecated and maps to `'compile'` with a warning.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -44,6 +44,7 @@
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/underscore-redirects": "workspace:*",
     "@cloudflare/vite-plugin": "^1.25.2",
+    "jiti": "^2.6.1",
     "piccolore": "^0.1.3",
     "tinyglobby": "^0.2.15",
     "vite": "^7.3.1"

--- a/packages/integrations/cloudflare/src/entrypoints/image-service-workerd.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/image-service-workerd.ts
@@ -16,6 +16,17 @@ import { baseService } from 'astro/assets';
 const service: LocalImageService = {
 	...baseService,
 
+	propertiesToHash: [...(baseService.propertiesToHash ?? []), '_serviceConfig'],
+
+	validateOptions(options, imageConfig) {
+		const validated = baseService.validateOptions!(options, imageConfig);
+		const config = imageConfig?.service?.config;
+		if (config && Object.keys(config).length > 0) {
+			(validated as any)._serviceConfig = config;
+		}
+		return validated;
+	},
+
 	async transform(inputBuffer, transform) {
 		return { data: inputBuffer, format: transform.format };
 	},

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -358,7 +358,7 @@ export default function createIntegration({
 							if (Array.isArray(service.propertiesToHash)) {
 								_transformAtBuildConfig.propertiesToHash = service.propertiesToHash;
 							}
-						} catch (e) {
+						} catch (_e) {
 							logger.warn(
 								`Could not resolve propertiesToHash from custom image service "${_buildServiceEntrypoint}". ` +
 									`Image cache hashes may not include custom properties.`,

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -25,6 +25,7 @@ import { parseEnv } from 'node:util';
 import { sessionDrivers } from 'astro/config';
 import { createCloudflarePrerenderer } from './prerenderer.js';
 import { createRequire } from 'node:module';
+import { createJiti } from 'jiti';
 
 export type { Runtime } from './utils/handler.js';
 
@@ -76,6 +77,14 @@ export default function createIntegration({
 	let cfPluginConfig: PluginConfig;
 	/** Relative path to the emitted image service file in the server output dir. */
 	let _servicePath: string | undefined;
+
+	/**
+	 * Mutable config object shared with `createConfigPlugin` via closure.
+	 * Populated in `config:setup`, then updated in `config:done` to add
+	 * the custom service's `propertiesToHash`.
+	 */
+	let _transformAtBuildConfig: import('./vite-plugin-config.js').TransformAtBuildConfig | null =
+		null;
 
 	const normalized = normalizeImageServiceConfig(imageService);
 
@@ -265,21 +274,23 @@ export default function createIntegration({
 									}
 								},
 							},
-							createConfigPlugin({
-								sessionKVBindingName,
-								compileImageConfig:
-									transformsAtBuild && command !== 'dev'
-										? {
-												base: config.base,
-												assetsPrefix:
-													typeof config.build.assetsPrefix === 'string'
-														? config.build.assetsPrefix
-														: undefined,
-												imageServiceEntrypoint: '@astrojs/cloudflare/image-service-workerd',
-												buildAssets: config.build.assets ?? '_astro',
-											}
-										: null,
-							}),
+							(() => {
+								if (transformsAtBuild && command !== 'dev') {
+									_transformAtBuildConfig = {
+										base: config.base,
+										assetsPrefix:
+											typeof config.build.assetsPrefix === 'string'
+												? config.build.assetsPrefix
+												: undefined,
+										imageServiceEntrypoint: '@astrojs/cloudflare/image-service-workerd',
+										buildAssets: config.build.assets ?? '_astro',
+									};
+								}
+								return createConfigPlugin({
+									sessionKVBindingName,
+									transformAtBuildConfig: _transformAtBuildConfig,
+								});
+							})(),
 							// In dev there's no bundle split — the Node middleware handles image transforms
 						// directly, so the virtual:image-service interceptor isn't needed.
 						...(needsInterceptor && command !== 'dev'
@@ -322,7 +333,7 @@ export default function createIntegration({
 				_isFullyStatic =
 					nonInternalRoutes.length > 0 && nonInternalRoutes.every((route) => route.isPrerendered);
 			},
-			'astro:config:done': ({ setAdapter, config, injectTypes, logger }) => {
+			'astro:config:done': async ({ setAdapter, config, injectTypes, logger }) => {
 				_config = config;
 
 				// Capture final entrypoint after all integrations have run their config:setup.
@@ -335,6 +346,24 @@ export default function createIntegration({
 						finalEntrypoint !== '@astrojs/cloudflare/image-service-workerd'
 					) {
 						_buildServiceEntrypoint = finalEntrypoint;
+					}
+
+					// Forward the custom service's propertiesToHash so the workerd
+					// stub produces matching cache hashes during prerendering.
+					if (_buildServiceEntrypoint && _transformAtBuildConfig) {
+						try {
+							const jiti = createJiti(config.root.pathname);
+							const mod = await jiti.import(_buildServiceEntrypoint);
+							const service = (mod as any).default ?? mod;
+							if (Array.isArray(service.propertiesToHash)) {
+								_transformAtBuildConfig.propertiesToHash = service.propertiesToHash;
+							}
+						} catch (e) {
+							logger.warn(
+								`Could not resolve propertiesToHash from custom image service "${_buildServiceEntrypoint}". ` +
+									`Image cache hashes may not include custom properties.`,
+							);
+						}
 					}
 				}
 

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -8,11 +8,14 @@ import type { AstroConfig, AstroIntegration, IntegrationResolvedRoute } from 'as
 import { astroFrontmatterScanPlugin } from './esbuild-plugin-astro-frontmatter.js';
 import { getParts } from './utils/generate-routes-json.js';
 import {
-	type ImageServiceConfig,
+	type ImageServiceOption,
+	WORKERD_COMPATIBLE_ENTRYPOINTS,
 	normalizeImageServiceConfig,
 	setImageConfig,
 } from './utils/image-config.js';
+import { createDevImageMiddlewarePlugin } from './vite-plugin-dev-image-middleware.js';
 import { createConfigPlugin } from './vite-plugin-config.js';
+import { createImageServicePlugins } from './vite-plugin-image-service.js';
 import {
 	cloudflareConfigCustomizer,
 	DEFAULT_SESSION_KV_BINDING_NAME,
@@ -31,7 +34,7 @@ export interface Options
 		'auxiliaryWorkers' | 'configPath' | 'inspectorPort' | 'persistState' | 'remoteBindings'
 	> {
 	/** Options for handling images. */
-	imageService?: ImageServiceConfig;
+	imageService?: ImageServiceOption;
 
 	/**
 	 * By default, Astro will be configured to use Cloudflare KV to store session data. The KV namespace
@@ -68,13 +71,39 @@ export default function createIntegration({
 	...cloudflareOptions
 }: Options = {}): AstroIntegration {
 	let _config: AstroConfig;
-
 	let _routes: IntegrationResolvedRoute[];
 	let _isFullyStatic = false;
 	let cfPluginConfig: PluginConfig;
+	/** Relative path to the emitted image service file in the server output dir. */
+	let _servicePath: string | undefined;
 
-	const { buildService, runtimeService } = normalizeImageServiceConfig(imageService);
-	const needsImagesBinding = runtimeService === 'cloudflare-binding';
+	const normalized = normalizeImageServiceConfig(imageService);
+
+	/**
+	 * Custom image service entrypoint for Node-side image transforms.
+	 * Initialized from explicit triple config, or captured in config:done
+	 * when a later integration overwrites config.image.service.
+	 */
+	let _buildServiceEntrypoint: string | undefined = normalized.serviceEntrypoint;
+	const { devService, runtimeService } = normalized;
+
+	const needsImagesBinding =
+		runtimeService.entrypoint === '@astrojs/cloudflare/image-service-workerd';
+	const transformsAtBuild = normalized.transformsAtBuild;
+	const isPresetConfig = imageService === undefined || typeof imageService === 'string';
+	const devServiceNeedsNode = !WORKERD_COMPATIBLE_ENTRYPOINTS.has(devService.entrypoint);
+
+	// Sharp auto-switches to passthrough at runtime (setImageConfig guard),
+	// so account for that when comparing entrypoints for the virtual module.
+	const effectiveRuntimeEntrypoint =
+		normalized.runtimeService.entrypoint === 'astro/assets/services/sharp'
+			? 'astro/assets/services/noop'
+			: normalized.runtimeService.entrypoint;
+
+	// The interceptor is needed when the build and runtime services differ
+	// (e.g. compile mode: workerd stub for prerender, passthrough for runtime).
+	const needsInterceptor =
+		normalized.buildService.entrypoint !== effectiveRuntimeEntrypoint;
 
 	return {
 		name: '@astrojs/cloudflare',
@@ -84,16 +113,18 @@ export default function createIntegration({
 					throw new Error('`workerd` does not run on Stackblitz.');
 				}
 
+				// TODO: remove when 'custom' preset is removed
+				if (imageService === 'custom') {
+					logger.warn(
+						`imageService: 'custom' is deprecated. Use the adapter's imageService option directly with { entrypoint, config } or a named preset instead.`,
+					);
+				}
+
 				let session = config.session;
-				const isCompile = buildService === 'compile';
 
 				if (needsImagesBinding) {
 					logger.info(
 						`Enabling image processing with Cloudflare Images for production with the "${imagesBindingName}" Images binding.`,
-					);
-				} else if (isCompile) {
-					logger.info(
-						`Enabling compile-time image optimization. Images will be pre-optimized at build time.`,
 					);
 				}
 
@@ -111,10 +142,13 @@ export default function createIntegration({
 					};
 				}
 
-				// In dev, `compile` needs the IMAGES binding for real transforms
-				// (the image-transform-endpoint uses it). At build time,
-				// `compile` uses Sharp on the Node side instead.
-				const needsImagesBindingForDev = isCompile && command === 'dev';
+				// In dev, if the dev image service uses the workerd stub and
+				// the Node middleware isn't handling images, the IMAGES binding
+				// is needed for real transforms via image-transform-endpoint.
+				const needsImagesBindingForDev =
+					command === 'dev' &&
+					devService.entrypoint === '@astrojs/cloudflare/image-service-workerd' &&
+					!devServiceNeedsNode;
 
 				cfPluginConfig = {
 					config: cloudflareConfigCustomizer({
@@ -138,8 +172,8 @@ export default function createIntegration({
 					},
 				};
 
-				// The preview entrypoint uses Cloudflare's vite plugin and so it needs access
-				// to the config. But there's no proper API for this so we use globalThis.
+				// The preview entrypoint (entrypoints/preview.ts) needs the Cloudflare Vite plugin
+				// config but there's no API to pass it directly, so we bridge via globalThis.
 				if (command === 'preview') {
 					globalThis.astroCloudflareOptions = cfPluginConfig;
 				}
@@ -234,7 +268,7 @@ export default function createIntegration({
 							createConfigPlugin({
 								sessionKVBindingName,
 								compileImageConfig:
-									isCompile && command !== 'dev'
+									transformsAtBuild && command !== 'dev'
 										? {
 												base: config.base,
 												assetsPrefix:
@@ -246,9 +280,31 @@ export default function createIntegration({
 											}
 										: null,
 							}),
+							// In dev there's no bundle split — the Node middleware handles image transforms
+						// directly, so the virtual:image-service interceptor isn't needed.
+						...(needsInterceptor && command !== 'dev'
+								? createImageServicePlugins({
+										prerenderEntrypoint: normalized.buildService.entrypoint,
+										runtimeEntrypoint: effectiveRuntimeEntrypoint,
+										getBuildServiceEntrypoint: () => _buildServiceEntrypoint,
+										onService: (relativePath) => {
+											_servicePath = relativePath;
+										},
+									})
+								: []),
+							...(devServiceNeedsNode && command === 'dev'
+								? [
+										createDevImageMiddlewarePlugin({
+											getDevServiceEntrypoint: () =>
+												_buildServiceEntrypoint ?? devService.entrypoint,
+											getImageConfig: () => _config.image,
+											base: config.base,
+										}),
+									]
+								: []),
 						],
 					},
-					image: setImageConfig(imageService, config.image, command, logger),
+					image: setImageConfig(normalized, config.image, command, logger),
 				});
 
 				if (cloudflareOptions.configPath) {
@@ -268,6 +324,19 @@ export default function createIntegration({
 			},
 			'astro:config:done': ({ setAdapter, config, injectTypes, logger }) => {
 				_config = config;
+
+				// Capture final entrypoint after all integrations have run their config:setup.
+				if (transformsAtBuild) {
+					const finalEntrypoint = config.image.service?.entrypoint;
+					if (
+						finalEntrypoint &&
+						finalEntrypoint !== 'astro/assets/services/sharp' &&
+						finalEntrypoint !== 'astro/assets/services/noop' &&
+						finalEntrypoint !== '@astrojs/cloudflare/image-service-workerd'
+					) {
+						_buildServiceEntrypoint = finalEntrypoint;
+					}
+				}
 
 				injectTypes({
 					filename: 'cloudflare.d.ts',
@@ -291,8 +360,7 @@ export default function createIntegration({
 							support: 'limited',
 							message:
 								'When using a custom image service, ensure it is compatible with the Cloudflare Workers runtime.',
-							// Only 'custom' could potentially use sharp at runtime.
-							suppress: buildService === 'custom' ? 'default' : 'all',
+							suppress: isPresetConfig ? 'all' : 'default',
 						},
 						envGetSecret: 'stable',
 					},
@@ -313,7 +381,7 @@ export default function createIntegration({
 					}
 				}
 			},
-			'astro:build:start': ({ setPrerenderer }) => {
+			'astro:build:start': ({ setPrerenderer, logger }) => {
 				setPrerenderer(
 					createCloudflarePrerenderer({
 						root: _config.root,
@@ -322,7 +390,9 @@ export default function createIntegration({
 						base: _config.base,
 						trailingSlash: _config.trailingSlash,
 						cfPluginConfig,
-						hasCompileImageService: buildService === 'compile',
+						hasTransformAtBuildService: transformsAtBuild,
+						getServicePath: () => _servicePath,
+						logger,
 					}),
 				);
 			},
@@ -352,6 +422,13 @@ export default function createIntegration({
 				}
 			},
 			'astro:build:done': async ({ dir, logger, assets }) => {
+				// Delete the emitted image service file — only needed during the build, not at runtime.
+				// It was only needed at build time for Node-side image transforms.
+				if (_servicePath) {
+					const serviceUrl = new URL(_servicePath, _config.build.server);
+					await rm(serviceUrl, { force: true });
+				}
+
 				let redirectsExists = false;
 				try {
 					const redirectsStat = await stat(new URL('./_redirects', _config.build.client));

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -391,6 +391,7 @@ export default function createIntegration({
 						trailingSlash: _config.trailingSlash,
 						cfPluginConfig,
 						hasTransformAtBuildService: transformsAtBuild,
+						expectsToTransformAtBuild: !!_buildServiceEntrypoint,
 						getServicePath: () => _servicePath,
 						logger,
 					}),

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -30,6 +30,13 @@ interface CloudflarePrerendererOptions {
 	trailingSlash: AstroConfig['trailingSlash'];
 	cfPluginConfig: PluginConfig;
 	hasTransformAtBuildService: boolean;
+	/**
+	 * True when a custom (non-Sharp) image service was expected to be emitted
+	 * as a Rollup chunk for build-time transforms. When the emitted file is
+	 * missing, this distinguishes a real bug from the normal Sharp fallback
+	 * used by presets like `'compile'`.
+	 */
+	expectsToTransformAtBuild: boolean;
 	/** Lazy getter — returns the relative path to the emitted image service file. */
 	getServicePath: () => string | undefined;
 	logger: AstroIntegrationLogger;
@@ -47,6 +54,7 @@ export function createCloudflarePrerenderer({
 	trailingSlash,
 	cfPluginConfig,
 	hasTransformAtBuildService,
+	expectsToTransformAtBuild,
 	getServicePath,
 	logger,
 }: CloudflarePrerendererOptions): AstroPrerenderer {
@@ -162,10 +170,9 @@ export function createCloudflarePrerenderer({
 							},
 						};
 					} else {
-						if (hasTransformAtBuildService) {
+						if (expectsToTransformAtBuild) {
 							logger.warn(
-								'Expected a compiled image service but none was found. Falling back to Sharp. ' +
-									'If you are using a custom image service, this is a bug — please file an issue at https://github.com/withastro/astro/issues.',
+								'A custom image service was configured for build-time transforms but was not found. Falling back to Sharp.',
 							);
 						}
 						const mod = await import('astro/assets/services/sharp');

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -1,11 +1,13 @@
 import type {
 	AstroConfig,
+	AstroIntegrationLogger,
 	AstroPrerenderer,
 	AssetsGlobalStaticImagesList,
 	PathWithRoute,
 } from 'astro';
 import { preview, type PreviewServer as VitePreviewServer } from 'vite';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
 import { mkdir } from 'node:fs/promises';
 import { cloudflare as cfVitePlugin, type PluginConfig } from '@cloudflare/vite-plugin';
 import { serializeRouteData, deserializeRouteData } from 'astro/app/manifest';
@@ -27,7 +29,10 @@ interface CloudflarePrerendererOptions {
 	base: AstroConfig['base'];
 	trailingSlash: AstroConfig['trailingSlash'];
 	cfPluginConfig: PluginConfig;
-	hasCompileImageService: boolean;
+	hasTransformAtBuildService: boolean;
+	/** Lazy getter — returns the relative path to the emitted image service file. */
+	getServicePath: () => string | undefined;
+	logger: AstroIntegrationLogger;
 }
 
 /**
@@ -41,7 +46,9 @@ export function createCloudflarePrerenderer({
 	base,
 	trailingSlash,
 	cfPluginConfig,
-	hasCompileImageService,
+	hasTransformAtBuildService,
+	getServicePath,
+	logger,
 }: CloudflarePrerendererOptions): AstroPrerenderer {
 	let previewServer: VitePreviewServer | undefined;
 	let serverUrl: string;
@@ -119,7 +126,7 @@ export function createCloudflarePrerenderer({
 			return response;
 		},
 
-		collectStaticImages: hasCompileImageService
+		collectStaticImages: hasTransformAtBuildService
 			? async (): Promise<AssetsGlobalStaticImagesList> => {
 					const response = await fetch(`${serverUrl}${STATIC_IMAGES_ENDPOINT}`, {
 						method: 'POST',
@@ -134,10 +141,37 @@ export function createCloudflarePrerenderer({
 
 					const entries: StaticImagesResponse = await response.json();
 
-					// Switch from the workerd stub to Sharp for the Node-side generation pipeline
-					const { default: sharpService } = await import('astro/assets/services/sharp');
-					globalThis.astroAsset ??= {};
-					globalThis.astroAsset.imageService = sharpService;
+					// Load into the global cache so getConfiguredImageService() in generate.ts picks it up.
+					const servicePath = getServicePath();
+					if (servicePath) {
+						// The emitter gives us a path relative to the server output dir.
+						const absolutePath = resolve(fileURLToPath(serverDir), servicePath);
+						const mod = await import(pathToFileURL(absolutePath).href);
+						if (!globalThis.astroAsset) globalThis.astroAsset = {};
+						const svc = mod.default;
+						globalThis.astroAsset.imageService = {
+							...svc,
+							async transform(buf: any, opts: any, imgConfig: any) {
+								// The workerd stub's validateOptions ran during prerendering but
+								// doesn't know about custom service defaults. Re-validate with the
+								// compiled service so those defaults are applied before transform.
+								if (svc.validateOptions) {
+									opts = await svc.validateOptions(opts, imgConfig);
+								}
+								return svc.transform(buf, opts, imgConfig);
+							},
+						};
+					} else {
+						if (hasTransformAtBuildService) {
+							logger.warn(
+								'Expected a compiled image service but none was found. Falling back to Sharp. ' +
+									'If you are using a custom image service, this is a bug — please file an issue at https://github.com/withastro/astro/issues.',
+							);
+						}
+						const mod = await import('astro/assets/services/sharp');
+						if (!globalThis.astroAsset) globalThis.astroAsset = {};
+						globalThis.astroAsset.imageService = mod.default;
+					}
 
 					const staticImages: AssetsGlobalStaticImagesList = new Map();
 					for (const entry of entries) {

--- a/packages/integrations/cloudflare/src/utils/handler.ts
+++ b/packages/integrations/cloudflare/src/utils/handler.ts
@@ -1,7 +1,7 @@
 import { env as globalEnv } from 'cloudflare:workers';
 import {
 	sessionKVBindingName,
-	compileImageConfig,
+	transformAtBuildConfig,
 	isPrerender,
 } from 'virtual:astro-cloudflare:config';
 import { createApp } from 'astro/app/entrypoint';
@@ -39,9 +39,9 @@ export async function handle(
 ): Promise<CfResponse> {
 	// Handle prerender endpoints (only active during build prerender phase)
 	if (isPrerender) {
-		if (compileImageConfig) {
+		if (transformAtBuildConfig) {
 			const { installAddStaticImage } = await import('./static-image-collection.js');
-			installAddStaticImage(compileImageConfig);
+			installAddStaticImage(transformAtBuildConfig);
 		}
 
 		if (isStaticPathsRequest(request)) {

--- a/packages/integrations/cloudflare/src/utils/image-config.ts
+++ b/packages/integrations/cloudflare/src/utils/image-config.ts
@@ -66,11 +66,11 @@ export interface NormalizedImageConfig {
 	/** When true, images are optimized at build time in Node, not at runtime in workerd. */
 	transformsAtBuild: boolean;
 	/**
-	 * Entrypoint to emit as a Node-side bundle for build-time image transforms.
-	 * Not set for preset/string configs — the entrypoint is unknown at normalize time and
-	 * read from `config.image.service` in `config:done` after all integrations have run.
-	 * This means any integration that sets `config.image.service` in its `config:setup`
-	 * hook will have its entrypoint picked up automatically by the `compile` preset.
+	 * Entrypoint to compile as a Node-side Rollup chunk for build-time image transforms.
+	 * Set at normalize time for explicit entrypoints (e.g. `'./src/my-service.ts'`).
+	 * Left undefined for presets like `'compile'` — the entrypoint isn't known yet
+	 * and is captured later in `config:done` from `config.image.service` after all
+	 * integrations have run their `config:setup` hooks.
 	 */
 	serviceEntrypoint?: string;
 	/**

--- a/packages/integrations/cloudflare/src/utils/image-config.ts
+++ b/packages/integrations/cloudflare/src/utils/image-config.ts
@@ -27,7 +27,7 @@ export type ImageServicePreset = 'cloudflare' | 'cloudflare-binding' | 'compile'
 type ImageServiceName = 'sharp' | 'passthrough' | 'cloudflare' | 'cloudflare-binding' | (string & {});
 
 /** A service reference: a shorthand name, a bare entrypoint, or a { entrypoint, config } object. */
-export type ImageServiceSlot =
+type ImageServiceSlot =
 	| ImageServiceName
 	| { entrypoint: ImageServiceName; config?: Record<string, any> };
 

--- a/packages/integrations/cloudflare/src/utils/image-config.ts
+++ b/packages/integrations/cloudflare/src/utils/image-config.ts
@@ -1,101 +1,333 @@
+/**
+ * Astro assumes one image service runs everywhere. On Cloudflare we have three
+ * execution contexts that all need to agree on image URLs and hashes: build
+ * (workerd — no native Node modules), dev (Node behind workerd proxy), and
+ * runtime (deployed Worker). All user config is normalised into a
+ * `{ buildService, devService, runtimeService }` triple.
+ *
+ * ```
+ * User config (imageService option)
+ *   → normalizeImageServiceConfig()         → NormalizedImageConfig (triple)
+ *   → setImageConfig()                      → config.image.service (per-command)
+ *   → index.ts config:setup                 → Vite plugins wired up
+ *   → vite-plugin-image-service.ts          → virtual:image-service branching
+ *   → vite-plugin-dev-image-middleware.ts   → /_image Node handler in dev
+ *   → index.ts config:done                  → captures final entrypoint for compile
+ *   → prerenderer.ts collectStaticImages()  → loads service in Node for transforms
+ * ```
+ */
 import type { AstroConfig, AstroIntegrationLogger, HookParameters } from 'astro';
+import type { ImageServiceConfig as AstroImageServiceConfig } from 'astro';
 import { passthroughImageService } from 'astro/config';
 
-export type ImageServiceMode =
-	| 'passthrough'
-	| 'cloudflare'
-	| 'cloudflare-binding'
-	| 'compile'
-	| 'custom';
+/** Named presets that expand into a full build / dev / runtime configuration. */
+export type ImageServicePreset = 'cloudflare' | 'cloudflare-binding' | 'compile' | 'passthrough';
 
-export type ImageServiceConfig =
-	| ImageServiceMode
-	| {
-			build: 'compile';
-			runtime?: 'passthrough' | 'cloudflare-binding';
-	  };
+/** Shorthand service names; any other string is treated as an entrypoint. */
+type ImageServiceName = 'sharp' | 'passthrough' | 'cloudflare' | 'cloudflare-binding' | (string & {});
 
-/** Normalize string | compound config into separate build/runtime modes. */
-export function normalizeImageServiceConfig(config: ImageServiceConfig | undefined): {
-	buildService: ImageServiceMode;
-	runtimeService: ImageServiceMode;
-} {
-	if (!config || typeof config === 'string') {
-		const mode = config ?? 'cloudflare-binding';
-		// `compile` is build-only; at runtime, serve pre-compiled static assets
+/** A service reference: a shorthand name, a bare entrypoint, or a { entrypoint, config } object. */
+export type ImageServiceSlot =
+	| ImageServiceName
+	| { entrypoint: ImageServiceName; config?: Record<string, any> };
+
+/** Explicit per-phase image service configuration. */
+export interface ImageServiceObject {
+	build: ImageServiceSlot;
+	dev: ImageServiceSlot;
+	runtime: ImageServiceSlot;
+	/**
+	 * Whether image transforms run at build time in Node.
+	 * - `true`: the build service is compiled as a Rollup chunk and loaded in Node
+	 *   for real transforms after prerendering. The workerd stub handles URL generation.
+	 * - `false`: the build service runs directly in workerd with no compilation step.
+	 * - `undefined` (default): auto-detected from the build service entrypoint.
+	 *   Unknown entrypoints are assumed to need Node.
+	 */
+	transformAtBuild?: boolean;
+}
+
+/** Shorthand { entrypoint, config? } form — same as a bare string but carries optional config. */
+export interface ImageServiceEntrypoint {
+	entrypoint: ImageServiceName;
+	config?: Record<string, any>;
+}
+
+export type ImageServiceOption =
+	| ImageServicePreset
+	| ImageServiceObject
+	| ImageServiceEntrypoint
+	| (string & {});
+
+export interface NormalizedImageConfig {
+	buildService: AstroImageServiceConfig;
+	devService: AstroImageServiceConfig;
+	runtimeService: AstroImageServiceConfig;
+	/** When true, images are optimized at build time in Node, not at runtime in workerd. */
+	transformsAtBuild: boolean;
+	/**
+	 * Entrypoint to emit as a Node-side bundle for build-time image transforms.
+	 * Not set for preset/string configs — the entrypoint is unknown at normalize time and
+	 * read from `config.image.service` in `config:done` after all integrations have run.
+	 * This means any integration that sets `config.image.service` in its `config:setup`
+	 * hook will have its entrypoint picked up automatically by the `compile` preset.
+	 */
+	serviceEntrypoint?: string;
+	/**
+	 * When true, `runtimeService` is resolved from `config.image.service` in `setImageConfig`
+	 * rather than from the normalised triple. Used by the deprecated `'custom'` preset to
+	 * preserve the user's existing image service at runtime.
+	 *
+	 * TODO: remove when 'custom' preset is removed
+	 */
+	runtimeServiceFromConfig?: boolean;
+}
+
+/** Cloudflare external image service (cdn-cgi/image URL transforms). */
+const CF_EXTERNAL_SERVICE: AstroImageServiceConfig = {
+	entrypoint: '@astrojs/cloudflare/image-service',
+};
+
+/** Workerd-compatible image service stub: baseService (no sharp) + passthrough transform. */
+const WORKERD_STUB_SERVICE: AstroImageServiceConfig = {
+	entrypoint: '@astrojs/cloudflare/image-service-workerd',
+};
+
+/** Endpoint that uses the Cloudflare IMAGES binding for real transforms. */
+const BINDING_ENDPOINT: NonNullable<AstroConfig['image']['endpoint']> = {
+	route: '/_image',
+	entrypoint: '@astrojs/cloudflare/image-transform-endpoint',
+};
+
+/** Generic Astro endpoint that loads images via fetch (no node:fs). */
+const GENERIC_ENDPOINT: NonNullable<AstroConfig['image']['endpoint']> = {
+	route: '/_image',
+	entrypoint: 'astro/assets/endpoint/generic',
+};
+
+/** Services that can run inside workerd — everything else needs Node (transformsAtBuild). */
+export const WORKERD_COMPATIBLE_ENTRYPOINTS = new Set([
+	'@astrojs/cloudflare/image-service-workerd',
+	'@astrojs/cloudflare/image-service',
+	'astro/assets/services/noop',
+]);
+
+/** Resolve a shorthand name to a full Astro image service config. */
+function resolveName(name: string): AstroImageServiceConfig {
+	switch (name) {
+		case 'sharp':
+			return { entrypoint: 'astro/assets/services/sharp' };
+		case 'passthrough':
+			return passthroughImageService();
+		case 'cloudflare':
+			return CF_EXTERNAL_SERVICE;
+		case 'cloudflare-binding':
+			return WORKERD_STUB_SERVICE;
+		case 'compile':
+			throw new Error(
+				`"compile" is a preset, not a service. Use \`imageService: 'compile'\` or specify individual services in { build, dev, runtime }.`,
+			);
+		default:
+			return { entrypoint: name };
+	}
+}
+
+/** Resolve a slot (shorthand string or { entrypoint, config } object) to a full Astro image service config. */
+function resolveSlot(slot: ImageServiceSlot): AstroImageServiceConfig {
+	if (typeof slot === 'string') {
+		return resolveName(slot);
+	}
+	const resolved = resolveName(slot.entrypoint);
+	if (slot.config) {
+		return { ...resolved, config: { ...resolved.config, ...slot.config } };
+	}
+	return resolved;
+}
+
+/** Expand a preset name into build / dev / runtime image service configs. */
+export function expandPreset(preset: ImageServicePreset): NormalizedImageConfig {
+	switch (preset) {
+		case 'cloudflare':
+			return {
+				buildService: CF_EXTERNAL_SERVICE,
+				devService: { entrypoint: 'astro/assets/services/sharp' },
+				runtimeService: CF_EXTERNAL_SERVICE,
+				transformsAtBuild: false,
+			};
+		case 'cloudflare-binding':
+			return {
+				buildService: WORKERD_STUB_SERVICE,
+				devService: WORKERD_STUB_SERVICE,
+				runtimeService: WORKERD_STUB_SERVICE,
+				transformsAtBuild: false,
+			};
+		case 'compile':
+			return {
+				buildService: WORKERD_STUB_SERVICE,
+				devService: { entrypoint: 'astro/assets/services/sharp' },
+				runtimeService: passthroughImageService(),
+				transformsAtBuild: true,
+			};
+		case 'passthrough':
+			return {
+				buildService: passthroughImageService(),
+				devService: passthroughImageService(),
+				runtimeService: passthroughImageService(),
+				transformsAtBuild: false,
+			};
+		default:
+			throw new Error(
+				`Unknown image service preset "${preset}". Valid presets: cloudflare, cloudflare-binding, compile, passthrough. For custom services, use { build, dev, runtime } or { entrypoint }.`,
+			);
+	}
+}
+
+const PRESETS = new Set<string>(['cloudflare', 'cloudflare-binding', 'compile', 'passthrough']);
+
+/** Normalize user-facing config into a resolved build / dev / runtime triple. */
+export function normalizeImageServiceConfig(
+	config: ImageServiceOption | undefined,
+	logger?: AstroIntegrationLogger,
+): NormalizedImageConfig {
+	if (config === undefined) {
+		return expandPreset('cloudflare-binding');
+	}
+
+	if (typeof config === 'string') {
+		// TODO: remove this entire block when 'custom' preset is removed
+		// Backwards compatibility: 'custom' was a no-op that passed through config.image unchanged.
+		// We use the compile pipeline (workerd stub for build, sharp for dev) but preserve the
+		// user's config.image.service at runtime via the runtimeServiceFromConfig flag.
+		if (config === 'custom') {
+			logger?.warn(
+				`imageService: 'custom' is deprecated. Use the adapter's imageService option directly with { entrypoint, config } or a named preset instead.`,
+			);
+			return {
+				buildService: WORKERD_STUB_SERVICE,
+				devService: { entrypoint: 'astro/assets/services/sharp' },
+				runtimeService: passthroughImageService(), // placeholder — overridden in setImageConfig
+				transformsAtBuild: true,
+				runtimeServiceFromConfig: true,
+			};
+		}
+		if (PRESETS.has(config)) {
+			return expandPreset(config as ImageServicePreset);
+		}
+		if (config === 'sharp') {
+			throw new Error(
+				`Use imageService: 'compile' instead of 'sharp'. The 'sharp' shorthand is only valid inside { build, dev, runtime } slots.`,
+			);
+		}
+		const resolved = resolveName(config);
+		const willTransformAtBuild = !WORKERD_COMPATIBLE_ENTRYPOINTS.has(resolved.entrypoint);
 		return {
-			buildService: mode,
-			runtimeService: mode === 'compile' ? 'passthrough' : mode,
+			buildService: willTransformAtBuild ? WORKERD_STUB_SERVICE : resolved,
+			devService: resolved,
+			runtimeService: willTransformAtBuild ? passthroughImageService() : resolved,
+			transformsAtBuild: willTransformAtBuild,
+			serviceEntrypoint: willTransformAtBuild ? resolved.entrypoint : undefined,
 		};
 	}
-	// Compound config: { build: 'compile', runtime?: ... }
+
+	if ('entrypoint' in config && !('build' in config)) {
+		const ep = (config as ImageServiceEntrypoint).entrypoint;
+		if (ep === 'sharp') {
+			throw new Error(
+				`Use imageService: 'compile' instead of { entrypoint: 'sharp' }. The 'sharp' shorthand is only valid inside { build, dev, runtime } slots.`,
+			);
+		}
+		if (PRESETS.has(ep)) {
+			throw new Error(
+				`Use imageService: '${ep}' instead of { entrypoint: '${ep}' }. Presets should be passed directly as a string.`,
+			);
+		}
+		const resolved = resolveSlot(config as ImageServiceEntrypoint);
+		const willTransformAtBuild = !WORKERD_COMPATIBLE_ENTRYPOINTS.has(resolved.entrypoint);
+		return {
+			buildService: willTransformAtBuild
+				? resolved.config
+					? { ...WORKERD_STUB_SERVICE, config: resolved.config }
+					: WORKERD_STUB_SERVICE
+				: resolved,
+			devService: resolved,
+			runtimeService: willTransformAtBuild ? passthroughImageService() : resolved,
+			transformsAtBuild: willTransformAtBuild,
+			serviceEntrypoint: willTransformAtBuild ? resolved.entrypoint : undefined,
+		};
+	}
+
+	const triple = config as ImageServiceObject;
+	const buildResolved = resolveSlot(triple.build);
+	const devResolved = resolveSlot(triple.dev);
+	const runtimeResolved = resolveSlot(triple.runtime);
+
+	const willTransformAtBuild =
+		triple.transformAtBuild ?? !WORKERD_COMPATIBLE_ENTRYPOINTS.has(buildResolved.entrypoint);
+
+	// When swapping to the workerd stub, preserve the original service's config.
+	// The stub ignores it (URL generation only), but Astro passes
+	// config.image.service.config through to transform() via imageConfig.
+	const buildService = willTransformAtBuild
+		? buildResolved.config
+			? { ...WORKERD_STUB_SERVICE, config: buildResolved.config }
+			: WORKERD_STUB_SERVICE
+		: buildResolved;
+
 	return {
-		buildService: 'compile',
-		runtimeService: config.runtime ?? 'passthrough',
+		buildService,
+		devService: devResolved,
+		runtimeService: runtimeResolved,
+		transformsAtBuild: willTransformAtBuild,
+		serviceEntrypoint: willTransformAtBuild ? buildResolved.entrypoint : undefined,
 	};
 }
 
-// The default Astro dev image endpoint uses node:fs which is unavailable in workerd.
-// Use the generic endpoint instead, which loads images via fetch through the dev server.
-const GENERIC_ENDPOINT = { entrypoint: 'astro/assets/endpoint/generic' };
+/** Determine the /_image endpoint handler for a given image service. */
+export function resolveEndpoint(
+	service: AstroImageServiceConfig,
+): NonNullable<AstroConfig['image']['endpoint']> | undefined {
+	if (service.entrypoint === '@astrojs/cloudflare/image-service-workerd') {
+		return BINDING_ENDPOINT;
+	}
+	if (service.entrypoint === 'astro/assets/services/noop') {
+		return GENERIC_ENDPOINT;
+	}
+	// For any other service (sharp, custom, etc.), use the generic endpoint
+	// to avoid Astro's dev.ts fallback which imports vite and crashes the dep optimizer.
+	return GENERIC_ENDPOINT;
+}
 
-// Workerd-compatible image service stub: baseService (no sharp) + passthrough transform.
-// Used by both `compile` and `cloudflare-binding` for URL generation in workerd.
-const WORKERD_IMAGE_SERVICE = { entrypoint: '@astrojs/cloudflare/image-service-workerd' };
-
+/**
+ * Set the Astro image config for the current command.
+ *
+ * `config.image.service` = what processes images for the current command.
+ * `config.image.endpoint` = the /_image route handler — derived from dev service
+ * (in dev) or runtime service (in build, since the endpoint runs in the deployed worker).
+ */
 export function setImageConfig(
-	service: ImageServiceConfig | undefined,
+	normalized: NormalizedImageConfig,
 	config: AstroConfig['image'],
 	command: HookParameters<'astro:config:setup'>['command'],
 	logger: AstroIntegrationLogger,
-) {
-	const { buildService, runtimeService } = normalizeImageServiceConfig(service);
-
-	switch (buildService) {
-		case 'passthrough':
-			return {
-				...config,
-				service: passthroughImageService(),
-				endpoint: command === 'dev' ? GENERIC_ENDPOINT : config.endpoint,
-			};
-
-		case 'cloudflare':
-			return {
-				...config,
-				service: { entrypoint: '@astrojs/cloudflare/image-service' },
-			};
-
-		case 'cloudflare-binding':
-			return {
-				...config,
-				service: WORKERD_IMAGE_SERVICE,
-				endpoint: {
-					entrypoint: '@astrojs/cloudflare/image-transform-endpoint',
-				},
-			};
-
-		case 'compile':
-			return {
-				...config,
-				service: WORKERD_IMAGE_SERVICE,
-				// Dev: IMAGES binding (via Cloudflare Vite plugin) for real transforms.
-				// Build: endpoint depends on runtime - `cloudflare-binding` uses IMAGES, `passthrough` uses generic.
-				endpoint:
-					command === 'dev' || runtimeService === 'cloudflare-binding'
-						? { entrypoint: '@astrojs/cloudflare/image-transform-endpoint' }
-						: GENERIC_ENDPOINT,
-			};
-
-		case 'custom':
-			return { ...config };
-
-		default:
-			if (config.service.entrypoint === 'astro/assets/services/sharp') {
-				logger.warn(
-					`The current configuration does not support image optimization. To allow your project to build with the original, unoptimized images, the image service has been automatically switched to the 'passthrough' option. See https://docs.astro.build/en/reference/configuration-reference/#imageservice`,
-				);
-				return { ...config, service: passthroughImageService() };
-			}
-			return { ...config };
+): AstroConfig['image'] {
+	// TODO: remove when 'custom' preset is removed
+	if (normalized.runtimeServiceFromConfig) {
+		normalized = { ...normalized, runtimeService: config.service };
 	}
+
+	if (normalized.runtimeService.entrypoint === 'astro/assets/services/sharp') {
+		logger.warn(
+			'Sharp cannot run in the Cloudflare Workers runtime. The runtime image service has been automatically switched to passthrough.',
+		);
+		normalized = { ...normalized, runtimeService: passthroughImageService() };
+	}
+
+	const activeService = command === 'dev' ? normalized.devService : normalized.buildService;
+	const endpointSource = command === 'dev' ? normalized.devService : normalized.runtimeService;
+
+	return {
+		...config,
+		service: { config: {}, ...activeService },
+		endpoint: resolveEndpoint(endpointSource) ?? config.endpoint,
+	};
 }

--- a/packages/integrations/cloudflare/src/utils/prerender-constants.ts
+++ b/packages/integrations/cloudflare/src/utils/prerender-constants.ts
@@ -8,5 +8,5 @@ export const STATIC_PATHS_ENDPOINT = '/__astro_static_paths';
 /** Internal endpoint for rendering a specific page during prerendering */
 export const PRERENDER_ENDPOINT = '/__astro_prerender';
 
-/** Internal endpoint for fetching static images collected in workerd during `compile` builds */
+/** Internal endpoint for fetching static images collected in workerd during build-time transforms */
 export const STATIC_IMAGES_ENDPOINT = '/__astro_static_images';

--- a/packages/integrations/cloudflare/src/utils/static-image-collection.ts
+++ b/packages/integrations/cloudflare/src/utils/static-image-collection.ts
@@ -1,14 +1,14 @@
 import { joinPaths, prependForwardSlash, removeBase } from '@astrojs/internal-helpers/path';
 import { hashTransform, propsToFilename } from 'astro/assets';
 import { isESMImportedImage } from 'astro/assets/utils';
-import type { CompileImageConfig } from '../vite-plugin-config.js';
+import type { TransformAtBuildConfig } from '../vite-plugin-config.js';
 
 /**
  * Installs `globalThis.astroAsset.addStaticImage` for use inside workerd
  * during prerendering. This mirrors the logic in astro's vite-plugin-assets.ts
  * but uses only workerd-safe APIs (no node: imports).
  */
-export function installAddStaticImage(config: CompileImageConfig): void {
+export function installAddStaticImage(config: TransformAtBuildConfig): void {
 	if (globalThis.astroAsset?.addStaticImage) return;
 
 	if (!globalThis.astroAsset) {
@@ -27,7 +27,11 @@ export function installAddStaticImage(config: CompileImageConfig): void {
 			config.assetsPrefix ?? '',
 		);
 
-		const hash = hashTransform(options, config.imageServiceEntrypoint, hashProperties);
+		const hash = hashTransform(
+			options,
+			config.imageServiceEntrypoint,
+			config.propertiesToHash ?? hashProperties,
+		);
 
 		let finalFilePath: string;
 		let transformsForPath = globalThis.astroAsset.staticImages.get(finalOriginalPath);

--- a/packages/integrations/cloudflare/src/vite-plugin-config.ts
+++ b/packages/integrations/cloudflare/src/vite-plugin-config.ts
@@ -3,16 +3,17 @@ import type { PluginOption } from 'vite';
 const VIRTUAL_CONFIG_ID = 'virtual:astro-cloudflare:config';
 const RESOLVED_VIRTUAL_CONFIG_ID = '\0' + VIRTUAL_CONFIG_ID;
 
-export interface CompileImageConfig {
+export interface TransformAtBuildConfig {
 	base: string;
 	assetsPrefix: string | undefined;
 	imageServiceEntrypoint: string;
 	buildAssets: string;
+	propertiesToHash?: string[];
 }
 
 export interface Config {
 	sessionKVBindingName: string;
-	compileImageConfig: CompileImageConfig | null;
+	transformAtBuildConfig: TransformAtBuildConfig | null;
 	isPrerender: boolean;
 }
 

--- a/packages/integrations/cloudflare/src/vite-plugin-dev-image-middleware.ts
+++ b/packages/integrations/cloudflare/src/vite-plugin-dev-image-middleware.ts
@@ -1,0 +1,106 @@
+import { isRemotePath } from '@astrojs/internal-helpers/path';
+import type { AstroConfig } from 'astro';
+import { createJiti } from 'jiti';
+import type { Plugin, ViteDevServer } from 'vite';
+import { isRemoteAllowed } from './utils/assets.js';
+
+export interface DevImageMiddlewareOptions {
+	/**
+	 * Lazy getter for the dev image service entrypoint.
+	 * Returns the final entrypoint after all integrations have run (config:done),
+	 * so custom services are picked up automatically.
+	 */
+	getDevServiceEntrypoint: () => string;
+	/** Lazy getter — `_config.image` is set in `config:done`, middleware runs later. */
+	getImageConfig: () => AstroConfig['image'];
+	/** The Astro `base` path (e.g. `/` or `/docs/`). */
+	base: string;
+}
+
+/**
+ * Vite plugin that intercepts `/_image` requests in dev and handles image
+ * transforms in Node. This allows custom image services
+ * to work in dev even though workerd can't load native bindings.
+ *
+ * The middleware runs before the workerd handler, so the workerd-based
+ * generic endpoint never sees these requests.
+ */
+export function createDevImageMiddlewarePlugin(options: DevImageMiddlewareOptions): Plugin {
+	const route = joinBase(options.base, '/_image');
+
+	return {
+		name: '@astrojs/cloudflare:dev-image-middleware',
+		configureServer(server) {
+			// Lazy init — only needed on first image request.
+			let jiti: ReturnType<typeof createJiti> | undefined;
+			server.middlewares.use(async (req, res, next) => {
+				if (!req.url?.startsWith(route)) return next();
+
+				if (!jiti) jiti = createJiti(import.meta.url);
+				try {
+					const entrypoint = options.getDevServiceEntrypoint();
+					const mod = await jiti.import(entrypoint);
+					const service = (mod as any).default ?? mod;
+					const imageConfig = options.getImageConfig();
+
+					const url = new URL(req.url, `http://${req.headers.host}`);
+					const transform = await service.parseURL(url, imageConfig);
+
+					if (!transform?.src) {
+						res.statusCode = 400;
+						res.end('Missing or invalid image source');
+						return;
+					}
+
+					const inputBuffer = await loadSourceImage(transform.src, server, imageConfig);
+					if (!inputBuffer) {
+						res.statusCode = 404;
+						res.end('Source image not found');
+						return;
+					}
+
+					const { data, format } = await service.transform(
+						inputBuffer,
+						transform,
+						imageConfig,
+					);
+
+					res.setHeader('Content-Type', `image/${format}`);
+					res.setHeader('Cache-Control', 'public, max-age=31536000');
+					res.end(data);
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					res.statusCode = 500;
+					res.end(`Image transform failed: ${message}`);
+				}
+			});
+		},
+	};
+}
+
+/** Load the source image — either from the Vite dev server (local) or via fetch (remote). */
+async function loadSourceImage(
+	src: string,
+	server: ViteDevServer,
+	imageConfig: AstroConfig['image'],
+): Promise<Uint8Array | null> {
+	if (isRemotePath(src)) {
+		if (!isRemoteAllowed(src, imageConfig)) return null;
+		const response = await fetch(src);
+		if (!response.ok) return null;
+		return new Uint8Array(await response.arrayBuffer());
+	}
+
+	const address = server.httpServer?.address();
+	if (!address || typeof address === 'string') return null;
+
+	const response = await fetch(new URL(src, `http://localhost:${address.port}`));
+	if (!response.ok) return null;
+	return new Uint8Array(await response.arrayBuffer());
+}
+
+/** Join a base path with a route, avoiding double slashes. */
+function joinBase(base: string, route: string): string {
+	const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+	return `${normalizedBase}${route}`;
+}

--- a/packages/integrations/cloudflare/src/vite-plugin-dev-image-middleware.ts
+++ b/packages/integrations/cloudflare/src/vite-plugin-dev-image-middleware.ts
@@ -36,7 +36,7 @@ export function createDevImageMiddlewarePlugin(options: DevImageMiddlewareOption
 			server.middlewares.use(async (req, res, next) => {
 				if (!req.url?.startsWith(route)) return next();
 
-				if (!jiti) jiti = createJiti(import.meta.url);
+				if (!jiti) jiti = createJiti(server.config.root);
 				try {
 					const entrypoint = options.getDevServiceEntrypoint();
 					const mod = await jiti.import(entrypoint);

--- a/packages/integrations/cloudflare/src/vite-plugin-image-service.ts
+++ b/packages/integrations/cloudflare/src/vite-plugin-image-service.ts
@@ -1,0 +1,96 @@
+import type { Plugin } from 'vite';
+
+/**
+ * The core `astro:assets` plugin resolves `virtual:image-service` to the
+ * configured `image.service.entrypoint`. With Cloudflare we need different
+ * behaviour per environment:
+ *
+ * - **Prerender** (workerd): use the workerd stub for URL generation only
+ * - **SSR** (runtime Worker): use the runtime service (passthrough / binding)
+ *
+ * The interceptor plugin runs with `enforce: 'pre'` so it claims the virtual
+ * module before Astro core can resolve it to the user's custom service (e.g.
+ * custom services). This keeps Node-only code out of all Worker bundles.
+ */
+const ASTRO_VIRTUAL_SERVICE_ID = 'virtual:image-service';
+const RESOLVED_ID = '\0cloudflare:image-service';
+
+export interface ImageServicePluginOptions {
+	/** Workerd-compatible stub used during prerendering (URL generation only). */
+	prerenderEntrypoint: string;
+	/** Service used at runtime in the deployed Worker. */
+	runtimeEntrypoint: string;
+	/** Lazy getter — returns the custom service entrypoint captured in config:done, if any. */
+	getBuildServiceEntrypoint: () => string | undefined;
+	/** Callback invoked with the relative output path of the emitted image service file. */
+	onService: (relativePath: string) => void;
+}
+
+/**
+ * Returns two Vite plugins that handle the workerd/Node service split:
+ *
+ * 1. **Interceptor** (`enforce: 'pre'`): hijacks `virtual:image-service` before
+ *    Astro core and emits branching code — `isPrerender ? stub : runtimeService`.
+ *    This keeps the real (Node-only) service out of all Worker bundles.
+ *
+ * 2. **Emitter** (SSR build only): compiles the custom image service as a
+ *    standalone Rollup chunk. This is the "smuggling" step — the chunk ends up
+ *    in the server output directory where `prerenderer.ts` can `import()` it in
+ *    Node after prerendering finishes. Without this, the custom service would
+ *    only exist inside the workerd bundle where it can't run.
+ */
+export function createImageServicePlugins(
+	options: ImageServicePluginOptions,
+): Plugin[] {
+	let emitRef: string | undefined;
+
+	const interceptor: Plugin = {
+		name: '@astrojs/cloudflare:image-service-interceptor',
+		enforce: 'pre',
+		resolveId: {
+			filter: { id: new RegExp(`^${ASTRO_VIRTUAL_SERVICE_ID}$`) },
+			handler(id) {
+				if (id === ASTRO_VIRTUAL_SERVICE_ID) {
+					return RESOLVED_ID;
+				}
+			},
+		},
+		load: {
+			filter: { id: new RegExp(`^${RESOLVED_ID.replace('\0', '\\0')}$`) },
+			handler(id) {
+				if (id !== RESOLVED_ID) return;
+				return [
+					`import { isPrerender } from 'virtual:astro-cloudflare:config';`,
+					`import prerenderService from ${JSON.stringify(options.prerenderEntrypoint)};`,
+					`import runtimeService from ${JSON.stringify(options.runtimeEntrypoint)};`,
+					`export default isPrerender ? prerenderService : runtimeService;`,
+				].join('\n');
+			},
+		},
+	};
+
+	const emitter: Plugin = {
+		name: '@astrojs/cloudflare:image-service-emitter',
+		applyToEnvironment: (env) => env.name === 'ssr',
+		buildStart() {
+			const entrypoint = options.getBuildServiceEntrypoint();
+			if (entrypoint) {
+				emitRef = this.emitFile({
+					type: 'chunk',
+					id: entrypoint,
+					name: 'custom-image-service',
+				});
+			}
+		},
+		generateBundle() {
+			if (emitRef) {
+				const fileName = this.getFileName(emitRef);
+				// fileName is relative to the output dir — we need an absolute path.
+				// The caller (index.ts) will resolve it against config.build.server.
+				options.onService(fileName);
+			}
+		},
+	};
+
+	return [interceptor, emitter];
+}

--- a/packages/integrations/cloudflare/test/dev-image-middleware.test.js
+++ b/packages/integrations/cloudflare/test/dev-image-middleware.test.js
@@ -1,0 +1,98 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createDevImageMiddlewarePlugin } from '../dist/vite-plugin-dev-image-middleware.js';
+
+describe('createDevImageMiddlewarePlugin', () => {
+	const baseOptions = {
+		getDevServiceEntrypoint: () => 'my-custom-image-service',
+		getImageConfig: () => ({
+			service: { entrypoint: 'my-custom-image-service' },
+			domains: [],
+			remotePatterns: [],
+		}),
+		base: '/',
+	};
+
+	it('returns a plugin with the correct name', () => {
+		const plugin = createDevImageMiddlewarePlugin(baseOptions);
+		assert.equal(plugin.name, '@astrojs/cloudflare:dev-image-middleware');
+	});
+
+	it('has a configureServer hook', () => {
+		const plugin = createDevImageMiddlewarePlugin(baseOptions);
+		assert.equal(typeof plugin.configureServer, 'function');
+	});
+
+	it('registers middleware on the dev server', () => {
+		const plugin = createDevImageMiddlewarePlugin(baseOptions);
+		let middlewareRegistered = false;
+		const mockServer = {
+			middlewares: {
+				use: (fn) => {
+					middlewareRegistered = true;
+					assert.equal(typeof fn, 'function');
+				},
+			},
+		};
+		plugin.configureServer(mockServer);
+		assert.ok(middlewareRegistered, 'Expected middleware to be registered');
+	});
+
+	it('middleware calls next() for non-image requests', async () => {
+		const plugin = createDevImageMiddlewarePlugin(baseOptions);
+		let registeredMiddleware;
+		const mockServer = {
+			middlewares: {
+				use: (fn) => {
+					registeredMiddleware = fn;
+				},
+			},
+		};
+		plugin.configureServer(mockServer);
+
+		let nextCalled = false;
+		await registeredMiddleware(
+			{ url: '/some-page' },
+			{},
+			() => {
+				nextCalled = true;
+			},
+		);
+		assert.ok(nextCalled, 'Expected next() to be called for non-image URL');
+	});
+
+	it('middleware calls next() when URL does not start with base + /_image', async () => {
+		const plugin = createDevImageMiddlewarePlugin({
+			...baseOptions,
+			base: '/docs/',
+		});
+		let registeredMiddleware;
+		const mockServer = {
+			middlewares: {
+				use: (fn) => {
+					registeredMiddleware = fn;
+				},
+			},
+		};
+		plugin.configureServer(mockServer);
+
+		let nextCalled = false;
+		await registeredMiddleware(
+			{ url: '/_image?href=test' },
+			{},
+			() => {
+				nextCalled = true;
+			},
+		);
+		assert.ok(nextCalled, 'Expected next() for /_image without /docs base');
+	});
+
+	it('respects custom base path in route matching', () => {
+		const plugin = createDevImageMiddlewarePlugin({
+			...baseOptions,
+			base: '/docs/',
+		});
+		// The plugin should be created without errors
+		assert.equal(plugin.name, '@astrojs/cloudflare:dev-image-middleware');
+	});
+});

--- a/packages/integrations/cloudflare/test/image-config.test.js
+++ b/packages/integrations/cloudflare/test/image-config.test.js
@@ -1,0 +1,293 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	expandPreset,
+	normalizeImageServiceConfig,
+	resolveEndpoint,
+	setImageConfig,
+} from '../dist/utils/image-config.js';
+
+describe('expandPreset', () => {
+	it('cloudflare → external for build+runtime, sharp for dev', () => {
+		const result = expandPreset('cloudflare');
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service');
+		assert.equal(result.devService.entrypoint, 'astro/assets/services/sharp');
+		assert.equal(result.runtimeService.entrypoint, '@astrojs/cloudflare/image-service');
+	});
+
+	it('cloudflare-binding → all three use workerd stub', () => {
+		const result = expandPreset('cloudflare-binding');
+		const expected = '@astrojs/cloudflare/image-service-workerd';
+		assert.equal(result.buildService.entrypoint, expected);
+		assert.equal(result.devService.entrypoint, expected);
+		assert.equal(result.runtimeService.entrypoint, expected);
+	});
+
+	it('compile → workerd build, sharp dev, passthrough runtime, transformsAtBuild flag', () => {
+		const result = expandPreset('compile');
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service-workerd');
+		assert.equal(result.devService.entrypoint, 'astro/assets/services/sharp');
+		assert.equal(result.runtimeService.entrypoint, 'astro/assets/services/noop');
+		assert.equal(result.transformsAtBuild, true);
+	});
+
+	it('passthrough → all three use noop', () => {
+		const result = expandPreset('passthrough');
+		const expected = 'astro/assets/services/noop';
+		assert.equal(result.buildService.entrypoint, expected);
+		assert.equal(result.devService.entrypoint, expected);
+		assert.equal(result.runtimeService.entrypoint, expected);
+	});
+
+	it('unknown preset throws', () => {
+		assert.throws(() => expandPreset('nope'), /Unknown image service preset/);
+	});
+});
+
+describe('normalizeImageServiceConfig', () => {
+	it('undefined → cloudflare-binding default', () => {
+		const result = normalizeImageServiceConfig(undefined);
+		const expected = '@astrojs/cloudflare/image-service-workerd';
+		assert.equal(result.buildService.entrypoint, expected);
+		assert.equal(result.devService.entrypoint, expected);
+		assert.equal(result.runtimeService.entrypoint, expected);
+	});
+
+	it('bare entrypoint string → auto-detects compile mode', () => {
+		const result = normalizeImageServiceConfig('my-custom-image-service');
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service-workerd');
+		assert.equal(result.devService.entrypoint, 'my-custom-image-service');
+		assert.equal(result.runtimeService.entrypoint, 'astro/assets/services/noop');
+		assert.equal(result.transformsAtBuild, true);
+		assert.equal(result.serviceEntrypoint, 'my-custom-image-service');
+	});
+
+	it('"custom" string → workerd stub build, sharp dev, passthrough placeholder runtime, runtimeServiceFromConfig flag', () => {
+		const result = normalizeImageServiceConfig('custom');
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service-workerd');
+		assert.equal(result.devService.entrypoint, 'astro/assets/services/sharp');
+		assert.equal(result.runtimeService.entrypoint, 'astro/assets/services/noop'); // placeholder
+		assert.equal(result.transformsAtBuild, true);
+		assert.equal(result.runtimeServiceFromConfig, true);
+	});
+
+	it('bare "sharp" string → throws, use compile preset instead', () => {
+		assert.throws(() => normalizeImageServiceConfig('sharp'), /Use imageService: 'compile'/);
+	});
+
+	it('bare workerd-compatible string → no compile', () => {
+		const result = normalizeImageServiceConfig('@astrojs/cloudflare/image-service');
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service');
+		assert.equal(result.runtimeService.entrypoint, '@astrojs/cloudflare/image-service');
+		assert.equal(result.transformsAtBuild, false);
+	});
+
+	it('{ entrypoint } shorthand → same as bare string', () => {
+		const shorthand = normalizeImageServiceConfig({ entrypoint: './src/custom.ts' });
+		const bare = normalizeImageServiceConfig('./src/custom.ts');
+		assert.deepEqual(shorthand, bare);
+	});
+
+	it('{ entrypoint, config } shorthand → config flows to devService and buildService stub', () => {
+		const result = normalizeImageServiceConfig({
+			entrypoint: './src/custom.ts',
+			config: { quality: 80 },
+		});
+		assert.equal(result.devService.entrypoint, './src/custom.ts');
+		assert.deepEqual(result.devService.config, { quality: 80 });
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service-workerd');
+		assert.deepEqual(result.buildService.config, { quality: 80 });
+		assert.equal(result.transformsAtBuild, true);
+		assert.equal(result.serviceEntrypoint, './src/custom.ts');
+	});
+
+	it('{ entrypoint: "sharp" } shorthand → throws, use compile preset instead', () => {
+		assert.throws(
+			() => normalizeImageServiceConfig({ entrypoint: 'sharp' }),
+			/Use imageService: 'compile'/,
+		);
+	});
+
+	it('{ entrypoint: preset } shorthand → throws, use preset directly', () => {
+		assert.throws(
+			() => normalizeImageServiceConfig({ entrypoint: 'cloudflare' }),
+			/Presets should be passed directly/,
+		);
+	});
+
+	it('{ entrypoint } with workerd-compatible service → no compile', () => {
+		const result = normalizeImageServiceConfig({
+			entrypoint: 'astro/assets/services/noop',
+		});
+		assert.equal(result.buildService.entrypoint, 'astro/assets/services/noop');
+		assert.equal(result.runtimeService.entrypoint, 'astro/assets/services/noop');
+		assert.equal(result.transformsAtBuild, false);
+	});
+
+	it('{ build, dev, runtime } with workerd-compatible build → no compile', () => {
+		const result = normalizeImageServiceConfig({
+			build: '@astrojs/cloudflare/image-service-workerd',
+			dev: '@astrojs/cloudflare/image-service-workerd',
+			runtime: 'passthrough',
+		});
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service-workerd');
+		assert.equal(result.transformsAtBuild, false);
+	});
+
+	it('{ build, dev, runtime } with custom build → infers compile mode', () => {
+		const result = normalizeImageServiceConfig({
+			build: 'my-custom-image-service',
+			dev: 'my-custom-image-service',
+			runtime: 'passthrough',
+		});
+		assert.equal(result.buildService.entrypoint, '@astrojs/cloudflare/image-service-workerd');
+		assert.equal(result.devService.entrypoint, 'my-custom-image-service');
+		assert.equal(result.transformsAtBuild, true);
+		assert.equal(result.serviceEntrypoint, 'my-custom-image-service');
+	});
+
+	it('{ entrypoint, config } slot merges config into resolved service', () => {
+		const result = normalizeImageServiceConfig({
+			build: { entrypoint: 'my-custom-image-service', config: { quality: 80 } },
+			dev: { entrypoint: 'sharp', config: { quality: 90 } },
+			runtime: 'passthrough',
+		});
+		assert.equal(result.serviceEntrypoint, 'my-custom-image-service');
+		assert.equal(result.devService.entrypoint, 'astro/assets/services/sharp');
+		assert.deepEqual(result.devService.config, { quality: 90 });
+		// Build service config survives the workerd stub swap so Astro
+		// can pass it through imageConfig → transform() at build time.
+		assert.deepEqual(result.buildService.config, { quality: 80 });
+	});
+
+	it('"compile" as slot value throws', () => {
+		assert.throws(
+			() => normalizeImageServiceConfig({ build: 'compile', dev: 'sharp', runtime: 'passthrough' }),
+			/preset, not a service/,
+		);
+	});
+
+	it('transformAtBuild: true → forces compile mode even for workerd-compatible service', () => {
+		const result = normalizeImageServiceConfig({
+			build: '@astrojs/cloudflare/image-service-workerd',
+			dev: '@astrojs/cloudflare/image-service-workerd',
+			runtime: 'passthrough',
+			transformAtBuild: true,
+		});
+		assert.equal(result.transformsAtBuild, true);
+		assert.equal(
+			result.serviceEntrypoint,
+			'@astrojs/cloudflare/image-service-workerd',
+		);
+		// Build service swapped to workerd stub
+		assert.equal(
+			result.buildService.entrypoint,
+			'@astrojs/cloudflare/image-service-workerd',
+		);
+	});
+
+	it('transformAtBuild: false → disables compile mode for custom service', () => {
+		const result = normalizeImageServiceConfig({
+			build: 'my-custom-image-service',
+			dev: 'my-custom-image-service',
+			runtime: 'passthrough',
+			transformAtBuild: false,
+		});
+		assert.equal(result.transformsAtBuild, false);
+		assert.equal(result.serviceEntrypoint, undefined);
+		// Build service used directly — no workerd stub swap
+		assert.equal(result.buildService.entrypoint, 'my-custom-image-service');
+	});
+
+	it('transformAtBuild: undefined → auto-detects from entrypoint', () => {
+		const result = normalizeImageServiceConfig({
+			build: 'my-custom-image-service',
+			dev: 'my-custom-image-service',
+			runtime: 'passthrough',
+		});
+		assert.equal(result.transformsAtBuild, true);
+		assert.equal(result.serviceEntrypoint, 'my-custom-image-service');
+	});
+});
+
+describe('resolveEndpoint', () => {
+	it('workerd stub → binding endpoint', () => {
+		const result = resolveEndpoint({ entrypoint: '@astrojs/cloudflare/image-service-workerd' });
+		assert.equal(result.entrypoint, '@astrojs/cloudflare/image-transform-endpoint');
+	});
+
+	it('any other service → generic endpoint', () => {
+		assert.equal(
+			resolveEndpoint({ entrypoint: 'astro/assets/services/noop' }).entrypoint,
+			'astro/assets/endpoint/generic',
+		);
+		assert.equal(
+			resolveEndpoint({ entrypoint: './custom.ts' }).entrypoint,
+			'astro/assets/endpoint/generic',
+		);
+	});
+});
+
+describe('setImageConfig', () => {
+	const baseConfig = {
+		service: { entrypoint: 'astro/assets/services/sharp' },
+		endpoint: { entrypoint: 'astro/assets/endpoint/node' },
+	};
+
+	const mockLogger = {
+		warn: () => {},
+		info: () => {},
+		error: () => {},
+		debug: () => {},
+		label: 'test',
+	};
+
+	it('dev command → uses devService for service', () => {
+		const normalized = expandPreset('compile');
+		const result = setImageConfig(normalized, baseConfig, 'dev', mockLogger);
+		assert.equal(result.service.entrypoint, 'astro/assets/services/sharp');
+	});
+
+	it('build command → uses buildService for service, runtimeService for endpoint', () => {
+		const normalized = expandPreset('compile');
+		const result = setImageConfig(normalized, baseConfig, 'build', mockLogger);
+		assert.equal(result.service.entrypoint, '@astrojs/cloudflare/image-service-workerd');
+		assert.equal(result.endpoint.entrypoint, 'astro/assets/endpoint/generic');
+	});
+
+	it('dev with cloudflare-binding → uses binding endpoint', () => {
+		const normalized = expandPreset('cloudflare-binding');
+		const result = setImageConfig(normalized, baseConfig, 'dev', mockLogger);
+		assert.equal(result.endpoint.entrypoint, '@astrojs/cloudflare/image-transform-endpoint');
+	});
+
+	it('sharp as runtime service → warns and auto-switches to passthrough', () => {
+		let warned = false;
+		const warningLogger = {
+			...mockLogger,
+			warn: (msg) => {
+				warned = true;
+				assert.ok(msg.includes('Sharp cannot run'));
+			},
+		};
+		const normalized = {
+			buildService: { entrypoint: 'astro/assets/services/sharp' },
+			devService: { entrypoint: 'astro/assets/services/sharp' },
+			runtimeService: { entrypoint: 'astro/assets/services/sharp' },
+			transformsAtBuild: false,
+		};
+		setImageConfig(normalized, baseConfig, 'build', warningLogger);
+		assert.ok(warned);
+	});
+
+	// TODO: remove when 'custom' preset is removed
+	it('runtimeServiceFromConfig → uses config.service at runtime', () => {
+		const normalized = normalizeImageServiceConfig('custom');
+		const customConfig = {
+			service: { entrypoint: 'my-custom-runtime-service' },
+			endpoint: { entrypoint: 'astro/assets/endpoint/node' },
+		};
+		const result = setImageConfig(normalized, customConfig, 'build', mockLogger);
+		assert.equal(result.endpoint.entrypoint, 'astro/assets/endpoint/generic');
+	});
+});

--- a/packages/integrations/cloudflare/test/image-service-plugin.test.js
+++ b/packages/integrations/cloudflare/test/image-service-plugin.test.js
@@ -1,0 +1,111 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createImageServicePlugins } from '../dist/vite-plugin-image-service.js';
+
+describe('createImageServicePlugins', () => {
+	const plugins = createImageServicePlugins({
+		prerenderEntrypoint: '@astrojs/cloudflare/image-service-workerd',
+		runtimeEntrypoint: 'astro/assets/services/noop',
+		getBuildServiceEntrypoint: () => undefined,
+		onService: () => {},
+	});
+
+	const interceptor = plugins[0];
+	const emitter = plugins[1];
+
+	it('returns two plugins', () => {
+		assert.equal(plugins.length, 2);
+	});
+
+	it('interceptor has enforce: pre', () => {
+		assert.equal(interceptor.enforce, 'pre');
+	});
+
+	it('interceptor resolves virtual:image-service', () => {
+		const result = interceptor.resolveId.handler.call({}, 'virtual:image-service');
+		assert.equal(result, '\0cloudflare:image-service');
+	});
+
+	it('interceptor load generates code with isPrerender ternary', () => {
+		const code = interceptor.load.handler.call({}, '\0cloudflare:image-service');
+		assert.ok(code.includes("import { isPrerender } from 'virtual:astro-cloudflare:config'"));
+		assert.ok(
+			code.includes(
+				'import prerenderService from "@astrojs/cloudflare/image-service-workerd"',
+			),
+		);
+		assert.ok(code.includes('import runtimeService from "astro/assets/services/noop"'));
+		assert.ok(code.includes('export default isPrerender ? prerenderService : runtimeService'));
+	});
+
+	it('emitter applies only to ssr environment', () => {
+		assert.equal(emitter.applyToEnvironment({ name: 'ssr' }), true);
+		assert.equal(emitter.applyToEnvironment({ name: 'client' }), false);
+		assert.equal(emitter.applyToEnvironment({ name: 'prerender' }), false);
+	});
+
+	it('emitter generateBundle invokes onService with the compiled filename', () => {
+		let capturedPath;
+		const testPlugins = createImageServicePlugins({
+			prerenderEntrypoint: '@astrojs/cloudflare/image-service-workerd',
+			runtimeEntrypoint: 'astro/assets/services/noop',
+			getBuildServiceEntrypoint: () => 'my-custom-service',
+			onService: (relativePath) => {
+				capturedPath = relativePath;
+			},
+		});
+
+		const testEmitter = testPlugins[1];
+
+		// Mock rollup context for buildStart — emitFile returns a reference ID
+		const emitFileRef = 'ref_123';
+		const mockBuildStartCtx = {
+			emitFile: (opts) => {
+				assert.equal(opts.type, 'chunk');
+				assert.equal(opts.id, 'my-custom-service');
+				return emitFileRef;
+			},
+		};
+		testEmitter.buildStart.call(mockBuildStartCtx);
+
+		// Mock rollup context for generateBundle — getFileName resolves the reference
+		const mockGenerateBundleCtx = {
+			getFileName: (ref) => {
+				assert.equal(ref, emitFileRef);
+				return 'chunks/custom-image-service-abc123.mjs';
+			},
+		};
+		testEmitter.generateBundle.call(mockGenerateBundleCtx);
+
+		assert.equal(capturedPath, 'chunks/custom-image-service-abc123.mjs');
+	});
+
+	it('emitter generateBundle does nothing when no build service entrypoint is set', () => {
+		const testPlugins = createImageServicePlugins({
+			prerenderEntrypoint: '@astrojs/cloudflare/image-service-workerd',
+			runtimeEntrypoint: 'astro/assets/services/noop',
+			getBuildServiceEntrypoint: () => undefined,
+			onService: () => {
+				assert.fail('onService should not be called');
+			},
+		});
+
+		const testEmitter = testPlugins[1];
+
+		// buildStart with no entrypoint — emitFile should not be called
+		const mockBuildStartCtx = {
+			emitFile: () => {
+				assert.fail('emitFile should not be called');
+			},
+		};
+		testEmitter.buildStart.call(mockBuildStartCtx);
+
+		// generateBundle should be a no-op
+		const mockGenerateBundleCtx = {
+			getFileName: () => {
+				assert.fail('getFileName should not be called');
+			},
+		};
+		testEmitter.generateBundle.call(mockGenerateBundleCtx);
+	});
+});

--- a/packages/integrations/cloudflare/test/image-service-workerd.test.js
+++ b/packages/integrations/cloudflare/test/image-service-workerd.test.js
@@ -1,0 +1,44 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import service from '../dist/entrypoints/image-service-workerd.js';
+
+/** Extract the fields that hashTransform uses — mirrors its reduce logic. */
+function extractHashFields(transform, propertiesToHash) {
+	return propertiesToHash.reduce((acc, prop) => {
+		acc[prop] = transform[prop];
+		return acc;
+	}, {});
+}
+
+describe('image-service-workerd', () => {
+	it('service config changes produce different hash inputs', () => {
+		const baseOptions = { src: '/test.jpg', width: 100, height: 100 };
+		const makeImageConfig = (config) => ({
+			service: { entrypoint: 'test', config },
+			domains: [],
+			remotePatterns: [],
+		});
+
+		const optsA = service.validateOptions(
+			{ ...baseOptions },
+			makeImageConfig({ defaultDitherAlgorithm: 'atkinson' }),
+		);
+		const optsB = service.validateOptions(
+			{ ...baseOptions },
+			makeImageConfig({ defaultDitherAlgorithm: 'bayer-16' }),
+		);
+
+		const fieldsA = extractHashFields(optsA, service.propertiesToHash);
+		const fieldsB = extractHashFields(optsB, service.propertiesToHash);
+
+		assert.notDeepEqual(fieldsA, fieldsB, 'hash inputs must differ when service config changes');
+	});
+
+	it('absent config does not inject _serviceConfig', () => {
+		const opts = service.validateOptions(
+			{ src: '/test.jpg', width: 100, height: 100 },
+			{ service: { entrypoint: 'test' }, domains: [], remotePatterns: [] },
+		);
+		assert.equal(opts._serviceConfig, undefined);
+	});
+});

--- a/packages/integrations/cloudflare/virtual.d.ts
+++ b/packages/integrations/cloudflare/virtual.d.ts
@@ -7,6 +7,11 @@ declare module 'virtual:astro-cloudflare:config' {
 	export const isPrerender: boolean;
 }
 
+declare module 'virtual:astro-cloudflare:image-service' {
+	const service: import('astro').ImageService;
+	export default service;
+}
+
 declare namespace Cloudflare {
 	interface Env {
 		[key: string]: unknown;

--- a/packages/integrations/cloudflare/virtual.d.ts
+++ b/packages/integrations/cloudflare/virtual.d.ts
@@ -3,7 +3,7 @@
 
 declare module 'virtual:astro-cloudflare:config' {
 	export const sessionKVBindingName: string;
-	export const compileImageConfig: import('./src/vite-plugin-config.js').CompileImageConfig | null;
+	export const transformAtBuildConfig: import('./src/vite-plugin-config.js').TransformAtBuildConfig | null;
 	export const isPrerender: boolean;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4913,6 +4913,9 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.25.2
         version: 1.25.2(@cloudflare/workers-types@4.20260228.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260219.0)
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       piccolore:
         specifier: ^0.1.3
         version: 0.1.3


### PR DESCRIPTION
## Changes

Normalises all `imageService` config into a `{ buildService, devService, runtimeService }` triple, makes custom Node-only image services work with compile, adds a Vite dev middleware that uses jiti to dynamically import the image service entrypoint in Node, so custom TypeScript services work in dev

### Config shapes

```js
export default defineConfig({
  adapter: cloudflare({
    imageService: 'compile',
  }),
});
```
```js
export default defineConfig({
  adapter: cloudflare({
    imageService: './src/my-service.ts'
  }),
});
```

```js
export default defineConfig({
  adapter: cloudflare({
    imageService: {
      entrypoint: './src/my-service.ts',
      config: { quality: 80 },
    },
  }),
});
```

```js
export default defineConfig({
  adapter: cloudflare({
    imageService: {
      build: 'sharp', // just an example lol 
      dev: './src/my-dev-service.ts',
      runtime: './src/my-runtime-service.ts',
      transformAtBuild: false,
    }
  }),
});
```

**Available presets:** `cloudflare-binding` (default) | `cloudflare` | `compile` | `passthrough` | `custom` (deprecated)

### What each preset resolves to

  | Preset | buildService | devService | runtimeService | transformsAtBuild |
  |--------|-------------|------------|----------------|-------------------|
  | `cloudflare-binding` (default) | `image-service-workerd` | `image-service-workerd` | `image-service-workerd` | `false` |
  | `cloudflare` | `image-service` (cdn-cgi) | `sharp` | `image-service` (cdn-cgi) | `false` |
  | `compile` | `image-service-workerd` (stub) | `sharp` | `passthrough` | `true` |
  | `passthrough` | `noop` | `noop` | `noop` | `false` |
  | `custom` (deprecated) | `image-service-workerd` (stub) | `sharp` | user's `config.image.service` | `true` |

When `transformsAtBuild` is true, images are transformed at build time in Node (via Sharp or a custom service), and the deployed Worker just serves transformed static assets.

### Other api facets

- `imageService: 'sharp'` throws with guidance to use `'compile'` instead
- `imageService: 'custom'` deprecated, eventually will be copy paste from their astro config.images to the config.adapter 
- Any integration that sets `config.image.service` in `config:setup` is automatically picked up by the `compile` preset (captured in `config:done`) (this means integrations like Chris's sweetcorn dithering tool will work with compile)

## Testing 

added tests

## Docs 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

Haven't written yet, will need to though, ideally get feedback on if this is the right api before writing them

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
