### PR TITLE
feat: tsconfig types like TS 5

### DIFF
--- a/.changeset/warm-worms-talk.md
+++ b/.changeset/warm-worms-talk.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Updates the base tsconfig `types` to `["*"]`, preserving the same behavior between TypeScript 5 and 6
+Reverts changes made to TSConfig templates

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -26,9 +26,7 @@
     // Allow JavaScript files to be imported
     "allowJs": true,
     // Allow JSX files (or files that are internally considered JSX, like Astro files) to be imported inside `.js` and `.ts` files.
-    "jsx": "preserve",
-    "types": ["*"],
-    "libReplacement": false
+    "jsx": "preserve"
   },
   "exclude": ["${configDir}/dist"],
   "include": ["${configDir}/.astro/types.d.ts", "${configDir}/**/*"]


### PR DESCRIPTION
## Changes

- We'll do `types: []` in Astro 7, when TS 6 will have more adoption
- Closes #15785

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- Changeset
- https://github.com/withastro/docs/pull/13353

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
