### PR TITLE
ci: harden GitHub Actions workflows with least-privilege permissions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,9 +79,6 @@
     "drizzle-orm",
     "sharp",
 
-    // manually bumping workflow actions
-    "actions/labeler",
-
     // follow vite deps version
     "postcss-load-config",
     "esbuild"

--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -4,8 +4,6 @@ on: pull_request_target
 
 permissions:
   pull-requests: write
-  checks: write
-  statuses: write
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,9 @@ on:
       - "pnpm-lock.yaml"
       - "packages/astro/types.d.ts"
 
+permissions:
+  contents: read
+
 env:
   ASTRO_TELEMETRY_DISABLED: true
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -7,6 +7,10 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/diff-dependencies.yml
+++ b/.github/workflows/diff-dependencies.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # allows the diff action to access git history
+          persist-credentials: false
 
       - name: Create Diff
         uses: e18e/action-dependency-diff@d995338f3b229fe7b2cd82048df5da930f70c7c3 # v1.4.4

--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Send a POST request to Netlify to rebuild preview.astro.new
-        run: 'curl -X POST -d {} ${{ env.BUILD_HOOK }}'
+        run: 'curl -X POST -d {} "$BUILD_HOOK"'
         env:
           BUILD_HOOK: ${{ secrets.NETLIFY_PREVIEWS_BUILD_HOOK }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,4 +12,5 @@ jobs:
     uses: withastro/automation/.github/workflows/format.yml@main
     with:
       command: "format"
-    secrets: inherit
+    secrets:
+      FREDKBOT_GITHUB_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,8 +9,10 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'withastro'
+    permissions:
+      pull-requests: write
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  actions: write
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,14 +87,18 @@ jobs:
       - name: Publish to VSCode Marketplace
         if: steps.vscode-published.outputs.published == 'true'
         working-directory: ./packages/language-tools/vscode
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
         run: |
-          npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
+          npx vsce publish -p "$VSCE_TOKEN" --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
 
       - name: Publish to OpenVSX
         if: steps.vscode-published.outputs.published == 'true'
         working-directory: ./packages/language-tools/vscode
+        env:
+          OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
         run: |
-          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
+          npx ovsx publish -p "$OVSX_TOKEN" --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
           
       - name: Restore root package.json and node_modules
         if: steps.vscode-published.outputs.published == 'true'
@@ -113,6 +117,9 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # 0.4.0
-        with:
-          args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"
+          DISCORD_MESSAGE: ${{ steps.message.outputs.DISCORD_MESSAGE }}
+        run: |
+          jq -n --arg content "$DISCORD_MESSAGE" '{content: $content}' | \
+            curl -X POST "$DISCORD_WEBHOOK" \
+              -H "Content-Type: application/json" \
+              -d @-

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -9,6 +9,10 @@ on:
       - "packages/astro/src/runtime/client/**/*"
       - "!packages/astro/src/runtime/client/dev-toolbar/**/*"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}

--- a/.github/workflows/test-hosts.yml
+++ b/.github/workflows/test-hosts.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 env:
   ASTRO_TELEMETRY_DISABLED: true
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Changes

- Pin `actions/labeler` to commit SHA and add explicit permissions block
- Enable Renovate automated updates for `actions/labeler`
- Replace `secrets: inherit` with explicit secret passing in `format.yml` workflow
- Add explicit permissions blocks to workflows that were inheriting default permissions (`check.yml`, `cleanup-cache.yml`, `scripts.yml`, `test-hosts.yml`)
- Remove unused `actions: write`, `checks: write`, and `statuses: write` permissions from workflows
- Add `persist-credentials: false` to `diff-dependencies.yml` checkout step
- Use environment variables instead of direct secret interpolation in shell commands for `VSCE_TOKEN`, `OVSX_TOKEN`, and Netlify webhook
- Replace third-party Discord notification action with direct `curl` call for better supply chain management

## Testing

No functional changes to workflow behavior. All changes follow GitHub Actions security best practices for:
- Principle of least privilege (explicit permissions)
- Secure credential handling (environment variables vs direct interpolation)
- Supply chain hardening (SHA-pinned actions, reduced third-party dependencies)

## Docs

No docs changes needed - these are internal CI/CD workflow improvements.
