### PR TITLE
fix(rss): unpin fast-xml-parser to resolve entity expansion CVEs

### DIFF
--- a/.changeset/unpin-fast-xml-parser.md
+++ b/.changeset/unpin-fast-xml-parser.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Unpin `fast-xml-parser` to `^5.5.7` to resolve entity expansion CVEs

--- a/packages/astro-rss/package.json
+++ b/packages/astro-rss/package.json
@@ -32,7 +32,7 @@
     "xml2js": "0.6.2"
   },
   "dependencies": {
-    "fast-xml-parser": "5.4.1",
+    "fast-xml-parser": "^5.5.7",
     "piccolore": "^0.1.3",
     "zod": "^4.3.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,8 +790,8 @@ importers:
   packages/astro-rss:
     dependencies:
       fast-xml-parser:
-        specifier: 5.4.1
-        version: 5.4.1
+        specifier: ^5.5.7
+        version: 5.5.7
       piccolore:
         specifier: ^0.1.3
         version: 0.1.3
@@ -12086,11 +12086,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.0.0:
-    resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
-  fast-xml-parser@5.4.1:
-    resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
+  fast-xml-parser@5.5.7:
+    resolution: {integrity: sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==}
     hasBin: true
 
   fastify-plugin@5.1.0:
@@ -13922,6 +13922,10 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-expression-matcher@1.1.3:
+    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -14969,8 +14973,8 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  strnum@2.1.2:
-    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+  strnum@2.2.1:
+    resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
 
   structured-source@4.0.0:
     resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
@@ -21372,12 +21376,15 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.0.0: {}
-
-  fast-xml-parser@5.4.1:
+  fast-xml-builder@1.1.4:
     dependencies:
-      fast-xml-builder: 1.0.0
-      strnum: 2.1.2
+      path-expression-matcher: 1.1.3
+
+  fast-xml-parser@5.5.7:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.1.3
+      strnum: 2.2.1
 
   fastify-plugin@5.1.0: {}
 
@@ -23640,6 +23647,8 @@ snapshots:
 
   path-exists@5.0.0: {}
 
+  path-expression-matcher@1.1.3: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -24933,7 +24942,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@2.1.2: {}
+  strnum@2.2.1: {}
 
   structured-source@4.0.0:
     dependencies:


### PR DESCRIPTION
## Changes

- Unpin `fast-xml-parser` from exact `5.4.1` to `^5.5.7`

The pin was introduced in #15830 because v5.5.0 shipped with a broken dependency declaration (`"fast-xml-builder": "file:../../fxp-builder"`). The upstream issue ([NaturalIntelligence/fast-xml-parser#799](https://github.com/NaturalIntelligence/fast-xml-parser/issues/799)) is now closed and resolved.

The pinned v5.4.1 has open CVEs related to entity expansion limits (XXE prevention), which are fixed in v5.5.7+:
- [CVE-2025-27098](https://github.com/advisories/GHSA-gpjq-rrqg-x8gj) — Prototype pollution via attribute parsing
- [CVE-2025-27439](https://github.com/advisories/GHSA-vg6x-rcgg-rjx6) — Entity expansion (billion laughs) attack

No breaking API changes exist between 5.4.1 and 5.5.7. The options used by `@astrojs/rss` (`ignoreAttributes`, `suppressEmptyNode`, `suppressBooleanAttributes`) are unchanged. The `fast-xml-builder` transitive dependency moved from `1.0.0` to `^1.1.4` (same major version).

## Testing

- All 21 existing `@astrojs/rss` tests pass with no changes needed
- Tests cover the full API surface: basic items, content encoding, custom data, stylesheets, self-closing tags, enclosures, sources, categories, and trailing slashes

## Docs

No user-facing behavior changes — this is a transparent dependency update.