### PR TITLE
Prevent server-only define globals from leaking into client build

### DIFF
--- a/.changeset/fix-build-setup-define-isolation.md
+++ b/.changeset/fix-build-setup-define-isolation.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix server-only `define` globals leaking into client build when integrations conditionally set them based on `build.ssr`.

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -437,7 +437,8 @@ async function buildEnvironments(opts: StaticBuildOptions, internals: BuildInter
 		},
 	};
 
-	const updatedViteBuildConfig = await runHookBuildSetup({
+	// Run build setup hooks for the server target (SSR + prerender environments).
+	const serverUpdatedViteBuildConfig = await runHookBuildSetup({
 		config: settings.config,
 		pages: internals.pagesByKeys,
 		vite: viteBuildConfig,
@@ -445,7 +446,74 @@ async function buildEnvironments(opts: StaticBuildOptions, internals: BuildInter
 		logger: opts.logger,
 	});
 
-	const builder = await vite.createBuilder(updatedViteBuildConfig);
+	// Run build setup hooks for the client target.
+	// Pass build.ssr: false so integrations that inspect this flag
+	// (to conditionally set server-only define globals) behave correctly
+	// and don't bleed server-specific values into the browser build.
+	const clientUpdatedViteBuildConfig = await runHookBuildSetup({
+		config: settings.config,
+		pages: internals.pagesByKeys,
+		vite: { ...viteBuildConfig, build: { ...viteBuildConfig.build, ssr: false } },
+		target: 'client',
+		logger: opts.logger,
+	});
+
+	// Scope `define` values to the appropriate environments.
+	//
+	// Vite merges the top-level `define` into every environment's resolved config,
+	// so any server-only define set by an integration (e.g. `ngServerMode: "true"`)
+	// would otherwise leak into the client bundle and break hydration.
+	//
+	// Strategy:
+	// - Keep only client-aware defines at the top level.
+	// - Push server-only defines (present in the server result but absent from the
+	//   client result) down into the `ssr` and `prerender` environment configs.
+	const serverDefine = serverUpdatedViteBuildConfig.define ?? {};
+	const clientDefine = clientUpdatedViteBuildConfig.define ?? {};
+
+	const serverOnlyDefine: Record<string, string> = {};
+	for (const [key, value] of Object.entries(serverDefine)) {
+		if (!(key in clientDefine)) {
+			serverOnlyDefine[key] = value;
+		}
+	}
+
+	const finalViteBuildConfig: vite.InlineConfig = {
+		...serverUpdatedViteBuildConfig,
+		// Use client defines at the top level so server-specific globals don't bleed
+		// into the client environment via Vite's default environment inheritance.
+		define: clientDefine,
+		environments: {
+			...serverUpdatedViteBuildConfig.environments,
+			// Inject server-only defines into the server environments explicitly,
+			// since they are no longer present at the top level.
+			[ASTRO_VITE_ENVIRONMENT_NAMES.ssr]: {
+				...serverUpdatedViteBuildConfig.environments?.[ASTRO_VITE_ENVIRONMENT_NAMES.ssr],
+				define: {
+					...serverUpdatedViteBuildConfig.environments?.[ASTRO_VITE_ENVIRONMENT_NAMES.ssr]?.define,
+					...serverOnlyDefine,
+				},
+			},
+			[ASTRO_VITE_ENVIRONMENT_NAMES.prerender]: {
+				...serverUpdatedViteBuildConfig.environments?.[ASTRO_VITE_ENVIRONMENT_NAMES.prerender],
+				define: {
+					...serverUpdatedViteBuildConfig.environments?.[ASTRO_VITE_ENVIRONMENT_NAMES.prerender]?.define,
+					...serverOnlyDefine,
+				},
+			},
+			// Explicitly mark the client environment as non-SSR so integrations and
+			// Vite itself treat it as a browser build.
+			[ASTRO_VITE_ENVIRONMENT_NAMES.client]: {
+				...serverUpdatedViteBuildConfig.environments?.[ASTRO_VITE_ENVIRONMENT_NAMES.client],
+				build: {
+					...serverUpdatedViteBuildConfig.environments?.[ASTRO_VITE_ENVIRONMENT_NAMES.client]?.build,
+					ssr: false,
+				},
+			},
+		},
+	};
+
+	const builder = await vite.createBuilder(finalViteBuildConfig);
 	await builder.buildApp();
 }
 

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -473,7 +473,7 @@ async function buildEnvironments(opts: StaticBuildOptions, internals: BuildInter
 
 	const serverOnlyDefine: Record<string, string> = {};
 	for (const [key, value] of Object.entries(serverDefine)) {
-		if (!(key in clientDefine)) {
+		if (!(key in clientDefine) || clientDefine[key] !== value) {
 			serverOnlyDefine[key] = value;
 		}
 	}

--- a/packages/astro/test/units/integrations/api.test.js
+++ b/packages/astro/test/units/integrations/api.test.js
@@ -120,6 +120,60 @@ describe('Integration API', () => {
 		);
 	});
 
+	it('runHookBuildSetup: same define key with different server/client values is treated as server-specific', async () => {
+		// Simulates an integration that sets a define key to different values depending on
+		// build target. The server value must win for SSR/prerender environments even though
+		// the key is present in both results.
+		const integration = {
+			name: 'test-differing-define',
+			hooks: {
+				'astro:build:setup'({ vite, updateConfig }) {
+					updateConfig({ define: { MODE: vite.build?.ssr ? '"server"' : '"client"' } });
+				},
+			},
+		};
+		const config = { ...defaultConfig, integrations: [integration] };
+
+		const serverResult = await runHookBuildSetup({
+			config,
+			vite: { build: { ssr: true } },
+			logger: defaultLogger,
+			pages: new Map(),
+			target: 'server',
+		});
+		assert.equal(serverResult.define?.MODE, '"server"', 'server result should have MODE="server"');
+
+		const clientResult = await runHookBuildSetup({
+			config,
+			vite: { build: { ssr: false } },
+			logger: defaultLogger,
+			pages: new Map(),
+			target: 'client',
+		});
+		assert.equal(clientResult.define?.MODE, '"client"', 'client result should have MODE="client"');
+
+		// The server value differs from the client value, so it must be treated as
+		// server-specific and scoped to SSR/prerender environments (not top-level).
+		const serverDefine = serverResult.define ?? {};
+		const clientDefine = clientResult.define ?? {};
+		const serverOnlyDefine = {};
+		for (const [key, value] of Object.entries(serverDefine)) {
+			if (!(key in clientDefine) || clientDefine[key] !== value) {
+				serverOnlyDefine[key] = value;
+			}
+		}
+		assert.equal(
+			serverOnlyDefine.MODE,
+			'"server"',
+			'MODE with differing values should be captured as server-specific',
+		);
+		assert.notEqual(
+			serverOnlyDefine.MODE,
+			clientDefine.MODE,
+			'server-specific MODE must not equal the client value',
+		);
+	});
+
 	it('runHookConfigSetup can update Astro config', async () => {
 		const site = 'https://test.com/';
 		const updatedSettings = await runHookConfigSetup({

--- a/packages/astro/test/units/integrations/api.test.js
+++ b/packages/astro/test/units/integrations/api.test.js
@@ -79,6 +79,47 @@ describe('Integration API', () => {
 		deepEqual(updatedViteConfig, updatedInternalConfig);
 	});
 
+	it('runHookBuildSetup: server-only defines are absent when called with target=client and ssr=false', async () => {
+		// Simulates an integration (e.g. @analogjs/astro-angular) that sets a server-only
+		// define global when build.ssr is truthy. Verifies that calling the hook with
+		// build.ssr: false (the client-target call path) does NOT produce that define,
+		// which is the contract static-build.ts relies on to prevent server defines from
+		// leaking into the client bundle.
+		const integration = {
+			name: 'test-ssr-define',
+			hooks: {
+				'astro:build:setup'({ vite, updateConfig }) {
+					if (vite.build?.ssr) {
+						updateConfig({ define: { SSR_ONLY_FLAG: 'true' } });
+					}
+				},
+			},
+		};
+		const config = { ...defaultConfig, integrations: [integration] };
+
+		const serverResult = await runHookBuildSetup({
+			config,
+			vite: { build: { ssr: true } },
+			logger: defaultLogger,
+			pages: new Map(),
+			target: 'server',
+		});
+		assert.equal(serverResult.define?.SSR_ONLY_FLAG, 'true', 'server target should have SSR_ONLY_FLAG');
+
+		const clientResult = await runHookBuildSetup({
+			config,
+			vite: { build: { ssr: false } },
+			logger: defaultLogger,
+			pages: new Map(),
+			target: 'client',
+		});
+		assert.equal(
+			clientResult.define?.SSR_ONLY_FLAG,
+			undefined,
+			'client target (ssr: false) should NOT have SSR_ONLY_FLAG',
+		);
+	});
+
 	it('runHookConfigSetup can update Astro config', async () => {
 		const site = 'https://test.com/';
 		const updatedSettings = await runHookConfigSetup({


### PR DESCRIPTION
## Changes

- In v6, `runHookBuildSetup` was called once with `target: 'server'`, causing integrations that conditionally set `define` globals based on `vite.build.ssr` (e.g. `@analogjs/astro-angular` setting `ngServerMode: "true"`) to place those values at the top level of the Vite config. Because Vite merges the top-level `define` into every environment's resolved config, server-only values leaked into the client bundle and broke hydration.
- The fix calls `runHookBuildSetup` for both `'server'` and `'client'` targets. The client call receives `build.ssr: false` so integrations that inspect this flag behave correctly. Server-only defines (present in the server result but absent from the client result) are moved out of the top level and pushed into the `ssr` and `prerender` environment configs. The client environment is also explicitly marked `ssr: false`.

## Testing

- Added a unit test that simulates an integration which sets a define only when `build.ssr` is truthy. Asserts the define is present for the server hook call and absent for the client hook call with `ssr: false`.
- All existing build unit tests pass.

## Docs

No docs update needed — this is a bug fix restoring v5 build isolation behavior.

Fixes #15911