### PR TITLE
fix(build): entrypoint leak

### DIFF
--- a/.changeset/polite-poets-push.md
+++ b/.changeset/polite-poets-push.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the build incorrectly leaked server entrypoint into the client environment, causing adapters to emit warnings during the build.

--- a/packages/astro/src/core/build/plugins/plugin-internals.ts
+++ b/packages/astro/src/core/build/plugins/plugin-internals.ts
@@ -1,15 +1,25 @@
-import type { EnvironmentOptions, Plugin as VitePlugin } from 'vite';
+import type { EnvironmentOptions, Plugin as VitePlugin, Rollup } from 'vite';
 import type { BuildInternals } from '../internal.js';
 import type { StaticBuildOptions } from '../types.js';
 import { normalizeEntryId } from './plugin-component-entry.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../constants.js';
 
+function getRollupInputAsSet(rollupInput: Rollup.InputOption | undefined): Set<string> {
+	if (Array.isArray(rollupInput)) {
+		return new Set(rollupInput);
+	} else if (typeof rollupInput === 'string') {
+		return new Set([rollupInput]);
+	} else if (rollupInput && typeof rollupInput === 'object') {
+		return new Set(Object.values(rollupInput) as string[]);
+	} else {
+		return new Set();
+	}
+}
+
 export function pluginInternals(
 	options: StaticBuildOptions,
 	internals: BuildInternals,
 ): VitePlugin {
-	let input: Set<string>;
-
 	return {
 		name: '@astro/plugin-build-internals',
 
@@ -42,21 +52,15 @@ export function pluginInternals(
 			}
 		},
 
-		configResolved(config) {
-			// Get input from rollupOptions
-			const rollupInput = config.build?.rollupOptions?.input;
-			if (Array.isArray(rollupInput)) {
-				input = new Set(rollupInput);
-			} else if (typeof rollupInput === 'string') {
-				input = new Set([rollupInput]);
-			} else if (rollupInput && typeof rollupInput === 'object') {
-				input = new Set(Object.values(rollupInput) as string[]);
-			} else {
-				input = new Set();
-			}
-		},
-
 		async generateBundle(_options, bundle) {
+			// Read the rollup input directly from the current environment's config rather than
+			// relying on a closure variable from configResolved. With Vite's per-environment config
+			// resolution, a shared closure variable would be overwritten by the last environment's
+			// configResolved call, causing inputs from one environment (e.g. SSR) to leak into
+			// another (e.g. client). This caused server-only modules like @astrojs/node/server.js
+			// to be resolved in the client environment, triggering spurious "externalized for
+			// browser compatibility" warnings.
+			const input = getRollupInputAsSet(this.environment?.config.build.rollupOptions.input);
 			const promises = [];
 			const mapping = new Map<string, Set<string>>();
 			const allInput = new Set([...input, ...internals.clientInput]);


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/15839

This was hard to find. AI helped a lot here.

The problem was caused by how entrypoints were calculated. We used a mix of hoisted `input` and `configResovled` (the correct hook), which didn't work in a environment-aware situation, because the `input` gets overridden continuously, and eventually creating the incorrect entrypoint.

## Testing

Manually tested, again. I'll do another preview release

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
