### PR TITLE
fix: save session data when session id is regenerated

### DIFF
--- a/.changeset/fix-session-regenerate-dirty.md
+++ b/.changeset/fix-session-regenerate-dirty.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused `session.regenerate()` to silently lose session data
+
+Previously, regenerated session data was not saved under the new session ID unless `set()` was also called.

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -243,6 +243,7 @@ export class AstroSession {
 		// Create new session
 		this.#sessionID = crypto.randomUUID();
 		this.#data = data;
+		this.#dirty = true;
 		await this.#setCookie();
 
 		// Clean up old session asynchronously

--- a/packages/astro/test/units/sessions/astro-session.test.js
+++ b/packages/astro/test/units/sessions/astro-session.test.js
@@ -131,6 +131,39 @@ describe('AstroSession - Session Regeneration', () => {
 
 		assert.notEqual(initialId, newId);
 	});
+
+	it('should persist data after regeneration without a subsequent set()', async () => {
+		const store = new Map();
+		const mockStorage = {
+			get: async (key) => {
+				const raw = store.get(key);
+				return raw ? JSON.parse(raw) : null;
+			},
+			setItem: async (key, value) => {
+				store.set(key, value);
+			},
+			removeItem: async (key) => {
+				store.delete(key);
+			},
+		};
+
+		const session = createSession(defaultConfig, defaultMockCookies, mockStorage);
+
+		session.set('user', 'alice');
+		await session[PERSIST_SYMBOL]();
+
+		await session.regenerate();
+		await session[PERSIST_SYMBOL]();
+
+		// Create a new session that reads from the same storage
+		const newSession = createSession(defaultConfig, {
+			...defaultMockCookies,
+			get: () => ({ value: session.sessionID }),
+		}, mockStorage);
+
+		const value = await newSession.get('user');
+		assert.equal(value, 'alice');
+	});
 });
 
 describe('AstroSession - Data Persistence', () => {


### PR DESCRIPTION
## Changes

Fixes a bug that caused `session.regenerate()` to silently lose session data

Previously, regenerated session data was not saved under the new session ID unless `set()` was also called. This PR fixes this by setting #dirty to true when regenrate is called.


## Testing

Added a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
