### PR TITLE
fix(dev): prevent Vite internal paths from being matched by SSR catch-all routes

### DIFF
--- a/.changeset/fix-ssr-catchall-vite-internal-paths.md
+++ b/.changeset/fix-ssr-catchall-vite-internal-paths.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix(dev): prevent Vite internal paths from being matched by SSR catch-all routes

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -185,11 +185,19 @@ export default function createVitePluginAstroServer({
 
 				if (ssrHandler) {
 					// Note that this function has a name so other middleware can find it.
-					viteServer.middlewares.use(async function astroDevHandler(request, response) {
+					viteServer.middlewares.use(async function astroDevHandler(request, response, next) {
 						if (request.url === undefined || !request.method) {
 							response.writeHead(500, 'Incomplete request');
 							response.end();
 							return;
+						}
+
+						if (request.url.startsWith('/@') || request.url.startsWith('/__')) {
+							return next();
+						}
+
+						if (request.url.includes('/node_modules/')) {
+							return next();
 						}
 
 						localStorage.run(request, () => {

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -175,6 +175,33 @@ describe('dev container', () => {
 		);
 	});
 
+	it('Vite internal paths are not matched by SSR catch-all routes', async () => {
+		const fixture = await createFixture({
+			'/src/pages/[...slug].astro': `
+				---
+				export const prerender = false;
+				---
+				<h1>{Astro.params.slug}</h1>
+			`,
+		});
+
+		await runInContainer(
+			{ inlineConfig: { root: fixture.path, output: 'server' } },
+			async (container) => {
+				// A Vite internal path should not be matched by the catch-all route
+				const r = createRequestAndResponse({
+					method: 'GET',
+					url: '/@id/astro/runtime/client/dev-toolbar/entrypoint.js',
+				});
+				container.handle(r.req, r.res);
+				await r.done;
+				// Should not render the catch-all page (which would return 200 with HTML)
+				const html = await r.text();
+				assert.equal(html.includes('<h1>'), false);
+			},
+		);
+	});
+
 	it('items in public/ are available from root when not using a base', async () => {
 		const fixture = await createFixture({
 			'/public/test.txt': `Test`,


### PR DESCRIPTION
## Summary

This fixes a bug where SSR catch-all routes in dev would try to handle Vite’s own internal dev/HMR URLs.

- Update `astroDevHandler` to use the same Vite internal path filter as `astroDevPrerenderHandler`
- Skip requests for `/@*`, `/__*`, and `/node_modules/` in the dev SSR middleware so they fall through to Vite
- Add a focused unit test to lock in the behavior for a representative Vite internal path

## Motivation

When running with an SSR catch-all like `[...slug].astro`, Vite internal URLs (for example the dev toolbar entrypoint) could be picked up by the SSR handler. That meant dev-only paths could render the catch-all page instead of being handled by Vite, which is surprising and can break tooling.

Aligning the dev SSR handler with the prerender handler keeps Vite internals out of user routes and matches the existing intent of the middleware.

## Testing

- [ ] `pnpm -C packages/astro exec astro-scripts test "test/units/dev/dev.test.js" -m "Vite internal paths"`
- [ ] (Optional) Manually verify that visiting a Vite internal URL in dev no longer hits the catch-all route
