### PR TITLE
Route server islands through prerender handler

### DIFF
--- a/.changeset/curly-mails-lie.md
+++ b/.changeset/curly-mails-lie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix dev routing for `server:defer` islands when adapters opt into handling prerendered routes in Astro core. Server island requests are now treated as prerender-handler eligible so prerendered pages using `prerenderEnvironment: 'node'` can load island content without `400` errors.

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -22,7 +22,7 @@ import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
 import { NOOP_MIDDLEWARE_FN } from '../core/middleware/noop-middleware.js';
 import { createViteLoader } from '../core/module-loader/index.js';
-import { matchAllRoutes } from '../core/routing/match.js';
+import { isRouteServerIsland, matchAllRoutes } from '../core/routing/match.js';
 import { resolveMiddlewareMode } from '../integrations/adapter-utils.js';
 import { SERIALIZED_MANIFEST_ID } from '../manifest/serialized.js';
 import type { AstroSettings } from '../types/astro.js';
@@ -176,7 +176,7 @@ export default function createVitePluginAstroServer({
 								const routesList = { routes: routes.map((r: any) => r.routeData) };
 								const matches = matchAllRoutes(pathname, routesList);
 
-								if (!matches.some((route) => route.prerender)) {
+								if (!matches.some((route) => route.prerender || isRouteServerIsland(route))) {
 									return next();
 								}
 

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/components/DeferredIsland.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/components/DeferredIsland.astro
@@ -1,0 +1,1 @@
+<p id="deferred-content">deferred island content</p>

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/pages/index.astro
@@ -3,6 +3,7 @@ export const prerender = true;
 
 import fs from 'node:fs';
 import path from 'node:path';
+import DeferredIsland from '../components/DeferredIsland.astro';
 
 const packageJsonPath = path.join(process.cwd(), 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
@@ -20,5 +21,8 @@ const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 	<body>
 		<h1>Prerendered</h1>
 		<p id="pkg-name">{packageJson.name}</p>
+		<DeferredIsland server:defer>
+			<p slot="fallback" id="deferred-fallback">loading...</p>
+		</DeferredIsland>
 	</body>
 </html>

--- a/packages/integrations/cloudflare/test/prerender-node-env.test.js
+++ b/packages/integrations/cloudflare/test/prerender-node-env.test.js
@@ -48,6 +48,27 @@ describe('prerenderEnvironment: node', () => {
 		);
 	});
 
+	it('serves server islands for prerendered routes in dev', async () => {
+		const res = await fixture.fetch('/');
+		assert.equal(res.status, 200);
+		const html = await res.text();
+		assert.ok(
+			html.includes('id="deferred-fallback"'),
+			'Expected fallback content in prerendered HTML',
+		);
+
+		const islandUrlMatch = html.match(/fetch\('(\/_server-islands\/[^']+)'/);
+		assert.ok(islandUrlMatch, 'Expected prerendered HTML to include a server island fetch URL');
+
+		const islandRes = await fixture.fetch(islandUrlMatch[1]);
+		assert.equal(islandRes.status, 200, 'Expected server island endpoint to return 200 in dev');
+		const islandHtml = await islandRes.text();
+		assert.ok(
+			islandHtml.includes('id="deferred-content"'),
+			'Expected server island response to include deferred island content',
+		);
+	});
+
 	it('renders SSR page through workerd with Astro.request.cf', async () => {
 		const res = await fixture.fetch('/ssr');
 		assert.equal(res.status, 200);


### PR DESCRIPTION
## Changes

- Route `/_server-islands/*` through the Astro core prerender dev handler by treating server island routes as prerender-handler eligible.
- This prevents it from being forwarded to the workerd environment which does not have the key.

## Testing

- Add a Cloudflare `prerenderEnvironment: 'node'` dev regression test that reproduces and verifies `server:defer` island fetches return `200`.

## Docs

- No docs changes needed. This is a dev routing bug fix and test coverage update.