### PR TITLE
Update README to reflect Cloudflare Workers support

### DIFF
--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -1,6 +1,6 @@
 # @astrojs/cloudflare
 
-An SSR adapter for use with Cloudflare Pages Functions targets. Write your code in Astro/JavaScript and deploy to Cloudflare Pages.
+An SSR adapter for use with Cloudflare Workers targets. Write your code in Astro/JavaScript and deploy to Cloudflare Workers.
 
 ## Documentation
 


### PR DESCRIPTION
Just updating the readme for the Cloudflare adapter which now targets Cloudflare Workers instead of Pages functions

