### PR TITLE
fix: add the missing changeset for`@astrojs/internal-helpers`

### DIFF
--- a/.changeset/wet-animals-pump.md
+++ b/.changeset/wet-animals-pump.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/internal-helpers': minor
+---
+
+Adds the new utilities `MANY_LEADING_SLASHES` and `collapseDuplicateLeadingSlashes`.


### PR DESCRIPTION
fixes: #15769

## Changes

The previous pull request #15717 was missing the changeset for `@astrojs/internal-helpers`, which caused a build error.
This PR adds the missing changeset to trigger the release and resolve the build error.

It seems variable [`MANY_LEADING_SLASHES`](https://github.com/withastro/astro/pull/15717/changes#diff-7d4db4450e82f22db4a12d0b0caf86bd4dce4f8c948d0307d62b14aaa3e9964b) is only used internally, but since it is exported, I included it in the changeset just in case.
## Testing
N/A

## Docs
N/A