### PR TITLE
fix(ci): restrict sandbox image workflow to main branch

### DIFF
--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -2,6 +2,7 @@ name: Build Sandbox Image
 
 on:
   push:
+    branches: [main]
     paths: ['.flue/sandbox/Dockerfile', '.flue/sandbox/AGENTS.md', '.github/workflows/build-sandbox-image.yml']
   workflow_dispatch:
 


### PR DESCRIPTION
## Changes

- Add `branches: [main]` filter to the `build-sandbox-image.yml` workflow's `push` trigger.
- Without a branch filter, the workflow ran on every push to every branch. Branches merging `main` would include the newly-added `.flue/sandbox/` files in the diff, satisfying the `paths` filter and triggering unnecessary builds (~47 runs, most on feature branches).

## Testing

Verified against GitHub Actions docs that `branches` and `paths` are AND conditions — the workflow will now only trigger on pushes to `main` that change the specified files.

## Docs

No docs needed — CI-only change.