### PR TITLE
fix(biome): use node_module Biome installed schema instead of remote source

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.2/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.

This PR brings really small change but valuable - change path for Biome schema to  `node_module` Biome installed schema instance instead of remote source.
This change fixup the maintenance overhead to keep the schema up-to-date when installed package can control it.
 
The Biome docs suggest to use the internal ones https://biomejs.dev/reference/configuration/#schema

FYI: I need a help defining which changeset I should use for this change.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tested in VsCode IDE, all rules, even after cmd-> 'Biome restart' works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
