### PR TITLE
chore: cut a language-tools release

### DIFF
--- a/.changeset/wet-cases-grow.md
+++ b/.changeset/wet-cases-grow.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Updates Volar services to 0.0.70. This updates notably mean that the transitive dependency yaml-language-server no longer depends on a vulnerable version of lodash, causing warnings to show when installing the language server.


### PR DESCRIPTION
## Changes

Renovate updated deps for the language-server to Volar's latest versions, this PR just cuts a release for it.

Fixes https://github.com/withastro/astro/issues/15303

## Testing

Tests should pass

## Docs

N/A
