### PR TITLE
fix: use Object.hasOwn for action name lookup

### DIFF
--- a/.changeset/fix-action-prototype-traversal.md
+++ b/.changeset/fix-action-prototype-traversal.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes action route handling to return 404 for requests to prototype method names like `constructor` or `toString` used as action paths

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -198,7 +198,7 @@ export abstract class Pipeline {
 		}
 
 		for (const key of pathKeys) {
-			if (!(key in server)) {
+			if (!Object.hasOwn(server, key)) {
 				throw new AstroError({
 					...ActionNotFoundError,
 					message: ActionNotFoundError.message(pathKeys.join('.')),

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -166,6 +166,19 @@ describe('Astro Actions', () => {
 			assert.equal(data.code, 'NOT_FOUND');
 		});
 
+		it('Returns 404 for prototype methods used as action names', async () => {
+			for (const name of ['constructor', '__proto__', 'toString', 'valueOf']) {
+				const res = await fixture.fetch(`/_actions/${name}`, {
+					method: 'POST',
+					body: JSON.stringify({}),
+					headers: {
+						'Content-Type': 'application/json',
+					},
+				});
+				assert.equal(res.status, 404, `Expected 404 for /_actions/${name}`);
+			}
+		});
+
 		it('Should fail when calling an action without using Astro.callAction', async () => {
 			const res = await fixture.fetch('/invalid/');
 			assert.equal(res.status, 500);
@@ -605,6 +618,20 @@ describe('Astro Actions', () => {
 			assert.equal(res.status, 404);
 			const data = await res.json();
 			assert.equal(data.code, 'NOT_FOUND');
+		});
+
+		it('Returns 404 for prototype methods used as action names', async () => {
+			for (const name of ['constructor', '__proto__', 'toString', 'valueOf']) {
+				const req = new Request(`http://example.com/_actions/${name}`, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({}),
+				});
+				const res = await app.render(req);
+				assert.equal(res.status, 404, `Expected 404 for /_actions/${name}`);
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Use `Object.hasOwn()` instead of `in` operator when resolving action names in `getAction()`, so prototype methods like `constructor` or `toString` are not treated as valid actions.

## Testing

- Added tests in both dev and build that POST to `/_actions/constructor`, `/_actions/__proto__`, `/_actions/toString`, and `/_actions/valueOf` and assert 404.

## Docs

N/A, bug fix