### PR TITLE
Cloudflare server islands in SSR runtime with shared key

### DIFF
--- a/.changeset/metal-apples-sort.md
+++ b/.changeset/metal-apples-sort.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Cloudflare dev server islands with `prerenderEnvironment: 'node'` by sharing the serialized manifest encryption key across dev environments and routing server island requests through the SSR runtime.

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -43,6 +43,15 @@ export function serializedManifestPlugin({
 	sync: boolean;
 }): Plugin {
 	const normalizedSrcDir = normalizePath(fileURLToPath(settings.config.srcDir));
+	let encodedKeyPromise: Promise<string> | undefined;
+
+	function getEncodedKey() {
+		encodedKeyPromise ??= (async () => {
+			const key = hasEnvironmentKey() ? await getEnvironmentKey() : await createKey();
+			return encodeKey(key);
+		})();
+		return encodedKeyPromise;
+	}
 
 	function reloadManifest(path: string | null, server: ViteDevServer) {
 		if (path != null && normalizePath(path).startsWith(normalizedSrcDir)) {
@@ -83,7 +92,7 @@ export function serializedManifestPlugin({
 					// See plugin-manifest.ts for full architecture explanation
 					manifestData = `'${MANIFEST_REPLACE}'`;
 				} else {
-					const serialized = await createSerializedManifest(settings);
+					const serialized = await createSerializedManifest(settings, await getEncodedKey());
 					manifestData = JSON.stringify(serialized);
 				}
 				const hasCacheConfig = !!settings.config.experimental?.cache?.provider;
@@ -122,7 +131,10 @@ export function serializedManifestPlugin({
 	};
 }
 
-async function createSerializedManifest(settings: AstroSettings): Promise<SerializedSSRManifest> {
+async function createSerializedManifest(
+	settings: AstroSettings,
+	encodedKey?: string,
+): Promise<SerializedSSRManifest> {
 	let i18nManifest: SSRManifestI18n | undefined;
 	let csp: SSRManifestCSP | undefined;
 	if (settings.config.i18n) {
@@ -185,7 +197,9 @@ async function createSerializedManifest(settings: AstroSettings): Promise<Serial
 		serverIslandBodySizeLimit: settings.config.security?.serverIslandBodySizeLimit
 			? settings.config.security.serverIslandBodySizeLimit
 			: 1024 * 1024, // 1mb default
-		key: await encodeKey(hasEnvironmentKey() ? await getEnvironmentKey() : await createKey()),
+		key:
+			encodedKey ??
+			(await encodeKey(hasEnvironmentKey() ? await getEnvironmentKey() : await createKey())),
 		sessionConfig: sessionConfigToManifest(settings.config.session),
 		cacheConfig: cacheConfigToManifest(
 			settings.config.experimental?.cache,

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -22,7 +22,7 @@ import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
 import { NOOP_MIDDLEWARE_FN } from '../core/middleware/noop-middleware.js';
 import { createViteLoader } from '../core/module-loader/index.js';
-import { isRouteServerIsland, matchAllRoutes } from '../core/routing/match.js';
+import { matchAllRoutes } from '../core/routing/match.js';
 import { resolveMiddlewareMode } from '../integrations/adapter-utils.js';
 import { SERIALIZED_MANIFEST_ID } from '../manifest/serialized.js';
 import type { AstroSettings } from '../types/astro.js';
@@ -169,7 +169,7 @@ export default function createVitePluginAstroServer({
 								const routesList = { routes: routes.map((r: any) => r.routeData) };
 								const matches = matchAllRoutes(pathname, routesList);
 
-								if (!matches.some((route) => route.prerender || isRouteServerIsland(route))) {
+								if (!matches.some((route) => route.prerender)) {
 									return next();
 								}
 

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/components/WorkerdIsland.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/components/WorkerdIsland.astro
@@ -1,0 +1,5 @@
+---
+const hasCf = !!Astro.request.cf;
+---
+
+<p id="island-has-cf">{String(hasCf)}</p>

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/pages/index.astro
@@ -4,6 +4,7 @@ export const prerender = true;
 import fs from 'node:fs';
 import path from 'node:path';
 import DeferredIsland from '../components/DeferredIsland.astro';
+import WorkerdIsland from '../components/WorkerdIsland.astro';
 
 const packageJsonPath = path.join(process.cwd(), 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
@@ -24,5 +25,8 @@ const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 		<DeferredIsland server:defer>
 			<p slot="fallback" id="deferred-fallback">loading...</p>
 		</DeferredIsland>
+		<WorkerdIsland server:defer>
+			<p slot="fallback" id="workerd-fallback">loading workerd island...</p>
+		</WorkerdIsland>
 	</body>
 </html>

--- a/packages/integrations/cloudflare/test/prerender-node-env.test.js
+++ b/packages/integrations/cloudflare/test/prerender-node-env.test.js
@@ -69,6 +69,39 @@ describe('prerenderEnvironment: node', () => {
 		);
 	});
 
+	it('serves server islands through workerd runtime (not Node prerender env)', async () => {
+		const res = await fixture.fetch('/');
+		assert.equal(res.status, 200);
+		const html = await res.text();
+
+		const islandUrlMatches = [...html.matchAll(/fetch\((['"])(\/_server-islands\/[^'"]+)\1/g)];
+		assert.ok(
+			islandUrlMatches.length > 0,
+			'Expected prerendered HTML to include server island fetch URLs',
+		);
+
+		let sawWorkerdIsland = false;
+		for (const islandUrlMatch of islandUrlMatches) {
+			const islandRes = await fixture.fetch(islandUrlMatch[2]);
+			assert.equal(islandRes.status, 200, 'Expected server island endpoint to return 200');
+			const islandHtml = await islandRes.text();
+
+			if (islandHtml.includes('id="island-has-cf"')) {
+				sawWorkerdIsland = true;
+				assert.ok(
+					islandHtml.includes('>true<'),
+					'Expected server island to have access to Astro.request.cf (runs in workerd, not Node)',
+				);
+				break;
+			}
+		}
+
+		assert.ok(
+			sawWorkerdIsland,
+			'Expected at least one server island response to include the WorkerdIsland marker',
+		);
+	});
+
 	it('renders SSR page through workerd with Astro.request.cf', async () => {
 		const res = await fixture.fetch('/ssr');
 		assert.equal(res.status, 200);


### PR DESCRIPTION
## Summary
- Share the serialized manifest encryption key across dev environments so prerender and SSR handlers use the same server-island encryption context.
- This fixes https://github.com/withastro/astro/issues/15946
- aka, so now the islands run in both prerendered and ssred pages.

## Testing
- Added test to verify that prerendered pages' server islands are built with workerd features.