### PR TITLE
Fix dependency installation broken on Windows

### DIFF
--- a/.changeset/windows-cmd-spawn-via-cmd-exe.md
+++ b/.changeset/windows-cmd-spawn-via-cmd-exe.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes dependency installation failing on Windows when running `npm create astro@latest`. The previous fix for DEP0190 warnings incorrectly assumed `.cmd` shims could be spawned directly without a shell — on Windows, `.cmd` files require `cmd.exe` to execute. Package manager commands are now invoked via `cmd.exe /d /s /c` on Windows. Also fixes the `[object Object]` error message that appeared when installation failed, replacing it with the actual error.

--- a/packages/create-astro/src/shell.ts
+++ b/packages/create-astro/src/shell.ts
@@ -20,10 +20,19 @@ interface Output {
 const text = (stream: NodeJS.ReadableStream | Readable | null) =>
 	stream ? textFromStream(stream).then((t) => t.trimEnd()) : '';
 
-function resolveCommand(command: string) {
-	if (process.platform !== 'win32') return command;
-	if (command.includes('/') || command.includes('\\') || command.includes('.')) return command;
-	return WINDOWS_CMD_SHIMS.has(command.toLowerCase()) ? `${command}.cmd` : command;
+/**
+ * On Windows, `.cmd` and `.bat` files cannot be spawned directly without a shell.
+ * For known package manager shims, we invoke them via `cmd.exe /d /s /c` instead.
+ * Returns [resolvedCommand, resolvedFlags] to use with spawn.
+ */
+function resolveCommand(command: string, flags: string[]): [string, string[]] {
+	if (process.platform !== 'win32') return [command, flags];
+	if (command.includes('/') || command.includes('\\') || command.includes('.'))
+		return [command, flags];
+	if (WINDOWS_CMD_SHIMS.has(command.toLowerCase())) {
+		return ['cmd.exe', ['/d', '/s', '/c', `${command}.cmd`, ...flags]];
+	}
+	return [command, flags];
 }
 
 export async function shell(
@@ -35,7 +44,8 @@ export async function shell(
 	let stdout = '';
 	let stderr = '';
 	try {
-		child = spawn(resolveCommand(command), flags, {
+		const [resolvedCommand, resolvedFlags] = resolveCommand(command, flags);
+		child = spawn(resolvedCommand, resolvedFlags, {
 			cwd: opts.cwd,
 			stdio: opts.stdio,
 			timeout: opts.timeout,
@@ -45,15 +55,16 @@ export async function shell(
 			child.once('close', () => resolve());
 		});
 		[stdout, stderr] = await Promise.all([text(child.stdout), text(child.stderr), done]);
-	} catch {
-		throw { stdout, stderr, exitCode: 1 };
+	} catch (e) {
+		const message = e instanceof Error ? e.message : stderr || 'Unknown error';
+		throw new Error(message);
 	}
 	const { exitCode } = child;
 	if (exitCode === null) {
 		throw new Error('Timeout');
 	}
 	if (exitCode !== 0) {
-		throw new Error(stderr);
+		throw new Error(stderr || `Process exited with code ${exitCode}`);
 	}
 	return { stdout, stderr, exitCode };
 }


### PR DESCRIPTION
## Changes

- Fixes `npm create astro@latest` failing to install dependencies on Windows since 5.0.1. The 5.0.1 change removed `shell: true` from `spawn()` to avoid DEP0190 warnings and attempted to handle Windows by appending `.cmd` to package manager names (e.g. `npm` → `npm.cmd`). However, `.cmd` files on Windows **cannot be spawned directly** without a shell — the Node.js docs explicitly state this. The fix now routes known package manager shims through `cmd.exe /d /s /c <name>.cmd` on Windows, which is the correct way to invoke them without `shell: true`.
- Fixes the `error [object Object]` message that appeared when installation failed. The `catch` block was throwing a plain object `{ stdout, stderr, exitCode: 1 }` instead of an `Error`, which stringified as `[object Object]` in the UI. It now throws a proper `Error` with the actual message.

## Testing

- All 116 existing `create-astro` tests pass. The Windows-specific spawn path is not unit-testable in CI (Linux/macOS), but the logic mirrors the approach documented in the Node.js child_process docs for invoking `.cmd`/`.bat` files without a shell.
- Manually confirmed by the reporter that 5.0.0 worked and 5.0.1 did not — the root cause matches exactly: 5.0.1 introduced the broken `.cmd` direct-spawn approach.

## Docs

No docs update needed — this is a bug fix in the CLI scaffolding tool with no user-facing API changes.