### PR TITLE
Fix remaining Vite 8 follow-up regressions

### DIFF
--- a/examples/container-with-vitest/vitest.config.ts
+++ b/examples/container-with-vitest/vitest.config.ts
@@ -1,4 +1,4 @@
-/// <reference types="vitest" />
+/// <reference types="vitest/config" />
 import { getViteConfig } from 'astro/config';
 
 export default getViteConfig({

--- a/examples/with-vitest/vitest.config.ts
+++ b/examples/with-vitest/vitest.config.ts
@@ -1,4 +1,4 @@
-/// <reference types="vitest" />
+/// <reference types="vitest/config" />
 import { getViteConfig } from 'astro/config';
 
 export default getViteConfig({

--- a/packages/astro/e2e/astro-component.test.js
+++ b/packages/astro/e2e/astro-component.test.js
@@ -5,6 +5,12 @@ const test = testFactory(import.meta.url, { root: './fixtures/astro-component/' 
 
 let devServer;
 
+async function waitForViteToSettle(page) {
+	// Headless Chrome can trigger one immediate follow-up load after the initial Vite connection.
+	// Wait for that to clear before asserting whether an edit caused a reload.
+	await page.waitForTimeout(500);
+}
+
 test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
@@ -16,6 +22,7 @@ test.afterAll(async () => {
 test.describe('Astro component HMR', () => {
 	test('component styles', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/'));
+		await waitForViteToSettle(page);
 
 		const hero = page.locator('section');
 		await expect(hero, 'hero has background: white').toHaveCSS(
@@ -43,6 +50,7 @@ test.describe('Astro component HMR', () => {
 
 		await page.goto(astro.resolveUrl('/'));
 		await initialLog;
+		await waitForViteToSettle(page);
 
 		const el = page.locator('#hoisted-script');
 		expect(await el.innerText()).toContain('Hoisted success');
@@ -68,6 +76,7 @@ test.describe('Astro component HMR', () => {
 
 		await page.goto(astro.resolveUrl('/'));
 		await initialLog;
+		await waitForViteToSettle(page);
 
 		const updatedLog = page.waitForEvent(
 			'console',
@@ -84,6 +93,7 @@ test.describe('Astro component HMR', () => {
 
 	test('update linked dep Astro html', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/'));
+		await waitForViteToSettle(page);
 		let h1 = page.locator('#astro-linked-lib');
 		expect(await h1.textContent()).toBe('astro-linked-lib');
 		await Promise.all([
@@ -98,6 +108,7 @@ test.describe('Astro component HMR', () => {
 
 	test('update linked dep Astro style', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/'));
+		await waitForViteToSettle(page);
 		let h1 = page.locator('#astro-linked-lib');
 		await expect(h1).toHaveCSS('color', 'rgb(255, 0, 0)');
 		await Promise.all([

--- a/packages/astro/e2e/hmr.test.js
+++ b/packages/astro/e2e/hmr.test.js
@@ -14,6 +14,12 @@ function throwPageShouldNotReload() {
 	throw new Error('Page should not reload in HMR');
 }
 
+async function waitForViteToSettle(page) {
+	// Headless Chrome can trigger one immediate follow-up load after the initial Vite connection.
+	// Wait for that to clear before asserting whether an edit caused a reload.
+	await page.waitForTimeout(500);
+}
+
 test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
@@ -29,6 +35,7 @@ test.afterAll(async () => {
 test.describe('Scripts with dependencies', () => {
 	test('refresh with HMR', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/script-dep'));
+		await waitForViteToSettle(page);
 
 		const h = page.locator('h1');
 		await expect(h, 'original text set').toHaveText('before');
@@ -44,6 +51,7 @@ test.describe('Scripts with dependencies', () => {
 test.describe('Styles', () => {
 	test('dependencies cause refresh with HMR', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/css-dep'));
+		await waitForViteToSettle(page);
 
 		page.once('load', throwPageShouldNotReload);
 
@@ -57,6 +65,7 @@ test.describe('Styles', () => {
 
 	test('external CSS refresh with HMR', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/css-external'));
+		await waitForViteToSettle(page);
 
 		page.once('load', throwPageShouldNotReload);
 
@@ -72,6 +81,7 @@ test.describe('Styles', () => {
 
 	test('inline styles refresh with HMR', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/css-inline'));
+		await waitForViteToSettle(page);
 
 		page.once('load', throwPageShouldNotReload);
 
@@ -86,6 +96,7 @@ test.describe('Styles', () => {
 
 	test('added style tag refresh with full-reload', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/css-inline-component'));
+		await waitForViteToSettle(page);
 
 		const h = page.locator('h1.title-with-no-color');
 		await expect(h).toHaveCSS('color', 'rgb(0, 0, 0)');
@@ -99,6 +110,7 @@ test.describe('Styles', () => {
 
 	test('multiple added style tags refresh with full-reload', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/css-inline-component'));
+		await waitForViteToSettle(page);
 
 		const h = page.locator('h1.title-with-color');
 		await expect(h).toHaveCSS('color', 'rgb(0, 0, 255)');
@@ -113,6 +125,7 @@ test.describe('Styles', () => {
 
 	test('removed style tag refresh with full-reload', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/css-inline-component'));
+		await waitForViteToSettle(page);
 
 		const h = page.locator('h1.title-with-color');
 		await expect(h).toHaveCSS('color', 'rgb(0, 0, 255)');

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -42,7 +42,10 @@ export default function hmrReload(): Plugin {
 				}
 
 				if (hasSsrOnlyModules) {
-					server.ws.send({ type: 'full-reload' });
+					server.environments.client.hot.send({
+						type: 'full-reload',
+						path: '*',
+					});
 					return [];
 				}
 			},

--- a/packages/astro/test/fixtures/vitest/vitest.config.js
+++ b/packages/astro/test/fixtures/vitest/vitest.config.js
@@ -1,4 +1,4 @@
-/// <reference types="vitest" />
+/// <reference types="vitest/config" />
 import { getViteConfig } from 'astro/config';
 
 export default getViteConfig({

--- a/packages/integrations/markdoc/test/propagated-assets.test.js
+++ b/packages/integrations/markdoc/test/propagated-assets.test.js
@@ -52,7 +52,7 @@ describe('Markdoc - propagated assets', () => {
 					assert.equal(links.length, 1);
 					styleContents = await fixture.readFile(links[0].href);
 				}
-				assert.equal(styleContents.includes('--color-base-purple: 269, 79%;'), true);
+				assert.match(styleContents, /--color-base-purple:\s*269,\s*79%;/);
 			});
 
 			it('[fails] Does not bleed styles to other page', async () => {


### PR DESCRIPTION
## Summary
- switch Vitest config references to `vitest/config` so the Vite 8/Vitest 4 examples and fixture type-check again
- route Astro's SSR-only full reloads through the client hot environment and let headless Chrome settle before HMR assertions
- relax the Markdoc propagated-assets assertion to match minified Vite 8 CSS output

## Validation
- `cd packages/astro && CI=1 bunx nve 22 pnpm exec playwright test e2e/astro-component.test.js e2e/hmr.test.js --project="Chrome Stable" --workers=1 --retries=0`
- `cd packages/integrations/markdoc && bunx nve 24.14.0 pnpm run test`

## Notes
- I couldn't fully rerun `test:check-examples` locally because this checkout's linked `@astrojs/check` workspace package is missing its language-tools build output, but the original CI failure there was the Vitest config typing error fixed in this patch.