### PR TITLE
fix(assets): exclude 304 Not Modified from redirect check in revalidateRemoteImage

### DIFF
--- a/.changeset/fix-remote-image-304.md
+++ b/.changeset/fix-remote-image-304.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed remote image revalidation incorrectly treating HTTP 304 Not Modified as a redirect

--- a/packages/astro/src/assets/build/remote.ts
+++ b/packages/astro/src/assets/build/remote.ts
@@ -53,7 +53,7 @@ export async function revalidateRemoteImage(
 	const req = new Request(src, { headers, cache: 'no-cache' });
 	const res = await fetch(req, { redirect: 'manual' });
 
-	if (res.status >= 300 && res.status < 400) {
+	if (res.status >= 300 && res.status < 400 && res.status !== 304) {
 		throw new Error(`Failed to revalidate cached remote image ${src}. The request was redirected.`);
 	}
 

--- a/packages/astro/test/units/assets/remote.test.js
+++ b/packages/astro/test/units/assets/remote.test.js
@@ -1,0 +1,63 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+/**
+ * Mock `fetch` to return controlled responses, then import `revalidateRemoteImage`.
+ * This lets us verify status-code handling without hitting the network.
+ */
+
+/** Helper: build a minimal Response with the given status and headers */
+function fakeResponse(status, headers = {}, body = '') {
+	return new Response(body, { status, headers });
+}
+
+describe('revalidateRemoteImage', () => {
+	it('does not throw on HTTP 304 Not Modified', async () => {
+		const original = globalThis.fetch;
+		try {
+			// Stub fetch to return 304
+			globalThis.fetch = mock.fn(() =>
+				Promise.resolve(fakeResponse(304, { 'Cache-Control': 'max-age=3600' })),
+			);
+
+			const { revalidateRemoteImage } = await import(
+				'../../../dist/assets/build/remote.js'
+			);
+
+			const result = await revalidateRemoteImage('https://example.com/img.jpg', {
+				etag: '"abc123"',
+			});
+
+			// 304 means "not modified" — data buffer should be empty
+			assert.equal(result.data.length, 0);
+			// etag should be preserved from the revalidation data
+			assert.equal(result.etag, '"abc123"');
+		} finally {
+			globalThis.fetch = original;
+		}
+	});
+
+	it('throws on actual redirects (e.g. 301)', async () => {
+		const original = globalThis.fetch;
+		try {
+			globalThis.fetch = mock.fn(() =>
+				Promise.resolve(fakeResponse(301, { Location: 'https://example.com/new.jpg' })),
+			);
+
+			const { revalidateRemoteImage } = await import(
+				'../../../dist/assets/build/remote.js'
+			);
+
+			await assert.rejects(
+				() =>
+					revalidateRemoteImage('https://example.com/img.jpg', {
+						etag: '"abc123"',
+					}),
+				/redirected/,
+			);
+		} finally {
+			globalThis.fetch = original;
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #15920

When revalidating cached remote images, `revalidateRemoteImage()` uses `fetch` with `redirect: 'manual'` and then checks the status code to detect redirects:

```ts
if (res.status >= 300 && res.status < 400) {
    throw new Error(`... The request was redirected.`);
}
```

The problem is that HTTP 304 (Not Modified) falls in the `[300, 400)` range, so it gets caught by this guard and throws a "redirected" error **before** the correct 304 handling logic on the subsequent lines can ever run. This causes a spurious warning during builds:

> [WARN] An error was encountered while revalidating a cached remote asset. Proceeding with stale cache. Error: Failed to revalidate cached remote image ... The request was redirected.

### Changes

- Added `&& res.status !== 304` to the redirect status check in `revalidateRemoteImage()`, so 304 responses pass through to the existing correct handling path that refreshes the cache TTL and preserves etag/lastModified values.
- Added a unit test verifying 304 does not throw and that actual redirects (e.g. 301) still throw as expected.
- Added a changeset.

### Why this works

The downstream code already handles 304 correctly:
- Line 61: `if (!res.ok && res.status !== 304)` excludes 304 from the error path
- Lines 75-80: Treats 304 as cacheable by mapping it to status 200 for TTL calculation
- Lines 87-89: Preserves stored etag/lastModified for 304 responses
- The caller in `generate.ts` (line 219) checks `if (revalidatedData.data.length)` — an empty buffer (304 case) means "use the cached file, just freshen the metadata"

The one-line fix simply lets 304 responses reach this existing logic.

## Test plan

- [ ] Verify the new unit test passes: `node --test packages/astro/test/units/assets/remote.test.js`
- [ ] Verify existing image tests still pass: `pnpm --filter astro run test:match "core-image"`
- [ ] Manual: build a project with remote `<Image />` where the origin returns 304 on revalidation — the warning should no longer appear