### PR TITLE
feat: warn when partial pages strip scoped styles and scripts

### DIFF
--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -354,6 +354,13 @@ export class RenderContext {
 					if (this.isRewriting) {
 						response.headers.set(REWRITE_DIRECTIVE_HEADER_KEY, REWRITE_DIRECTIVE_HEADER_VALUE);
 					}
+
+					if (this.result.partial && (this.result.styles.size > 0 || this.result.scripts.size > 0)) {
+						logger.warn(
+							null,
+							`Route ${colors.green(this.routeData.route)} is rendered as a partial, so scoped styles and scripts are stripped from the HTML output. Use a non-partial page if this route needs these assets.`,
+						);
+					}
 					break;
 				}
 				case 'fallback': {

--- a/packages/astro/test/fixtures/partials/src/pages/partials/with-assets.astro
+++ b/packages/astro/test/fixtures/partials/src/pages/partials/with-assets.astro
@@ -1,0 +1,15 @@
+---
+export const partial = true;
+---
+
+<style>
+	.alert {
+		color: red;
+	}
+</style>
+
+<script>
+	console.log('partial route script');
+</script>
+
+<div class="alert">Partial with assets</div>

--- a/packages/astro/test/partials.test.js
+++ b/packages/astro/test/partials.test.js
@@ -3,6 +3,22 @@ import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
+async function captureStdoutLogs(run) {
+	const originalWrite = process.stdout.write.bind(process.stdout);
+	let output = '';
+	process.stdout.write = (chunk, encoding, callback) => {
+		output += chunk?.toString?.() ?? '';
+		if (typeof callback === 'function') callback();
+		return true;
+	};
+	try {
+		await run();
+	} finally {
+		process.stdout.write = originalWrite;
+	}
+	return output;
+}
+
 describe('Partials', () => {
 	/** @type {import('./test-utils.js').Fixture} */
 	let fixture;
@@ -10,6 +26,7 @@ describe('Partials', () => {
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/partials/',
+			logLevel: 'warn',
 		});
 	});
 
@@ -35,6 +52,13 @@ describe('Partials', () => {
 			const $ = cheerio.load(html);
 			assert.equal($('#true').text(), 'test');
 		});
+
+		it('warns when partial pages include styles or scripts', async () => {
+			const output = await captureStdoutLogs(async () => {
+				await fixture.fetch('/partials/with-assets/').then((res) => res.text());
+			});
+			assert.match(output, /rendered as a partial, so scoped styles and scripts are stripped/);
+		});
 	});
 
 	describe('build', () => {
@@ -50,6 +74,13 @@ describe('Partials', () => {
 		it('Works with mdx', async () => {
 			const html = await fixture.readFile('/partials/docs/index.html');
 			assert.equal(html.startsWith('<h1'), true);
+		});
+
+		it('warns during build when partial pages include styles or scripts', async () => {
+			const output = await captureStdoutLogs(async () => {
+				await fixture.build();
+			});
+			assert.match(output, /rendered as a partial, so scoped styles and scripts are stripped/);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Partials intentionally skip head rendering, which means scoped `<style>` and `<script>` blocks are silently dropped. This adds a runtime warning so developers get immediate feedback when that happens.

### What changed
- Added a warning in `RenderContext` after page rendering when `partial` is enabled and collected styles/scripts would be stripped.
- Added a partial fixture with both scoped styles and scripts (`with-assets.astro`).
- Added integration assertions (dev + build) that the warning is emitted.

## Why this helps

This improves DX for partial routes by surfacing a common gotcha directly in logs, instead of requiring developers to notice missing behavior and then discover the docs note later.

## Testing

- `pnpm install`
- `pnpm --filter astro run build:ci`

I also attempted to run `pnpm --filter astro run test:integration partials.test.js`, but local workspace dist dependencies for sibling packages were not fully built in this checkout yet.
