### PR TITLE
Add locals to render context

### DIFF
--- a/.changeset/good-tires-say.md
+++ b/.changeset/good-tires-say.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Exposes `locals` to the render context so integrations can access them

--- a/.changeset/jolly-pens-write.md
+++ b/.changeset/jolly-pens-write.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': minor
+---
+
+Adds a new `appEntrypoint` option. Specify a path to a file that contains a default-exported React component. The component will wrap every React island.

--- a/.changeset/twenty-glasses-cross.md
+++ b/.changeset/twenty-glasses-cross.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': minor
+---
+
+Passes `Astro.locals` through to `appEntrypoint` as `locals`

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -573,6 +573,7 @@ export class RenderContext {
 			componentMetadata,
 			compressHTML,
 			cookies,
+			locals: this.locals,
 			/** This function returns the `Astro` faux-global */
 			createAstro: (props, slots) => this.createAstro(result, props, slots, ctx),
 			links,

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -226,6 +226,7 @@ export interface SSRResult {
 	 */
 	pathname: string;
 	cookies: AstroCookies | undefined;
+	locals: App.Locals;
 	serverIslandNameMap: Map<string, string>;
 	trailingSlash: AstroConfig['trailingSlash'];
 	key: Promise<CryptoKey>;

--- a/packages/integrations/react/env.d.ts
+++ b/packages/integrations/react/env.d.ts
@@ -6,3 +6,9 @@ declare module 'astro:react:opts' {
 	const options: Options;
 	export = options;
 }
+
+declare module 'virtual:astro:react-app' {
+	import type { ComponentType } from 'react';
+	import type { AppEntrypointProps } from './src/index.js';
+	export const AppEntrypoint: ComponentType<AppEntrypointProps> | undefined;
+}

--- a/packages/integrations/react/src/client-v17.ts
+++ b/packages/integrations/react/src/client-v17.ts
@@ -1,5 +1,6 @@
 import { createElement } from 'react';
 import { hydrate, render, unmountComponentAtNode } from 'react-dom';
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import StaticHtml from './static-html.js';
 
 export default (element: HTMLElement) =>
@@ -12,11 +13,14 @@ export default (element: HTMLElement) =>
 		for (const [key, value] of Object.entries(slotted)) {
 			props[key] = createElement(StaticHtml, { value, name: key });
 		}
-		const componentEl = createElement(
+		const baseComponentEl = createElement(
 			Component,
 			props,
 			children != null ? createElement(StaticHtml, { value: children }) : children,
 		);
+		const componentEl = AppEntrypoint
+			? createElement(AppEntrypoint, null, baseComponentEl)
+			: baseComponentEl;
 
 		const isHydrate = client !== 'only';
 		const bootstrap = isHydrate ? hydrate : render;

--- a/packages/integrations/react/src/client.ts
+++ b/packages/integrations/react/src/client.ts
@@ -1,5 +1,6 @@
 import { createElement, startTransition } from 'react';
 import { createRoot, hydrateRoot, type Root } from 'react-dom/client';
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import StaticHtml from './static-html.js';
 
 function isAlreadyHydrated(element: HTMLElement) {
@@ -90,11 +91,14 @@ export default (element: HTMLElement) =>
 			props[key] = createElement(StaticHtml, { value, name: key });
 		}
 
-		const componentEl = createElement(
+		const baseComponentEl = createElement(
 			Component,
 			props,
 			getChildren(children, element.hasAttribute('data-react-children')),
 		);
+		const componentEl = AppEntrypoint
+			? createElement(AppEntrypoint, null, baseComponentEl)
+			: baseComponentEl;
 		const rootKey = isAlreadyHydrated(element);
 		// HACK: delete internal react marker for nested components to suppress aggressive warnings
 		if (rootKey) {

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -38,6 +38,10 @@ export interface AppEntrypointProps {
 	 * The React island being wrapped.
 	 */
 	children?: ReactNode;
+	/**
+	 * `Astro.locals`, available only in a server environment.
+	 */
+	locals?: App.Locals;
 }
 
 /**

--- a/packages/integrations/react/src/server-v17.ts
+++ b/packages/integrations/react/src/server-v17.ts
@@ -1,3 +1,4 @@
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
@@ -61,7 +62,10 @@ async function renderToStaticMarkup(
 			value: newChildren,
 		});
 	}
-	const vnode = React.createElement(Component, newProps);
+	const componentElement = React.createElement(Component, newProps);
+	const vnode = AppEntrypoint
+		? React.createElement(AppEntrypoint, null, componentElement)
+		: componentElement;
 	let html: string;
 	if (metadata?.hydrate) {
 		html = ReactDOM.renderToString(vnode);

--- a/packages/integrations/react/src/server-v17.ts
+++ b/packages/integrations/react/src/server-v17.ts
@@ -3,11 +3,12 @@ import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro'
 import React from 'react';
 import ReactDOM from 'react-dom/server';
 import StaticHtml from './static-html.js';
+import type { RendererContext } from './types.js';
 
 const slotName = (str: string) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w.toUpperCase());
 const reactTypeof = Symbol.for('react.element');
 
-function check(Component: any, props: Record<string, any>, children: any) {
+function check(this: RendererContext, Component: any, props: Record<string, any>, children: any) {
 	// Note: there are packages that do some unholy things to create "components".
 	// Checking the $$typeof property catches most of these patterns.
 	if (typeof Component === 'object') {
@@ -32,12 +33,13 @@ function check(Component: any, props: Record<string, any>, children: any) {
 		return React.createElement('div');
 	}
 
-	renderToStaticMarkup(Tester, props, children, {} as any);
+	renderToStaticMarkup.call(this, Tester, props, children, {} as any);
 
 	return isReactComponent;
 }
 
 async function renderToStaticMarkup(
+	this: RendererContext,
 	Component: any,
 	props: Record<string, any>,
 	{ default: children, ...slotted }: Record<string, any>,
@@ -64,7 +66,7 @@ async function renderToStaticMarkup(
 	}
 	const componentElement = React.createElement(Component, newProps);
 	const vnode = AppEntrypoint
-		? React.createElement(AppEntrypoint, null, componentElement)
+		? React.createElement(AppEntrypoint, { locals: this?.result?.locals }, componentElement)
 		: componentElement;
 	let html: string;
 	if (metadata?.hydrate) {

--- a/packages/integrations/react/src/server.ts
+++ b/packages/integrations/react/src/server.ts
@@ -1,4 +1,5 @@
 import opts from 'astro:react:opts';
+import { AppEntrypoint } from 'virtual:astro:react-app';
 import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
@@ -108,7 +109,10 @@ async function renderToStaticMarkup(
 		attrs['data-action-key'] = formState[1];
 		attrs['data-action-name'] = formState[2];
 	}
-	const vnode = React.createElement(Component, newProps);
+	const componentElement = React.createElement(Component, newProps);
+	const vnode = AppEntrypoint
+		? React.createElement(AppEntrypoint, null, componentElement)
+		: componentElement;
 	const renderOptions = {
 		identifierPrefix: prefix,
 		formState,

--- a/packages/integrations/react/src/server.ts
+++ b/packages/integrations/react/src/server.ts
@@ -111,7 +111,7 @@ async function renderToStaticMarkup(
 	}
 	const componentElement = React.createElement(Component, newProps);
 	const vnode = AppEntrypoint
-		? React.createElement(AppEntrypoint, null, componentElement)
+		? React.createElement(AppEntrypoint, { locals: this?.result?.locals }, componentElement)
 		: componentElement;
 	const renderOptions = {
 		identifierPrefix: prefix,

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/astro.config.mjs
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/astro.config.mjs
@@ -1,0 +1,11 @@
+import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [
+		react({
+			appEntrypoint: '/src/react-app.tsx',
+		}),
+	],
+});

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/package.json
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/react-app-entrypoint",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/react": "workspace:*",
+    "astro": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/components/Counter.tsx
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/components/Counter.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { useTheme } from '../react-app';
+
+export default function Counter() {
+	const [count, setCount] = useState(0);
+	const theme = useTheme();
+
+	return (
+		<div data-testid="counter" data-theme={theme}>
+			<p>Count: {count}</p>
+			<p>Theme: {theme}</p>
+			<button onClick={() => setCount((c) => c + 1)}>Increment</button>
+		</div>
+	);
+}

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/layouts/Layout.astro
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/layouts/Layout.astro
@@ -1,0 +1,12 @@
+---
+// Set data on Astro.locals - this will be passed to the wrapper component
+Astro.locals.serverData = 'from-locals';
+---
+<html>
+	<head>
+		<title>React App Entrypoint Test</title>
+	</head>
+	<body>
+		<slot />
+	</body>
+</html>

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/pages/index.astro
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import Counter from '../components/Counter';
+---
+<html>
+	<head>
+		<title>React App Entrypoint Test</title>
+	</head>
+	<body>
+		<h1>React App Entrypoint Test</h1>
+		<Counter client:load />
+	</body>
+</html>

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/pages/with-locals.astro
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/pages/with-locals.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Counter from '../components/Counter';
+---
+<Layout>
+	<h1>React App Entrypoint with Locals</h1>
+	<Counter client:load />
+</Layout>

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/react-app.tsx
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/react-app.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { AppEntrypointProps } from '@astrojs/react';
+
+const ThemeContext = createContext<string>('light');
+
+export function useTheme() {
+	return useContext(ThemeContext);
+}
+
+export default function Wrapper({ children }: AppEntrypointProps) {
+	return (
+		<ThemeContext.Provider value="dark">
+			<div data-testid="wrapper">
+				{children}
+			</div>
+		</ThemeContext.Provider>
+	);
+}

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/src/react-app.tsx
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/src/react-app.tsx
@@ -7,10 +7,10 @@ export function useTheme() {
 	return useContext(ThemeContext);
 }
 
-export default function Wrapper({ children }: AppEntrypointProps) {
+export default function Wrapper({ children, locals }: AppEntrypointProps) {
 	return (
 		<ThemeContext.Provider value="dark">
-			<div data-testid="wrapper">
+			<div data-testid="wrapper" data-server={locals?.serverData}>
 				{children}
 			</div>
 		</ThemeContext.Provider>

--- a/packages/integrations/react/test/fixtures/react-app-entrypoint/tsconfig.json
+++ b/packages/integrations/react/test/fixtures/react-app-entrypoint/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "astro/tsconfigs/strict",
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "react"
+	},
+	"include": ["src/**/*", ".astro/types.d.ts"]
+}

--- a/packages/integrations/react/test/react-app-entrypoint.test.js
+++ b/packages/integrations/react/test/react-app-entrypoint.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { load as cheerioLoad } from 'cheerio';
+import { isWindows, loadFixture } from '../../../astro/test/test-utils.js';
+
+let fixture;
+
+describe('React App Entrypoint', () => {
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/react-app-entrypoint/', import.meta.url),
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('Wraps React islands with the wrapper component', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			// The wrapper component should wrap the counter
+			const wrapper = $('[data-testid="wrapper"]');
+			assert.equal(wrapper.length, 1);
+
+			// The counter should be inside the wrapper
+			const counter = wrapper.find('[data-testid="counter"]');
+			assert.equal(counter.length, 1);
+
+			// The counter should have access to the theme from context
+			assert.equal(counter.attr('data-theme'), 'dark');
+		});
+	});
+
+	if (isWindows) return;
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('Wraps React islands with the wrapper component in dev mode', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			// The wrapper component should wrap the counter
+			const wrapper = $('[data-testid="wrapper"]');
+			assert.equal(wrapper.length, 1);
+
+			// The counter should be inside the wrapper
+			const counter = wrapper.find('[data-testid="counter"]');
+			assert.equal(counter.length, 1);
+
+			// The counter should have access to the theme from context
+			assert.equal(counter.attr('data-theme'), 'dark');
+		});
+	});
+});

--- a/packages/integrations/react/test/react-app-entrypoint.test.js
+++ b/packages/integrations/react/test/react-app-entrypoint.test.js
@@ -32,6 +32,15 @@ describe('React App Entrypoint', () => {
 			// The counter should have access to the theme from context
 			assert.equal(counter.attr('data-theme'), 'dark');
 		});
+
+		it('Passes Astro.locals props to the wrapper', async () => {
+			const html = await fixture.readFile('/with-locals/index.html');
+			const $ = cheerioLoad(html);
+
+			// The wrapper should receive serverData from Astro.locals
+			const wrapper = $('[data-testid="wrapper"]');
+			assert.equal(wrapper.attr('data-server'), 'from-locals');
+		});
 	});
 
 	if (isWindows) return;
@@ -61,6 +70,15 @@ describe('React App Entrypoint', () => {
 
 			// The counter should have access to the theme from context
 			assert.equal(counter.attr('data-theme'), 'dark');
+		});
+
+		it('Passes Astro.locals props to the wrapper in dev mode', async () => {
+			const html = await fixture.fetch('/with-locals').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			// The wrapper should receive serverData from Astro.locals
+			const wrapper = $('[data-testid="wrapper"]');
+			assert.equal(wrapper.attr('data-server'), 'from-locals');
 		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6103,6 +6103,21 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
 
+  packages/integrations/react/test/fixtures/react-app-entrypoint:
+    dependencies:
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+
   packages/integrations/react/test/fixtures/react-component:
     dependencies:
       '@astrojs/react':


### PR DESCRIPTION
## Changes

(ignore first commit please, it’s the commit for https://github.com/withastro/astro/pull/15368)

Accessing Astro context in a React SSR environment requires some (big imo) unnecessary shenanigans. Some folks have [hacked around this limitation](https://github.com/lilnasy/gratelets/tree/main/packages/global). I see this and I think "why are we making people do this song and dance", especially when it’s so easy to just pass the Astro context in where it’s needed so that integrations can use it.

In this PR I’ve added `Astro.locals` to `RendererContext`, and I’ve updated the React integration to make use of the now-available `locals` value as well.

## Testing

New tests added

## Docs

Not documented yet

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
