### PR TITLE
fix(cloudflare): Workaround build and runtime 500

### DIFF
--- a/.changeset/whole-spies-exist.md
+++ b/.changeset/whole-spies-exist.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Adds workaround for build and runtime 500 because of `import.meta.url`.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -28,6 +28,7 @@
     "./image-passthrough-endpoint": "./dist/entrypoints/image-passthrough-endpoint.js",
     "./image-service-workerd": "./dist/entrypoints/image-service-workerd.js",
     "./handler": "./dist/utils/handler.js",
+    "./node-module-polyfill": "./dist/node-module-polyfill.js",
     "./types.d.ts": "./types.d.ts",
     "./package.json": "./package.json"
   },

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -302,6 +302,12 @@ export default function createIntegration({
 										conf.ssr.external = undefined;
 										conf.ssr.noExternal = true;
 									}
+									// Workaround for https://github.com/vitejs/vite/issues/21969
+									conf.resolve ||= {};
+									conf.resolve.alias = {
+										'module': '@astrojs/cloudflare/node-module-polyfill',
+										...conf.resolve.alias,
+									};
 								},
 							},
 							createConfigPlugin({

--- a/packages/integrations/cloudflare/src/node-module-polyfill.ts
+++ b/packages/integrations/cloudflare/src/node-module-polyfill.ts
@@ -1,0 +1,8 @@
+function require(_: unknown) {
+	throw new Error("Not supported");
+}
+require.resolve = () => { throw new Error("Not supported") };
+
+export function createRequire(_: unknown) {
+	return require;
+}


### PR DESCRIPTION
## Changes

The issue is caused by upstream, this patch only provides a workaround to prevent Astro projects from build failure and runtime 500 error (if it's a server) instead of actually fixing.

The issue happens because a piece of code from "fdir" uses `require()`, and it would be compiled to a call to the function returned by `createRequire(import.meta.url)`.  However, `import.meta.url` is undefined in workerd runtime.

    [ERROR] TypeError: The argument 'path' The argument must be a file URL object, a file URL string, or an absolute path string.. Received 'undefined'
        at createRequire (node:module:34:15)
        at .../dist/server/chunks/index_DJvu3f_r.mjs:11716:33

See also:
- https://github.com/vitejs/vite/issues/21969
- https://github.com/thecodrr/fdir/blob/790c182eb54809ea7bc14f1bcb40acce89506bb4/src/builder/index.ts#L17

Similar issues:
- https://github.com/better-auth/better-auth/issues/6690
- https://github.com/nitrojs/nitro/issues/4132

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

This is a workaround that is expected to be reverted after we use a fixed version of dependency.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

It doesn't add or change any documented behavior but makes it work as expected.