### PR TITLE
Teach the PR writer skill about changesets

### DIFF
--- a/.agents/skills/astro-pr-writer/SKILL.md
+++ b/.agents/skills/astro-pr-writer/SKILL.md
@@ -148,7 +148,7 @@ Adds logging for content collections configuration errors.
 Fixes a bug where the toolbar audit would incorrectly flag images as above the fold
 ```
 
-**New features (minor)** — start with "Adds", name the new API, and describe what users can now do. Include a code example when helpful:
+**New features (minor)** — start with "Adds", name the new API, and describe what users can now do. Include a code example when helpful. New features are also an opportunity to write a richer description that can feed into blog posts — see https://contribute.docs.astro.build/docs-for-code-changes/changesets/#new-features for guidance.
 
 ```md
 ---


### PR DESCRIPTION
## Changes

- Adds a `Changesets` section to the `astro-pr-writer` skill covering when changesets are required, file format, bump type rules, and CI restrictions on `major`/`minor` core bumps
- Documents the Astro changeset message writing conventions from https://contribute.docs.astro.build/docs-for-code-changes/changesets/ — verb-first present tense, user-facing framing, and type-specific guidance (patch, minor, breaking)
- Instructs agents to always write the changeset file manually rather than offering the interactive CLI wizard, which agents cannot use
- Adds a self-check item to verify a changeset exists before posting any package-modifying PR

## Testing

- Manual review of the updated skill content against the Astro contribution docs and the existing changeset files in the repo

## Docs

- No docs update needed; this change is to an agent skill, not user-facing Astro documentation.