### PR TITLE
fix(node): harden static file handler path resolution

### DIFF
--- a/.changeset/soft-vans-ask.md
+++ b/.changeset/soft-vans-ask.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Hardens static file handler path resolution to ensure resolved paths stay within the client directory

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -9,6 +9,32 @@ import type { NodeAppHeadersJson, Options } from './types.js';
 import { createRequest } from 'astro/app/node';
 
 /**
+ * Resolves a URL path to a filesystem path within the client directory,
+ * and checks whether it is a directory.
+ *
+ * Returns `isDirectory: false` if the resolved path escapes the client root
+ * (e.g. via `..` path traversal segments).
+ */
+export function resolveStaticPath(client: string, urlPath: string) {
+	const filePath = path.join(client, urlPath);
+	const resolved = path.resolve(filePath);
+	const resolvedClient = path.resolve(client);
+
+	// Prevent path traversal: if the resolved path is outside the client
+	// directory, treat it as non-existent rather than probing the filesystem.
+	if (resolved !== resolvedClient && !resolved.startsWith(resolvedClient + path.sep)) {
+		return { filePath: resolved, isDirectory: false };
+	}
+
+	let isDirectory = false;
+	try {
+		isDirectory = fs.lstatSync(filePath).isDirectory();
+	} catch {}
+
+	return { filePath: resolved, isDirectory };
+}
+
+/**
  * Creates a Node.js http listener for static files and prerendered pages.
  * In standalone mode, the static handler is queried first for the static files.
  * If one matching the request path is not found, it relegates to the SSR handler.
@@ -32,12 +58,7 @@ export function createStaticHandler(
 			}
 
 			const [urlPath, urlQuery] = fullUrl.split('?');
-			const filePath = path.join(client, app.removeBase(urlPath));
-
-			let isDirectory = false;
-			try {
-				isDirectory = fs.lstatSync(filePath).isDirectory();
-			} catch {}
+			const { isDirectory } = resolveStaticPath(client, app.removeBase(urlPath));
 
 			const hasSlash = urlPath.endsWith('/');
 			let pathname = urlPath;

--- a/packages/integrations/node/test/units/serve-static-path-traversal.test.js
+++ b/packages/integrations/node/test/units/serve-static-path-traversal.test.js
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, before, after } from 'node:test';
+import { resolveStaticPath } from '../../dist/serve-static.js';
+
+describe('resolveStaticPath', () => {
+	let tmpRoot;
+	let clientDir;
+
+	before(() => {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'astro-test-'));
+		clientDir = path.join(tmpRoot, 'client');
+		fs.mkdirSync(clientDir);
+		fs.mkdirSync(path.join(clientDir, 'assets'));
+		fs.writeFileSync(path.join(clientDir, 'index.html'), '<h1>hello</h1>');
+		fs.mkdirSync(path.join(tmpRoot, 'secret'));
+	});
+
+	after(() => {
+		fs.rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it('detects a subdirectory within client root', () => {
+		const result = resolveStaticPath(clientDir, '/assets');
+		assert.equal(result.isDirectory, true);
+	});
+
+	it('returns false for a non-existent path', () => {
+		const result = resolveStaticPath(clientDir, '/nope');
+		assert.equal(result.isDirectory, false);
+	});
+
+	it('returns false for a sibling directory via ../', () => {
+		const result = resolveStaticPath(clientDir, '/../secret');
+		assert.equal(result.isDirectory, false);
+	});
+
+	it('returns false for the parent directory', () => {
+		const result = resolveStaticPath(clientDir, '/..');
+		assert.equal(result.isDirectory, false);
+	});
+
+	it('returns false for deep .. traversal', () => {
+		const result = resolveStaticPath(clientDir, '/../../../../../../../usr');
+		assert.equal(result.isDirectory, false);
+	});
+
+	it('returns false for .. traversal with trailing slash', () => {
+		const result = resolveStaticPath(clientDir, '/../secret/');
+		assert.equal(result.isDirectory, false);
+	});
+
+	it('detects the client root itself', () => {
+		const result = resolveStaticPath(clientDir, '/');
+		assert.equal(result.isDirectory, true);
+	});
+});


### PR DESCRIPTION
## Changes

- Extracts path resolution logic in the node adapter static file handler into a `resolveStaticPath` function
- Adds a bounds check to ensure resolved paths stay within the client directory before hitting the filesystem

## Testing

Added unit tests in `packages/integrations/node/test/units/serve-static-path-traversal.test.js`

## Docs

N/A, bug fix