### PR TITLE
Fix server islands returning 404 in Netlify production with output: static

### DIFF
--- a/.changeset/giant-islands-stare.md
+++ b/.changeset/giant-islands-stare.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/netlify": patch
+---
+
+Fixes server islands returning 404 in production when using `output: 'static'` (the default)

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -687,11 +687,9 @@ export default function netlifyIntegration(
 			'astro:routes:resolved': (params) => {
 				routes = params.routes;
 			},
-			'astro:config:done': async ({ config, setAdapter, buildOutput }) => {
-				rootDir = config.root;
-				_config = config;
-
-				finalBuildOutput = buildOutput;
+			'astro:config:done': async (params) => {
+				rootDir = params.config.root;
+				_config = params.config;
 
 				// Resolve middleware mode with backward compatibility
 				const middlewareMode =
@@ -699,7 +697,7 @@ export default function netlifyIntegration(
 					(integrationConfig?.edgeMiddleware ? 'edge' : 'classic');
 				const useStaticHeaders = integrationConfig?.staticHeaders ?? false;
 
-				setAdapter({
+				params.setAdapter({
 					name: '@astrojs/netlify',
 					entrypointResolution: 'auto',
 					serverEntrypoint: '@astrojs/netlify/ssr-function.js',
@@ -727,6 +725,11 @@ export default function netlifyIntegration(
 							: undefined,
 					},
 				});
+
+				// Read buildOutput AFTER setAdapter() so we get the value that setAdapter()
+				// may have updated. Destructuring before setAdapter() would capture a stale
+				// 'static' snapshot even when setAdapter() upgrades it to 'server'.
+				finalBuildOutput = params.buildOutput;
 			},
 			'astro:build:generated': ({ routeToHeaders }) => {
 				staticHeadersMap = routeToHeaders;

--- a/packages/integrations/netlify/test/static/static-headers.test.js
+++ b/packages/integrations/netlify/test/static/static-headers.test.js
@@ -1,4 +1,5 @@
 import * as assert from 'node:assert/strict';
+import { existsSync, readdirSync } from 'node:fs';
 import { before, describe, it } from 'node:test';
 import { loadFixture } from '../../../../astro/test/test-utils.js';
 
@@ -8,6 +9,15 @@ describe('Static headers', () => {
 	before(async () => {
 		fixture = await loadFixture({ root: new URL('./fixtures/static-headers/', import.meta.url) });
 		await fixture.build();
+	});
+
+	it('SSR function is generated when server islands are used with output: static', async () => {
+		const ssrFunctionDir = new URL(
+			'./fixtures/static-headers/.netlify/v1/functions/ssr/',
+			import.meta.url,
+		);
+		assert.ok(existsSync(ssrFunctionDir), 'SSR function directory should exist');
+		assert.ok(readdirSync(ssrFunctionDir).length > 0, 'SSR function directory should not be empty');
 	});
 
 	it('CSP headers are added when CSP is enabled', async () => {


### PR DESCRIPTION
## Changes

- Server Islands (`server:defer`) now work correctly in Netlify production deployments when using `output: 'static'` (the default). Previously the `/_server-islands/*` endpoint returned 404.
- The bug was in `astro:config:done`: `buildOutput` was destructured from the hook params before `setAdapter()` was called, capturing a stale `'static'` snapshot. Since `buildOutput` is a getter on `settings.buildOutput`, and `setAdapter()` upgrades it to `'server'`, the fix is to read `params.buildOutput` after `setAdapter()` rather than destructuring it upfront.

## Testing

- Added a regression test in `test/static/static-headers.test.js` that asserts the SSR function directory is created after building a `output: 'static'` project with a `server:defer` island — the exact scenario from the bug report.
- The existing `static-headers` fixture already had this setup, so no new fixture was needed.

## Docs

No docs update needed — this is a bug fix restoring already-documented behavior.

Closes #16049