### PR TITLE
fix: distURL build regression

### DIFF
--- a/.changeset/dirty-breads-wish.md
+++ b/.changeset/dirty-breads-wish.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression where the the routes emitted by the `astro:build:done` hook didn't have the `distURL` array correctly populated.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -189,6 +189,24 @@ export async function generatePages(
 		}
 	}
 
+	// After generation, propagate distURL from the deserialized routes (used during generation)
+	// back to the original routes in allPages. The prerenderer operates on deserialized route
+	// objects (reconstructed from the serialized manifest), so distURL mutations during generation
+	// don't affect the original route objects that are later passed to the astro:build:done hook.
+	for (const { route: generatedRoute } of filteredPaths) {
+		if (generatedRoute.distURL && generatedRoute.distURL.length > 0) {
+			for (const pageData of Object.values(options.allPages)) {
+				if (
+					pageData.route.route === generatedRoute.route &&
+					pageData.route.component === generatedRoute.component
+				) {
+					pageData.route.distURL = generatedRoute.distURL;
+					break;
+				}
+			}
+		}
+	}
+
 	const staticImageList = getStaticImageList();
 
 	// Must happen before teardown since collectStaticImages fetches from the prerender server

--- a/packages/astro/test/static-build-page-dist-url.test.js
+++ b/packages/astro/test/static-build-page-dist-url.test.js
@@ -24,9 +24,14 @@ describe('Static build: pages routes have distURL', () => {
 	});
 	it('Pages routes have distURL', async () => {
 		assert.equal(assets.size > 0, true, 'Pages not found: build end hook not being called');
-		for (const [p, distURL] of assets.entries()) {
+		for (const [route, distURL] of assets.entries()) {
+			assert.equal(
+				distURL.length > 0,
+				true,
+				`Route "${route}" has an empty distURL array — asset URLs were not propagated to astro:build:done`,
+			);
 			for (const url of distURL) {
-				assert.equal(url instanceof URL, true, `${p.pathname} doesn't include distURL`);
+				assert.equal(url instanceof URL, true, `Route "${route}" distURL entry is not a URL`);
 			}
 		}
 	});


### PR DESCRIPTION
## Changes

Found a bug where `distURL` was empty. We didn't catch it because our tests were weak.

## Testing

The existing tests now checks for their `length` too

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
