### PR TITLE
chores(transitions): replace deprecated constants with string literals

### DIFF
--- a/packages/astro/src/transitions/events.ts
+++ b/packages/astro/src/transitions/events.ts
@@ -12,12 +12,9 @@ export const TRANSITION_AFTER_SWAP = 'astro:after-swap';
 /** @deprecated This will be removed in Astro 7 */
 export const TRANSITION_PAGE_LOAD = 'astro:page-load';
 
-type Events =
-	| typeof TRANSITION_AFTER_PREPARATION
-	| typeof TRANSITION_AFTER_SWAP
-	| typeof TRANSITION_PAGE_LOAD;
+type Events = 'astro:after-preparation' | 'astro:after-swap' | 'astro:page-load';
 export const triggerEvent = (name: Events) => document.dispatchEvent(new Event(name));
-export const onPageLoad = () => triggerEvent(TRANSITION_PAGE_LOAD);
+export const onPageLoad = () => triggerEvent('astro:page-load');
 
 /*
  * Common stuff
@@ -91,7 +88,7 @@ export class TransitionBeforePreparationEvent extends BeforeEvent {
 		loader: (event: TransitionBeforePreparationEvent) => Promise<void>,
 	) {
 		super(
-			TRANSITION_BEFORE_PREPARATION,
+			'astro:before-preparation',
 			{ cancelable: true },
 			from,
 			to,
@@ -116,7 +113,7 @@ export class TransitionBeforePreparationEvent extends BeforeEvent {
  */
 /** @deprecated This will be removed in Astro 7 */
 export const isTransitionBeforeSwapEvent = (value: any): value is TransitionBeforeSwapEvent =>
-	value.type === TRANSITION_BEFORE_SWAP;
+	value.type === 'astro:before-swap';
 export class TransitionBeforeSwapEvent extends BeforeEvent {
 	readonly direction: Direction | string;
 	readonly viewTransition: ViewTransition;
@@ -124,7 +121,7 @@ export class TransitionBeforeSwapEvent extends BeforeEvent {
 
 	constructor(afterPreparation: BeforeEvent, viewTransition: ViewTransition) {
 		super(
-			TRANSITION_BEFORE_SWAP,
+			'astro:before-swap',
 			undefined,
 			afterPreparation.from,
 			afterPreparation.to,
@@ -173,7 +170,7 @@ export async function doPreparation(
 	if (document.dispatchEvent(event)) {
 		await event.loader();
 		if (!event.defaultPrevented) {
-			triggerEvent(TRANSITION_AFTER_PREPARATION);
+			triggerEvent('astro:after-preparation');
 			if (event.navigationType !== 'traverse') {
 				// save the current scroll position before we change the DOM and transition to the new page
 				updateScrollPosition({ scrollX, scrollY });

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -1,13 +1,7 @@
 import { internalFetchHeaders } from 'virtual:astro:adapter-config/client';
 import type { TransitionBeforePreparationEvent } from './events.js';
-import {
-	doPreparation,
-	doSwap,
-	TRANSITION_AFTER_SWAP,
-	onPageLoad,
-	triggerEvent,
-	updateScrollPosition,
-} from './events.js';
+
+import { doPreparation, doSwap, onPageLoad, triggerEvent, updateScrollPosition } from './events.js';
 import { detectScriptExecuted } from './swap-functions.js';
 import type { Direction, Fallback, Options } from './types.js';
 
@@ -319,7 +313,7 @@ async function updateDOM(
 		animateFallbackOld,
 	);
 	moveToLocation(swapEvent.to, swapEvent.from, options, pageTitleForBrowserHistory, historyState);
-	triggerEvent(TRANSITION_AFTER_SWAP);
+	triggerEvent('astro:after-swap');
 
 	// Resolve the finished promise of the simulation's ViewTransition.
 	// For 'animate', wait for the new-page animation to complete first.


### PR DESCRIPTION
## Changes

With Astro v6, we deprecated constants for event names.
The client router code itself was still using those.
This change replaces them with their string literals.

## Testing

covered by existing tests

## Docs

n.a. internal refactor.
