### PR TITLE
fix(fonts): preserve explicit fallback stacks

### DIFF
--- a/.changeset/contributor-03-font-fallback-stack.md
+++ b/.changeset/contributor-03-font-fallback-stack.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Preserve explicit Fonts API fallback stacks like `Georgia, serif` instead of prepending a generated optimized fallback face ahead of them.

--- a/packages/astro/src/assets/fonts/core/optimize-fallbacks.ts
+++ b/packages/astro/src/assets/fonts/core/optimize-fallbacks.ts
@@ -36,6 +36,10 @@ export async function optimizeFallbacks({
 	if (!isGenericFontFamily(lastFallback)) {
 		return null;
 	}
+	// Respect explicit fallback stacks like `Georgia, serif` instead of prepending a generated face.
+	if (fallbacks.length > 1) {
+		return null;
+	}
 
 	// If it's a generic family name, we get the associated local fonts (eg. Arial)
 	const localFonts = systemFallbacksProvider.getLocalFonts(lastFallback);

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -177,8 +177,9 @@ export type FontFamily<TFontProvider extends FontProvider = FontProvider> = Fami
 		 * fallbacks: []
 		 * ```
 		 *
-		 * If the last font in the `fallbacks` array is a [generic family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name), Astro will attempt to
-		 * generate [optimized fallbacks](https://developer.chrome.com/blog/font-fallbacks) using font metrics will be generated. To disable this optimization, set `optimizedFallbacks` to false.
+		 * If the `fallbacks` array only contains a [generic family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name), Astro will attempt to
+		 * generate [optimized fallbacks](https://developer.chrome.com/blog/font-fallbacks) using font metrics. If you provide explicit fallback fonts yourself, Astro preserves that stack as-is.
+		 * To disable this optimization, set `optimizedFallbacks` to false.
 		 */
 		fallbacks?: Array<string> | undefined;
 		/**

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2554,7 +2554,7 @@ export interface AstroUserConfig<
 	 * fallbacks: []
 	 * ```
 	 *
-	 * Specify at least a [generic family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name) matching the intended appearance of your font. Astro will then attempt to generate [optimized fallbacks](https://developer.chrome.com/blog/font-fallbacks) using font metrics. To disable this optimization, set `optimizedFallbacks` to false.
+	 * If the `fallbacks` array only contains a [generic family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name) matching the intended appearance of your font, Astro will attempt to generate [optimized fallbacks](https://developer.chrome.com/blog/font-fallbacks) using font metrics. If you provide named fallback fonts yourself, Astro preserves that stack as-is. To disable this optimization, set `optimizedFallbacks` to false.
 	 */
 
 	/**

--- a/packages/astro/test/units/assets/fonts/core.test.js
+++ b/packages/astro/test/units/assets/fonts/core.test.js
@@ -1511,21 +1511,34 @@ describe('fonts core', () => {
 			);
 		});
 
-		it('places optimized fallbacks at the start', async () => {
+		it('places optimized fallbacks at the start for a generic fallback', async () => {
 			const result = await optimizeFallbacks({
 				family,
-				fallbacks: ['foo', 'sans-serif'],
+				fallbacks: ['sans-serif'],
 				collectedFonts: [{ url: '', id: '', data: {}, init: undefined }],
 				systemFallbacksProvider,
 				fontMetricsResolver,
 			});
-			assert.deepStrictEqual(result?.fallbacks, ['Test-xxx fallback: Arial', 'foo', 'sans-serif']);
+			assert.deepStrictEqual(result?.fallbacks, ['Test-xxx fallback: Arial', 'sans-serif']);
+		});
+
+		it('skips if explicit fallbacks precede a generic fallback', async () => {
+			assert.equal(
+				await optimizeFallbacks({
+					family,
+					fallbacks: ['Georgia', 'serif'],
+					collectedFonts: [{ url: '', id: '', data: {}, init: undefined }],
+					systemFallbacksProvider,
+					fontMetricsResolver,
+				}),
+				null,
+			);
 		});
 
 		it('outputs correct css', async () => {
 			const result = await optimizeFallbacks({
 				family,
-				fallbacks: ['foo', 'sans-serif'],
+				fallbacks: ['sans-serif'],
 				collectedFonts: [
 					{ url: '', id: '', data: { weight: '400' }, init: undefined },
 					{ url: '', id: '', data: { weight: '500' }, init: undefined },


### PR DESCRIPTION
## Summary
- skip generated optimized fallback faces when the configured stack already includes an explicit fallback before the trailing generic family
- keep optimized fallback generation for bare generic stacks like `['sans-serif']`
- add regression coverage plus matching Fonts API fallback docs and a patch changeset

Closes #16127

## Testing
- corepack pnpm -C packages/astro build:ci
- .\packages\astro\node_modules\.bin\astro-scripts.ps1 test "test/units/assets/fonts/core.test.js" --teardown ./test/units/teardown.js