### PR TITLE
fix: regression JSX rendering

### DIFF
--- a/.changeset/ripe-geckos-lie.md
+++ b/.changeset/ripe-geckos-lie.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a regression where using the adapter would throw an error when using an integration that uses JSX.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -188,6 +188,7 @@ export default function createIntegration({
 													'astro > unstorage',
 													'astro > neotraverse/modern',
 													'astro > piccolore',
+													'astro > picomatch',
 													'astro/app',
 													'astro/assets',
 													'astro/compiler-runtime',


### PR DESCRIPTION
## Changes

Fixes a regression caused by https://github.com/withastro/astro/pull/15700

We added `picomatch` to `internal-helpers`, which doesn't play well with the CF adapter because it contains Node.js code.

Adding it to the `noExternal` fixes the failure.

## Testing

I tested it manually, because the monorepo doesn't show the error.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
