### PR TITLE
Harden clientAddress IP format validation

### DIFF
--- a/.changeset/harden-client-address-validation.md
+++ b/.changeset/harden-client-address-validation.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens `clientAddress` resolution to validate that extracted IP values are well-formed IPv4 or IPv6 addresses

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Http2ServerResponse } from 'node:http2';
+import { isIP } from 'node:net';
 import type { Socket } from 'node:net';
 import type { RemotePattern } from '../../types/public/config.js';
 import { clientAddressSymbol, nodeRequestAbortControllerCleanupSymbol } from '../constants.js';
@@ -149,7 +150,11 @@ export function createRequest(
 	const forwardedClientIp = hostValidated
 		? getFirstForwardedValue(req.headers['x-forwarded-for'])
 		: undefined;
-	const clientIp = forwardedClientIp || req.socket?.remoteAddress;
+	// Validate that the IP address is a syntactically valid IPv4 or IPv6 address.
+	// This ensures only well-formed IP strings are propagated as clientAddress.
+	const validatedForwardedIp =
+		forwardedClientIp && isIP(forwardedClientIp) ? forwardedClientIp : undefined;
+	const clientIp = validatedForwardedIp || req.socket?.remoteAddress;
 	if (clientIp) {
 		Reflect.set(request, clientAddressSymbol, clientIp);
 	}

--- a/packages/astro/src/core/routing/request.ts
+++ b/packages/astro/src/core/routing/request.ts
@@ -2,6 +2,8 @@
  * Utilities for extracting information from `Request`
  */
 
+import { isIP } from 'node:net';
+
 // Parses multiple header and returns first value if available.
 function getFirstForwardedValue(multiValueHeader?: string | string[] | null) {
 	return multiValueHeader
@@ -11,10 +13,15 @@ function getFirstForwardedValue(multiValueHeader?: string | string[] | null) {
 }
 
 /**
- * Returns the first value associated to the `x-forwarded-for` header.
+ * Returns the first value associated to the `x-forwarded-for` header,
+ * validated as a proper IPv4 or IPv6 address.
  *
  * @param {Request} request
  */
 export function getClientIpAddress(request: Request): string | undefined {
-	return getFirstForwardedValue(request.headers.get('x-forwarded-for'));
+	const ip = getFirstForwardedValue(request.headers.get('x-forwarded-for'));
+	if (ip && isIP(ip)) {
+		return ip;
+	}
+	return undefined;
 }

--- a/packages/astro/test/units/app/node.test.js
+++ b/packages/astro/test/units/app/node.test.js
@@ -201,6 +201,123 @@ describe('node', () => {
 				// Host doesn't match allowedDomains, so XFF is not trusted
 				assert.equal(result[Symbol.for('astro.clientAddress')], '2.2.2.2');
 			});
+
+			it('rejects HTML injection in x-forwarded-for and falls back to remoteAddress', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': '<script>alert(1)</script>',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				// Invalid IP format should be rejected, falling back to remoteAddress
+				assert.equal(result[Symbol.for('astro.clientAddress')], '2.2.2.2');
+			});
+
+			it('rejects SQL injection in x-forwarded-for and falls back to remoteAddress', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': "'; DROP TABLE users; --",
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal(result[Symbol.for('astro.clientAddress')], '2.2.2.2');
+			});
+
+			it('rejects path traversal in x-forwarded-for and falls back to remoteAddress', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': '../../etc/passwd',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal(result[Symbol.for('astro.clientAddress')], '2.2.2.2');
+			});
+
+			it('rejects oversized strings in x-forwarded-for and falls back to remoteAddress', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': 'A'.repeat(10000),
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal(result[Symbol.for('astro.clientAddress')], '2.2.2.2');
+			});
+
+			it('accepts valid IPv4 address in x-forwarded-for', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': '192.168.1.1',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal(result[Symbol.for('astro.clientAddress')], '192.168.1.1');
+			});
+
+			it('accepts valid IPv6 address in x-forwarded-for', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': '::1',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal(result[Symbol.for('astro.clientAddress')], '::1');
+			});
+
+			it('accepts valid full IPv6 address in x-forwarded-for', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal(
+					result[Symbol.for('astro.clientAddress')],
+					'2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+				);
+			});
+
+			it('rejects arbitrary string as x-forwarded-for even in multi-value chain', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': '<img src=x onerror=alert(1)>, 8.8.8.8',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				// First value is invalid, should fall back to remoteAddress
+				assert.equal(result[Symbol.for('astro.clientAddress')], '2.2.2.2');
+			});
 		});
 
 		describe('x-forwarded-host', () => {


### PR DESCRIPTION
## Changes

- Validates that `clientAddress` values are well-formed IPv4 or IPv6 addresses using Node.js `net.isIP()` before propagating them
- Applies validation in `createRequest()` (Node adapter path) so only valid IP strings from `x-forwarded-for` are accepted
- Applies validation in `getClientIpAddress()` (middleware path) for consistent behavior
- Invalid IP format values fall back to `req.socket.remoteAddress` rather than propagating malformed strings

## Testing

- Added 8 unit tests to `test/units/app/node.test.js` covering:
  - Rejection of HTML strings, SQL-like strings, path traversal sequences, and oversized strings in `x-forwarded-for`
  - Acceptance of valid IPv4 addresses, IPv6 shorthand (`::1`), and full IPv6 addresses
  - Rejection of invalid values in multi-value `x-forwarded-for` chains

## Docs

No docs changes needed.
