### PR TITLE
Fix false positive missing-content audit for hidden anchors

### DIFF
--- a/.changeset/few-apples-double.md
+++ b/.changeset/few-apples-double.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix a false positive in the dev toolbar accessibility audit for anchors with text inside closed `<details>` elements.

--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -259,4 +259,19 @@ test.describe('Dev Toolbar - Audits', () => {
 		const count = await auditHighlights.count();
 		expect(count).toEqual(0);
 	});
+
+	test('does not warn about anchor text inside closed details', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/a11y-hidden-anchor'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
+		await appButton.click();
+
+		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
+		const missingContentHighlights = auditCanvas.locator(
+			'astro-dev-toolbar-highlight[data-audit-code="a11y-missing-content"]',
+		);
+
+		await expect(missingContentHighlights).toHaveCount(0);
+	});
 });

--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -260,7 +260,10 @@ test.describe('Dev Toolbar - Audits', () => {
 		expect(count).toEqual(0);
 	});
 
-	test('does not warn about anchor text inside closed details', async ({ page, astro }) => {
+	test('does not warn about anchor text inside closed details but still warns for hidden text', async ({
+		page,
+		astro,
+	}) => {
 		await page.goto(astro.resolveUrl('/a11y-hidden-anchor'));
 
 		const toolbar = page.locator('astro-dev-toolbar');
@@ -272,6 +275,6 @@ test.describe('Dev Toolbar - Audits', () => {
 			'astro-dev-toolbar-highlight[data-audit-code="a11y-missing-content"]',
 		);
 
-		await expect(missingContentHighlights).toHaveCount(0);
+		await expect(missingContentHighlights).toHaveCount(1);
 	});
 });

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-hidden-anchor.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-hidden-anchor.astro
@@ -1,0 +1,7 @@
+---
+---
+
+<details>
+	<summary>More links</summary>
+	<a href="/docs">Read the documentation</a>
+</details>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-hidden-anchor.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-hidden-anchor.astro
@@ -5,3 +5,8 @@
 	<summary>More links</summary>
 	<a href="/docs">Read the documentation</a>
 </details>
+
+<a href="/hidden">
+	<span style="display: inline-block; width: 1rem; height: 1rem"></span>
+	<span hidden>Hidden label</span>
+</a>

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -31,6 +31,10 @@ import type { AuditRuleWithSelector } from './index.js';
 
 const WHITESPACE_REGEX = /\s+/;
 
+function getTrimmedTextContent(element: Node | null | undefined): string {
+	return element?.textContent?.trim() ?? '';
+}
+
 const a11y_required_attributes = {
 	a: ['href'],
 	area: ['alt', 'aria-label', 'aria-labelledby'],
@@ -301,9 +305,8 @@ export const a11y: AuditRuleWithSelector[] = [
 			const nestedLabelableElement = element.querySelector(`${labelableElements.join(', ')}`);
 			if (!hasFor && !nestedLabelableElement) return true;
 
-			// Label must have text content, using innerText to ignore hidden text
-			const innerText = element.innerText.trim();
-			if (innerText === '') return true;
+			const textContent = getTrimmedTextContent(element);
+			if (textContent === '') return true;
 		},
 	},
 	{
@@ -364,12 +367,11 @@ export const a11y: AuditRuleWithSelector[] = [
 		code: 'a11y-missing-content',
 		title: 'Missing content',
 		message:
-			'Headings and anchors must have an accessible name, which can come from: inner text, aria-label, aria-labelledby, an img with alt property, or an svg with a tag <title></title>.',
+			'Headings and anchors must have an accessible name, which can come from: text content, aria-label, aria-labelledby, an img with alt property, or an svg with a tag <title></title>.',
 		selector: a11y_required_content.join(','),
 		match(element: HTMLElement) {
-			// innerText is used to ignore hidden text
-			const innerText = element.innerText?.trim();
-			if (innerText && innerText !== '') return false;
+			const textContent = getTrimmedTextContent(element);
+			if (textContent !== '') return false;
 
 			// Check for aria-label
 			const ariaLabel = element.getAttribute('aria-label')?.trim();
@@ -381,7 +383,7 @@ export const a11y: AuditRuleWithSelector[] = [
 				const ids = ariaLabelledby.split(' ');
 				for (const id of ids) {
 					const referencedElement = document.getElementById(id);
-					if (referencedElement && referencedElement.innerText.trim() !== '') return false;
+					if (getTrimmedTextContent(referencedElement) !== '') return false;
 				}
 			}
 
@@ -417,7 +419,7 @@ export const a11y: AuditRuleWithSelector[] = [
 					const ids = inputAriaLabelledby.split(' ');
 					for (const id of ids) {
 						const referencedElement = document.getElementById(id);
-						if (referencedElement && referencedElement.innerText.trim() !== '') return false;
+						if (getTrimmedTextContent(referencedElement) !== '') return false;
 					}
 				}
 

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -31,8 +31,15 @@ import type { AuditRuleWithSelector } from './index.js';
 
 const WHITESPACE_REGEX = /\s+/;
 
-function getTrimmedTextContent(element: Node | null | undefined): string {
-	return element?.textContent?.trim() ?? '';
+function isHiddenByClosedDetails(element: HTMLElement): boolean {
+	for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+		if (parent.localName !== 'details' || (parent as HTMLDetailsElement).open) continue;
+
+		const summary = Array.from(parent.children).find((child) => child.localName === 'summary');
+		if (!summary?.contains(element)) return true;
+	}
+
+	return false;
 }
 
 const a11y_required_attributes = {
@@ -305,8 +312,9 @@ export const a11y: AuditRuleWithSelector[] = [
 			const nestedLabelableElement = element.querySelector(`${labelableElements.join(', ')}`);
 			if (!hasFor && !nestedLabelableElement) return true;
 
-			const textContent = getTrimmedTextContent(element);
-			if (textContent === '') return true;
+			// Label must have text content, using innerText to ignore hidden text
+			const innerText = element.innerText.trim();
+			if (innerText === '') return true;
 		},
 	},
 	{
@@ -367,11 +375,14 @@ export const a11y: AuditRuleWithSelector[] = [
 		code: 'a11y-missing-content',
 		title: 'Missing content',
 		message:
-			'Headings and anchors must have an accessible name, which can come from: text content, aria-label, aria-labelledby, an img with alt property, or an svg with a tag <title></title>.',
+			'Headings and anchors must have an accessible name, which can come from: inner text, aria-label, aria-labelledby, an img with alt property, or an svg with a tag <title></title>.',
 		selector: a11y_required_content.join(','),
 		match(element: HTMLElement) {
-			const textContent = getTrimmedTextContent(element);
-			if (textContent !== '') return false;
+			if (isHiddenByClosedDetails(element)) return false;
+
+			// innerText is used to ignore hidden text
+			const innerText = element.innerText?.trim();
+			if (innerText && innerText !== '') return false;
 
 			// Check for aria-label
 			const ariaLabel = element.getAttribute('aria-label')?.trim();
@@ -383,7 +394,7 @@ export const a11y: AuditRuleWithSelector[] = [
 				const ids = ariaLabelledby.split(' ');
 				for (const id of ids) {
 					const referencedElement = document.getElementById(id);
-					if (getTrimmedTextContent(referencedElement) !== '') return false;
+					if (referencedElement && referencedElement.innerText.trim() !== '') return false;
 				}
 			}
 
@@ -419,7 +430,7 @@ export const a11y: AuditRuleWithSelector[] = [
 					const ids = inputAriaLabelledby.split(' ');
 					for (const id of ids) {
 						const referencedElement = document.getElementById(id);
-						if (getTrimmedTextContent(referencedElement) !== '') return false;
+						if (referencedElement && referencedElement.innerText.trim() !== '') return false;
 					}
 				}
 


### PR DESCRIPTION
## Summary
- use text content instead of innerText for dev-toolbar a11y name checks
- cover anchors inside closed <details> so hidden-but-valid text is not flagged
- reuse the same text-content check for label and aria-labelledby paths

## Testing
- pnpm run build:ci
- pnpm exec playwright test e2e/dev-toolbar-audits.test.js

Fixes #16009