### PR TITLE
Avoid MaxListeners warning on dev startup with content collections

### DIFF
--- a/.changeset/fair-points-raise.md
+++ b/.changeset/fair-points-raise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Avoid a `MaxListenersExceededWarning` during `astro dev` startup by increasing the shared Vite watcher listener limit when attaching content server listeners.

--- a/packages/astro/src/content/server-listeners.ts
+++ b/packages/astro/src/content/server-listeners.ts
@@ -18,6 +18,13 @@ export async function attachContentServerListeners({
 	logger,
 	settings,
 }: ContentServerListenerParams) {
+	// The default max listeners is 10, which is easy to exceed in dev when
+	// integrations and internal features all subscribe to the same watcher.
+	const maxListeners = viteServer.watcher.getMaxListeners();
+	if (maxListeners !== 0 && maxListeners < 50) {
+		viteServer.watcher.setMaxListeners(50);
+	}
+
 	const contentGenerator = await createContentTypesGenerator({
 		fs,
 		settings,

--- a/packages/astro/test/units/content-collections/frontmatter.test.js
+++ b/packages/astro/test/units/content-collections/frontmatter.test.js
@@ -1,10 +1,11 @@
+import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { attachContentServerListeners } from '../../../dist/content/index.js';
 import { createFixture, runInContainer } from '../test-utils.js';
 
 describe('frontmatter', () => {
-	it('errors in content/ does not crash server', async () => {
-		const fixture = await createFixture({
+	async function createContentFixture() {
+		return await createFixture({
 			'/src/content/posts/blog.md': `\
 					---
 					title: One
@@ -35,6 +36,10 @@ describe('frontmatter', () => {
 					</html>
 				`,
 		});
+	}
+
+	it('errors in content/ does not crash server', async () => {
+		const fixture = await createContentFixture();
 
 		await runInContainer({ inlineConfig: { root: fixture.path } }, async (container) => {
 			await attachContentServerListeners(container);
@@ -50,6 +55,19 @@ describe('frontmatter', () => {
 			);
 			await new Promise((resolve) => setTimeout(resolve, 100));
 			// Note, if we got here, it didn't crash
+		});
+	});
+
+	it('increases watcher max listeners to avoid startup warnings', async () => {
+		const fixture = await createContentFixture();
+
+		await runInContainer({ inlineConfig: { root: fixture.path } }, async (container) => {
+			const watcher = container.viteServer.watcher;
+			watcher.setMaxListeners(10);
+
+			await attachContentServerListeners(container);
+
+			assert.equal(watcher.getMaxListeners(), 50);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Raise the Vite watcher max listener limit in `attachContentServerListeners()` when it is below 50 (and not unlimited), preventing noisy `MaxListenersExceededWarning` on `astro dev` startup.
- Fixes https://github.com/withastro/astro/issues/15883

## Testing

- Add a unit regression test that verifies the watcher max listener value is increased during content listener attachment.

## Docs

- No docs update needed; this is an internal dev-server warning fix with no user-facing API changes.