### PR TITLE
fix(i18n): only trigger fallback for 404 responses

### DIFF
--- a/.changeset/fix-i18n-fallback-redirect.md
+++ b/.changeset/fix-i18n-fallback-redirect.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes i18n fallback middleware intercepting non-404 responses
+
+The fallback middleware was triggering for all responses with status >= 300, including legitimate 3xx redirects, 403 forbidden, and 5xx server errors. This broke auth flows and form submissions on localized server routes. The fallback now correctly only triggers for 404 (page not found) responses.

--- a/packages/astro/src/i18n/fallback.ts
+++ b/packages/astro/src/i18n/fallback.ts
@@ -54,8 +54,8 @@ export function computeFallbackRoute(options: ComputeFallbackRouteOptions): Fall
 		base,
 	} = options;
 
-	// Only apply fallback for 3xx+ status codes
-	if (responseStatus < 300) {
+	// Only apply fallback for 404 status codes (page not found in this locale)
+	if (responseStatus !== 404) {
 		return { type: 'none' };
 	}
 

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -372,7 +372,7 @@ export function redirectToFallback({
 	fallbackType,
 }: MiddlewarePayload) {
 	return async function (context: APIContext, response: Response): Promise<Response> {
-		if (response.status >= 300 && fallback) {
+		if (response.status === 404 && fallback) {
 			const fallbackKeys = fallback ? Object.keys(fallback) : [];
 			// we split the URL using the `/`, and then check in the returned array we have the locale
 			const segments = context.url.pathname.split('/');

--- a/packages/astro/test/units/i18n/fallback.test.js
+++ b/packages/astro/test/units/i18n/fallback.test.js
@@ -4,8 +4,8 @@ import { computeFallbackRoute } from '../../../dist/i18n/fallback.js';
 import { makeFallbackOptions } from './test-helpers.js';
 
 describe('computeFallbackRoute', () => {
-	describe('when response status < 300', () => {
-		it('returns none (no fallback needed)', () => {
+	describe('when response status is not 404', () => {
+		it('returns none for 200 (success)', () => {
 			const result = computeFallbackRoute(
 				makeFallbackOptions({
 					pathname: '/es/missing',
@@ -18,11 +18,50 @@ describe('computeFallbackRoute', () => {
 			assert.equal(result.type, 'none');
 		});
 
-		it('returns none for 299 status', () => {
+		it('returns none for 301 (redirect)', () => {
 			const result = computeFallbackRoute(
 				makeFallbackOptions({
-					pathname: '/es/missing',
-					responseStatus: 299,
+					pathname: '/es/redirect',
+					responseStatus: 301,
+					currentLocale: 'es',
+					fallback: { es: 'en' },
+				}),
+			);
+
+			assert.equal(result.type, 'none');
+		});
+
+		it('returns none for 302 (temporary redirect)', () => {
+			const result = computeFallbackRoute(
+				makeFallbackOptions({
+					pathname: '/es/redirect',
+					responseStatus: 302,
+					currentLocale: 'es',
+					fallback: { es: 'en' },
+				}),
+			);
+
+			assert.equal(result.type, 'none');
+		});
+
+		it('returns none for 403 (forbidden)', () => {
+			const result = computeFallbackRoute(
+				makeFallbackOptions({
+					pathname: '/es/forbidden',
+					responseStatus: 403,
+					currentLocale: 'es',
+					fallback: { es: 'en' },
+				}),
+			);
+
+			assert.equal(result.type, 'none');
+		});
+
+		it('returns none for 500 (server error)', () => {
+			const result = computeFallbackRoute(
+				makeFallbackOptions({
+					pathname: '/es/error',
+					responseStatus: 500,
 					currentLocale: 'es',
 					fallback: { es: 'en' },
 				}),
@@ -148,7 +187,7 @@ describe('computeFallbackRoute', () => {
 			assert.equal(result.pathname, '/es/missing');
 		});
 
-		it('handles 3xx redirect status', () => {
+		it('only triggers for 404 status, not 3xx', () => {
 			const result = computeFallbackRoute(
 				makeFallbackOptions({
 					pathname: '/es/redirect',
@@ -159,10 +198,10 @@ describe('computeFallbackRoute', () => {
 				}),
 			);
 
-			assert.equal(result.type, 'redirect');
+			assert.equal(result.type, 'none');
 		});
 
-		it('handles 4xx status', () => {
+		it('triggers for 404 status', () => {
 			const result = computeFallbackRoute(
 				makeFallbackOptions({
 					pathname: '/es/notfound',
@@ -176,7 +215,7 @@ describe('computeFallbackRoute', () => {
 			assert.equal(result.type, 'redirect');
 		});
 
-		it('handles 5xx status', () => {
+		it('only triggers for 404 status, not 5xx', () => {
 			const result = computeFallbackRoute(
 				makeFallbackOptions({
 					pathname: '/es/error',
@@ -187,7 +226,7 @@ describe('computeFallbackRoute', () => {
 				}),
 			);
 
-			assert.equal(result.type, 'redirect');
+			assert.equal(result.type, 'none');
 		});
 	});
 

--- a/packages/astro/test/units/i18n/manual-routing.test.js
+++ b/packages/astro/test/units/i18n/manual-routing.test.js
@@ -961,7 +961,7 @@ describe('notFound', () => {
 
 describe('redirectToFallback', () => {
 	describe('basic fallback behavior', () => {
-		it('should return original response when status < 300', async () => {
+		it('should return original response when status is not 404', async () => {
 			const payload = createMiddlewarePayload({
 				fallback: { es: 'en' },
 			});
@@ -974,7 +974,7 @@ describe('redirectToFallback', () => {
 			assert.equal(response, originalResponse);
 		});
 
-		it('should redirect when status >= 300 and locale has fallback', async () => {
+		it('should redirect when status is 404 and locale has fallback', async () => {
 			const payload = createMiddlewarePayload({
 				locales: ['en', 'es', 'fr'],
 				defaultLocale: 'en',
@@ -1087,7 +1087,7 @@ describe('redirectToFallback', () => {
 			assert.equal(response.headers.get('Location'), '/search?q=test');
 		});
 
-		it('should handle 3xx status codes', async () => {
+		it('should not redirect for 3xx status codes', async () => {
 			const payload = createMiddlewarePayload({
 				locales: ['en', 'es'],
 				fallback: { es: 'en' },
@@ -1099,10 +1099,10 @@ describe('redirectToFallback', () => {
 
 			const response = await fallbackFn(context, originalResponse);
 
-			assert.equal(response.status, 302);
+			assert.equal(response, originalResponse);
 		});
 
-		it('should handle 4xx status codes', async () => {
+		it('should not redirect for non-404 4xx status codes', async () => {
 			const payload = createMiddlewarePayload({
 				locales: ['en', 'es'],
 				fallback: { es: 'en' },
@@ -1114,10 +1114,10 @@ describe('redirectToFallback', () => {
 
 			const response = await fallbackFn(context, originalResponse);
 
-			assert.equal(response.status, 302);
+			assert.equal(response, originalResponse);
 		});
 
-		it('should handle 5xx status codes', async () => {
+		it('should not redirect for 5xx status codes', async () => {
 			const payload = createMiddlewarePayload({
 				locales: ['en', 'es'],
 				fallback: { es: 'en' },
@@ -1129,7 +1129,7 @@ describe('redirectToFallback', () => {
 
 			const response = await fallbackFn(context, originalResponse);
 
-			assert.equal(response.status, 302);
+			assert.equal(response, originalResponse);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes #15688

The i18n fallback middleware was incorrectly intercepting all responses with `status >= 300` (in `redirectToFallback`) and `status < 300` as the pass-through gate (in `computeFallbackRoute`). This caused legitimate 3xx redirects, 403 forbidden, and 5xx server errors on localized routes to be incorrectly redirected/rewritten to fallback locales.

**Impact:** Auth flows returning 302 redirects, form submissions returning 303 See Other, and API routes returning 500 errors on localized server routes were all being caught by the fallback middleware and redirected to fallback locale URLs.

### Changes

**`packages/astro/src/i18n/index.ts`** (line 375):
- Changed `response.status >= 300` → `response.status === 404`

**`packages/astro/src/i18n/fallback.ts`** (line 58):  
- Changed `responseStatus < 300` (pass-through) → `responseStatus !== 404` (only 404 triggers fallback)

### Test plan

- [x] Updated `fallback.test.js` — added tests for 301, 302, 403, 500 all returning `none` (no fallback)
- [x] Updated `manual-routing.test.js` — 3xx/4xx(non-404)/5xx now correctly return original response unchanged
- [x] All 244 i18n unit tests pass
- [x] Build passes