### PR TITLE
fix: prerender i18n fallback rewrites in hybrid builds

### DIFF
--- a/.changeset/hybrid-i18n-fallback-rewrite.md
+++ b/.changeset/hybrid-i18n-fallback-rewrite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix prerendered i18n fallback rewrite pages when using a hybrid static build with the `@astrojs/node` adapter.

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -358,7 +358,7 @@ export class RenderContext {
 					break;
 				}
 				case 'fallback': {
-					return new Response(null, { status: 500, headers: { [ROUTE_TYPE_HEADER]: 'fallback' } });
+					return new Response(null, { status: 404, headers: { [ROUTE_TYPE_HEADER]: 'fallback' } });
 				}
 			}
 			// We need to merge the cookies from the response back into this.cookies

--- a/packages/astro/test/i18n-routing-fallback-rewrite-hybrid.test.js
+++ b/packages/astro/test/i18n-routing-fallback-rewrite-hybrid.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+function getClientFileUrl(fixture, pathname) {
+	return new URL(pathname.replace(/^\//, ''), fixture.config.build.client);
+}
+
+describe('i18n fallback rewrites in hybrid builds', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/i18n-routing-fallback-rewrite-hybrid/',
+		});
+		await fixture.build();
+	});
+
+	it('writes fallback locale pages into the client build output', async () => {
+		await assert.doesNotReject(fs.access(getClientFileUrl(fixture, '/es/slug-1/index.html')));
+		await assert.doesNotReject(fs.access(getClientFileUrl(fixture, '/es/slug-2/index.html')));
+
+		const fallbackSlug1 = await fs.readFile(getClientFileUrl(fixture, '/es/slug-1/index.html'), 'utf8');
+		const fallbackSlug2 = await fs.readFile(getClientFileUrl(fixture, '/es/slug-2/index.html'), 'utf8');
+
+		assert.match(fallbackSlug1, /slug-1 - es/);
+		assert.match(fallbackSlug2, /slug-2 - es/);
+	});
+});


### PR DESCRIPTION
## Summary
- return a 404 for internal `fallback` route renders so the i18n middleware can apply `fallbackType: 'rewrite'`
- add a hybrid-build integration regression that verifies missing localized fallback routes are emitted into `dist/client`
- add the `astro` patch changeset for this user-facing fix

## Testing
- .\\node_modules\\.bin\\astro-scripts.cmd test "test/i18n-routing-fallback-rewrite-hybrid.test.js"
- .\\node_modules\\.bin\\astro-scripts.cmd test "test/units/i18n/fallback.test.js"
- .\\node_modules\\.bin\\astro-scripts.cmd test "test/units/i18n/i18n-static-build.test.js"

Closes #16113.
