### PR TITLE
fix(env): add validation against vite.envPrefix

### DIFF
--- a/.changeset/fix-envprefix-secret-leak.md
+++ b/.changeset/fix-envprefix-secret-leak.md
@@ -1,0 +1,24 @@
+---
+'astro': patch
+---
+
+Prevents `vite.envPrefix` misconfiguration from exposing `access: "secret"` environment variables in client-side bundles. Astro now throws a clear error at startup if any `vite.envPrefix` entry matches a variable declared with `access: "secret"` in `env.schema`.
+
+For example, the following configuration will throw an error for `API_SECRET` because it's defined as `secret` its name matches `['PUBLIC_', 'API_']` defined in `env.schema`:
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  env: {
+    schema: {
+      API_SECRET: envField.string({ context: 'server', access: 'secret', optional: true }),
+      API_URL: envField.string({ context: 'server', access: 'public', optional: true }),
+    }
+  },
+  vite: {
+    envPrefix: ['PUBLIC_', 'API_'],
+  },
+})
+```

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -12,6 +12,7 @@ import {
 	astroContentVirtualModPlugin,
 } from '../content/index.js';
 import { createEnvLoader } from '../env/env-loader.js';
+import { validateEnvPrefixAgainstSchema } from '../env/validators.js';
 import { astroEnv } from '../env/vite-plugin-env.js';
 import { importMetaEnv } from '../env/vite-plugin-import-meta-env.js';
 import astroInternationalization from '../i18n/vite-plugin-i18n.js';
@@ -110,6 +111,9 @@ export async function createVite(
 		mode,
 		config: settings.config,
 	});
+
+	// Validate that envPrefix doesn't conflict with secret env schema variables
+	validateEnvPrefixAgainstSchema(settings.config);
 
 	// Start with the Vite configuration that Astro core needs
 	const commonConfig: vite.InlineConfig = {

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1311,6 +1311,23 @@ export const EnvInvalidVariables = {
 /**
  * @docs
  * @description
+ * The configured `vite.envPrefix` includes prefixes that match environment variables declared with `access: "secret"` in `env.schema`.
+ * This would cause Vite to expose those secret values in client-side JavaScript bundles, bypassing the `access: "secret"` protection.
+ *
+ * To fix this, either:
+ * - Remove the conflicting prefixes from `vite.envPrefix`, or
+ * - Rename your secret environment variables to use a prefix that is not in `vite.envPrefix`.
+ */
+export const EnvPrefixConflictsWithSecret = {
+	name: 'EnvPrefixConflictsWithSecret',
+	title: 'envPrefix conflicts with secret environment variables',
+	message: (conflicts: Array<string>) =>
+		`The following environment variables are declared with \`access: "secret"\` in \`env.schema\`, but their names match a prefix in \`vite.envPrefix\`, which would expose them in client-side bundles:\n\n${conflicts.map((c) => `- ${c}`).join('\n')}\n\nEither remove the conflicting prefixes from \`vite.envPrefix\`, or rename these variables to use a prefix not in \`vite.envPrefix\`.`,
+} satisfies ErrorData;
+
+/**
+ * @docs
+ * @description
  * This module is only available server-side.
  */
 export const ServerOnlyModule = {

--- a/packages/astro/src/env/env-loader.ts
+++ b/packages/astro/src/env/env-loader.ts
@@ -1,21 +1,41 @@
 import { fileURLToPath } from 'node:url';
 import { loadEnv } from 'vite';
 import type { AstroConfig } from '../types/public/index.js';
+import type { EnvSchema } from './schema.js';
 
 // Match valid JS variable names (identifiers), which accepts most alphanumeric characters,
 // except that the first character cannot be a number.
 const isValidIdentifierRe = /^[_$a-zA-Z][\w$]*$/;
 
 /**
+ * Collects the set of env variable names declared with `access: "secret"` in the env schema.
+ */
+function getSecretKeys(envSchema: EnvSchema): Set<string> {
+	const secrets = new Set<string>();
+	for (const [key, options] of Object.entries(envSchema)) {
+		if (options.access === 'secret') {
+			secrets.add(key);
+		}
+	}
+	return secrets;
+}
+
+/**
  * From public env, returns private env. Each value may be stringified, transformed as `process.env`
  * or coerced depending on options.
+ *
+ * Variables declared with `access: "secret"` in the env schema are always treated as private,
+ * even if their name matches a configured `envPrefix`. This prevents envPrefix misconfiguration
+ * from leaking secrets to client bundles.
  */
 function getPrivateEnv({
 	fullEnv,
 	viteConfig,
+	envSchema,
 }: {
 	fullEnv: Record<string, string>;
 	viteConfig: AstroConfig['vite'];
+	envSchema: EnvSchema;
 }): Record<string, string> {
 	let envPrefixes: string[] = ['PUBLIC_'];
 	if (viteConfig.envPrefix) {
@@ -24,12 +44,25 @@ function getPrivateEnv({
 			: [viteConfig.envPrefix];
 	}
 
+	const secretKeys = getSecretKeys(envSchema);
 	const privateEnv: Record<string, string> = {};
 	for (const key in fullEnv) {
-		// Ignore public env var
-		if (!isValidIdentifierRe.test(key) || envPrefixes.some((prefix) => key.startsWith(prefix))) {
+		if (!isValidIdentifierRe.test(key)) {
 			continue;
 		}
+
+		// Variables declared as secret in the env schema are always private,
+		// regardless of whether they match an envPrefix.
+		if (secretKeys.has(key)) {
+			privateEnv[key] = JSON.stringify(fullEnv[key]);
+			continue;
+		}
+
+		// Skip variables matching envPrefix — these are public (handled by Vite)
+		if (envPrefixes.some((prefix) => key.startsWith(prefix))) {
+			continue;
+		}
+
 		privateEnv[key] = JSON.stringify(fullEnv[key]);
 	}
 	return privateEnv;
@@ -42,7 +75,11 @@ interface EnvLoaderOptions {
 
 function getEnv({ mode, config }: EnvLoaderOptions) {
 	const loaded = loadEnv(mode, config.vite.envDir ?? fileURLToPath(config.root), '');
-	const privateEnv = getPrivateEnv({ fullEnv: loaded, viteConfig: config.vite });
+	const privateEnv = getPrivateEnv({
+		fullEnv: loaded,
+		viteConfig: config.vite,
+		envSchema: config.env.schema,
+	});
 
 	return { loaded, privateEnv };
 }

--- a/packages/astro/src/env/validators.ts
+++ b/packages/astro/src/env/validators.ts
@@ -1,3 +1,5 @@
+import { AstroError, AstroErrorData } from '../core/errors/index.js';
+import type { AstroConfig } from '../types/public/index.js';
 import type { EnumSchema, EnvFieldType, NumberSchema, StringSchema } from './schema.js';
 
 export type ValidationResultValue = EnvFieldType['default'];
@@ -176,4 +178,38 @@ export function validateEnvVariable(
 	}
 
 	return selectValidator(options)(value);
+}
+
+/**
+ * Validates that `vite.envPrefix` doesn't match any environment variables declared
+ * with `access: "secret"` in `env.schema`. If it does, those secrets would be exposed
+ * by Vite in client-side bundles via `import.meta.env`, completely bypassing the
+ * `access: "secret"` protection.
+ *
+ * Throws an `AstroError` if conflicts are found.
+ */
+export function validateEnvPrefixAgainstSchema(config: AstroConfig): void {
+	const schema = config.env.schema;
+	const envPrefix = config.vite?.envPrefix;
+
+	// No schema or using default prefix — nothing to validate
+	if (Object.keys(schema).length === 0 || !envPrefix) {
+		return;
+	}
+
+	const prefixes = Array.isArray(envPrefix) ? envPrefix : [envPrefix];
+	const conflicts: string[] = [];
+
+	for (const [key, options] of Object.entries(schema)) {
+		if (options.access === 'secret' && prefixes.some((prefix) => key.startsWith(prefix))) {
+			conflicts.push(key);
+		}
+	}
+
+	if (conflicts.length > 0) {
+		throw new AstroError({
+			...AstroErrorData.EnvPrefixConflictsWithSecret,
+			message: AstroErrorData.EnvPrefixConflictsWithSecret.message(conflicts),
+		});
+	}
 }

--- a/packages/astro/test/env-secret-envprefix.test.js
+++ b/packages/astro/test/env-secret-envprefix.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+describe('astro:env secret variables with envPrefix conflict', () => {
+	it('throws an error when envPrefix matches a secret env schema variable', async () => {
+		const fixture = await loadFixture({
+			root: './fixtures/astro-env-secret-envprefix/',
+		});
+
+		try {
+			await fixture.build();
+			assert.fail('expected build to throw');
+		} catch (error) {
+			assert.equal(error instanceof Error, true);
+			assert.equal(error.name, 'EnvPrefixConflictsWithSecret');
+			assert.equal(error.message.includes('API_SECRET'), true);
+		}
+	});
+
+	it('does not throw when envPrefix does not match any secret env schema variable', async () => {
+		// Use the server-secret fixture which has secrets but default envPrefix (PUBLIC_)
+		const fixture = await loadFixture({
+			root: './fixtures/astro-env-server-secret/',
+			output: 'server',
+			adapter: (await import('./test-adapter.js')).default({
+				env: {
+					KNOWN_SECRET: '123456',
+					UNKNOWN_SECRET: 'abc',
+				},
+			}),
+		});
+		await fixture.build();
+		assert.equal(true, true);
+	});
+});

--- a/packages/astro/test/fixtures/astro-env-secret-envprefix/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-env-secret-envprefix/astro.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig, envField } from 'astro/config';
+
+export default defineConfig({
+	env: {
+		schema: {
+			API_SECRET: envField.string({ context: 'server', access: 'secret', optional: true }),
+			API_URL: envField.string({ context: 'server', access: 'public', optional: true }),
+		},
+	},
+	vite: {
+		envPrefix: ['PUBLIC_', 'API_'],
+	},
+});

--- a/packages/astro/test/fixtures/astro-env-secret-envprefix/package.json
+++ b/packages/astro/test/fixtures/astro-env-secret-envprefix/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-env-secret-envprefix",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-env-secret-envprefix/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-env-secret-envprefix/src/pages/index.astro
@@ -1,0 +1,18 @@
+---
+import { API_SECRET, getSecret } from "astro:env/server"
+---
+
+<html lang="en">
+<body>
+<pre id="data">{JSON.stringify({ API_SECRET })}</pre>
+<script>
+	const el = document.createElement('pre');
+	el.id = 'client-env';
+	el.textContent = JSON.stringify({
+		API_SECRET: import.meta.env.API_SECRET,
+		PUBLIC_APP_NAME: import.meta.env.PUBLIC_APP_NAME,
+	});
+	document.body.appendChild(el);
+</script>
+</body>
+</html>

--- a/packages/astro/test/units/env/env-validators.test.js
+++ b/packages/astro/test/units/env/env-validators.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
-import { getEnvFieldType, validateEnvVariable } from '../../../dist/env/validators.js';
+import {
+	getEnvFieldType,
+	validateEnvVariable,
+	validateEnvPrefixAgainstSchema,
+} from '../../../dist/env/validators.js';
 
 /**
  * @typedef {Parameters<typeof validateEnvVariable>} Params
@@ -547,6 +551,132 @@ describe('astro:env validators', () => {
 				default: 'a',
 			});
 			fixture.thenResultShouldBeValid('b');
+		});
+	});
+});
+
+describe('validateEnvPrefixAgainstSchema', () => {
+	/**
+	 * Helper to build a minimal config object matching the shape
+	 * validateEnvPrefixAgainstSchema expects.
+	 *
+	 * @param {Record<string, any>} schema
+	 * @param {string | string[] | undefined} envPrefix
+	 */
+	function makeConfig(schema, envPrefix) {
+		return /** @type {any} */ ({
+			env: { schema },
+			vite: envPrefix !== undefined ? { envPrefix } : {},
+		});
+	}
+
+	it('should not throw when schema is empty', () => {
+		assert.doesNotThrow(() => {
+			validateEnvPrefixAgainstSchema(makeConfig({}, ['PUBLIC_', 'API_']));
+		});
+	});
+
+	it('should not throw when envPrefix is not set', () => {
+		assert.doesNotThrow(() => {
+			validateEnvPrefixAgainstSchema(
+				makeConfig(
+					{ API_SECRET: { context: 'server', access: 'secret', type: 'string' } },
+					undefined,
+				),
+			);
+		});
+	});
+
+	it('should not throw when envPrefix does not match any secret variable', () => {
+		assert.doesNotThrow(() => {
+			validateEnvPrefixAgainstSchema(
+				makeConfig({ DB_PASSWORD: { context: 'server', access: 'secret', type: 'string' } }, [
+					'PUBLIC_',
+					'API_',
+				]),
+			);
+		});
+	});
+
+	it('should not throw when envPrefix matches a public variable', () => {
+		assert.doesNotThrow(() => {
+			validateEnvPrefixAgainstSchema(
+				makeConfig({ API_URL: { context: 'server', access: 'public', type: 'string' } }, [
+					'PUBLIC_',
+					'API_',
+				]),
+			);
+		});
+	});
+
+	it('should throw when envPrefix matches a secret variable (array prefix)', () => {
+		assert.throws(
+			() => {
+				validateEnvPrefixAgainstSchema(
+					makeConfig({ API_SECRET: { context: 'server', access: 'secret', type: 'string' } }, [
+						'PUBLIC_',
+						'API_',
+					]),
+				);
+			},
+			(err) => {
+				assert.equal(err.name, 'EnvPrefixConflictsWithSecret');
+				assert.equal(err.message.includes('API_SECRET'), true);
+				return true;
+			},
+		);
+	});
+
+	it('should throw when envPrefix matches a secret variable (string prefix)', () => {
+		assert.throws(
+			() => {
+				validateEnvPrefixAgainstSchema(
+					makeConfig(
+						{ SECRET_KEY: { context: 'server', access: 'secret', type: 'string' } },
+						'SECRET_',
+					),
+				);
+			},
+			(err) => {
+				assert.equal(err.name, 'EnvPrefixConflictsWithSecret');
+				assert.equal(err.message.includes('SECRET_KEY'), true);
+				return true;
+			},
+		);
+	});
+
+	it('should list all conflicting secret variables in the error', () => {
+		assert.throws(
+			() => {
+				validateEnvPrefixAgainstSchema(
+					makeConfig(
+						{
+							API_SECRET: { context: 'server', access: 'secret', type: 'string' },
+							API_KEY: { context: 'server', access: 'secret', type: 'string' },
+							API_URL: { context: 'server', access: 'public', type: 'string' },
+						},
+						['PUBLIC_', 'API_'],
+					),
+				);
+			},
+			(err) => {
+				assert.equal(err.name, 'EnvPrefixConflictsWithSecret');
+				assert.equal(err.message.includes('API_SECRET'), true);
+				assert.equal(err.message.includes('API_KEY'), true);
+				assert.equal(err.message.includes('API_URL'), false);
+				return true;
+			},
+		);
+	});
+
+	it('should not throw when only the default PUBLIC_ prefix is used', () => {
+		assert.doesNotThrow(() => {
+			validateEnvPrefixAgainstSchema(
+				makeConfig(
+					{ DB_PASSWORD: { context: 'server', access: 'secret', type: 'string' } },
+					'PUBLIC_',
+				),
+			);
 		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2192,6 +2192,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/astro-env-secret-envprefix:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/astro-env-server-fail:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

This PR fixes an issue where certain secrete can be exposed to the client if `vite.envPrefix` includes them.

cc @florian-lefebvre 


## Testing

Added unit tests and integration tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
