### PR TITLE
Preserve RegExp flags during client component prop serialization

### DIFF
--- a/.changeset/fix-regexp-flags-serialization.md
+++ b/.changeset/fix-regexp-flags-serialization.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes RegExp flags being lost when serializing component props for client-side hydration

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -14,13 +14,13 @@ declare const Astro: {
 
 {
 	interface PropTypeSelector {
-		[k: string]: (value: any) => any;
+		[k: string]: (value: any, extra?: any) => any;
 	}
 
 	const propTypes: PropTypeSelector = {
 		0: (value) => reviveObject(value),
 		1: (value) => reviveArray(value),
-		2: (value) => new RegExp(value),
+		2: (value, flags) => new RegExp(value, flags),
 		3: (value) => new Date(value),
 		4: (value) => new Map(reviveArray(value)),
 		5: (value) => new Set(reviveArray(value)),
@@ -35,7 +35,7 @@ declare const Astro: {
 	// Not using JSON.parse reviver because it's bottom-up but we want top-down
 	const reviveTuple = (raw: any): any => {
 		const [type, value] = raw;
-		return type in propTypes ? propTypes[type](value) : undefined;
+		return type in propTypes ? propTypes[type](value, raw[2]) : undefined;
 	};
 
 	const reviveArray = (raw: any): any => (raw as Array<any>).map(reviveTuple);

--- a/packages/astro/src/runtime/server/serialize.ts
+++ b/packages/astro/src/runtime/server/serialize.ts
@@ -58,14 +58,14 @@ function convertToSerializedForm(
 	value: any,
 	metadata: AstroComponentMetadata | Record<string, any> = {},
 	parents = new WeakSet<any>(),
-): [ValueOf<typeof PROP_TYPE>, any] | [ValueOf<typeof PROP_TYPE>] {
+): [ValueOf<typeof PROP_TYPE>, any] | [ValueOf<typeof PROP_TYPE>] | [ValueOf<typeof PROP_TYPE>, any, any] {
 	const tag = Object.prototype.toString.call(value);
 	switch (tag) {
 		case '[object Date]': {
 			return [PROP_TYPE.Date, (value as Date).toISOString()];
 		}
 		case '[object RegExp]': {
-			return [PROP_TYPE.RegExp, (value as RegExp).source];
+			return [PROP_TYPE.RegExp, (value as RegExp).source, (value as RegExp).flags];
 		}
 		case '[object Map]': {
 			return [PROP_TYPE.Map, serializeArray(Array.from(value as Map<any, any>), metadata, parents)];

--- a/packages/astro/test/serialize.test.js
+++ b/packages/astro/test/serialize.test.js
@@ -45,8 +45,8 @@ describe('serialize', () => {
 		assert.equal(serializeProps(input), output);
 	});
 	it('serializes a regular expression', () => {
-		const input = { a: /b/ };
-		const output = `{"a":[2,"b"]}`;
+		const input = { a: /b/gi };
+		const output = `{"a":[2,"b","gi"]}`;
 		assert.equal(serializeProps(input), output);
 	});
 	it('serializes a Date', () => {


### PR DESCRIPTION
## Changes

- RegExp flags (e.g. `g`, `i`, `m`, `s`) were silently dropped when passing RegExp props to client-hydrated components. A regex like `/pattern/gi` would be deserialized as `/pattern/` on the client, producing incorrect matching behavior.
- The serialized form now includes `.flags` alongside `.source` in the tuple: `[PROP_TYPE.RegExp, source, flags]`. On the client, the `astro-island` deserializer passes flags to `new RegExp(value, flags)`.
- This change is backwards-compatible: old serialized data without a flags element passes `undefined` as the flags argument, which `new RegExp(source, undefined)` handles identically to `new RegExp(source)`.

## Testing

- Updated the existing "serializes a regular expression" unit test in `serialize.test.js` to use a regex with flags (`/b/gi`) and verify flags appear in the serialized output (`[2,"b","gi"]`).
- All 22 serialize tests pass.

## Docs

- No docs update needed — this is a bug fix with no new API surface.