### PR TITLE
fix: add changeset to bump @astrojs/markdown-remark and fix missing `./shiki` export

### DIFF
--- a/.changeset/long-chefs-tie.md
+++ b/.changeset/long-chefs-tie.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fixes an issue where the use of the `Code` component would result in an unexpected error.


### PR DESCRIPTION
fixes: #15675

## Changes

A changeset was missing for the `./shiki` subpath export addition in @astrojs/markdown-remark, so the package was never re-published with that change.
As a result, the published version (7.0.0-beta.7) is outdated and packages that depend on @astrojs/markdown-remark (such as astro itself) fail when trying to resolve the `./shiki` specifier.
This PR adds the missing changeset to trigger a new release.

## Testing

N/A

## Docs

N/A