### PR TITLE
Harden server island POST endpoint to use own-property checks

### DIFF
--- a/.changeset/harden-server-island-validation.md
+++ b/.changeset/harden-server-island-validation.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens server island POST endpoint validation to use own-property checks for improved consistency

--- a/packages/astro/src/core/server-islands/endpoint.ts
+++ b/packages/astro/src/core/server-islands/endpoint.ts
@@ -77,12 +77,12 @@ export async function getRequestData(request: Request): Promise<Response | Rende
 				const data = JSON.parse(raw);
 
 				// Validate that slots is not plaintext
-				if ('slots' in data && typeof data.slots === 'object') {
+				if (Object.hasOwn(data, 'slots') && typeof data.slots === 'object') {
 					return badRequest('Plaintext slots are not allowed. Slots must be encrypted.');
 				}
 
 				// Validate that componentExport is not plaintext
-				if ('componentExport' in data && typeof data.componentExport === 'string') {
+				if (Object.hasOwn(data, 'componentExport') && typeof data.componentExport === 'string') {
 					return badRequest(
 						'Plaintext componentExport is not allowed. componentExport must be encrypted.',
 					);

--- a/packages/astro/test/units/server-islands/endpoint.test.js
+++ b/packages/astro/test/units/server-islands/endpoint.test.js
@@ -146,6 +146,44 @@ describe('getRequestData', () => {
 			assert.equal(result.encryptedProps, '');
 			assert.equal(result.encryptedSlots, '');
 		});
+
+		it('only checks own properties for `slots` validation', async () => {
+			// Temporarily pollute Object.prototype to simulate inherited properties
+			Object.prototype.slots = { default: 'polluted' };
+			try {
+				const req = makePostRequest({
+					encryptedComponentExport: 'encExport',
+					encryptedProps: 'encProps',
+					encryptedSlots: 'encSlots',
+				});
+				const result = await getRequestData(req);
+				assert.ok(
+					!(result instanceof Response),
+					`Expected RenderOptions but got Response with status ${result instanceof Response ? result.status : 'N/A'} — inherited 'slots' should not trigger rejection`,
+				);
+			} finally {
+				delete Object.prototype.slots;
+			}
+		});
+
+		it('only checks own properties for `componentExport` validation', async () => {
+			// Temporarily pollute Object.prototype to simulate inherited properties
+			Object.prototype.componentExport = 'default';
+			try {
+				const req = makePostRequest({
+					encryptedComponentExport: 'encExport',
+					encryptedProps: 'encProps',
+					encryptedSlots: 'encSlots',
+				});
+				const result = await getRequestData(req);
+				assert.ok(
+					!(result instanceof Response),
+					`Expected RenderOptions but got Response with status ${result instanceof Response ? result.status : 'N/A'} — inherited 'componentExport' should not trigger rejection`,
+				);
+			} finally {
+				delete Object.prototype.componentExport;
+			}
+		});
 	});
 	// #endregion
 


### PR DESCRIPTION
Note there isn't a security issue here, this is defense in depth.

## Changes

- Updates server island POST endpoint validation in `getRequestData()` to use `Object.hasOwn()` instead of the `in` operator when checking for plaintext `slots` and `componentExport` properties
- This ensures only own properties on the parsed JSON data are validated, improving consistency with standard property-checking patterns

## Testing

- Added two unit tests to `packages/astro/test/units/server-islands/endpoint.test.js` verifying that validation checks only consider own properties on the parsed request data
- All existing endpoint tests continue to pass

## Docs

No docs changes needed.
