### PR TITLE
Fix Netlify adapter error

### DIFF
--- a/.changeset/fix-netlify-external.md
+++ b/.changeset/fix-netlify-external.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes builds that were failing with "Entry module cannot be external" error when using the Netlify adapter
+
+This error was preventing sites from building after recent internal changes. Your builds should now work as expected without any changes to your code.

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -649,6 +649,9 @@ export default function netlifyIntegration(
 								packageVersion,
 							}),
 						],
+						ssr: {
+							noExternal: ['@astrojs/netlify'],
+						},
 						server: {
 							watch: {
 								ignored: [fileURLToPath(new URL('./.netlify/**', rootDir))],


### PR DESCRIPTION
## Changes

- Was failing with "Entry module cannot be external"
  - This happened after a refactor to use the new adapter API

## Testing

- Verified manually in astro.build

## Docs

N/A, bug fix