### PR TITLE
Add agent skill: Vite dep optimizer debugging guide

### DIFF
--- a/.agents/skills/optimize-deps/SKILL.md
+++ b/.agents/skills/optimize-deps/SKILL.md
@@ -7,7 +7,7 @@ description: Deep reference on Vite's dep optimizer (optimizeDeps) as it applies
 
 ## Why this matters
 
-`astro build` uses Rollup/Rolldown and handles CJS→ESM transformation reliably. `astro dev` uses Vite's dev server, which serves modules individually and relies on esbuild's **dep optimizer** to pre-bundle certain dependencies as ESM before they reach the runtime. When a dep bypasses the optimizer — especially with ESM-only runtimes like Cloudflare Workers (workerd) — you get errors like `require is not defined` at runtime in dev, even though the build works fine.
+`astro build` uses Rollup and handles CJS→ESM transformation reliably. `astro dev` uses Vite 7's dev server, which serves modules individually and relies on esbuild's **dep optimizer** to pre-bundle certain dependencies as ESM before they reach the runtime. When a dep bypasses the optimizer — especially with ESM-only runtimes like Cloudflare Workers (workerd) — you get errors like `require is not defined` at runtime in dev, even though the build works fine.
 
 This is a category of subtle bugs. There is rarely one definitive fix — the right approach depends on _why_ the dep was missed by the optimizer.
 


### PR DESCRIPTION
## Changes

- Adds a new agent skill at `.agents/skills/optimize-deps/SKILL.md` documenting tribal knowledge about Vite's dep optimizer as it applies to the Astro dev server.
- Covers how `optimizeDeps` works (scan phase vs bundle phase), why non-JS files like `.astro` require special handling, the roles of `vitefu`, `vite-plugin-environment`, and `astroFrontmatterScanPlugin`, and a debugging playbook with logging techniques and potential fix patterns.

## Testing

- No code changes — this is documentation/tooling only.

## Docs

- This IS the docs. No other changes needed.