### PR TITLE
Correct Astro.url root pathname for file format builds

### DIFF
--- a/.changeset/small-jeans-whisper.md
+++ b/.changeset/small-jeans-whisper.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `Astro.url.pathname` for the root page when using `build.format: "file"` so it resolves to `/index.html` instead of `/.html` during builds.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -538,7 +538,11 @@ function getUrlForPath(
 	}
 	let buildPathname: string;
 	if (pathname === '/' || pathname === '') {
-		buildPathname = collapseDuplicateTrailingSlashes(base + ending, trailingSlash !== 'never');
+		if (format === 'file') {
+			buildPathname = joinPaths(base, 'index.html');
+		} else {
+			buildPathname = collapseDuplicateTrailingSlashes(base + ending, trailingSlash !== 'never');
+		}
 	} else if (routeType === 'endpoint') {
 		const buildPathRelative = removeLeadingForwardSlash(pathname);
 		buildPathname = joinPaths(base, buildPathRelative);

--- a/packages/astro/test/fixtures/page-format/src/pages/index.astro
+++ b/packages/astro/test/fixtures/page-format/src/pages/index.astro
@@ -1,6 +1,10 @@
 ---
+const url = Astro.url;
 ---
 <html>
 	<head><title>testing</title></head>
-	<body><h1>testing</h1></body>
+	<body>
+		<h1>testing</h1>
+		<h2 id="url">{url.pathname}</h2>
+	</body>
 </html>

--- a/packages/astro/test/fixtures/page-format/src/pages/nested/page.astro
+++ b/packages/astro/test/fixtures/page-format/src/pages/nested/page.astro
@@ -1,4 +1,6 @@
 ---
 const another = new URL('./another/', Astro.url);
+const url = Astro.url;
 ---
 <a id="another" href={another.pathname}></a>
+<p id="url">{url.pathname}</p>

--- a/packages/astro/test/page-format.test.js
+++ b/packages/astro/test/page-format.test.js
@@ -43,6 +43,18 @@ describe('build.format', () => {
 				await fixture.build();
 			});
 
+			it('Astro.url pathname includes /index.html for root page in build', async () => {
+				let html = await fixture.readFile('/index.html');
+				let $ = cheerio.load(html);
+				assert.equal($('#url').text(), '/index.html');
+			});
+
+			it('Astro.url pathname includes .html for non-root pages in build', async () => {
+				let html = await fixture.readFile('/nested/page.html');
+				let $ = cheerio.load(html);
+				assert.equal($('#url').text(), '/nested/page.html');
+			});
+
 			it('relative urls created point to sibling folders', async () => {
 				let html = await fixture.readFile('/nested/page.html');
 				let $ = cheerio.load(html);


### PR DESCRIPTION
## Changes
- fix root `Astro.url.pathname` in `build.format: \"file\"` builds to return `/index.html` instead of `/.html`

## Testing

- add integration assertions for root and non-root `Astro.url.pathname` behavior in `page-format` tests

# Docs

N/A, bug fix

Closes #15866