### PR TITLE
correct noExternal hint to Vite 7 key

### DIFF
--- a/.changeset/wise-cats-check.md
+++ b/.changeset/wise-cats-check.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update the unknown file extension error hint to recommend `vite.resolve.noExternal`, which is the correct Vite 7 config key.

--- a/packages/astro/src/core/errors/dev/utils.ts
+++ b/packages/astro/src/core/errors/dev/utils.ts
@@ -140,7 +140,7 @@ function generateHint(err: ErrorWithMetadata): string | undefined {
 	const commonBrowserAPIs = ['document', 'window'];
 
 	if (/Unknown file extension "\.(?:jsx|vue|svelte|astro|css)" for /.test(err.message)) {
-		return 'You likely need to add this package to `vite.ssr.noExternal` in your astro config file.';
+		return 'You likely need to add this package to `vite.resolve.noExternal` in your astro config file.';
 	} else if (commonBrowserAPIs.some((api) => err.toString().includes(api))) {
 		const hint = `Browser APIs are not available on the server.
 


### PR DESCRIPTION
## Changes

- Update the unknown file extension error hint to recommend `vite.resolve.noExternal` instead of `vite.ssr.noExternal`.
- Aligns guidance with Astro 6 / Vite 7 config behavior.
- Fixes https://github.com/withastro/astro/issues/15856

## Testing

N/A

## Docs

N/A bug fix