### PR TITLE
fix(astro-check): improve watch mode resilience for extensionless root files

### DIFF
--- a/packages/language-tools/astro-check/src/index.ts
+++ b/packages/language-tools/astro-check/src/index.ts
@@ -7,6 +7,36 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { options } from './options.js';
 
+const DEFAULT_WATCH_EXTENSIONS = [
+	'.astro',
+	'.ts',
+	'.tsx',
+	'.js',
+	'.jsx',
+	'.mjs',
+	'.cjs',
+	'.mts',
+	'.cts',
+	'.json',
+];
+
+export function resolveWatchExtensions(rootFileNames: string[]): string[] {
+	const uniqueExtensions = Array.from(
+		new Set(
+			rootFileNames
+				.map((fileName) => path.extname(fileName))
+				.filter((extension) => extension.length > 0),
+		),
+	);
+
+	// Keep watch mode useful even when a project has no discoverable root-file extensions.
+	if (uniqueExtensions.length === 0) {
+		return DEFAULT_WATCH_EXTENSIONS;
+	}
+
+	return uniqueExtensions;
+}
+
 /**
  * Given a list of arguments from the command line (such as `process.argv`), return parsed and processed options
  */
@@ -42,9 +72,7 @@ export async function check(flags: Partial<Flags>): Promise<boolean | void> {
 		}
 
 		// Dynamically get the list of extensions to watch from the files already included in the project
-		const checkedExtensions = Array.from(
-			new Set(checker.linter.getRootFileNames().map((fileName) => path.extname(fileName))),
-		);
+		const checkedExtensions = resolveWatchExtensions(checker.linter.getRootFileNames());
 		createWatcher(workspaceRoot, checkedExtensions)
 			.on('add', (fileName) => {
 				checker.linter.fileCreated(fileName);
@@ -61,7 +89,9 @@ export async function check(flags: Partial<Flags>): Promise<boolean | void> {
 	}
 
 	async function update() {
-		if (!flags.preserveWatchOutput) process.stdout.write('\x1Bc');
+		if (!flags.preserveWatchOutput && process.stdout.isTTY) {
+			process.stdout.write('\x1Bc');
+		}
 		await lint();
 	}
 

--- a/packages/language-tools/astro-check/test/watchExtensions.test.ts
+++ b/packages/language-tools/astro-check/test/watchExtensions.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { resolveWatchExtensions } from '../dist/index.js';
+
+describe('astro-check - resolveWatchExtensions', async () => {
+	it('returns unique non-empty extensions from root files', async () => {
+		const result = resolveWatchExtensions([
+			'/project/src/index.ts',
+			'/project/src/page.astro',
+			'/project/src/index.ts',
+			'/project/src/no-extension',
+		]);
+
+		assert.deepStrictEqual(result, ['.ts', '.astro']);
+	});
+
+	it('falls back to default watch extensions when no extension is found', async () => {
+		const result = resolveWatchExtensions([
+			'/project/Dockerfile',
+			'/project/Makefile',
+			'/project/README',
+		]);
+
+		assert.deepStrictEqual(result, [
+			'.astro',
+			'.ts',
+			'.tsx',
+			'.js',
+			'.jsx',
+			'.mjs',
+			'.cjs',
+			'.mts',
+			'.cts',
+			'.json',
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- make watch extension resolution robust when root file names do not include extensions
- filter out empty extensions and use a safe fallback extension set for watch mode
- avoid writing terminal clear control codes when stdout is not a TTY, improving CI/log readability
- add targeted tests for extension deduplication and fallback behavior

## Why
Some projects can surface root file names without extensions (for example, Dockerfile-style entries). In those cases, watch filtering can become ineffective and miss relevant updates. This change ensures watch mode remains reliable across more project layouts and runtime environments.

## Changes
- add resolveWatchExtensions(rootFileNames) in @astrojs/check to centralize and harden extension selection
- update watch setup to use the resolved extension list
- gate screen-clear behavior behind process.stdout.isTTY
- add watchExtensions.test.ts covering:
      - unique extension extraction
      - fallback behavior when no valid extensions are present
## Test plan
- [ ] Run `corepack pnpm --filter @astrojs/check build`
- [ ] Run `corepack pnpm --filter @astrojs/check test`
- [ ] Validate watch mode behavior in a project with extensionless root files
