### PR TITLE
fix: bump packages that failed to publish

### DIFF
--- a/.changeset/great-mice-greet.md
+++ b/.changeset/great-mice-greet.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/language-server': patch
+'@astrojs/ts-plugin': patch
+'@astrojs/partytown': patch
+'@astrojs/yaml2ts': patch
+'@astrojs/underscore-redirects': patch
+---
+
+Fixes broken publish

--- a/packages/language-tools/language-server/package.json
+++ b/packages/language-tools/language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrojs/language-server",
-  "version": "2.16.1",
+  "version": "2.16.3",
   "author": "withastro",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Changes

A few packages failed to publish during Astro 6 because of beta things. Apart from @astrojs/language-server they just had one version above, but the language server had a few patches so needed a manual package.json bump

## Testing

N/A

## Docs

N/A
