### PR TITLE
Prevent dev server hang on first request with Cloudflare adapter

### DIFF
--- a/.changeset/fix-cloudflare-dev-css-deadlock.md
+++ b/.changeset/fix-cloudflare-dev-css-deadlock.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a dev server hang on the first request when using the Cloudflare adapter

--- a/packages/astro/src/vite-plugin-css/index.ts
+++ b/packages/astro/src/vite-plugin-css/index.ts
@@ -55,6 +55,17 @@ async function ensureModulesLoaded(
 		// Mirror the stopping point used by collectCSSWithOrder — don't descend into propagated
 		// asset modules, as the CSS walk intentionally stops there too.
 		if (imp.id.includes(PROPAGATED_ASSET_QUERY_PARAM)) continue;
+		// Skip virtual dev-css modules to prevent circular deadlocks with the Cloudflare adapter.
+		// The dev-css-all module statically imports all per-route dev-css:* modules, and those
+		// modules' load handlers may already be running (waiting on ensureModulesLoaded), causing
+		// a permanent deadlock via Vite's _pendingRequests map. These are CSS collector virtuals
+		// that don't contain CSS themselves, so skipping them has no effect on CSS injection.
+		if (
+			imp.id === RESOLVED_MODULE_DEV_CSS ||
+			imp.id === RESOLVED_MODULE_DEV_CSS_ALL ||
+			imp.id.startsWith(RESOLVED_MODULE_DEV_CSS_PREFIX)
+		)
+			continue;
 
 		// If this module hasn't been transformed yet, fetch it to populate its importedModules
 		if (!imp.transformResult) {


### PR DESCRIPTION
## Changes

- Fixes a permanent hang on the first HTTP request when using `@astrojs/cloudflare` in dev mode. The server would start successfully but every request would time out with no response.
- The root cause was in `ensureModulesLoaded()` (added in #15988): it traversed into `virtual:astro:dev-css-all`, which statically imports all per-route `virtual:astro:dev-css:*` modules. So basically it hangs because of a circular  import call.
- The fix skips `virtual:astro:dev-css`, `virtual:astro:dev-css-all`, and `virtual:astro:dev-css:*` modules during the traversal. These are CSS collector virtuals that contain no CSS themselves, so skipping them has no effect on CSS injection — `collectCSSWithOrder()` handles that separately.

## Testing

- Manually verified against a multi-route Cloudflare adapter project where the hang was reliably reproducible.
- The existing `css-dynamic-import-dev` test (added in #15988) continues to cover the original fix for dynamic import CSS injection on first load.

## Docs

- No docs update needed — this restores expected dev server behavior with no user-facing API changes.

Fixes #16010
