### PR TITLE
Add devEnvironment option to run Cloudflare dev SSR in Node.js

### DIFF
--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -87,11 +87,6 @@ export const pipelineSymbol = Symbol.for('astro.pipeline');
 export const devPrerenderMiddlewareSymbol = Symbol.for('astro.devPrerenderMiddleware');
 
 /**
- * Use this symbol to opt into handling SSR routes in Astro core dev middleware.
- */
-export const devSsrMiddlewareSymbol = Symbol.for('astro.devSsrMiddleware');
-
-/**
  * The symbol used as a field on the request object to store a cleanup callback associated with aborting the request when the underlying socket closes.
  */
 export const nodeRequestAbortControllerCleanupSymbol = Symbol.for(

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -5,11 +5,7 @@ import { isRunnableDevEnvironment, type RunnableDevEnvironment } from 'vite';
 import { toFallbackType } from '../core/app/common.js';
 import { toRoutingStrategy } from '../core/app/entrypoints/index.js';
 import type { SSRManifest, SSRManifestCSP, SSRManifestI18n } from '../core/app/types.js';
-import {
-	ASTRO_VITE_ENVIRONMENT_NAMES,
-	devPrerenderMiddlewareSymbol,
-	devSsrMiddlewareSymbol,
-} from '../core/constants.js';
+import { ASTRO_VITE_ENVIRONMENT_NAMES, devPrerenderMiddlewareSymbol } from '../core/constants.js';
 import {
 	getAlgorithm,
 	getDirectives,
@@ -56,14 +52,10 @@ export default function createVitePluginAstroServer({
 		},
 		async configureServer(viteServer) {
 			const ssrEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.ssr];
-			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const prerenderEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.prerender];
 
 			const runnableSsrEnvironment = isRunnableDevEnvironment(ssrEnvironment)
 				? (ssrEnvironment as RunnableDevEnvironment)
-				: undefined;
-			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
-				? (astroEnvironment as RunnableDevEnvironment)
 				: undefined;
 			const runnablePrerenderEnvironment = isRunnableDevEnvironment(prerenderEnvironment)
 				? (prerenderEnvironment as RunnableDevEnvironment)
@@ -83,24 +75,12 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			let ssrHandler: Awaited<ReturnType<typeof createHandler>> | undefined;
-			let prerenderHandler: Awaited<ReturnType<typeof createHandler>> | undefined;
-
-			async function getSsrHandler() {
-				if (!runnableSsrEnvironment) return undefined;
-				if (!ssrHandler) {
-					ssrHandler = await createHandler(runnableSsrEnvironment);
-				}
-				return ssrHandler;
-			}
-
-			async function getPrerenderHandler() {
-				if (!runnablePrerenderEnvironment) return undefined;
-				if (!prerenderHandler) {
-					prerenderHandler = await createHandler(runnablePrerenderEnvironment);
-				}
-				return prerenderHandler;
-			}
+			const ssrHandler = runnableSsrEnvironment
+				? await createHandler(runnableSsrEnvironment)
+				: undefined;
+			const prerenderHandler = runnablePrerenderEnvironment
+				? await createHandler(runnablePrerenderEnvironment)
+				: undefined;
 			const localStorage = new AsyncLocalStorage();
 
 			function handleUnhandledRejection(rejection: any) {
@@ -132,7 +112,7 @@ export default function createVitePluginAstroServer({
 				}
 			}
 
-			if (runnableSsrEnvironment || runnablePrerenderEnvironment || runnableAstroEnvironment) {
+			if (ssrHandler || prerenderHandler) {
 				process.on('unhandledRejection', handleUnhandledRejection);
 				viteServer.httpServer?.on('close', () => {
 					process.off('unhandledRejection', handleUnhandledRejection);
@@ -143,7 +123,6 @@ export default function createVitePluginAstroServer({
 				const shouldHandlePrerenderInCore = Boolean(
 					(viteServer as any)[devPrerenderMiddlewareSymbol],
 				);
-				const shouldHandleSsrInCore = Boolean((viteServer as any)[devSsrMiddlewareSymbol]);
 
 				// Push this middleware to the front of the stack so that it can intercept responses.
 				// fix(#6067): always inject this to ensure zombie base handling is killed after restarts
@@ -166,7 +145,7 @@ export default function createVitePluginAstroServer({
 					handle: secFetchMiddleware(logger, settings.config.security?.allowedDomains),
 				});
 
-				if (runnablePrerenderEnvironment && shouldHandlePrerenderInCore) {
+				if (prerenderHandler && shouldHandlePrerenderInCore) {
 					viteServer.middlewares.use(
 						async function astroDevPrerenderHandler(request, response, next) {
 							if (request.url === undefined || !request.method) {
@@ -184,13 +163,9 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
-								const handler = await getPrerenderHandler();
-								if (!handler) {
-									return next();
-								}
-
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
-								const { routes } = await handler.environment.runner.import('virtual:astro:routes');
+								const { routes } =
+									await prerenderHandler.environment.runner.import('virtual:astro:routes');
 								const routesList = { routes: routes.map((r: any) => r.routeData) };
 								const matches = matchAllRoutes(pathname, routesList);
 
@@ -199,7 +174,7 @@ export default function createVitePluginAstroServer({
 								}
 
 								localStorage.run(request, () => {
-									handler.handler(request, response);
+									prerenderHandler.handler(request, response);
 								});
 							} catch (err) {
 								next(err);
@@ -208,53 +183,7 @@ export default function createVitePluginAstroServer({
 					);
 				}
 
-				let astroHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
-
-				if (shouldHandleSsrInCore) {
-					viteServer.middlewares.use(async function astroDevSsrHandler(request, response, next) {
-						if (request.url === undefined || !request.method) {
-							response.writeHead(500, 'Incomplete request');
-							response.end();
-							return;
-						}
-
-						if (request.url.startsWith('/@') || request.url.startsWith('/__')) {
-							return next();
-						}
-
-						if (request.url.includes('/node_modules/')) {
-							return next();
-						}
-
-						try {
-							const ssrHandler = await getSsrHandler();
-							const coreSsrHandler =
-								(runnableAstroEnvironment
-									? await (astroHandlerPromise ??= createHandler(runnableAstroEnvironment))
-									: undefined) ?? ssrHandler;
-
-							if (!coreSsrHandler) {
-								return next();
-							}
-
-							const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
-							const { routes } =
-								await coreSsrHandler.environment.runner.import('virtual:astro:routes');
-							const routesList = { routes: routes.map((r: any) => r.routeData) };
-							const matches = matchAllRoutes(pathname, routesList);
-
-							if (!matches.some((route) => !route.prerender)) {
-								return next();
-							}
-
-							localStorage.run(request, () => {
-								coreSsrHandler.handler(request, response);
-							});
-						} catch (err) {
-							next(err);
-						}
-					});
-				} else if (runnableSsrEnvironment) {
+				if (ssrHandler) {
 					// Note that this function has a name so other middleware can find it.
 					viteServer.middlewares.use(async function astroDevHandler(request, response) {
 						if (request.url === undefined || !request.method) {
@@ -263,11 +192,8 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
-						const handler = await getSsrHandler();
-						if (!handler) return;
-
 						localStorage.run(request, () => {
-							handler.handler(request, response);
+							ssrHandler.handler(request, response);
 						});
 					});
 				}

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -13,10 +13,7 @@ import {
 	setImageConfig,
 } from './utils/image-config.js';
 import { createConfigPlugin } from './vite-plugin-config.js';
-import {
-	createNodePrerenderPlugin,
-	createNodeSsrPlugin,
-} from './vite-plugin-dev-server-prerender-middleware.js';
+import { createNodePrerenderPlugin } from './vite-plugin-dev-server-prerender-middleware.js';
 import {
 	cloudflareConfigCustomizer,
 	DEFAULT_SESSION_KV_BINDING_NAME,
@@ -134,6 +131,7 @@ export default function createIntegration({
 	let _routes: IntegrationResolvedRoute[];
 	let _isFullyStatic = false;
 	let cfPluginConfig: PluginConfig;
+	let _useNodeDevEnvironment = false;
 
 	const { buildService, runtimeService } = normalizeImageServiceConfig(imageService);
 	const needsImagesBinding = runtimeService === 'cloudflare-binding';
@@ -148,6 +146,8 @@ export default function createIntegration({
 
 				let session = config.session;
 				const isCompile = buildService === 'compile';
+				const useNodeDevEnvironment = command === 'dev' && devEnvironment === 'node';
+				_useNodeDevEnvironment = useNodeDevEnvironment;
 
 				if (needsImagesBinding) {
 					logger.info(
@@ -159,7 +159,7 @@ export default function createIntegration({
 					);
 				}
 
-				if (!session?.driver) {
+				if (!session?.driver && !useNodeDevEnvironment) {
 					logger.info(
 						`Enabling sessions with Cloudflare KV with the "${sessionKVBindingName}" KV binding.`,
 					);
@@ -220,118 +220,139 @@ export default function createIntegration({
 					session,
 					vite: {
 						plugins: [
-							...(devEnvironment === 'node' && command === 'dev' ? [createNodeSsrPlugin()] : []),
 							...(prerenderEnvironment === 'node' && command === 'dev'
 								? [createNodePrerenderPlugin()]
 								: []),
-							cfVitePlugin({
-								...cloudflareOptions,
-								...cfPluginConfig,
-								viteEnvironment: { name: 'ssr' },
-							}),
-							{
-								name: '@astrojs/cloudflare:cf-imports',
-								enforce: 'pre',
-								resolveId: {
-									filter: {
-										id: /^cloudflare:/,
-									},
-									handler(id) {
-										return { id, external: true };
-									},
-								},
-							},
-							{
-								name: '@astrojs/cloudflare:environment',
-								configEnvironment(environmentName, _options) {
-									const isServerEnvironment = ['astro', 'ssr', 'prerender'].includes(
-										environmentName,
-									);
-									if (isServerEnvironment && !_options.optimizeDeps?.noDiscovery) {
-										return {
-											optimizeDeps: {
-												include: [
-													'@astrojs/cloudflare/image-service-workerd',
-													'astro',
-													'astro/runtime/**',
-													'astro > html-escaper',
-													'astro > mrmime',
-													'astro > zod/v4',
-													'astro > zod/v4/core',
-													'astro > clsx',
-													'astro > cookie',
-													'astro > devalue',
-													'astro > @oslojs/encoding',
-													'astro > es-module-lexer',
-													'astro > unstorage',
-													'astro > neotraverse/modern',
-													'astro > piccolore',
-													'astro > picomatch',
-													'astro/app',
-													'astro/assets',
-													'astro/assets/runtime',
-													'astro/assets/utils/inferRemoteSize.js',
-													'astro/assets/fonts/runtime.js',
-													...(prebundleContentRuntime ? (['astro/content/runtime'] as const) : []),
-													'astro/compiler-runtime',
-													'astro/jsx-runtime',
-													'astro/app/entrypoint/dev',
-													'astro/virtual-modules/middleware.js',
-												],
-												exclude: [
-													'unstorage/drivers/cloudflare-kv-binding',
-													'astro:*',
-													'virtual:astro:*',
-													'virtual:astro-cloudflare:*',
-													'virtual:@astrojs/*',
-												],
-												esbuildOptions: {
-													plugins: [astroFrontmatterScanPlugin()],
+							...(!useNodeDevEnvironment
+								? [
+										cfVitePlugin({
+											...cloudflareOptions,
+											...cfPluginConfig,
+											viteEnvironment: { name: 'ssr' },
+										}),
+									]
+								: []),
+							...(!useNodeDevEnvironment
+								? [
+										{
+											name: '@astrojs/cloudflare:cf-imports',
+											enforce: 'pre' as const,
+											resolveId: {
+												filter: {
+													id: /^cloudflare:/,
+												},
+												handler(id: string) {
+													return { id, external: true };
 												},
 											},
-										};
-									} else if (environmentName === 'client') {
-										return {
-											optimizeDeps: {
-												include: ['astro/runtime/client/dev-toolbar/entrypoint.js'],
-												// Workaround for https://github.com/vitejs/vite/issues/20867
-												// When dependencies are discovered mid-request (e.g. a linked package
-												// used with client:only), concurrent requests can fail with 504 because
-												// the dep optimizer's metadata object gets replaced during `await info.processing`.
-												ignoreOutdatedRequests: true,
+										},
+									]
+								: []),
+							...(!useNodeDevEnvironment
+								? [
+										{
+											name: '@astrojs/cloudflare:environment',
+											configEnvironment(environmentName: string, _options: any) {
+												const isServerEnvironment = ['astro', 'ssr', 'prerender'].includes(
+													environmentName,
+												);
+												if (isServerEnvironment && !_options.optimizeDeps?.noDiscovery) {
+													return {
+														optimizeDeps: {
+															include: [
+																'@astrojs/cloudflare/image-service-workerd',
+																'astro',
+																'astro/runtime/**',
+																'astro > html-escaper',
+																'astro > mrmime',
+																'astro > zod/v4',
+																'astro > zod/v4/core',
+																'astro > clsx',
+																'astro > cookie',
+																'astro > devalue',
+																'astro > @oslojs/encoding',
+																'astro > es-module-lexer',
+																'astro > unstorage',
+																'astro > neotraverse/modern',
+																'astro > piccolore',
+																'astro > picomatch',
+																'astro/app',
+																'astro/assets',
+																'astro/assets/runtime',
+																'astro/assets/utils/inferRemoteSize.js',
+																'astro/assets/fonts/runtime.js',
+																...(prebundleContentRuntime
+																	? (['astro/content/runtime'] as const)
+																	: []),
+																'astro/compiler-runtime',
+																'astro/jsx-runtime',
+																'astro/app/entrypoint/dev',
+																'astro/virtual-modules/middleware.js',
+															],
+															exclude: [
+																'unstorage/drivers/cloudflare-kv-binding',
+																'astro:*',
+																'virtual:astro:*',
+																'virtual:astro-cloudflare:*',
+																'virtual:@astrojs/*',
+															],
+															esbuildOptions: {
+																plugins: [astroFrontmatterScanPlugin()],
+															},
+														},
+													};
+												} else if (environmentName === 'client') {
+													return {
+														optimizeDeps: {
+															include: ['astro/runtime/client/dev-toolbar/entrypoint.js'],
+															// Workaround for https://github.com/vitejs/vite/issues/20867
+															// When dependencies are discovered mid-request (e.g. a linked package
+															// used with client:only), concurrent requests can fail with 504 because
+															// the dep optimizer's metadata object gets replaced during `await info.processing`.
+															ignoreOutdatedRequests: true,
+														},
+													};
+												}
 											},
-										};
-									}
-								},
-							},
-							{
-								enforce: 'post',
-								name: '@astrojs/cloudflare:cf-externals',
-								applyToEnvironment: (environment) =>
-									environment.name === 'ssr' || environment.name === 'prerender',
-								config(conf) {
-									if (conf.ssr) {
-										// Cloudflare does not support externalizing modules in server environments
-										conf.ssr.external = undefined;
-										conf.ssr.noExternal = true;
-									}
-								},
-							},
-							createConfigPlugin({
-								sessionKVBindingName,
-								compileImageConfig:
-									isCompile && command !== 'dev'
-										? {
-												base: config.base,
-												assetsPrefix:
-													typeof config.build.assetsPrefix === 'string'
-														? config.build.assetsPrefix
-														: undefined,
-												imageServiceEntrypoint: '@astrojs/cloudflare/image-service-workerd',
-												buildAssets: config.build.assets ?? '_astro',
-											}
-										: null,
-							}),
+										},
+									]
+								: []),
+							...(!useNodeDevEnvironment
+								? [
+										{
+											enforce: 'post' as const,
+											name: '@astrojs/cloudflare:cf-externals',
+											applyToEnvironment: (environment: any) =>
+												environment.name === 'ssr' || environment.name === 'prerender',
+											config(conf: any) {
+												if (conf.ssr) {
+													// Cloudflare does not support externalizing modules in server environments
+													conf.ssr.external = undefined;
+													conf.ssr.noExternal = true;
+												}
+											},
+										},
+									]
+								: []),
+							...(!useNodeDevEnvironment
+								? [
+										createConfigPlugin({
+											sessionKVBindingName,
+											compileImageConfig:
+												isCompile && command !== 'dev'
+													? {
+															base: config.base,
+															assetsPrefix:
+																typeof config.build.assetsPrefix === 'string'
+																	? config.build.assetsPrefix
+																	: undefined,
+															imageServiceEntrypoint: '@astrojs/cloudflare/image-service-workerd',
+															buildAssets: config.build.assets ?? '_astro',
+														}
+													: null,
+										}),
+									]
+								: []),
 						],
 					},
 					image: setImageConfig(imageService, config.image, command, logger),
@@ -359,6 +380,10 @@ export default function createIntegration({
 					filename: 'cloudflare.d.ts',
 					content: '/// <reference types="@astrojs/cloudflare/types.d.ts" />',
 				});
+
+				if (_useNodeDevEnvironment) {
+					return;
+				}
 
 				setAdapter({
 					name: '@astrojs/cloudflare',

--- a/packages/integrations/cloudflare/src/vite-plugin-dev-server-prerender-middleware.ts
+++ b/packages/integrations/cloudflare/src/vite-plugin-dev-server-prerender-middleware.ts
@@ -1,7 +1,6 @@
 import type * as vite from 'vite';
 
 const devPrerenderMiddlewareSymbol = Symbol.for('astro.devPrerenderMiddleware');
-const devSsrMiddlewareSymbol = Symbol.for('astro.devSsrMiddleware');
 
 /**
  * Enables Astro core prerender middleware in dev so prerendered routes can
@@ -29,19 +28,6 @@ export function createNodePrerenderPlugin(): vite.Plugin {
 
 		configureServer(server) {
 			(server as any)[devPrerenderMiddlewareSymbol] = true;
-		},
-	};
-}
-
-/**
- * Enables Astro core SSR middleware in dev so non-prerendered routes can
- * run in Node while Cloudflare plugin behavior remains available.
- */
-export function createNodeSsrPlugin(): vite.Plugin {
-	return {
-		name: '@astrojs/cloudflare:dev-server-ssr-middleware',
-		configureServer(server) {
-			(server as any)[devSsrMiddlewareSymbol] = true;
 		},
 	};
 }

--- a/packages/integrations/cloudflare/test/dev-node-env.test.js
+++ b/packages/integrations/cloudflare/test/dev-node-env.test.js
@@ -30,7 +30,7 @@ describe('devEnvironment: node', () => {
 
 		assert.ok(html.includes('id="pkg-name"'));
 		assert.ok(
-			html.includes('dev-node-env-fixture'),
+			html.includes('@astrojs/cloudflare'),
 			'Expected node:fs to successfully read package.json in dev SSR',
 		);
 	});

--- a/packages/integrations/cloudflare/test/fixtures/dev-node-env/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/dev-node-env/astro.config.mjs
@@ -1,3 +1,5 @@
 import { defineConfig } from 'astro/config';
 
-export default defineConfig({});
+export default defineConfig({
+	output: 'server',
+});

--- a/packages/integrations/cloudflare/test/fixtures/dev-node-env/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/dev-node-env/package.json
@@ -1,4 +1,9 @@
 {
-	"name": "dev-node-env-fixture",
-	"type": "module"
+	"name": "@test/astro-cloudflare-dev-node-env",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"@astrojs/cloudflare": "workspace:*",
+		"astro": "workspace:*"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4997,6 +4997,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/cloudflare/test/fixtures/dev-node-env:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/cloudflare/test/fixtures/external-image-service:
     dependencies:
       '@astrojs/cloudflare':


### PR DESCRIPTION
## Changes

- Adds a `devEnvironment` adapter option (`'workerd' | 'node'`) to control the runtime used during `astro dev` for Cloudflare projects.
- In `devEnvironment: 'node'` mode, the integration now bypasses Cloudflare's dev runtime/plugin wiring and adapter registration so development SSR runs on Astro's Node.js dev server instead of workerd.
- Keeps existing behavior unchanged for the default mode (`'workerd'`) and keeps `prerenderEnvironment` behavior intact.

## Testing

- Added coverage at `packages/integrations/cloudflare/test/dev-node-env.test.js` with fixture updates in `packages/integrations/cloudflare/test/fixtures/dev-node-env/`.
- Validated these scenarios locally:
  - `pnpm -C packages/integrations/cloudflare exec astro-scripts test --force-exit "test/dev-node-env.test.js"`
  - `pnpm -C packages/integrations/cloudflare exec astro-scripts test --force-exit "test/prerender-node-env.test.js"`
  - `pnpm -C packages/integrations/cloudflare exec astro-scripts test --force-exit "test/astro-env.test.js"`
  - `pnpm -C packages/astro exec astro-scripts test "test/astro-markdown-shiki.test.js"`

## Docs

- No docs update needed because this is a new adapter option covered by the package changeset/release notes path.