### PR TITLE
Normalize static file paths before evaluating dotfile access rules

### DIFF
--- a/.changeset/normalize-dotfile-pathname.md
+++ b/.changeset/normalize-dotfile-pathname.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Normalizes static file paths before evaluating dotfile access rules for improved consistency

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -119,9 +119,10 @@ export function createStaticHandler(
 			// app.removeBase sometimes returns a path without a leading slash
 			pathname = prependForwardSlash(app.removeBase(pathname));
 
-			const stream = send(req, pathname, {
+			const normalizedPathname = path.posix.normalize(pathname);
+			const stream = send(req, normalizedPathname, {
 				root: client,
-				dotfiles: pathname.startsWith('/.well-known/') ? 'allow' : 'deny',
+				dotfiles: normalizedPathname.startsWith('/.well-known/') ? 'allow' : 'deny',
 			});
 
 			let forwardError = false;
@@ -138,7 +139,7 @@ export function createStaticHandler(
 			});
 			stream.on('headers', (_res: ServerResponse) => {
 				// assets in dist/_astro are hashed and should get the immutable header
-				if (pathname.startsWith(`/${app.manifest.assetsDir}/`)) {
+				if (normalizedPathname.startsWith(`/${app.manifest.assetsDir}/`)) {
 					// This is the "far future" cache header, used for static files whose name includes their digest hash.
 					// 1 year (31,536,000 seconds) is convention.
 					// Taken from https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#immutable

--- a/packages/integrations/node/test/fixtures/well-known-locations/public/.hidden-file
+++ b/packages/integrations/node/test/fixtures/well-known-locations/public/.hidden-file
@@ -1,0 +1,1 @@
+should-not-serve

--- a/packages/integrations/node/test/well-known-locations.test.js
+++ b/packages/integrations/node/test/well-known-locations.test.js
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
-import { loadFixture } from './test-utils.js';
+import { createRequestAndResponse, loadFixture } from './test-utils.js';
 
 describe('test URIs beginning with a dot', () => {
 	/** @type {import('./test-utils').Fixture} */
@@ -41,6 +41,44 @@ describe('test URIs beginning with a dot', () => {
 			const res = await fixture.fetch('/.hidden/file.json');
 
 			assert.equal(res.status, 404);
+		});
+	});
+
+	describe('dotfile access via unnormalized paths', async () => {
+		it('denies dotfile access when path contains .well-known/../ traversal', async () => {
+			const { handler } = await import('./fixtures/well-known-locations/dist/server/entry.mjs');
+			const { req, res, done } = createRequestAndResponse({
+				method: 'GET',
+				url: '/.well-known/../.hidden-file',
+			});
+
+			handler(req, res);
+			req.send();
+
+			await done;
+			assert.notEqual(
+				res.statusCode,
+				200,
+				'dotfile should not be served via .well-known path traversal',
+			);
+		});
+
+		it('denies dotfolder file access when path contains .well-known/../ traversal', async () => {
+			const { handler } = await import('./fixtures/well-known-locations/dist/server/entry.mjs');
+			const { req, res, done } = createRequestAndResponse({
+				method: 'GET',
+				url: '/.well-known/../.hidden/file.json',
+			});
+
+			handler(req, res);
+			req.send();
+
+			await done;
+			assert.notEqual(
+				res.statusCode,
+				200,
+				'dotfolder file should not be served via .well-known path traversal',
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Normalizes static file paths using `path.posix.normalize()` before evaluating dotfile access rules in the Node adapter's static file handler
- Ensures the `.well-known/` check and the `send` library operate on the same normalized path for consistent behavior

## Testing

- Added tests in `well-known-locations.test.js` to verify dotfile access rules are applied consistently when paths contain `..` segments
- Added a `.hidden-file` test fixture for dotfile-at-root-level test coverage

## Docs

No docs changes needed.
