### PR TITLE
Invalidate dev CSS map when routes change

### DIFF
--- a/.changeset/new-routes-dev-css.md
+++ b/.changeset/new-routes-dev-css.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix a dev server bug where newly created pages could miss layout-imported CSS until restart.

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -16,6 +16,7 @@ import { createDefaultAstroMetadata } from '../vite-plugin-astro/metadata.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
 import { isAstroServerEnvironment } from '../environments.js';
+import { RESOLVED_MODULE_DEV_CSS_ALL } from '../vite-plugin-css/const.js';
 import { PAGE_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
 
 type Payload = {
@@ -125,6 +126,12 @@ export default async function astroPluginRoutes({
 				if (!virtualMod) continue;
 
 				environment.moduleGraph.invalidateModule(virtualMod);
+
+				const cssMod = environment.moduleGraph.getModuleById(RESOLVED_MODULE_DEV_CSS_ALL);
+				if (cssMod) {
+					environment.moduleGraph.invalidateModule(cssMod);
+				}
+
 				// Signal that routes have changed so running apps can update
 				// NOTE: Consider adding debouncing here if rapid file changes cause performance issues
 				environment.hot.send('astro:routes-updated', {});


### PR DESCRIPTION
## Changes

- Fix dev-only CSS missing on newly created pages until server restart.
- Invalidate `virtual:astro:dev-css-all` when routes are rebuilt so the route-to-CSS map is regenerated.
- Fixes https://github.com/withastro/astro/issues/15863

## Testing

- Tested manually. Patched an example app, created a new page, new log was shown.

## Docs

- N/A (bug fix).