### PR TITLE
Fix Bun usage in create-astro on Windows

### DIFF
--- a/.changeset/bun-windows-exe-shim.md
+++ b/.changeset/bun-windows-exe-shim.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes dependency installation failing on Windows when using Bun as the package manager

--- a/packages/create-astro/src/shell.ts
+++ b/packages/create-astro/src/shell.ts
@@ -5,7 +5,9 @@ import { spawn } from 'node:child_process';
 import type { Readable } from 'node:stream';
 import { text as textFromStream } from 'node:stream/consumers';
 
-const WINDOWS_CMD_SHIMS = new Set(['npm', 'npx', 'pnpm', 'pnpx', 'yarn', 'yarnpkg', 'bun', 'bunx']);
+const WINDOWS_CMD_SHIMS = new Set(['npm', 'npx', 'pnpm', 'pnpx', 'yarn', 'yarnpkg']);
+// Bun ships as .exe on Windows, not .cmd, so it can be spawned directly with the .exe extension
+const WINDOWS_EXE_SHIMS = new Set(['bun', 'bunx']);
 
 interface ExecaOptions {
 	cwd?: string | URL;
@@ -23,14 +25,19 @@ const text = (stream: NodeJS.ReadableStream | Readable | null) =>
 /**
  * On Windows, `.cmd` and `.bat` files cannot be spawned directly without a shell.
  * For known package manager shims, we invoke them via `cmd.exe /d /s /c` instead.
+ * Bun ships as `.exe` on Windows (not `.cmd`), so it can be spawned directly.
  * Returns [resolvedCommand, resolvedFlags] to use with spawn.
  */
 function resolveCommand(command: string, flags: string[]): [string, string[]] {
 	if (process.platform !== 'win32') return [command, flags];
 	if (command.includes('/') || command.includes('\\') || command.includes('.'))
 		return [command, flags];
-	if (WINDOWS_CMD_SHIMS.has(command.toLowerCase())) {
+	const cmd = command.toLowerCase();
+	if (WINDOWS_CMD_SHIMS.has(cmd)) {
 		return ['cmd.exe', ['/d', '/s', '/c', `${command}.cmd`, ...flags]];
+	}
+	if (WINDOWS_EXE_SHIMS.has(cmd)) {
+		return [`${command}.exe`, flags];
 	}
 	return [command, flags];
 }


### PR DESCRIPTION
## Changes

- Rework of create-astro uses .cmd as the executable on Windows, but Bun ships an .exe. This fixes that.

## Testing

- https://discord.com/channels/830184174198718474/1449132280432951398/1486907497657794581

## Docs

N/A, bug fix