### PR TITLE
Harden AstroCookies to use null-prototype object consistently

### DIFF
--- a/.changeset/hardened-cookie-parsing.md
+++ b/.changeset/hardened-cookie-parsing.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens internal cookie parsing to use a null-prototype object consistently for the fallback path, aligning with how the cookie library handles parsed values

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -253,7 +253,7 @@ class AstroCookies implements AstroCookiesInterface {
 			this.#parse();
 		}
 		if (!this.#requestValues) {
-			this.#requestValues = {};
+			this.#requestValues = Object.create(null) as Record<string, string | undefined>;
 		}
 		return this.#requestValues;
 	}

--- a/packages/astro/test/units/cookies/get.test.js
+++ b/packages/astro/test/units/cookies/get.test.js
@@ -56,6 +56,16 @@ describe('astro/src/core/cookies', () => {
 			assert.equal(cookie, undefined);
 		});
 
+		it('does not return values from Object.prototype when no cookie header is present', () => {
+			const req = new Request('http://example.com/');
+			let cookies = new AstroCookies(req);
+			// These are properties that exist on Object.prototype
+			assert.equal(cookies.get('toString'), undefined);
+			assert.equal(cookies.get('constructor'), undefined);
+			assert.equal(cookies.get('hasOwnProperty'), undefined);
+			assert.equal(cookies.get('valueOf'), undefined);
+		});
+
 		it('handles malformed cookie values gracefully', () => {
 			// Test with invalid URI sequence (e.g., incomplete percent encoding)
 			const req = new Request('http://example.com/', {

--- a/packages/astro/test/units/cookies/has.test.js
+++ b/packages/astro/test/units/cookies/has.test.js
@@ -26,5 +26,14 @@ describe('astro/src/core/cookies', () => {
 			cookies.set('foo', 'bar');
 			assert.equal(cookies.has('foo'), true);
 		});
+
+		it('returns false for Object.prototype properties when no cookie header is present', () => {
+			let req = new Request('http://example.com/');
+			let cookies = new AstroCookies(req);
+			assert.equal(cookies.has('toString'), false);
+			assert.equal(cookies.has('constructor'), false);
+			assert.equal(cookies.has('hasOwnProperty'), false);
+			assert.equal(cookies.has('valueOf'), false);
+		});
 	});
 });


### PR DESCRIPTION
## Changes

- Uses `Object.create(null)` instead of `{}` for the fallback object in `AstroCookies#ensureParsed()` when no Cookie header is present
- This aligns the fallback path with how the `cookie` library already creates parsed objects (using `NullObject`), ensuring consistent behavior

## Testing

- Added unit tests for `cookies.get()` verifying that Object.prototype properties are not returned when no cookie header is present
- Added unit tests for `cookies.has()` verifying that Object.prototype properties are not detected when no cookie header is present

## Docs

No docs changes needed.
