### PR TITLE
Fix HMR crash when editing content collection files in Cloudflare adapter projects using zod v4

### DIFF
--- a/.changeset/fix-ssr-import-meta-collision.md
+++ b/.changeset/fix-ssr-import-meta-collision.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fix HMR crash when editing content collection files caused by Vite's SSR transform colliding with zod v4's `meta` export

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -273,6 +273,11 @@ export default function createIntegration({
 													'virtual:@astrojs/*',
 												],
 												esbuildOptions: {
+													// Suppress Vite's `createRequire(import.meta.url)` banner to work around
+													// https://github.com/vitejs/vite/issues/22004 — Vite's SSR transform
+													// incorrectly rewrites identifiers inside `import.meta` when an imported
+													// binding shares the same name (e.g. zod v4 exports `meta`).
+													banner: { js: '' },
 													plugins: [astroFrontmatterScanPlugin()],
 												},
 											},


### PR DESCRIPTION
## Changes

- Fixes a crash (`Cannot split a chunk that has already been edited`) that occurs when editing content collection files during dev in Cloudflare adapter
- Adds `banner: { js: '' }` to `esbuildOptions` in the `configEnvironment` hook for server environments. This suppresses the `createRequire(import.meta.url)` banner that Vite prepends to pre-bundled SSR chunks, which is the trigger for the collision.
- The root cause is a Vite bug ([vitejs/vite#22004](https://github.com/vitejs/vite/issues/22004)): Vite's SSR transform replaces `import.meta` at positions 69–80, then tries to also replace the `meta` identifier (positions 76–80) from zod v4's `meta` export — but those positions are already inside the edited range. The fix is merged on Vite `main` ([vitejs/vite#22019](https://github.com/vitejs/vite/pull/22019)) but not yet backported to v7.

## Testing

- Manually verified

## Docs

N/A, bug fix