### PR TITLE
Exit prerelease mode for Astro 6 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "astro": "5.13.7",


### PR DESCRIPTION
Exit prerelease mode, merging this will update the CI release to publish 6, which will be blocked until release.