### PR TITLE
chore: change `baseBranch` of changeset from `origin/next` to `origin/main`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "origin/next",
+  "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
## Changes
This is because the next branch has seen no activity for three weeks, and v6, previously targeted to next, is already out.

## Testing

N/A

## Docs

N/A