### PR TITLE
fix(render): preserve script position in Astro.slots.render() output

### DIFF
--- a/.changeset/fix-script-position-slot-render.md
+++ b/.changeset/fix-script-position-slot-render.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes script position regression when rendered through `Astro.slots.render()`
+
+Scripts in components rendered via `Astro.slots.render('default')` with `set:html` were being hoisted to the top of the slot output instead of rendering at their original position. This broke CSS `:first-child` selectors and sibling selectors. Scripts now use positional placeholders in the content stream to preserve their original location while maintaining deduplication behavior.

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -125,7 +125,15 @@ function stringifyChunk(
 				out += stringifyChunk(result, instr);
 			}
 		}
-		out += chunk.toString();
+		let content = chunk.toString();
+		// Replace script placeholders with their actual stringified content
+		// at their original position, preserving script deduplication
+		if (c.scriptInstructions?.size) {
+			for (const [placeholder, instr] of c.scriptInstructions) {
+				content = content.replace(placeholder, stringifyChunk(result, instr));
+			}
+		}
+		out += content;
 		return out;
 	}
 

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -171,6 +171,20 @@ export class ServerIslandComponent {
 						}
 					}
 				}
+				// Script instructions use positional placeholders in the content string.
+				// Replace them with the actual script content for the island response.
+				if (slotContent.scriptInstructions?.size) {
+					for (const [placeholder, instruction] of slotContent.scriptInstructions) {
+						if (instruction.type === 'script') {
+							if (!this.result._metadata.renderedScripts.has(instruction.id)) {
+								this.result._metadata.renderedScripts.add(instruction.id);
+								slotHtml = slotHtml.replace(placeholder, instruction.content);
+							} else {
+								slotHtml = slotHtml.replace(placeholder, '');
+							}
+						}
+					}
+				}
 				renderedSlots[name] = slotHtml;
 			}
 		}

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -15,10 +15,16 @@ const slotString = Symbol.for('astro:slot-string');
 
 export class SlotString extends HTMLString {
 	public instructions: null | RenderInstruction[];
+	public scriptInstructions: null | Map<string, RenderInstruction>;
 	public [slotString]: boolean;
-	constructor(content: string, instructions: null | RenderInstruction[]) {
+	constructor(
+		content: string,
+		instructions: null | RenderInstruction[],
+		scriptInstructions?: null | Map<string, RenderInstruction>,
+	) {
 		super(content);
 		this.instructions = instructions;
+		this.scriptInstructions = scriptInstructions ?? null;
 		this[slotString] = true;
 	}
 }
@@ -38,6 +44,23 @@ export function mergeSlotInstructions(
 	if (source.instructions?.length) {
 		target ??= [];
 		target.push(...source.instructions);
+	}
+	return target;
+}
+
+/**
+ * Collects script instructions from a SlotString into the target map.
+ * Returns the (possibly newly created) script instructions map.
+ */
+export function mergeSlotScriptInstructions(
+	target: Map<string, RenderInstruction> | null,
+	source: SlotString,
+): Map<string, RenderInstruction> | null {
+	if (source.scriptInstructions?.size) {
+		target ??= new Map();
+		for (const [key, value] of source.scriptInstructions) {
+			target.set(key, value);
+		}
 	}
 	return target;
 }
@@ -64,18 +87,29 @@ export async function renderSlotToString(
 ): Promise<string> {
 	let content = '';
 	let instructions: null | RenderInstruction[] = null;
+	let scriptInstructions: null | Map<string, RenderInstruction> = null;
+	let scriptIndex = 0;
 	const temporaryDestination: RenderDestination = {
 		write(chunk) {
 			// if the chunk is already a SlotString, we concatenate
 			if (chunk instanceof SlotString) {
 				content += chunk;
 				instructions = mergeSlotInstructions(instructions, chunk);
+				scriptInstructions = mergeSlotScriptInstructions(scriptInstructions, chunk);
 			} else if (chunk instanceof Response) return;
 			else if (typeof chunk === 'object' && 'type' in chunk && typeof chunk.type === 'string') {
-				if (instructions === null) {
-					instructions = [];
+				// Script instructions need positional handling — embed a placeholder
+				// in the content stream so they render at their original position
+				// instead of being hoisted to the top of the slot output.
+				if (chunk.type === 'script') {
+					const placeholder = `<!--astro:script:${scriptIndex++}-->`;
+					scriptInstructions ??= new Map();
+					scriptInstructions.set(placeholder, chunk);
+					content += placeholder;
+				} else {
+					instructions ??= [];
+					instructions.push(chunk);
 				}
-				instructions.push(chunk);
 			} else {
 				content += chunkToString(result, chunk);
 			}
@@ -83,7 +117,7 @@ export async function renderSlotToString(
 	};
 	const renderInstance = renderSlot(result, slotted, fallback);
 	await renderInstance.render(temporaryDestination);
-	return markHTMLString(new SlotString(content, instructions));
+	return markHTMLString(new SlotString(content, instructions, scriptInstructions));
 }
 
 interface RenderSlotsResult {

--- a/packages/astro/test/astro-scripts.test.js
+++ b/packages/astro/test/astro-scripts.test.js
@@ -80,6 +80,16 @@ describe('Scripts', () => {
 			assert.equal($('script').length, 1, 'script should be rendered');
 		});
 
+		it('Scripts rendered via Astro.slots.render preserve their position', async () => {
+			let html = await fixture.readFile('/slot-script-position/index.html');
+			let $ = cheerio.load(html);
+
+			assert.equal($('script').length, 1, 'script should be rendered');
+			// The script should appear inside the <li>, not before the <ol>
+			const scriptParent = $('script').parent();
+			assert.equal(scriptParent.is('li'), true, 'script should be inside <li>, not hoisted out');
+		});
+
 		describe('Inlining', () => {
 			/** @type {import('./test-utils').Fixture} */
 			// eslint-disable-next-line @typescript-eslint/no-shadow

--- a/packages/astro/test/fixtures/astro-scripts/src/components/RenderSlotWrapper.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/RenderSlotWrapper.astro
@@ -1,0 +1,4 @@
+---
+const content = await Astro.slots.render('default');
+---
+<div class="wrapper" set:html={content} />

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/slot-script-position.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/slot-script-position.astro
@@ -1,0 +1,18 @@
+---
+import RenderSlotWrapper from '../components/RenderSlotWrapper.astro'
+import ScriptComponent from '../components/ScriptComponent.astro'
+---
+<html lang="en">
+    <head>
+        <title>Slot Script Position Test</title>
+    </head>
+    <body>
+        <RenderSlotWrapper>
+            <ol>
+                <li>Item before</li>
+                <li><ScriptComponent /></li>
+                <li>Item after</li>
+            </ol>
+        </RenderSlotWrapper>
+    </body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #15627

Scripts rendered through `Astro.slots.render('default')` with `set:html` were being hoisted to the top of the slot output instead of rendering at their original position. This regression was introduced by PR #15147, which changed `renderScript()` from returning a plain HTML string to returning a `RenderInstruction` object.

### Root Cause

In `renderSlotToString()`, `RenderInstruction` objects (including scripts) were collected into a separate `instructions` array. When the `SlotString` was stringified in `stringifyChunk()`, all instructions were rendered **before** the content string — causing scripts to be hoisted to the top of the slot output regardless of their original position.

### Fix

Uses positional placeholders (`<!--astro:script:N-->`) embedded in the content string at each script's original position. The actual script instructions are stored in a `scriptInstructions` map on `SlotString`. At stringification time, placeholders are replaced with the real script HTML.

This preserves:
- **Script position** — the placeholder marks where the script should appear
- **Script deduplication** — still goes through `stringifyChunk` which checks `renderedScripts`
- **Unused Fragment slot behavior** — if a slot is unused, script instructions are never stringified (PR #15147's fix preserved)
- **Server island slot scripts** — updated `server-islands.ts` to resolve script placeholders in island responses

### Files Changed

- `packages/astro/src/runtime/server/render/slot.ts` — Added `scriptInstructions` field to `SlotString`, script instructions now use positional placeholders in content string
- `packages/astro/src/runtime/server/render/common.ts` — Replace script placeholders with stringified content during `SlotString` processing
- `packages/astro/src/runtime/server/render/server-islands.ts` — Resolve script placeholders when serializing slot content for island responses

### Test plan

- [x] New test: "Scripts rendered via Astro.slots.render preserve their position" — verifies script is inside `<li>`, not hoisted before `<ol>`
- [x] Existing test passes: "Scripts in Fragment slots are processed when another slot is unused"
- [x] Existing test passes: "includes script from slotted component in island response"
- [x] All 35 script + server-island tests pass
- [x] Build passes