### PR TITLE
fix(prefetch): exclude prefetch module from Vite dep optimization

### DIFF
--- a/.changeset/fix-prefetch-optimizedeps.md
+++ b/.changeset/fix-prefetch-optimizedeps.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed prefetch placeholder constants not being replaced when `<ClientRouter />` is used, which caused `ReferenceError: __PREFETCH_PREFETCH_ALL__ is not defined` in the browser console. The prefetch module is now excluded from Vite's dependency optimization to ensure the transform hook runs correctly.

--- a/packages/astro/src/prefetch/vite-plugin-prefetch.ts
+++ b/packages/astro/src/prefetch/vite-plugin-prefetch.ts
@@ -31,6 +31,13 @@ export default function astroPrefetch({ settings }: { settings: AstroSettings })
 
 	return {
 		name: 'astro:prefetch',
+		config() {
+			return {
+				optimizeDeps: {
+					exclude: ['astro/virtual-modules/prefetch.js'],
+				},
+			};
+		},
 		resolveId: {
 			filter: {
 				id: new RegExp(`^${VIRTUAL_MODULE_ID}$`),


### PR DESCRIPTION
Fixes #15520

When `<ClientRouter />` is used, Vite's dependency optimizer pre-bundles the prefetch module (`astro/virtual-modules/prefetch.js`) via esbuild as a transitive dependency through the transitions import chain. Since esbuild does not invoke Vite plugin `transform` hooks, the placeholder constants (`__PREFETCH_PREFETCH_ALL__`, `__PREFETCH_DEFAULT_STRATEGY__`, `__EXPERIMENTAL_CLIENT_PRERENDER__`) are never replaced, causing `ReferenceError` at runtime.

The fix adds a `config()` hook to the `astroPrefetch` plugin that excludes `astro/virtual-modules/prefetch.js` from `optimizeDeps`, ensuring the module always goes through the Vite transform pipeline where the placeholders are correctly replaced.

This is consistent with how `astro:transitions` handles its own placeholders by configuring `optimizeDeps` in its `config()` hook.

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
