### PR TITLE
Skip emitFile() in astro:scripts plugin during serve mode

### DIFF
--- a/.changeset/fix-emitfile-serve-warning.md
+++ b/.changeset/fix-emitfile-serve-warning.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the `emitFile() is not supported in serve mode` warning that appears during `astro dev` when using integrations that inject before-hydration scripts (e.g. `@astrojs/react`)

--- a/packages/astro/src/vite-plugin-scripts/index.ts
+++ b/packages/astro/src/vite-plugin-scripts/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin as VitePlugin } from 'vite';
+import type { Plugin as VitePlugin, ConfigEnv } from 'vite';
 import type { AstroSettings } from '../types/astro.js';
 import type { InjectedScriptStage } from '../types/public/integrations.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
@@ -14,8 +14,12 @@ export const PAGE_SCRIPT_ID = `${SCRIPT_ID_PREFIX}${'page' as InjectedScriptStag
 export const PAGE_SSR_SCRIPT_ID = `${SCRIPT_ID_PREFIX}${'page-ssr' as InjectedScriptStage}.js`;
 
 export default function astroScriptsPlugin({ settings }: { settings: AstroSettings }): VitePlugin {
+	let command: 'build' | 'serve';
 	return {
 		name: 'astro:scripts',
+		config(_: any, env: ConfigEnv) {
+			command = env.command;
+		},
 
 		resolveId: {
 			filter: {
@@ -58,6 +62,7 @@ export default function astroScriptsPlugin({ settings }: { settings: AstroSettin
 			},
 		},
 		buildStart() {
+			if (command === 'serve') return;
 			const hasHydrationScripts = settings.scripts.some((s) => s.stage === 'before-hydration');
 			if (
 				hasHydrationScripts &&


### PR DESCRIPTION
## Changes

- Guards the `buildStart` hook in the `astro:scripts` Vite plugin to skip `this.emitFile()` when Vite is running in serve mode (`astro dev`).
- `emitFile()` is a Rollup build-time API that Vite stubs out during dev, producing a spurious warning:
  ```
  [WARN] [vite] [plugin:astro:scripts] context method emitFile() is not supported in serve mode.
  ```
- The fix captures the Vite command via the `config` hook and returns early from `buildStart` when `command === 'serve'`. The `emitFile()` call still runs during `build` as intended, ensuring before-hydration script chunks are correctly emitted for production builds.

Closes #16026
Closes #15975

## Testing

- **`before-hydration.test.js`** — All 7 tests pass, covering both SSG and SSR scenarios, in dev and build modes, with and without hydration scripts injected by integrations. This validates that the before-hydration chunk is still correctly emitted during builds while the warning is suppressed during dev.
- **`astro-scripts.test.js`** — All 11 tests pass, covering script rendering, hoisting, inlining, and `injectScript` in both dev and build modes.

## Docs

- No docs update needed — this is a bug fix removing a spurious warning, with no change to user-facing APIs or behavior.