### PR TITLE
test: strengthen test coverage

### DIFF
--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -134,28 +134,30 @@ function createContext({
  * A serializable value contains plain values. For example, `Proxy`, `Set`, `Map`, functions, etc.
  * are not accepted because they can't be serialized.
  */
-function isLocalsSerializable(value: unknown): boolean {
-	let type = typeof value;
-	let plainObject = true;
-	if (type === 'object' && isPlainObject(value)) {
-		for (const [, nestedValue] of Object.entries(value)) {
-			if (!isLocalsSerializable(nestedValue)) {
-				plainObject = false;
-				break;
-			}
-		}
-	} else {
-		plainObject = false;
-	}
-	let result =
-		value === null ||
-		type === 'string' ||
-		type === 'number' ||
-		type === 'boolean' ||
-		Array.isArray(value) ||
-		plainObject;
+export function isLocalsSerializable(value: unknown): boolean {
+	const stack: unknown[] = [value];
+	while (stack.length > 0) {
+		const current = stack.pop();
+		const type = typeof current;
 
-	return result;
+		if (current === null || type === 'string' || type === 'number' || type === 'boolean') {
+			continue;
+		}
+
+		if (Array.isArray(current)) {
+			stack.push(...current);
+			continue;
+		}
+
+		if (type === 'object' && isPlainObject(current)) {
+			stack.push(...Object.values(current as Record<string, unknown>));
+			continue;
+		}
+
+		// Any other type (Date, Map, Set, class instance, function, …) is not serializable.
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/packages/astro/test/units/actions/action-status.test.js
+++ b/packages/astro/test/units/actions/action-status.test.js
@@ -1,0 +1,84 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createComponent, render } from '../../../dist/runtime/server/index.js';
+import { serializeActionResult } from '../../../dist/actions/runtime/server.js';
+import { createTestApp, createPage } from '../mocks.js';
+
+// Build locals with an _actionPayload to simulate an action having run.
+// Mirrors the shape of ActionsLocals from src/actions/runtime/types.ts.
+// We use serializeActionResult from the server runtime to produce
+// properly-formatted payloads that deserializeActionResult can parse.
+
+// Minimal ActionError-compatible object — ActionError class is not exported from
+// the dist client bundle so we construct the shape it expects directly.
+function makeActionError(code, message = 'test error') {
+	const codeToStatus = {
+		BAD_REQUEST: 400,
+		UNPROCESSABLE_CONTENT: 422,
+		NOT_FOUND: 404,
+		UNAUTHORIZED: 401,
+		FORBIDDEN: 403,
+		INTERNAL_SERVER_ERROR: 500,
+	};
+	return { type: 'AstroActionError', code, message, status: codeToStatus[code] ?? 500 };
+}
+
+function makeLocalsWithError(code) {
+	const actionResult = serializeActionResult({ error: makeActionError(code), data: undefined });
+	return { _actionPayload: { actionName: 'testAction', actionResult } };
+}
+
+function makeLocalsWithData(data = null) {
+	const actionResult = serializeActionResult({ data, error: undefined });
+	return { _actionPayload: { actionName: 'testAction', actionResult } };
+}
+
+describe('action result status computation', () => {
+	it('uses default status when no action payload is present', async () => {
+		let capturedStatus;
+		const page = createComponent((result, props, slots) => {
+			const Astro = result.createAstro(props, slots);
+			capturedStatus = Astro.response.status;
+			return render`<p>ok</p>`;
+		});
+
+		const app = createTestApp([createPage(page, { route: '/test', prerender: false })]);
+		await app.render(new Request('http://example.com/test'));
+
+		assert.equal(capturedStatus, 200);
+	});
+
+	it('uses the error status code when an action error result is in locals', async () => {
+		let capturedStatus;
+		const page = createComponent((result, props, slots) => {
+			const Astro = result.createAstro(props, slots);
+			capturedStatus = Astro.response.status;
+			return render`<p>ok</p>`;
+		});
+
+		const app = createTestApp([createPage(page, { route: '/test', prerender: false })]);
+		const request = new Request('http://example.com/test');
+
+		// Simulate middleware having set the action payload on locals
+		await app.render(request, { locals: makeLocalsWithError('UNPROCESSABLE_CONTENT') });
+
+		assert.equal(capturedStatus, 422);
+	});
+
+	it('uses default status for a successful action data result', async () => {
+		let capturedStatus;
+		const page = createComponent((result, props, slots) => {
+			const Astro = result.createAstro(props, slots);
+			capturedStatus = Astro.response.status;
+			return render`<p>ok</p>`;
+		});
+
+		const app = createTestApp([createPage(page, { route: '/test', prerender: false })]);
+		const request = new Request('http://example.com/test');
+
+		await app.render(request, { locals: makeLocalsWithData() });
+
+		assert.equal(capturedStatus, 200);
+	});
+});

--- a/packages/astro/test/units/app/test-helpers.js
+++ b/packages/astro/test/units/app/test-helpers.js
@@ -20,6 +20,8 @@ export function createManifest({
 	actions = undefined,
 	actionBodySizeLimit = 0,
 	i18n = undefined,
+	csp = undefined,
+	serverLike = true,
 } = {}) {
 	const rootDir = new URL('file:///astro-test/');
 	const buildDir = new URL('file:///astro-test/dist/');
@@ -35,7 +37,7 @@ export function createManifest({
 		compressHTML: false,
 		assetsPrefix: undefined,
 		renderers: [],
-		serverLike: true,
+		serverLike,
 		middlewareMode: /** @type {'classic'} */ ('classic'),
 		clientDirectives: new Map(),
 		entryModules: {},
@@ -63,7 +65,7 @@ export function createManifest({
 		assetsDir: 'assets',
 		buildClientDir: buildDir,
 		buildServerDir: buildDir,
-		csp: undefined,
+		csp,
 		image: {},
 		shouldInjectCspMetaTags: false,
 		devToolbar: {

--- a/packages/astro/test/units/cookies/merge.test.js
+++ b/packages/astro/test/units/cookies/merge.test.js
@@ -1,0 +1,105 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { AstroCookies } from '../../../dist/core/cookies/index.js';
+import {
+	attachCookiesToResponse,
+	getSetCookiesFromResponse,
+} from '../../../dist/core/cookies/response.js';
+
+const req = () => new Request('http://example.com/');
+
+describe('AstroCookies.merge()', () => {
+	it('copies all cookies from source into an empty target', () => {
+		const source = new AstroCookies(req());
+		source.set('foo', 'bar');
+		source.set('baz', 'qux');
+
+		const target = new AstroCookies(req());
+		target.merge(source);
+
+		const headers = Array.from(target.headers());
+		assert.equal(headers.length, 2);
+		assert.ok(headers.some((h) => h.startsWith('foo=')));
+		assert.ok(headers.some((h) => h.startsWith('baz=')));
+	});
+
+	it('overwrites same-key cookies in target', () => {
+		const source = new AstroCookies(req());
+		source.set('foo', 'new');
+
+		const target = new AstroCookies(req());
+		target.set('foo', 'old');
+		target.merge(source);
+
+		const headers = Array.from(target.headers());
+		assert.equal(headers.length, 1);
+		assert.ok(headers[0].startsWith('foo=new'));
+	});
+
+	it('preserves non-conflicting keys from target', () => {
+		const source = new AstroCookies(req());
+		source.set('a', '1');
+
+		const target = new AstroCookies(req());
+		target.set('b', '2');
+		target.merge(source);
+
+		const headers = Array.from(target.headers());
+		assert.equal(headers.length, 2);
+		assert.ok(headers.some((h) => h.startsWith('a=')));
+		assert.ok(headers.some((h) => h.startsWith('b=')));
+	});
+
+	it('is a no-op when source has no outgoing cookies', () => {
+		const source = new AstroCookies(req()); // no set() calls
+
+		const target = new AstroCookies(req());
+		target.set('foo', 'bar');
+		target.merge(source);
+
+		const headers = Array.from(target.headers());
+		assert.equal(headers.length, 1);
+		assert.ok(headers[0].startsWith('foo='));
+	});
+});
+
+describe('AstroCookies.headers()', () => {
+	it('yields nothing when no cookies have been set', () => {
+		const cookies = new AstroCookies(req());
+		const headers = Array.from(cookies.headers());
+		assert.equal(headers.length, 0);
+	});
+
+	it('yields one header string per set cookie', () => {
+		const cookies = new AstroCookies(req());
+		cookies.set('a', '1');
+		cookies.set('b', '2');
+		cookies.set('c', '3');
+
+		const headers = Array.from(cookies.headers());
+		assert.equal(headers.length, 3);
+	});
+});
+
+describe('attachCookiesToResponse + getSetCookiesFromResponse', () => {
+	it('roundtrip: attached cookies are readable from the response', () => {
+		const cookies = new AstroCookies(req());
+		cookies.set('session', 'abc');
+		cookies.set('theme', 'dark');
+
+		const response = new Response(null);
+		attachCookiesToResponse(response, cookies);
+
+		const setCookies = Array.from(getSetCookiesFromResponse(response));
+		assert.equal(setCookies.length, 2);
+		assert.ok(setCookies.some((h) => h.startsWith('session=')));
+		assert.ok(setCookies.some((h) => h.startsWith('theme=')));
+	});
+
+	it('getSetCookiesFromResponse returns empty when no cookies attached', () => {
+		const response = new Response(null);
+		const setCookies = Array.from(getSetCookiesFromResponse(response));
+		assert.equal(setCookies.length, 0);
+	});
+});

--- a/packages/astro/test/units/middleware/locals.test.js
+++ b/packages/astro/test/units/middleware/locals.test.js
@@ -1,0 +1,80 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isLocalsSerializable, trySerializeLocals } from '../../../dist/core/middleware/index.js';
+
+describe('isLocalsSerializable', () => {
+	it('returns true for null', () => {
+		assert.equal(isLocalsSerializable(null), true);
+	});
+
+	it('returns true for string', () => {
+		assert.equal(isLocalsSerializable('hello'), true);
+	});
+
+	it('returns true for number', () => {
+		assert.equal(isLocalsSerializable(42), true);
+	});
+
+	it('returns true for boolean', () => {
+		assert.equal(isLocalsSerializable(true), true);
+		assert.equal(isLocalsSerializable(false), true);
+	});
+
+	it('returns true for a plain object', () => {
+		assert.equal(isLocalsSerializable({ a: 1, b: 'two' }), true);
+	});
+
+	it('returns true for a nested plain object', () => {
+		assert.equal(isLocalsSerializable({ a: { b: { c: 3 } } }), true);
+	});
+
+	it('returns true for an array', () => {
+		assert.equal(isLocalsSerializable([1, 'two', null]), true);
+	});
+
+	it('returns false for a Date', () => {
+		assert.equal(isLocalsSerializable(new Date()), false);
+	});
+
+	it('returns false for a Map', () => {
+		assert.equal(isLocalsSerializable(new Map()), false);
+	});
+
+	it('returns false for a Set', () => {
+		assert.equal(isLocalsSerializable(new Set()), false);
+	});
+
+	it('returns false for a class instance', () => {
+		class Foo {}
+		assert.equal(isLocalsSerializable(new Foo()), false);
+	});
+
+	it('returns false for a plain object containing a non-serializable value', () => {
+		assert.equal(isLocalsSerializable({ date: new Date() }), false);
+	});
+
+	it('handles deeply nested objects without stack overflow (iterative implementation)', () => {
+		// Build a 10,000-level deep object — would overflow the call stack with recursion
+		let deep = /** @type {any} */ ({});
+		let current = deep;
+		for (let i = 0; i < 10_000; i++) {
+			current.child = {};
+			current = current.child;
+		}
+		current.value = 'leaf';
+		assert.equal(isLocalsSerializable(deep), true);
+	});
+});
+
+describe('trySerializeLocals', () => {
+	it('returns a JSON string for a serializable object', () => {
+		const result = trySerializeLocals({ user: 'alice', count: 3 });
+		assert.equal(typeof result, 'string');
+		assert.deepEqual(JSON.parse(result), { user: 'alice', count: 3 });
+	});
+
+	it('throws for a non-serializable value', () => {
+		assert.throws(() => trySerializeLocals({ date: new Date() }), /serialized/i);
+	});
+});

--- a/packages/astro/test/units/render/context-helpers.test.js
+++ b/packages/astro/test/units/render/context-helpers.test.js
@@ -1,0 +1,73 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createComponent, render } from '../../../dist/runtime/server/index.js';
+import { createTestApp, createPage } from '../mocks.js';
+
+async function renderAndCapture(page, manifestOverrides = {}) {
+	const app = createTestApp(
+		[createPage(page, { route: '/test', prerender: false })],
+		manifestOverrides,
+	);
+	const response = await app.render(new Request('http://example.com/test'));
+	return response;
+}
+
+describe('Astro.session getter', () => {
+	it('returns undefined when no session driver is configured', async () => {
+		let sessionValue = 'not-called';
+		const page = createComponent((result, props, slots) => {
+			const Astro = result.createAstro(props, slots);
+			sessionValue = Astro.session;
+			return render`<p>done</p>`;
+		});
+
+		await renderAndCapture(page);
+
+		assert.equal(sessionValue, undefined);
+	});
+});
+
+describe('Astro.csp getter', () => {
+	it('returns undefined when CSP is not configured in the manifest', async () => {
+		let cspValue = 'not-called';
+		const page = createComponent((result, props, slots) => {
+			const Astro = result.createAstro(props, slots);
+			cspValue = Astro.csp;
+			return render`<p>done</p>`;
+		});
+
+		await renderAndCapture(page);
+
+		assert.equal(cspValue, undefined);
+	});
+
+	it('returns an object with insert* methods when CSP is configured', async () => {
+		let cspValue;
+		const page = createComponent((result, props, slots) => {
+			const Astro = result.createAstro(props, slots);
+			cspValue = Astro.csp;
+			return render`<p>done</p>`;
+		});
+
+		await renderAndCapture(page, {
+			csp: {
+				algorithm: 'SHA-256',
+				cspDestination: 'header',
+				scriptHashes: [],
+				styleHashes: [],
+				scriptResources: [],
+				styleResources: [],
+				directives: [],
+				isStrictDynamic: false,
+			},
+		});
+
+		assert.ok(cspValue !== undefined, 'expected csp object when CSP is configured');
+		assert.equal(typeof cspValue.insertScriptHash, 'function');
+		assert.equal(typeof cspValue.insertStyleHash, 'function');
+		assert.equal(typeof cspValue.insertScriptResource, 'function');
+		assert.equal(typeof cspValue.insertStyleResource, 'function');
+		assert.equal(typeof cspValue.insertDirective, 'function');
+	});
+});

--- a/packages/astro/test/units/routing/rewrite-validation.test.js
+++ b/packages/astro/test/units/routing/rewrite-validation.test.js
@@ -1,0 +1,113 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { createComponent, render } from '../../../dist/runtime/server/index.js';
+import { sequence } from '../../../dist/core/middleware/index.js';
+import { createTestApp, createPage } from '../mocks.js';
+
+function rewriteTo(target) {
+	return createComponent((result, props, slots) => {
+		const Astro = result.createAstro(props, slots);
+		return Astro.rewrite(target);
+	});
+}
+
+const targetPage = createComponent(() => render`<h1>Target</h1>`);
+const custom500 = createComponent(() => render`<h1>ForbiddenRewrite</h1>`);
+
+describe('SSR-to-prerendered rewrite validation — via Astro.rewrite() (#executeRewrite)', () => {
+	it('returns 500 when SSR source rewrites to a prerendered target', async () => {
+		// serverLike=true (default), source prerender=false, target prerender=true → ForbiddenRewrite
+		const app = createTestApp([
+			createPage(rewriteTo('/prerendered'), { route: '/ssr', prerender: false }),
+			createPage(targetPage, { route: '/prerendered', prerender: true }),
+			createPage(custom500, { route: '/500', component: '500.astro' }),
+		]);
+		const res = await app.render(new Request('http://example.com/ssr'));
+		assert.equal(res.status, 500);
+		const $ = cheerio.load(await res.text());
+		// App renders the custom 500 page when an AstroError is thrown
+		assert.equal($('h1').text(), 'ForbiddenRewrite');
+	});
+
+	it('succeeds when SSR source rewrites to an SSR target', async () => {
+		// Both SSR → no ForbiddenRewrite
+		const app = createTestApp([
+			createPage(rewriteTo('/target'), { route: '/source', prerender: false }),
+			createPage(targetPage, { route: '/target', prerender: false }),
+		]);
+		const res = await app.render(new Request('http://example.com/source'));
+		assert.equal(res.status, 200);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('h1').text(), 'Target');
+	});
+
+	it('succeeds when manifest.serverLike is false (static-only build)', async () => {
+		// serverLike=false → ForbiddenRewrite condition never fires, even SSR→prerendered is allowed
+		const app = createTestApp(
+			[
+				createPage(rewriteTo('/target'), { route: '/source', prerender: false }),
+				createPage(targetPage, { route: '/target', prerender: false }),
+			],
+			{ serverLike: false },
+		);
+		const res = await app.render(new Request('http://example.com/source'));
+		assert.equal(res.status, 200);
+	});
+});
+
+describe('SSR-to-prerendered rewrite validation — via sequence()', () => {
+	it('returns 500 when chained middleware via sequence() rewrites from SSR to prerendered', async () => {
+		const firstMiddleware = async (_ctx, next) => next();
+		const secondMiddleware = async (ctx, next) => {
+			if (ctx.url.pathname === '/ssr') {
+				return ctx.rewrite('/prerendered');
+			}
+			return next();
+		};
+
+		const app = createTestApp(
+			[
+				createPage(
+					createComponent(() => render`<h1>SSR</h1>`),
+					{ route: '/ssr', prerender: false },
+				),
+				createPage(targetPage, { route: '/prerendered', prerender: true }),
+				createPage(custom500, { route: '/500', component: '500.astro' }),
+			],
+			{ middleware: () => ({ onRequest: sequence(firstMiddleware, secondMiddleware) }) },
+		);
+
+		const res = await app.render(new Request('http://example.com/ssr'));
+		assert.equal(res.status, 500);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('h1').text(), 'ForbiddenRewrite');
+	});
+
+	it('succeeds when chained middleware via sequence() rewrites from SSR to SSR', async () => {
+		const firstMiddleware = async (_ctx, next) => next();
+		const secondMiddleware = async (ctx, next) => {
+			if (ctx.url.pathname === '/source') {
+				return ctx.rewrite('/target');
+			}
+			return next();
+		};
+
+		const app = createTestApp(
+			[
+				createPage(
+					createComponent(() => render`<h1>Source</h1>`),
+					{ route: '/source', prerender: false },
+				),
+				createPage(targetPage, { route: '/target', prerender: false }),
+			],
+			{ middleware: () => ({ onRequest: sequence(firstMiddleware, secondMiddleware) }) },
+		);
+
+		const res = await app.render(new Request('http://example.com/source'));
+		assert.equal(res.status, 200);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('h1').text(), 'Target');
+	});
+});


### PR DESCRIPTION
## Changes

This PR adds more unit tests to some functions that didn't have any coverage.

It also refactors `isLocalsSerializable` to use a stack-based approach. I applied the refactor **after** I added the tests.

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
