### PR TITLE
fix(db): read `ASTRO_DATABASE_FILE` from `.env` files correctly

### DIFF
--- a/.changeset/fix-db-env-var-loading.md
+++ b/.changeset/fix-db-env-var-loading.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Fixed `ASTRO_DATABASE_FILE` environment variable not being read from `.env` files during build. The `databaseFileEnvDefined()` function now uses `getAstroEnv()` which correctly loads `ASTRO_`-prefixed env vars, instead of Vite's `loadEnv()` which defaults to only loading `VITE_`-prefixed variables.

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -7,7 +7,6 @@ import colors from 'piccolore';
 import {
 	createServer,
 	type HotPayload,
-	loadEnv,
 	mergeConfig,
 	type RunnableDevEnvironment,
 	type UserConfig,
@@ -20,7 +19,7 @@ import { CONFIG_FILE_NAMES, DB_PATH, VIRTUAL_MODULE_ID } from '../consts.js';
 import { EXEC_DEFAULT_EXPORT_ERROR, EXEC_ERROR } from '../errors.js';
 import { resolveDbConfig } from '../load-file.js';
 import { SEED_DEV_FILE_NAME } from '../queries.js';
-import { getDbDirectoryUrl, getRemoteDatabaseInfo, type VitePlugin } from '../utils.js';
+import { getAstroEnv, getDbDirectoryUrl, getRemoteDatabaseInfo, type VitePlugin } from '../utils.js';
 import { fileURLIntegration } from './file-url.js';
 import { getDtsContent } from './typegen.js';
 import {
@@ -209,7 +208,7 @@ function astroDBIntegration(options?: AstroDBConfig): AstroIntegration {
 }
 
 function databaseFileEnvDefined() {
-	const env = loadEnv('', process.cwd());
+	const env = getAstroEnv();
 	return env.ASTRO_DATABASE_FILE != null || process.env.ASTRO_DATABASE_FILE != null;
 }
 


### PR DESCRIPTION
Fixes #15607

The `databaseFileEnvDefined()` function used Vite's `loadEnv('', process.cwd())` which defaults to only loading `VITE_`-prefixed environment variables. This meant `ASTRO_DATABASE_FILE` set in `.env` files was never detected, causing a false error during `astro build`.

The fix reuses the existing `getAstroEnv()` utility which correctly passes the `'ASTRO_'` prefix to `loadEnv()`, consistent with how other parts of the `@astrojs/db` package load environment variables.

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
