### PR TITLE
Prebundle astro/toolbar for custom dev toolbar apps

### DIFF
--- a/.changeset/fix-dev-toolbar-optimize-deps.md
+++ b/.changeset/fix-dev-toolbar-optimize-deps.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prebundle `astro/toolbar` in dev when custom dev toolbar apps are registered, preventing re-optimization reloads that can hide or break the toolbar.

--- a/packages/astro/src/toolbar/vite-plugin-dev-toolbar.ts
+++ b/packages/astro/src/toolbar/vite-plugin-dev-toolbar.ts
@@ -16,7 +16,11 @@ export default function astroDevToolbar({ settings, logger }: AstroPluginOptions
 			return {
 				optimizeDeps: {
 					// Optimize CJS dependencies used by the dev toolbar
-					include: ['astro > aria-query', 'astro > axobject-query'],
+					include: [
+						'astro > aria-query',
+						'astro > axobject-query',
+						...(settings.devToolbarApps.length > 0 ? ['astro/toolbar'] : []),
+					],
 				},
 			};
 		},


### PR DESCRIPTION
Fixes #15857.

## Changes

- Add `astro/toolbar` to `optimizeDeps.include` in the dev toolbar Vite plugin.
- Only include it when custom dev toolbar apps are registered (`settings.devToolbarApps.length > 0`).

## Testing

- Not run locally for this small config change.

## Docs

- N/A, bug fix