### PR TITLE
Harden error page response merging to strip framing headers

### DIFF
--- a/.changeset/harden-merge-responses-framing.md
+++ b/.changeset/harden-merge-responses-framing.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens error page response merging to ensure framing headers from the original response are not carried over to the rendered error page

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -728,9 +728,17 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 				: originalResponse.status;
 
 		try {
-			// this function could throw an error...
+			// this function could throw an error if the headers are immutable...
 			originalResponse.headers.delete('Content-type');
-		} catch {}
+			// Framing headers describe the original response's body encoding/size and must
+			// not carry over to the error page response which has a different body.
+			originalResponse.headers.delete('Content-Length');
+			originalResponse.headers.delete('Transfer-Encoding');
+		} catch {
+			// Headers may be immutable (e.g. when the Response was constructed by a fetch).
+			// In that case, the loop below still copies from originalResponse.headers,
+			// so we need to filter out framing headers there instead.
+		}
 		// Build merged headers using append() to preserve multi-value headers (e.g. Set-Cookie).
 		// Headers from the original response take priority over new response headers for
 		// single-value headers, but we use append to avoid collapsing multi-value entries.

--- a/packages/astro/test/units/middleware/middleware-app.test.js
+++ b/packages/astro/test/units/middleware/middleware-app.test.js
@@ -761,6 +761,132 @@ describe('Middleware via App.render()', () => {
 		});
 	});
 
+	describe('framing headers on error pages', () => {
+		it('should not preserve Content-Length from middleware when rendering 404 error page', async () => {
+			// Middleware calls next(), then decides to return 404 with a stale Content-Length header.
+			// On re-render for the error page, middleware passes the response through unchanged.
+			let callCount = 0;
+			const onRequest = async (ctx, next) => {
+				callCount++;
+				const response = await next();
+				if (callCount === 1 && ctx.url.pathname.startsWith('/api/guarded')) {
+					return new Response(null, {
+						status: 404,
+						headers: { 'Content-Length': '999', 'X-Custom': 'keep-me' },
+					});
+				}
+				return response;
+			};
+
+			const guardedRouteData = createRouteData({
+				route: '/api/guarded/[...path]',
+				pathname: undefined,
+				segments: undefined,
+			});
+			guardedRouteData.params = ['...path'];
+			guardedRouteData.pattern = /^\/api\/guarded(?:\/(.*))?$/;
+			guardedRouteData.pathname = undefined;
+			guardedRouteData.segments = [
+				[{ content: 'api', dynamic: false, spread: false }],
+				[{ content: 'guarded', dynamic: false, spread: false }],
+				[{ content: '...path', dynamic: true, spread: true }],
+			];
+
+			const pageMap = new Map([
+				[
+					guardedRouteData.component,
+					async () => ({
+						page: async () => ({
+							default: simplePage(),
+						}),
+					}),
+				],
+				[
+					notFoundRouteData.component,
+					async () => ({ page: async () => ({ default: notFoundPage }) }),
+				],
+			]);
+			const app = createAppWithMiddleware({
+				onRequest,
+				routes: [{ routeData: guardedRouteData }, { routeData: notFoundRouteData }],
+				pageMap,
+			});
+
+			const response = await app.render(new Request('http://localhost/api/guarded/secret'));
+
+			assert.equal(response.status, 404);
+			// Content-Length from middleware's original response must not leak into the error page response
+			assert.equal(
+				response.headers.get('Content-Length'),
+				null,
+				'Content-Length from middleware should be stripped during error page merge',
+			);
+			// Non-framing custom headers should still be preserved
+			assert.equal(response.headers.get('X-Custom'), 'keep-me');
+		});
+
+		it('should not preserve Transfer-Encoding from middleware when rendering 500 error page', async () => {
+			let callCount = 0;
+			const onRequest = async (ctx, next) => {
+				callCount++;
+				const response = await next();
+				if (callCount === 1 && ctx.url.pathname.startsWith('/api/error')) {
+					return new Response(null, {
+						status: 500,
+						headers: { 'Transfer-Encoding': 'chunked', 'X-Error-Source': 'middleware' },
+					});
+				}
+				return response;
+			};
+
+			const errorRouteData = createRouteData({
+				route: '/api/error/[...path]',
+				pathname: undefined,
+				segments: undefined,
+			});
+			errorRouteData.params = ['...path'];
+			errorRouteData.pattern = /^\/api\/error(?:\/(.*))?$/;
+			errorRouteData.pathname = undefined;
+			errorRouteData.segments = [
+				[{ content: 'api', dynamic: false, spread: false }],
+				[{ content: 'error', dynamic: false, spread: false }],
+				[{ content: '...path', dynamic: true, spread: true }],
+			];
+
+			const pageMap = new Map([
+				[
+					errorRouteData.component,
+					async () => ({
+						page: async () => ({
+							default: simplePage(),
+						}),
+					}),
+				],
+				[
+					serverErrorRouteData.component,
+					async () => ({ page: async () => ({ default: serverErrorPage }) }),
+				],
+			]);
+			const app = createAppWithMiddleware({
+				onRequest,
+				routes: [{ routeData: errorRouteData }, { routeData: serverErrorRouteData }],
+				pageMap,
+			});
+
+			const response = await app.render(new Request('http://localhost/api/error/test'));
+
+			assert.equal(response.status, 500);
+			// Transfer-Encoding from middleware's original response must not leak into the error page response
+			assert.equal(
+				response.headers.get('Transfer-Encoding'),
+				null,
+				'Transfer-Encoding from middleware should be stripped during error page merge',
+			);
+			// Non-framing custom headers should still be preserved
+			assert.equal(response.headers.get('X-Error-Source'), 'middleware');
+		});
+	});
+
 	describe('middleware with custom headers', () => {
 		it('should correctly set custom headers in middleware', async () => {
 			const onRequest = async (_ctx, next) => {


### PR DESCRIPTION
## Changes

- Strips `Content-Length` and `Transfer-Encoding` headers from the original response before merging in `mergeResponses()`, matching the existing treatment of `Content-type`
- Ensures framing headers from the original response do not carry over to a rendered error page that has a different body

## Testing

- Added unit tests in `middleware-app.test.js` verifying that `Content-Length` and `Transfer-Encoding` from middleware responses are not preserved when rendering 404/500 error pages
- Non-framing custom headers (e.g. `X-Custom`) are confirmed to still be preserved

## Docs

No docs changes needed.
