### PR TITLE
fix(svg): track inline styles for CSP

### DIFF
--- a/.changeset/jolly-dragons-hear.md
+++ b/.changeset/jolly-dragons-hear.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where `<style>` tags inside SVG components weren't correctly tracked when enabling CSP.

--- a/packages/astro/src/assets/runtime.ts
+++ b/packages/astro/src/assets/runtime.ts
@@ -1,22 +1,41 @@
+import { generateCspDigest } from '../core/encryption.js';
 import {
 	createComponent,
 	render,
 	spreadAttributes,
 	unescapeHTML,
 } from '../runtime/server/index.js';
+import type { SSRResult } from '../types/public/internal.js';
 import type { ImageMetadata } from './types.js';
 
 export interface SvgComponentProps {
 	meta: ImageMetadata;
 	attributes: Record<string, string>;
 	children: string;
+	styles: string[];
 }
 
-export function createSvgComponent({ meta, attributes, children }: SvgComponentProps) {
-	const Component = createComponent((_, props) => {
-		const normalizedProps = normalizeProps(attributes, props);
+export function createSvgComponent({ meta, attributes, children, styles }: SvgComponentProps) {
+	const hasStyles = styles.length > 0;
 
-		return render`<svg${spreadAttributes(normalizedProps)}>${unescapeHTML(children)}</svg>`;
+	const Component = createComponent({
+		async factory(result: SSRResult, props: Record<string, any>) {
+			const normalizedProps = normalizeProps(attributes, props);
+
+			// When CSP is enabled, hash each SVG <style> so the browser allows them.
+			// The styles stay inside the <svg> where they belong — we only need the
+			// hashes registered before the CSP meta tag is emitted in the <head>.
+			// propagation: 'self' ensures init() runs during bufferHeadContent().
+			if (hasStyles && result.cspDestination) {
+				for (const style of styles) {
+					const hash = await generateCspDigest(style, result.cspAlgorithm);
+					result._metadata.extraStyleHashes.push(hash);
+				}
+			}
+
+			return render`<svg${spreadAttributes(normalizedProps)}>${unescapeHTML(children)}</svg>`;
+		},
+		propagation: hasStyles ? 'self' : 'none',
 	});
 
 	if (import.meta.env.DEV) {

--- a/packages/astro/src/assets/utils/svg.ts
+++ b/packages/astro/src/assets/utils/svg.ts
@@ -1,5 +1,5 @@
 import { optimize } from 'svgo';
-import { parse, renderSync } from 'ultrahtml';
+import { ELEMENT_NODE, TEXT_NODE, parse, renderSync } from 'ultrahtml';
 import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import type { AstroConfig } from '../../types/public/config.js';
 import type { SvgComponentProps } from '../runtime.js';
@@ -33,7 +33,7 @@ function parseSvg({
 	}
 	const root = parse(processedContents);
 	const svgNode = root.children.find(
-		({ name, type }: { name: string; type: number }) => type === 1 /* Element */ && name === 'svg',
+		({ name, type }: { name: string; type: number }) => type === ELEMENT_NODE && name === 'svg',
 	);
 	if (!svgNode) {
 		throw new Error('SVG file does not contain an <svg> element');
@@ -41,7 +41,21 @@ function parseSvg({
 	const { attributes, children } = svgNode;
 	const body = renderSync({ ...root, children });
 
-	return { attributes, body };
+	// Collect text content of <style> elements for head propagation and CSP hashing
+	const styles: string[] = [];
+	for (const child of children) {
+		if (child.type === ELEMENT_NODE && child.name === 'style') {
+			const textContent = child.children
+				?.filter((c: { type: number }) => c.type === TEXT_NODE)
+				.map((c: { value: string }) => c.value)
+				.join('');
+			if (textContent) {
+				styles.push(textContent);
+			}
+		}
+	}
+
+	return { attributes, body, styles };
 }
 
 export function makeSvgComponent(
@@ -50,7 +64,11 @@ export function makeSvgComponent(
 	svgoConfig: AstroConfig['experimental']['svgo'],
 ): string {
 	const file = typeof contents === 'string' ? contents : contents.toString('utf-8');
-	const { attributes, body: children } = parseSvg({
+	const {
+		attributes,
+		body: children,
+		styles,
+	} = parseSvg({
 		path: meta.fsPath,
 		contents: file,
 		svgoConfig,
@@ -59,6 +77,7 @@ export function makeSvgComponent(
 		meta,
 		attributes: dropAttributes(attributes),
 		children,
+		styles,
 	};
 
 	return `import { createSvgComponent } from 'astro/assets/runtime';
@@ -74,12 +93,16 @@ export function parseSvgComponentData(
 	meta: ImageMetadata,
 	contents: Buffer | string,
 	svgoConfig: AstroConfig['experimental']['svgo'],
-): { attributes: Record<string, string>; children: string } {
+): { attributes: Record<string, string>; children: string; styles: string[] } {
 	const file = typeof contents === 'string' ? contents : contents.toString('utf-8');
-	const { attributes, body: children } = parseSvg({
+	const {
+		attributes,
+		body: children,
+		styles,
+	} = parseSvg({
 		path: meta.fsPath,
 		contents: file,
 		svgoConfig,
 	});
-	return { attributes: dropAttributes(attributes), children };
+	return { attributes: dropAttributes(attributes), children, styles };
 }

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -521,7 +521,13 @@ function updateImageReferencesInData<T extends Record<string, unknown>>(
 				return;
 			}
 			const imported = imageAssetMap?.get(id) as
-				| (ImageMetadata & { __svgData?: { attributes: Record<string, string>; children: string } })
+				| (ImageMetadata & {
+						__svgData?: {
+							attributes: Record<string, string>;
+							children: string;
+							styles: string[];
+						};
+				  })
 				| undefined;
 			if (imported) {
 				if (imported.__svgData) {

--- a/packages/astro/test/csp.test.js
+++ b/packages/astro/test/csp.test.js
@@ -121,6 +121,43 @@ describe('CSP', () => {
 		assert.ok(styleMatches && styleMatches.length > 0, 'CSP should contain style hashes');
 	});
 
+	it('should generate hashes for SVG component inline styles', async () => {
+		fixture = await loadFixture({
+			root: './fixtures/csp/',
+			outDir: './dist/csp-svg',
+		});
+		await fixture.build();
+		const html = await fixture.readFile('/svg/index.html');
+		const $ = cheerio.load(html);
+
+		// The SVG should be rendered inline with its <style> tag intact
+		const svg = $('svg');
+		assert.ok(svg.length > 0, 'SVG should be rendered inline');
+		const svgStyle = $('svg style');
+		assert.ok(svgStyle.length > 0, 'SVG should contain its <style> element');
+		assert.ok(
+			svgStyle.text().includes('.square{fill: red}'),
+			'SVG style should have original content',
+		);
+
+		// The style should NOT be duplicated in the <head> — it stays inside the <svg>
+		const headStyles = $('head style');
+		const headHasSvgStyle = headStyles
+			.toArray()
+			.some((el) => $(el).text().includes('.square{fill: red}'));
+		assert.ok(!headHasSvgStyle, 'SVG style should not be duplicated in <head>');
+
+		// The CSP meta tag should contain a hash for the SVG's inline style
+		const meta = $('meta[http-equiv="Content-Security-Policy"]');
+		const cspContent = meta.attr('content').toString();
+		assert.ok(cspContent.includes('style-src'), 'CSP should have style-src directive');
+		// sha256 hash of ".square{fill: red}"
+		assert.ok(
+			cspContent.includes("'sha256-TFjYo91aZcH4Kex6qdJUFz/POAVYu5H/OgkpRfHpLfw='"),
+			'CSP should contain the hash of the SVG inline style',
+		);
+	});
+
 	it('should return CSP header inside a hook', async () => {
 		let routeToHeaders;
 		fixture = await loadFixture({

--- a/packages/astro/test/fixtures/csp/src/assets/test.svg
+++ b/packages/astro/test/fixtures/csp/src/assets/test.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+	<rect x="0" y="0" width="24" height="24" class="square" />
+	<style>.square{fill: red}</style>
+</svg>

--- a/packages/astro/test/fixtures/csp/src/pages/svg.astro
+++ b/packages/astro/test/fixtures/csp/src/pages/svg.astro
@@ -1,0 +1,17 @@
+---
+import Icon from "../assets/test.svg"
+---
+
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<meta name="viewport" content="width=device-width"/>
+	<title>Image CSP Test</title>
+</head>
+<body>
+<main>
+	<h1>Image with layout</h1>
+	<Icon />
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/15838

We now track the `style` tags inside the SVG elements, and we pass them to `createSvgComponent`.

If there are styles, we pass the propagation hint so that we can write styles in the end, and correctly generate and track CSP hashes.

## Testing

Added a new test, existing tests should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
