### PR TITLE
fix(csrf): increase defence for astro actions endpoints

### DIFF
--- a/.changeset/brave-tigers-thank.md
+++ b/.changeset/brave-tigers-thank.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes the CSRF origin check middleware to enforce origin validation on Astro Action endpoints regardless of the request `Content-Type`. Both RPC-style (`/_actions/*`) and form-style (`?_action=`) action endpoints are now covered. The origin check for non-action endpoints is unchanged.
+Fixes the CSRF origin check to block cross-origin requests regardless of `Content-Type`. Previously, requests with non-form content types (e.g. `application/json`) bypassed the origin check entirely. Now that's not the case anymore.

--- a/packages/astro/src/core/app/middlewares.ts
+++ b/packages/astro/src/core/app/middlewares.ts
@@ -1,18 +1,5 @@
 import type { MiddlewareHandler } from '../../types/public/common.js';
-import { ACTION_QUERY_PARAMS, ACTION_RPC_ROUTE_PATTERN } from '../../actions/consts.js';
 import { defineMiddleware } from '../middleware/defineMiddleware.js';
-
-/**
- * Content types that can be passed when sending a request via a form
- *
- * https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/enctype
- * @private
- */
-const FORM_CONTENT_TYPES = [
-	'application/x-www-form-urlencoded',
-	'multipart/form-data',
-	'text/plain',
-];
 
 // Note: TRACE is unsupported by undici/Node.js
 const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
@@ -24,7 +11,7 @@ const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
  */
 export function createOriginCheckMiddleware(): MiddlewareHandler {
 	return defineMiddleware((context, next) => {
-		const { request, url, isPrerendered, routePattern } = context;
+		const { request, url, isPrerendered } = context;
 		// Prerendered pages should be excluded
 		if (isPrerendered) {
 			return next();
@@ -33,86 +20,14 @@ export function createOriginCheckMiddleware(): MiddlewareHandler {
 		if (SAFE_METHODS.includes(request.method)) {
 			return next();
 		}
+		const isSameOrigin = request.headers.get('origin') === url.origin;
 
-		// Reconstruct the expected origin from the Host request header, which is
-		// reliable even behind proxies. url.origin can be wrong (e.g. missing port)
-		// because the node adapter may fall back to 'localhost' without port.
-		const hostHeader = request.headers.get('host');
-		const expectedOrigin = hostHeader ? `${url.protocol}//${hostHeader}` : url.origin;
-
-		const originHeader = request.headers.get('origin');
-		const isSameOrigin = originHeader === expectedOrigin;
-
-		// Check if this is an action endpoint
-		const isActionRpc = routePattern === ACTION_RPC_ROUTE_PATTERN;
-		const isActionForm = url.searchParams.has(ACTION_QUERY_PARAMS.actionName);
-		const isActionEndpoint = isActionRpc || isActionForm;
-
-		if (isActionEndpoint) {
-			// For action endpoints, enforce origin check regardless of content type.
-			// This closes the bypass where non-form Content-Types (e.g. application/json)
-			// were never validated against the Origin header.
-			if (originHeader && !isSameOrigin) {
-				return new Response(`Cross-site ${request.method} action submissions are forbidden`, {
-					status: 403,
-				});
-			}
-
-			// No Origin header: check Referer as fallback per OWASP guidance.
-			if (!originHeader) {
-				const refererHeader = request.headers.get('referer');
-				if (refererHeader) {
-					let refererOrigin: string;
-					if (URL.canParse(refererHeader)) {
-						refererOrigin = new URL(refererHeader).origin;
-					} else {
-						return new Response(`Cross-site ${request.method} action submissions are forbidden`, {
-							status: 403,
-						});
-					}
-					if (refererOrigin !== expectedOrigin) {
-						return new Response(`Cross-site ${request.method} action submissions are forbidden`, {
-							status: 403,
-						});
-					}
-				}
-				// Neither Origin nor Referer present: allow.
-				// Non-browser clients that omit both headers bypass CSRF protection
-				// regardless; defending against them requires token-based CSRF or auth.
-			}
-
-			return next();
-		}
-
-		// For non-action endpoints, preserve the original behaviour:
-		// only enforce origin check for form-like content types.
-		const hasContentType = request.headers.has('content-type');
-		if (hasContentType) {
-			const formLikeHeader = hasFormLikeHeader(request.headers.get('content-type'));
-			if (formLikeHeader && !isSameOrigin) {
-				return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
-					status: 403,
-				});
-			}
-		} else {
-			if (!isSameOrigin) {
-				return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
-					status: 403,
-				});
-			}
+		if (!isSameOrigin) {
+			return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
+				status: 403,
+			});
 		}
 
 		return next();
 	});
-}
-
-function hasFormLikeHeader(contentType: string | null): boolean {
-	if (contentType) {
-		for (const FORM_CONTENT_TYPE of FORM_CONTENT_TYPES) {
-			if (contentType.toLowerCase().includes(FORM_CONTENT_TYPE)) {
-				return true;
-			}
-		}
-	}
-	return false;
 }

--- a/packages/astro/test/csrf-protection.test.js
+++ b/packages/astro/test/csrf-protection.test.js
@@ -264,7 +264,7 @@ describe('CSRF origin check', () => {
 	});
 });
 
-describe('CSRF origin check for Actions', () => {
+describe('CSRF origin check — non-form content types', () => {
 	let app;
 
 	before(async () => {
@@ -276,164 +276,23 @@ describe('CSRF origin check for Actions', () => {
 		app = await fixture.loadTestAdapterApp();
 	});
 
-	// --- RPC endpoint (/_actions/getSecret) ---
-
-	it('blocks cross-origin POST with application/json to RPC action endpoint', async () => {
-		const request = new Request('http://example.com/_actions/getSecret', {
-			method: 'POST',
-			headers: {
-				origin: 'http://evil.com',
-				'content-type': 'application/json',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 403);
-	});
-
-	it('blocks cross-origin POST with application/x-www-form-urlencoded to RPC action endpoint', async () => {
-		const request = new Request('http://example.com/_actions/getSecret', {
-			method: 'POST',
-			headers: {
-				origin: 'http://evil.com',
-				'content-type': 'application/x-www-form-urlencoded',
-			},
-			body: 'foo=bar',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 403);
-	});
-
-	it('allows same-origin POST with application/json to RPC action endpoint', async () => {
-		const request = new Request('http://example.com/_actions/getSecret', {
-			method: 'POST',
-			headers: {
-				origin: 'http://example.com',
-				'content-type': 'application/json',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 200);
-	});
-
-	it('allows POST without Origin header to RPC action endpoint', async () => {
-		const request = new Request('http://example.com/_actions/getSecret', {
-			method: 'POST',
-			headers: {
-				'content-type': 'application/json',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 200);
-	});
-
-	// --- Form-style action endpoint (/?_action=getSecret) ---
-
-	it('blocks cross-origin POST with application/json to form-style action endpoint', async () => {
-		const request = new Request('http://example.com/?_action=getSecret', {
-			method: 'POST',
-			headers: {
-				origin: 'http://evil.com',
-				'content-type': 'application/json',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 403);
-	});
-
-	it('blocks cross-origin POST with application/x-www-form-urlencoded to form-style action endpoint', async () => {
-		const request = new Request('http://example.com/?_action=getSecret', {
-			method: 'POST',
-			headers: {
-				origin: 'http://evil.com',
-				'content-type': 'application/x-www-form-urlencoded',
-			},
-			body: 'foo=bar',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 403);
-	});
-
-	it('allows same-origin POST with application/json to form-style action endpoint', async () => {
-		const request = new Request('http://example.com/?_action=getSecret', {
-			method: 'POST',
-			headers: {
-				origin: 'http://example.com',
-				'content-type': 'application/json',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 200);
-	});
-
-	it('allows POST without Origin header to form-style action endpoint', async () => {
-		const request = new Request('http://example.com/?_action=getSecret', {
-			method: 'POST',
-			headers: {
-				'content-type': 'application/json',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 200);
-	});
-
-	it('blocks form-style action when Referer points to a different origin', async () => {
-		const request = new Request('http://example.com/?_action=getSecret', {
-			method: 'POST',
-			headers: {
-				'content-type': 'application/json',
-				referer: 'http://evil.com/attack',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 403);
-	});
-
-	it('allows form-style action when Referer matches the origin', async () => {
-		const request = new Request('http://example.com/?_action=getSecret', {
-			method: 'POST',
-			headers: {
-				'content-type': 'application/json',
-				referer: 'http://example.com/page',
-			},
-			body: '{}',
-		});
-		const response = await app.render(request);
-		assert.equal(response.status, 200);
-	});
-
-	// --- Non-action endpoints: original behaviour preserved ---
-
-	it('does NOT block cross-origin POST with application/json to a regular (non-action) endpoint', async () => {
+	it('returns 403 for cross-origin POST with application/json', async () => {
 		const request = new Request('http://example.com/api/', {
 			method: 'POST',
-			headers: {
-				origin: 'http://evil.com',
-				'content-type': 'application/json',
-			},
+			headers: { origin: 'http://evil.com', 'content-type': 'application/json' },
 			body: '{}',
 		});
 		const response = await app.render(request);
-		// Regular endpoints with non-form content types are unaffected by the CSRF check
-		assert.equal(response.status, 200);
+		assert.equal(response.status, 403);
 	});
 
-	it('still blocks cross-origin POST with form content-type to a regular (non-action) endpoint', async () => {
+	it('returns 200 for same-origin POST with application/json', async () => {
 		const request = new Request('http://example.com/api/', {
 			method: 'POST',
-			headers: {
-				origin: 'http://evil.com',
-				'content-type': 'application/x-www-form-urlencoded',
-			},
-			body: 'foo=bar',
+			headers: { origin: 'http://example.com', 'content-type': 'application/json' },
+			body: '{}',
 		});
 		const response = await app.render(request);
-		assert.equal(response.status, 403);
+		assert.equal(response.status, 200);
 	});
 });

--- a/packages/astro/test/fixtures/csrf-check-origin/src/actions/index.ts
+++ b/packages/astro/test/fixtures/csrf-check-origin/src/actions/index.ts
@@ -1,9 +1,0 @@
-import { defineAction } from 'astro:actions';
-
-export const server = {
-	getSecret: defineAction({
-		handler: async () => {
-			return { secret: 'sensitive-data' };
-		},
-	}),
-};

--- a/packages/astro/test/fixtures/csrf-check-origin/src/pages/index.astro
+++ b/packages/astro/test/fixtures/csrf-check-origin/src/pages/index.astro
@@ -1,9 +1,0 @@
----
-import { actions } from 'astro:actions';
-const result = Astro.getActionResult(actions.getSecret);
----
-<html>
-  <body>
-    {result?.data && <p id="secret">{result.data.secret}</p>}
-  </body>
-</html>


### PR DESCRIPTION
## Changes

This PR increases the `checkOrigin` defence mechanism for Astro Action endpoints. The check is done regardless of the content-type received, if the route is an Astro Action.

## Testing

Added various cases 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Probably it needs a mention

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
