### PR TITLE
fix(fonts): too many builds

### DIFF
--- a/.changeset/itchy-tires-speak.md
+++ b/.changeset/itchy-tires-speak.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where fonts files would unecessarily be copied several times during the build

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -74,6 +74,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 	let isBuild: boolean;
 	let fontFetcher: FontFetcher | null = null;
 	let fontTypeExtractor: FontTypeExtractor | null = null;
+	let built = false;
 
 	const cleanup = () => {
 		componentDataByCssVariable = null;
@@ -88,6 +89,9 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 			isBuild = command === 'build';
 		},
 		async buildStart() {
+			if (sync) {
+				return;
+			}
 			const { root } = settings.config;
 			// Dependencies. Once extracted to a dedicated vite plugin, those may be passed as
 			// a Vite plugin option.
@@ -304,6 +308,10 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 			},
 		},
 		async buildEnd() {
+			// Run once during the build, no matter how many environments there are
+			if (built) {
+				return;
+			}
 			if (sync || !settings.config.fonts?.length || !isBuild) {
 				cleanup();
 				return;
@@ -335,6 +343,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 				}
 			} finally {
 				cleanup();
+				built = true;
 			}
 		},
 	};


### PR DESCRIPTION
## Changes

- Font files would be copied several times during the build because it would run for each environment
- This PR fixes it by making sure it runs once during the build

## Testing

Manually, tests should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
