### PR TITLE
Update changeset wording for node middleware static assets fix

### DIFF
--- a/.changeset/fix-ssr-assets-manifest-middleware.md
+++ b/.changeset/fix-ssr-assets-manifest-middleware.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes CSS, fonts, and other assets failing to load when using `@astrojs/node` in middleware mode with a catch-all route. Previously these assets were incorrectly matched by the catch-all instead of being served as static files.
+Fixes catch-all routes incorrectly intercepting requests for static assets when using the `@astrojs/node` adapter in middleware mode.


### PR DESCRIPTION
## Changes

- Updates the changeset description for the fix landed in #16047 to avoid implying that static assets will definitely load (which depends on the user adding their own static file middleware)

## Testing

- No behavior change — changeset text only

## Docs

- No docs update needed; this is a changelog wording fix only