### PR TITLE
fix(frontmatter): Correctly handle bare returns

### DIFF
--- a/.changeset/dull-clowns-sin.md
+++ b/.changeset/dull-clowns-sin.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': patch
+'astro': patch
+---
+
+Fixes `return;` syntax not working in the frontmatter correctly in certain contexts

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -110,7 +110,9 @@ async function enhanceCompileError({
 	const scannedFrontmatter = frontmatterRE.exec(source);
 	if (scannedFrontmatter) {
 		// Top-level return is not supported, so replace `return` with throw
-		const frontmatter = scannedFrontmatter[1].replace(/\breturn\b/g, 'throw');
+		const frontmatter = scannedFrontmatter[1]
+			.replace(/\breturn\s*;/g, 'throw 0;')
+			.replace(/\breturn\b/g, 'throw ');
 
 		// If frontmatter does not actually include the offending line, skip
 		if (lineText && !frontmatter.includes(lineText)) throw err;

--- a/packages/integrations/cloudflare/src/esbuild-plugin-astro-frontmatter.ts
+++ b/packages/integrations/cloudflare/src/esbuild-plugin-astro-frontmatter.ts
@@ -30,7 +30,9 @@ export function astroFrontmatterScanPlugin(): ESBuildPlugin {
 						//
 						// Known Limitation: Using regex /\breturn\b/ will incorrectly match
 						// identifiers like `$return` or aliases like `import { return as ret }`.
-						const contents = frontmatterMatch[1].replace(/\breturn\b/g, 'throw ');
+						const contents = frontmatterMatch[1]
+							.replace(/\breturn\s*;/g, 'throw 0;')
+							.replace(/\breturn\b/g, 'throw ');
 
 						return {
 							contents,

--- a/packages/integrations/cloudflare/test/fixtures/top-level-return/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/top-level-return/src/pages/index.astro
@@ -13,6 +13,10 @@ if (guard()) {
   return Astro.redirect("/404")
 }
 
+// Bare return (no value) — must not produce invalid `throw ;` syntax during dep scanning
+const source = "hello";
+if (!source) return;
+
 ---
 
 <html>


### PR DESCRIPTION
## Changes

For import analysis, we have to remove top-level returns from Astro files in the Cloudflare adapter, we do this using a pretty naive replace, but it's fine. However, we didn't handle bare returns, i.e. `return;` so this fixes that.

The same code is also present in Astro for better errors during compile errors, so fixed that there too.

## Testing

Added a test to the CF adapter

## Docs

N/A