### PR TITLE
fix(vercel): Fix ISR path rewrite to prevent 404

### DIFF
--- a/.changeset/common-cats-travel.md
+++ b/.changeset/common-cats-travel.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix vercel ISR path rewrite

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -3,6 +3,7 @@ import {
 	ASTRO_LOCALS_HEADER,
 	ASTRO_MIDDLEWARE_SECRET_HEADER,
 	ASTRO_PATH_HEADER,
+	ASTRO_PATH_PARAM,
 } from '../index.js';
 import { middlewareSecret, skewProtection } from 'virtual:astro-vercel:config';
 import { createApp } from 'astro/app/entrypoint';
@@ -17,7 +18,12 @@ export default {
 		const url = new URL(request.url);
 		const middlewareSecretHeader = request.headers.get(ASTRO_MIDDLEWARE_SECRET_HEADER);
 		const hasValidMiddlewareSecret = middlewareSecretHeader === middlewareSecret;
-		const realPath = hasValidMiddlewareSecret ? request.headers.get(ASTRO_PATH_HEADER) : null;
+		let realPath = undefined;
+		if(hasValidMiddlewareSecret) {
+			realPath = request.headers.get(ASTRO_PATH_HEADER)
+		} else if(request.headers.get('x-vercel-isr') === '1') {
+			realPath = url.searchParams.get(ASTRO_PATH_PARAM);
+		}
 		if (typeof realPath === 'string') {
 			url.pathname = realPath;
 			request = new Request(url.toString(), {


### PR DESCRIPTION
## Changes

Fix a bug which prevented pages from being served by ISR by the vercel adapter.

[This PR](https://github.com/withastro/astro/pull/15959) introduced a bug with the vercel adaptor which made any route served by ISR result in a 404. This is due to an intricacy with how vercel ISR works, in that we need to change the request path when serving an ISR path. This was noticed by [a commenter](github.com/withastro/astro/pull/15959#issuecomment-4103539941) in the PR.

## Testing

No additional test cases added. Manual e2e tests performed on [a test vercel project](https://isr-with-query-i5fzjrhph-epoulter-uclanacuks-projects.vercel.app/one) (note this includes other code from another PR I am working on, but the upshot is that it is a ISR page, which does not 404, as opposed to [an earlier deployment without this fix](https://isr-with-query-4jzt20i06-epoulter-uclanacuks-projects.vercel.app/one) which does 404).

## Docs

No docs needed as a bug fix for internal adapter logic
