### PR TITLE
fix: update peer dependency range

### DIFF
--- a/.changeset/loud-towns-camp.md
+++ b/.changeset/loud-towns-camp.md
@@ -1,0 +1,12 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/markdoc': patch
+'@astrojs/netlify': patch
+'@astrojs/svelte': patch
+'@astrojs/vercel': patch
+'@astrojs/node': patch
+'@astrojs/mdx': patch
+'@astrojs/vue': patch
+---
+
+Updates the Astro `peerDependencies#astro` to be `6.0.0`.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -50,7 +50,7 @@
     "vite": "^7.3.1"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0",
+    "astro": "^6.0.0",
     "wrangler": "^4.61.1"
   },
   "devDependencies": {

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -71,7 +71,7 @@
     "htmlparser2": "^10.1.0"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0"
+    "astro": "^6.0.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -49,7 +49,7 @@
     "vfile": "^6.0.3"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0"
+    "astro": "^6.0.0"
   },
   "devDependencies": {
     "@shikijs/rehype": "^4.0.0",

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -50,7 +50,7 @@
     "vite": "^7.3.1"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0"
+    "astro": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.6",

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -38,7 +38,7 @@
     "server-destroy": "^1.0.1"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0"
+    "astro": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.6",

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -49,7 +49,7 @@
     "svelte": "^5.53.6"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0",
+    "astro": "^6.0.0",
     "svelte": "^5.43.6",
     "typescript": "^5.3.3"
   },

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -55,7 +55,7 @@
     "tinyglobby": "^0.2.15"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0"
+    "astro": "^6.0.0"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -52,7 +52,7 @@
     "vue": "^3.5.29"
   },
   "peerDependencies": {
-    "astro": "^6.0.0-alpha.0",
+    "astro": "^6.0.0",
     "vue": "^3.5.24"
   },
   "engines": {


### PR DESCRIPTION
## Changes

Updates our integrations to point to `6.0.0` as a peer dep

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
