### PR TITLE
fix: correctly exclude entrypoint via environments

### DIFF
--- a/.changeset/wise-turkeys-tan.md
+++ b/.changeset/wise-turkeys-tan.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/netlify': patch
+'@astrojs/node': patch
+---
+
+Fixes an issue where the adapter would cause a series of warnings during the build.

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -664,9 +664,6 @@ export default function netlifyIntegration(
 								cacheOnDemandPages: !!integrationConfig?.cacheOnDemandPages,
 							}),
 						],
-						ssr: {
-							noExternal: ['@astrojs/netlify'],
-						},
 						server: {
 							watch: {
 								ignored: [fileURLToPath(new URL('./.netlify/**', rootDir))],

--- a/packages/integrations/netlify/src/vite-plugin-config.ts
+++ b/packages/integrations/netlify/src/vite-plugin-config.ts
@@ -8,9 +8,20 @@ export interface Config {
 	cacheOnDemandPages: boolean;
 }
 
+const SERVER_ENVIRONMENTS = ['ssr', 'prerender', 'astro'];
+
 export function createConfigPlugin(config: Config): PluginOption {
 	return {
 		name: VIRTUAL_CONFIG_ID,
+		configEnvironment(environmentName) {
+			if (SERVER_ENVIRONMENTS.includes(environmentName)) {
+				return {
+					resolve: {
+						noExternal: ['@astrojs/netlify'],
+					},
+				};
+			}
+		},
 		resolveId: {
 			filter: {
 				id: new RegExp(`^${VIRTUAL_CONFIG_ID}$`),

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -54,6 +54,9 @@
     "@fastify/static": "^9.0.0",
     "node-mocks-http": "^1.17.2"
   },
+  "astro": {
+    "external": true
+  },
   "publishConfig": {
     "provenance": true
   }

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -67,9 +67,6 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 					},
 					session,
 					vite: {
-						ssr: {
-							noExternal: ['@astrojs/node'],
-						},
 						plugins: [
 							createConfigPlugin({
 								...userOptions,
@@ -79,6 +76,7 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 								port: _config.server.port,
 								staticHeaders: userOptions.staticHeaders ?? false,
 								bodySizeLimit: userOptions.bodySizeLimit ?? 1024 * 1024 * 1024,
+								experimentalDisableStreaming: userOptions.experimentalDisableStreaming ?? false,
 							}),
 						],
 					},

--- a/packages/integrations/node/src/vite-plugin-config.ts
+++ b/packages/integrations/node/src/vite-plugin-config.ts
@@ -4,11 +4,22 @@ import type { Options } from './types.js';
 const VIRTUAL_CONFIG_ID = 'virtual:astro-node:config';
 const RESOLVED_VIRTUAL_CONFIG_ID = '\0' + VIRTUAL_CONFIG_ID;
 
+const SERVER_ENVIRONMENTS = ['ssr', 'prerender', 'astro'];
+
 export function createConfigPlugin(
 	config: Options,
 ): NonNullable<AstroConfig['vite']['plugins']>[number] {
 	return {
 		name: VIRTUAL_CONFIG_ID,
+		configEnvironment(environmentName) {
+			if (SERVER_ENVIRONMENTS.includes(environmentName)) {
+				return {
+					resolve: {
+						noExternal: ['@astrojs/node'],
+					},
+				};
+			}
+		},
 		resolveId: {
 			filter: {
 				id: new RegExp(`^${VIRTUAL_CONFIG_ID}$`),


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/15839

- Applies `noExternal` using the proper `configEnvrionment` hook for node and netlify adapters
- Added a missing configuration to the node adapter 

## Testing

Manually tested. It was the only way. I'll do a preview release too

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
