### PR TITLE
Stop emitFile() from running in dev mode in the astro:scripts plugin

### DIFF
--- a/.changeset/fix-emit-file-serve-mode-warning.md
+++ b/.changeset/fix-emit-file-serve-mode-warning.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a spurious Vite warning about `emitFile()` not being supported in serve mode during `astro dev`

--- a/packages/astro/src/vite-plugin-scripts/index.ts
+++ b/packages/astro/src/vite-plugin-scripts/index.ts
@@ -14,8 +14,13 @@ export const PAGE_SCRIPT_ID = `${SCRIPT_ID_PREFIX}${'page' as InjectedScriptStag
 export const PAGE_SSR_SCRIPT_ID = `${SCRIPT_ID_PREFIX}${'page-ssr' as InjectedScriptStage}.js`;
 
 export default function astroScriptsPlugin({ settings }: { settings: AstroSettings }): VitePlugin {
+	let isBuild = false;
 	return {
 		name: 'astro:scripts',
+
+		config(_config, env) {
+			isBuild = env.command === 'build';
+		},
 
 		resolveId: {
 			filter: {
@@ -58,6 +63,7 @@ export default function astroScriptsPlugin({ settings }: { settings: AstroSettin
 			},
 		},
 		buildStart() {
+			if (!isBuild) return;
 			const hasHydrationScripts = settings.scripts.some((s) => s.stage === 'before-hydration');
 			if (
 				hasHydrationScripts &&


### PR DESCRIPTION
## Changes

- Fixes a spurious Vite warning (`context method emitFile() is not supported in serve mode`) that appeared during `astro dev` for any project using `@astrojs/react` or any other integration that injects `before-hydration` scripts.
- The `buildStart()` hook in `vite-plugin-scripts` was calling `this.emitFile()` unconditionally. Since `emitFile()` is a Rollup build-time API, Vite stubs it out in serve mode and logs a warning. The fix adds a guard so the hook returns early when `this.environment.mode !== 'build'`.
- The `emitFile()` call is only needed during production builds — in dev mode, the before-hydration script is resolved on-demand through Vite's module graph.

## Testing

- Regression introduced by #15904. The warning affects any project with `@astrojs/react` (or any integration injecting before-hydration scripts) on Astro 6.0.5+.
- Verified that the build still works correctly and the `before-hydration` script chunk is still emitted during `astro build`.

## Docs

- No docs update needed; this is a purely internal fix with no user-facing API changes.

Closes #16026