### PR TITLE
fix(cloudflare): forward PluginConfig options to Cloudflare Vite Plugin

### DIFF
--- a/.changeset/fix-cloudflare-configpath.md
+++ b/.changeset/fix-cloudflare-configpath.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+fix(cloudflare): forward `configPath` and other `PluginConfig` options to the Cloudflare Vite Plugin
+
+Options like `configPath`, `inspectorPort`, `persistState`, `remoteBindings`, and `auxiliaryWorkers` were accepted by the type system but never forwarded to `cfVitePlugin()`, making them silently ignored.
+
+Also fixes `addWatchFile` for `configPath` which resolved the path relative to the adapter's `node_modules` directory instead of the project root.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -21,7 +21,6 @@ import {
 import { parseEnv } from 'node:util';
 import { sessionDrivers } from 'astro/config';
 import { createCloudflarePrerenderer } from './prerenderer.js';
-import { createRequire } from 'node:module';
 
 const CLOUDFLARE_KV_SESSION_DRIVER_ENTRYPOINT = sessionDrivers.cloudflareKVBinding().entrypoint;
 
@@ -176,7 +175,7 @@ export default function createIntegration({
 					session,
 					vite: {
 						plugins: [
-							cfVitePlugin({ ...cfPluginConfig, viteEnvironment: { name: 'ssr' } }),
+							cfVitePlugin({ ...cloudflareOptions, ...cfPluginConfig, viteEnvironment: { name: 'ssr' } }),
 							{
 								name: '@astrojs/cloudflare:cf-imports',
 								enforce: 'pre',
@@ -278,7 +277,7 @@ export default function createIntegration({
 				});
 
 				if (cloudflareOptions.configPath) {
-					addWatchFile(createRequire(import.meta.url).resolve(cloudflareOptions.configPath));
+					addWatchFile(new URL(cloudflareOptions.configPath, config.root));
 				}
 
 				addWatchFile(new URL('./wrangler.toml', config.root));


### PR DESCRIPTION
## Summary

Fixes #15846

- **Forward `cloudflareOptions` to `cfVitePlugin()`** — Options like `configPath`, `inspectorPort`, `persistState`, `remoteBindings`, and `auxiliaryWorkers` are accepted by the type system (via `Pick<PluginConfig, ...>` in the `Options` type) but were never spread into the `cfVitePlugin()` call, making them silently ignored.

- **Fix `addWatchFile` path resolution for `configPath`** — `createRequire(import.meta.url).resolve(configPath)` resolves relative to the adapter's own `node_modules/@astrojs/cloudflare/dist/` directory instead of the project root, causing a `Cannot find module` error. Replaced with `new URL(configPath, config.root)` to match how the other wrangler config watch files are resolved.

## Reproduction

```ts
// astro.config.ts — with wrangler-review.jsonc at project root, no wrangler.jsonc
export default defineConfig({
  adapter: cloudflare({
    configPath: "./wrangler-review.jsonc",
  }),
});
```

Running `astro dev` crashes with:
```
Cannot find module './wrangler-review.jsonc'
Require stack:
- node_modules/@astrojs/cloudflare/dist/index.js
```

## Changes

3-line diff in `packages/integrations/cloudflare/src/index.ts`:

1. Spread `cloudflareOptions` into `cfVitePlugin()` so all `PluginConfig` options are forwarded
2. Use `new URL(configPath, config.root)` instead of `createRequire(import.meta.url).resolve(configPath)`
3. Remove unused `createRequire` import

## Use case

Projects using separate wrangler configs per environment (`wrangler-review.jsonc` for dev/staging, `wrangler-prod.jsonc` for production) with CI renaming the appropriate file at deploy time. In `@astrojs/cloudflare` v12, `platformProxy.configPath` handled this. After migrating to v13, `configPath` is the documented replacement but doesn't work.