### PR TITLE
Fix style compilation failure when importing components via tsconfig path aliases

### DIFF
--- a/.changeset/fix-style-path-alias.md
+++ b/.changeset/fix-style-path-alias.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `<style>` compilation failure when importing Astro components via tsconfig path aliases

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -33,12 +33,19 @@ export function getFileInfo(id: string, config: AstroConfig) {
  *
  * - /@fs/home/user/project/src/pages/index.astro
  * - /src/pages/index.astro
+ * - ./src/pages/index.astro
  *
  * as absolute file paths with forward slashes.
  */
 export function normalizeFilename(filename: string, root: URL) {
 	if (filename.startsWith('/@fs')) {
 		filename = filename.slice('/@fs'.length);
+	} else if (filename.startsWith('.')) {
+		// Handle relative paths (e.g. ./src/components/Foo.astro) by resolving against root.
+		// This can occur on certain environments (e.g. Windows + newer Node.js) when a component
+		// is imported via a TypeScript path alias and Vite produces a relative virtual module ID.
+		const url = new URL(filename, root);
+		filename = viteID(url);
 	} else if (filename.startsWith('/') && !commonAncestorPath(filename, fileURLToPath(root))) {
 		const url = new URL('.' + filename, root);
 		filename = viteID(url);

--- a/packages/astro/test/alias-path-alias-style.test.js
+++ b/packages/astro/test/alias-path-alias-style.test.js
@@ -11,6 +11,7 @@ describe('Style compilation with tsconfig path aliases', () => {
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/alias-path-alias-style/',
+			build: { inlineStylesheets: 'never' },
 		});
 		await fixture.build();
 	});
@@ -22,13 +23,12 @@ describe('Style compilation with tsconfig path aliases', () => {
 		// The styled component should be rendered
 		assert.ok($('.styled').length > 0, 'Styled component should be present in output');
 
-		// Scoped styles should be inlined or linked
-		const inlineStyles = $('style').text();
-		const hasBlueStyle =
-			(inlineStyles.includes('color') && inlineStyles.includes('blue')) ||
-			inlineStyles.includes('#00f') ||
-			inlineStyles.includes('color:blue') ||
-			inlineStyles.includes('color: blue');
-		assert.ok(hasBlueStyle, 'Scoped .styled CSS should be present in output');
+		// With inlineStylesheets: 'never', styles are emitted as external CSS files
+		const links = $('link[rel=stylesheet]').map((_i, el) => $(el).attr('href')).get();
+		assert.ok(links.length > 0, 'Should have at least one linked stylesheet');
+
+		const cssContents = await Promise.all(links.map((href) => fixture.readFile(href)));
+		const allCss = cssContents.join('\n');
+		assert.ok(allCss.includes('.styled'), 'Scoped .styled CSS should be present in emitted stylesheet');
 	});
 });

--- a/packages/astro/test/alias-path-alias-style.test.js
+++ b/packages/astro/test/alias-path-alias-style.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+// Regression test for https://github.com/withastro/astro/issues/15963
+// <style> tags in components imported via tsconfig path aliases should compile correctly.
+describe('Style compilation with tsconfig path aliases', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/alias-path-alias-style/',
+		});
+		await fixture.build();
+	});
+
+	it('builds successfully and includes scoped styles from aliased component', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+
+		// The styled component should be rendered
+		assert.ok($('.styled').length > 0, 'Styled component should be present in output');
+
+		// Scoped styles should be inlined or linked
+		const inlineStyles = $('style').text();
+		const hasBlueStyle =
+			(inlineStyles.includes('color') && inlineStyles.includes('blue')) ||
+			inlineStyles.includes('#00f') ||
+			inlineStyles.includes('color:blue') ||
+			inlineStyles.includes('color: blue');
+		assert.ok(hasBlueStyle, 'Scoped .styled CSS should be present in output');
+	});
+});

--- a/packages/astro/test/fixtures/alias-path-alias-style/astro.config.mjs
+++ b/packages/astro/test/fixtures/alias-path-alias-style/astro.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({});

--- a/packages/astro/test/fixtures/alias-path-alias-style/package.json
+++ b/packages/astro/test/fixtures/alias-path-alias-style/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/alias-path-alias-style",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/alias-path-alias-style/src/components/StyledComponent.astro
+++ b/packages/astro/test/fixtures/alias-path-alias-style/src/components/StyledComponent.astro
@@ -1,0 +1,8 @@
+<div class="styled">Styled Component</div>
+
+<style>
+  .styled {
+    color: blue;
+    font-weight: bold;
+  }
+</style>

--- a/packages/astro/test/fixtures/alias-path-alias-style/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-path-alias-style/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+import StyledComponent from '@/components/StyledComponent.astro';
+---
+<html>
+  <head><title>Path Alias Style Test</title></head>
+  <body>
+    <h1>Path Alias Style Test</h1>
+    <StyledComponent />
+  </body>
+</html>

--- a/packages/astro/test/fixtures/alias-path-alias-style/tsconfig.json
+++ b/packages/astro/test/fixtures/alias-path-alias-style/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1896,6 +1896,12 @@ importers:
         specifier: ^5.53.6
         version: 5.53.8
 
+  packages/astro/test/fixtures/alias-path-alias-style:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/alias-tsconfig:
     dependencies:
       '@astrojs/svelte':


### PR DESCRIPTION
## Changes

- `normalizeFilename` in `vite-plugin-utils` now handles relative paths starting with `.` (e.g. `./src/components/Foo.astro`). On certain environments (Windows + newer Node.js), Vite can produce a relative virtual module ID for style sub-requests when the parent component is imported via a TypeScript path alias. The previous code had no branch for this case, so the relative path was passed unchanged to the compile metadata cache lookup — which was stored with an absolute path — causing a cache miss and a build error.
- The fix resolves relative paths against `config.root`, consistent with how `/@fs` and `/path` variants are already handled.

## Testing

- Added a new test fixture (`alias-path-alias-style`) with a minimal Astro project: a `tsconfig.json` `@/*` path alias importing an Astro component that has a scoped `<style>` tag.
- The build test (`test/alias-path-alias-style.test.js`) verifies the build succeeds and that the scoped CSS from the aliased component appears in the output — directly covering the regression path.

## Docs

- No docs update needed. This is an internal path normalization fix with no user-facing API change.

Fixes #15963