### PR TITLE
Fix defineLiveCollection interface loader typing

### DIFF
--- a/.changeset/tiny-cameras-teach.md
+++ b/.changeset/tiny-cameras-teach.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix `defineLiveCollection()` so `LiveLoader` data types declared as interfaces are accepted.

--- a/packages/astro/src/content/loaders/types.ts
+++ b/packages/astro/src/content/loaders/types.ts
@@ -84,7 +84,7 @@ export interface LoadCollectionContext<TCollectionFilter = unknown> {
 }
 
 export interface LiveLoader<
-	TData extends Record<string, any> = Record<string, unknown>,
+	TData extends Record<string, any> = Record<string, any>,
 	TEntryFilter extends Record<string, any> | never = never,
 	TCollectionFilter extends Record<string, any> | never = never,
 	TError extends Error = Error,

--- a/packages/astro/src/types/public/content.ts
+++ b/packages/astro/src/types/public/content.ts
@@ -162,7 +162,7 @@ export interface CacheHint {
 	lastModified?: Date;
 }
 
-export interface LiveDataEntry<TData extends Record<string, any> = Record<string, unknown>> {
+export interface LiveDataEntry<TData extends Record<string, any> = Record<string, any>> {
 	/** The ID of the entry. Unique per collection. */
 	id: string;
 	/** The parsed entry data */
@@ -175,14 +175,14 @@ export interface LiveDataEntry<TData extends Record<string, any> = Record<string
 	cacheHint?: CacheHint;
 }
 
-export interface LiveDataCollection<TData extends Record<string, any> = Record<string, unknown>> {
+export interface LiveDataCollection<TData extends Record<string, any> = Record<string, any>> {
 	entries: Array<LiveDataEntry<TData>>;
 	/** A hint for how to cache this collection. Individual entries can also have cache hints */
 	cacheHint?: CacheHint;
 }
 
 export interface LiveDataCollectionResult<
-	TData extends Record<string, any> = Record<string, unknown>,
+	TData extends Record<string, any> = Record<string, any>,
 	TError extends Error = Error,
 > {
 	entries?: Array<LiveDataEntry<TData>>;
@@ -191,7 +191,7 @@ export interface LiveDataCollectionResult<
 }
 
 export interface LiveDataEntryResult<
-	TData extends Record<string, any> = Record<string, unknown>,
+	TData extends Record<string, any> = Record<string, any>,
 	TError extends Error = Error,
 > {
 	entry?: LiveDataEntry<TData>;

--- a/packages/astro/test/types/define-live-collection.ts
+++ b/packages/astro/test/types/define-live-collection.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import { expectTypeOf } from 'expect-type';
+import { defineLiveCollection } from 'astro/content/config';
+import type { LiveLoader } from 'astro/loaders';
+
+function assertType<T>(data: T, cb: (data: NoInfer<T>) => void) {
+	cb(data);
+}
+
+interface Data {
+	body: string;
+}
+
+const loader: LiveLoader<Data> = {
+	name: 'test-loader',
+	loadEntry: async () => ({
+		id: 'hello-world',
+		data: { body: 'Hello world' },
+	}),
+	loadCollection: async () => ({
+		entries: [
+			{
+				id: 'hello-world',
+				data: { body: 'Hello world' },
+			},
+		],
+	}),
+};
+
+describe('defineLiveCollection()', () => {
+	it('accepts live loaders whose data type is declared as an interface', () => {
+		assertType(defineLiveCollection({ loader }), (config) => {
+			expectTypeOf(config.loader).toEqualTypeOf<LiveLoader<Data>>();
+		});
+	});
+});


### PR DESCRIPTION
Fixes #16012.

## Summary
- align the default `LiveLoader` data type with its existing `Record<string, any>` constraint
- update the related live content public types to use the same default
- add a type regression covering `defineLiveCollection()` with a `LiveLoader` whose data shape is declared as an interface

## Verification
- `pnpm run build:ci`
- `pnpm exec tsc --noEmit --moduleResolution bundler --module esnext --target es2022 --types node ./test/types/define-live-collection.ts`