### PR TITLE
fix(hmr): normalize paths when reloading manifest

### DIFF
--- a/.changeset/sweet-socks-tap.md
+++ b/.changeset/sweet-socks-tap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where HMR didn't correctly work on Windows when adding/changing/deleting routes in `pages/`.

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -1,4 +1,5 @@
-import type { Plugin, ViteDevServer } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { normalizePath, type Plugin, type ViteDevServer } from 'vite';
 import { ACTIONS_ENTRYPOINT_VIRTUAL_MODULE_ID } from '../actions/consts.js';
 import { toFallbackType } from '../core/app/common.js';
 import { toRoutingStrategy } from '../core/app/entrypoints/index.js';
@@ -41,8 +42,10 @@ export function serializedManifestPlugin({
 	command: 'dev' | 'build';
 	sync: boolean;
 }): Plugin {
+	const normalizedSrcDir = normalizePath(fileURLToPath(settings.config.srcDir));
+
 	function reloadManifest(path: string | null, server: ViteDevServer) {
-		if (path != null && path.startsWith(settings.config.srcDir.pathname)) {
+		if (path != null && normalizePath(path).startsWith(normalizedSrcDir)) {
 			const environment = server.environments[ASTRO_VITE_ENVIRONMENT_NAMES.ssr];
 			const virtualMod = environment.moduleGraph.getModuleById(SERIALIZED_MANIFEST_RESOLVED_ID);
 			if (!virtualMod) return;

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -79,11 +79,13 @@ export default async function astroPluginRoutes({
 		},
 	);
 
+	const normalizedSrcDir = normalizePath(fileURLToPath(settings.config.srcDir));
+
 	async function rebuildRoutes(path: string | null = null, server: ViteDevServer) {
-		if (path != null && path.startsWith(settings.config.srcDir.pathname)) {
+		if (path != null && normalizePath(path).startsWith(normalizedSrcDir)) {
 			logger.debug(
 				'update',
-				`Re-calculating routes for ${path.slice(settings.config.srcDir.pathname.length)}`,
+				`Re-calculating routes for ${normalizePath(path).slice(normalizedSrcDir.length)}`,
 			);
 			const file = pathToFileURL(normalizePath(path));
 			const newRoutesList = await createRoutesList(


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/15909

In HMR, when checking if we need to reload the manifest, we now normalise paths.

Using Node.js and vite is safe, we're inside a vite plugin.

## Testing

I don't have windows and we skip these tests on windows. Will probably use a preview release.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
