### PR TITLE
docs: fix grammar in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ To understand which file causes the issue, you can modify the `test` script insi
 }
 ```
 
-Save the change and **push it** to your PR. This change will make the test CI slower, but it will allow to see which files cause the timeout. Once you fixed the issue **revert the change and push it**.
+Save the change and **push it** to your PR. This change will make the test CI slower, but it will allow you to see which files cause the timeout. Once you fixed the issue **revert the change and push it**.
 
 #### E2E tests
 


### PR DESCRIPTION
## Changes\n- Fix a small grammar issue in CONTRIBUTING.\n- No changeset needed for a docs-only change.\n\n## Testing\n- Not run (docs-only).\n\n## Docs\n- Not needed beyond this change (already in docs).