### PR TITLE
Validate non-prerendered routes after resolution

### DIFF
--- a/.changeset/fair-buttons-float.md
+++ b/.changeset/fair-buttons-float.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro:actions` validation to check resolved routes, so projects using default static output with at least one `prerender = false` page or endpoint no longer fail during startup.

--- a/packages/astro/src/actions/integration.ts
+++ b/packages/astro/src/actions/integration.ts
@@ -1,5 +1,6 @@
 import { AstroError } from '../core/errors/errors.js';
 import { ActionsWithoutServerOutputError } from '../core/errors/errors-data.js';
+import { hasNonPrerenderedProjectRoute } from '../core/routing/helpers.js';
 import { viteID } from '../core/util.js';
 import type { AstroSettings } from '../types/astro.js';
 import type { AstroIntegration } from '../types/public/integrations.js';
@@ -29,21 +30,22 @@ export default function astroIntegrationActionsRouteHandler({
 				});
 			},
 			'astro:config:done': async (params) => {
-				if (params.buildOutput === 'static') {
-					const error = new AstroError(ActionsWithoutServerOutputError);
-					error.stack = undefined;
-					throw error;
-				}
-
 				const stringifiedActionsImport = JSON.stringify(
 					viteID(new URL(`./${filename}`, params.config.srcDir)),
 				);
 				settings.injectedTypes.push({
 					filename: ACTIONS_TYPES_FILE,
 					content: `declare module "astro:actions" {
-	export const actions: typeof import(${stringifiedActionsImport})["server"];
+		export const actions: typeof import(${stringifiedActionsImport})["server"];
 }`,
 				});
+			},
+			'astro:routes:resolved': ({ routes }) => {
+				if (!hasNonPrerenderedProjectRoute(routes)) {
+					const error = new AstroError(ActionsWithoutServerOutputError);
+					error.stack = undefined;
+					throw error;
+				}
 			},
 		},
 	};

--- a/packages/astro/src/core/routing/helpers.ts
+++ b/packages/astro/src/core/routing/helpers.ts
@@ -1,4 +1,5 @@
 import type { RouteData } from '../../types/public/internal.js';
+import type { IntegrationResolvedRoute } from '../../types/public/integrations.js';
 import type { RouteInfo } from '../app/types.js';
 import type { RoutesList } from '../../types/astro.js';
 import { isRoute404, isRoute500 } from './internal/route-errors.js';
@@ -61,4 +62,28 @@ export function getCustom404Route(manifestData: RoutesList): RouteData | undefin
  */
 export function getCustom500Route(manifestData: RoutesList): RouteData | undefined {
 	return manifestData.routes.find((r) => isRoute500(r.route));
+}
+
+export function hasNonPrerenderedProjectRoute(
+	routes: Array<Pick<RouteData, 'type' | 'origin' | 'prerender'>>,
+	options?: { includeEndpoints?: boolean },
+): boolean;
+export function hasNonPrerenderedProjectRoute(
+	routes: Array<Pick<IntegrationResolvedRoute, 'type' | 'origin' | 'isPrerendered'>>,
+	options?: { includeEndpoints?: boolean },
+): boolean;
+export function hasNonPrerenderedProjectRoute(
+	routes: Array<
+		| Pick<RouteData, 'type' | 'origin' | 'prerender'>
+		| Pick<IntegrationResolvedRoute, 'type' | 'origin' | 'isPrerendered'>
+	>,
+	options?: { includeEndpoints?: boolean },
+): boolean {
+	const includeEndpoints = options?.includeEndpoints ?? true;
+	const routeTypes: ReadonlyArray<string> = includeEndpoints ? ['page', 'endpoint'] : ['page'];
+
+	return routes.some((route) => {
+		const isPrerendered = 'isPrerendered' in route ? route.isPrerendered : route.prerender;
+		return routeTypes.includes(route.type) && route.origin === 'project' && !isPrerendered;
+	});
 }

--- a/packages/astro/src/vite-plugin-renderers/index.ts
+++ b/packages/astro/src/vite-plugin-renderers/index.ts
@@ -1,5 +1,6 @@
 import type { ConfigEnv, Plugin as VitePlugin } from 'vite';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
+import { hasNonPrerenderedProjectRoute } from '../core/routing/helpers.js';
 import type { AstroSettings, RoutesList } from '../types/astro.js';
 
 export const ASTRO_RENDERERS_MODULE_ID = 'virtual:astro:renderers';
@@ -9,17 +10,6 @@ interface PluginOptions {
 	settings: AstroSettings;
 	routesList: RoutesList;
 	command: ConfigEnv['command'];
-}
-
-/**
- * Checks whether any non-prerendered route needs component rendering (i.e., is a page).
- * Internal routes like `_server-islands` are excluded because they only need renderers
- * when server islands are actually used, and those are detected separately during the build.
- */
-function ssrBuildNeedsRenderers(routesList: RoutesList): boolean {
-	return routesList.routes.some(
-		(route) => route.type === 'page' && !route.prerender && route.origin !== 'internal',
-	);
 }
 
 export default function vitePluginRenderers(options: PluginOptions): VitePlugin {
@@ -47,7 +37,9 @@ export default function vitePluginRenderers(options: PluginOptions): VitePlugin 
 					options.command === 'build' &&
 					this.environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr &&
 					renderers.length > 0 &&
-					!ssrBuildNeedsRenderers(options.routesList)
+					!hasNonPrerenderedProjectRoute(options.routesList.routes, {
+						includeEndpoints: false,
+					})
 				) {
 					return { code: `export const renderers = [];` };
 				}

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -636,6 +636,41 @@ describe('Astro Actions', () => {
 	});
 });
 
+describe('Astro Actions in static mode with prerender = false routes', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/actions-static-prerender-false/',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer?.stop();
+	});
+
+	it('starts in dev and exposes action RPC routes', async () => {
+		assert.ok(devServer, 'Expected dev server to start');
+
+		const res = await fixture.fetch('/_actions/ping', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: '{}',
+		});
+
+		assert.equal(res.ok, true);
+		assert.equal(res.headers.get('Content-Type'), 'application/json+devalue');
+
+		const data = devalue.parse(await res.text());
+		assert.equal(data.ok, true);
+	});
+});
+
 it('Base path should be used', async () => {
 	const fixture = await loadFixture({
 		root: './fixtures/actions/',

--- a/packages/astro/test/fixtures/actions-static-prerender-false/astro.config.mjs
+++ b/packages/astro/test/fixtures/actions-static-prerender-false/astro.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({});

--- a/packages/astro/test/fixtures/actions-static-prerender-false/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions-static-prerender-false/src/actions/index.ts
@@ -1,0 +1,9 @@
+import { defineAction } from 'astro:actions';
+
+export const server = {
+	ping: defineAction({
+		handler: async () => {
+			return { ok: true };
+		},
+	}),
+};

--- a/packages/astro/test/fixtures/actions-static-prerender-false/src/pages/index.astro
+++ b/packages/astro/test/fixtures/actions-static-prerender-false/src/pages/index.astro
@@ -1,0 +1,5 @@
+---
+export const prerender = false;
+---
+
+<p>Live page</p>


### PR DESCRIPTION
## Changes
- move Astro Actions server-output validation from `astro:config:done` to `astro:routes:resolved` so it runs after prerender resolution
- add a shared routing helper to detect non-prerendered project routes and reuse it in the renderers plugin

## Testing

- add a regression fixture/test for static projects with a `prerender = false` route, and include a patch changeset

## Docs

N/A, bug fix