### PR TITLE
Document empty {} for allowing any domain

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -644,7 +644,7 @@ export interface AstroUserConfig<
 		 * }
 		 * ```
 		 *
-		 * To allow all domains (useful for applications behind trusted reverse proxies with dynamic domains), use an empty object:
+		 * In some specific contexts (e.g., applications behind trusted reverse proxies with dynamic domains), you may need to allow all domains. To do this, use an empty object:
 		 *
 		 * ```js
 		 * {


### PR DESCRIPTION
## Changes

- None, just docs

## Testing

N/A

## Docs

- Explains that `{}` is for allowing any domain, pathname, etc.
- Gives the use-case (behind a trusted proxy).

Fixes https://github.com/withastro/astro/issues/15660