### PR TITLE
fix: serve public assets under base path with Cloudflare adapter

### DIFF
--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -61,11 +61,6 @@ export default function createVitePluginAstroServer({
 				? (prerenderEnvironment as RunnableDevEnvironment)
 				: undefined;
 
-			// TODO: let this handle non-runnable environments that don't intercept requests
-			if (!runnableSsrEnvironment && !runnablePrerenderEnvironment) {
-				return;
-			}
-
 			async function createHandler(environment: RunnableDevEnvironment) {
 				const loader = createViteLoader(viteServer, environment);
 				const { default: createAstroServerApp } =
@@ -117,19 +112,17 @@ export default function createVitePluginAstroServer({
 				}
 			}
 
-			process.on('unhandledRejection', handleUnhandledRejection);
-			viteServer.httpServer?.on('close', () => {
-				process.off('unhandledRejection', handleUnhandledRejection);
-			});
+			if (ssrHandler || prerenderHandler) {
+				process.on('unhandledRejection', handleUnhandledRejection);
+				viteServer.httpServer?.on('close', () => {
+					process.off('unhandledRejection', handleUnhandledRejection);
+				});
+			}
 
 			return () => {
 				const shouldHandlePrerenderInCore = Boolean(
 					(viteServer as any)[devPrerenderMiddlewareSymbol],
 				);
-
-				if (!ssrHandler && !(prerenderHandler && shouldHandlePrerenderInCore)) {
-					return;
-				}
 
 				// Push this middleware to the front of the stack so that it can intercept responses.
 				// fix(#6067): always inject this to ensure zombie base handling is killed after restarts


### PR DESCRIPTION
## Changes

Fixes [#15914](https://github.com/withastro/astro/issues/15914): public assets in `astro dev` are now served under the configured `base` path when using the `@astrojs/cloudflare` adapter.

## Problem

With `base: "/docs/"` and the Cloudflare adapter enabled:

- The page correctly renders URLs like `/docs/test.svg`.
- `GET /docs/test.svg` returns **404**.
- `GET /test.svg` returns **200**.

Without the adapter, `/docs/test.svg` works as expected. The bug is adapter-specific.

## Root cause

Astro’s dev server uses custom middleware (`baseMiddleware`, etc.) to strip the `base` prefix from requests before Vite’s static middleware serves files from `public/`. That middleware is only registered when at least one **runnable** SSR/prerender environment exists.

With `@astrojs/cloudflare`, the SSR environment is a workerd-backed `CloudflareDevEnvironment`, which is not “runnable” in Node. So `configureServer` returned early and never registered the middleware stack. As a result, requests like `/docs/test.svg` reached Vite with the base prefix intact, and Vite looked for `public/docs/test.svg` → 404.

## Solution

- **Always** return the post-hook from `configureServer` and **always** register the core dev middleware (`baseMiddleware`, `trailingSlashMiddleware`, `routeGuardMiddleware`, `secFetchMiddleware`), regardless of whether the SSR/prerender environments are runnable.
- SSR/prerender request handlers remain conditional on `ssrHandler` / `prerenderHandler`, so Cloudflare’s workerd still handles those requests; only the base-path and security middleware are now applied in all cases.
- The `unhandledRejection` listener is only registered when at least one runnable handler exists, to avoid attaching it when no handlers are present.

## Testing

- [x] Reproduced the issue with the minimal repro from #15914 (Cloudflare adapter + `base: "/docs/"`).
- [x] After the fix, `GET /docs/test.svg` returns 200 when `public/test.svg` exists.
- [x] Verified `astro dev` without the Cloudflare adapter still behaves as before.
