### PR TITLE
fix: keep ClientRouter fragment scroll aligned after layout shifts

### DIFF
--- a/.changeset/fix-view-transitions-fragment-scroll.md
+++ b/.changeset/fix-view-transitions-fragment-scroll.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Keep cross-page `ClientRouter` fragment navigation aligned to the target when late layout shifts move the anchor after the initial scroll.

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/fragment-shift-from.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/fragment-shift-from.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../components/Layout.astro';
+---
+<Layout>
+	<p id="fragment-shift-from">Fragment shift source</p>
+	<a id="click-fragment-shift" href="/fragment-shift-to#shift-target"
+		>go to shifted target</a
+	>
+</Layout>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/fragment-shift-to.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/fragment-shift-to.astro
@@ -1,0 +1,32 @@
+---
+import Layout from '../components/Layout.astro';
+---
+<Layout>
+	<article id="fragment-shift-to">
+		<div id="shift-insert-before"></div>
+		<h2 id="shift-target">Shift target</h2>
+		<p id="shift-target-copy">This target should stay in view after navigation.</p>
+		<div style="height: 2200px">Content that stays below the target.</div>
+	</article>
+</Layout>
+<style is:global>
+	html,
+	body {
+		overflow-anchor: none;
+	}
+</style>
+<script is:inline>
+	document.addEventListener(
+		'astro:page-load',
+		() => {
+			setTimeout(() => {
+				if (document.getElementById('shift-spacer')) return;
+				const spacer = document.createElement('div');
+				spacer.id = 'shift-spacer';
+				spacer.style.height = '1800px';
+				document.getElementById('shift-insert-before')?.before(spacer);
+			}, 300);
+		},
+		{ once: true },
+	);
+</script>

--- a/packages/astro/e2e/view-transitions-preview.test.js
+++ b/packages/astro/e2e/view-transitions-preview.test.js
@@ -1,0 +1,32 @@
+import { expect } from '@playwright/test';
+import { testFactory } from './test-utils.js';
+
+const test = testFactory(import.meta.url, { root: './fixtures/view-transitions/' });
+
+let previewServer;
+
+test.beforeAll(async ({ astro }) => {
+	test.setTimeout(180_000);
+	await astro.build();
+	previewServer = await astro.preview();
+});
+
+test.afterAll(async () => {
+	await previewServer?.stop();
+});
+
+test.describe('View Transitions preview', () => {
+	test('cross-page fragment navigation stays on target after late layout shifts', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/fragment-shift-from'));
+		await page.click('#click-fragment-shift');
+
+		const spacer = page.locator('#shift-spacer');
+		await expect(spacer).toBeVisible();
+
+		const target = page.locator('#shift-target');
+		await expect(target).toBeInViewport();
+	});
+});

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -68,6 +68,8 @@ let parser: DOMParser;
 // you can figure it using an index. On pushState the index is incremented so you
 // can use that to determine popstate if going forward or back.
 let currentHistoryIndex = 0;
+const HASH_SCROLL_CORRECTION_TIMEOUT_MS = 1000;
+let stopHashScrollCorrection: (() => void) | undefined;
 
 if (inBrowser) {
 	if (history.state) {
@@ -163,6 +165,58 @@ function runScripts() {
 	return wait;
 }
 
+function findHashTarget(hash: string) {
+	const id = hash.slice(1);
+	if (!id) return document.body;
+
+	let decodedId = id;
+	try {
+		decodedId = decodeURIComponent(id);
+	} catch {
+		// Leave malformed hashes untouched and let the browser behavior stand.
+	}
+
+	return (
+		document.getElementById(decodedId) ??
+		document.querySelector(`[name="${CSS.escape(decodedId)}"]`)
+	);
+}
+
+function scrollToHashTarget(hash: string) {
+	findHashTarget(hash)?.scrollIntoView();
+}
+
+function queueHashScrollCorrection(hash: string) {
+	stopHashScrollCorrection?.();
+
+	if (!hash) return;
+
+	let animationFrame = 0;
+	let timeoutId = 0;
+	const observer = new ResizeObserver(() => {
+		cancelAnimationFrame(animationFrame);
+		animationFrame = requestAnimationFrame(() => {
+			scrollToHashTarget(hash);
+		});
+	});
+
+	const cleanup = () => {
+		cancelAnimationFrame(animationFrame);
+		clearTimeout(timeoutId);
+		observer.disconnect();
+		if (stopHashScrollCorrection === cleanup) {
+			stopHashScrollCorrection = undefined;
+		}
+	};
+
+	stopHashScrollCorrection = cleanup;
+	timeoutId = window.setTimeout(cleanup, HASH_SCROLL_CORRECTION_TIMEOUT_MS);
+
+	observer.observe(document.documentElement);
+	if (document.body) observer.observe(document.body);
+	scrollToHashTarget(hash);
+}
+
 // Add a new entry to the browser history. This also sets the new page in the browser address bar.
 // Sets the scroll position according to the hash fragment of the new location.
 const moveToLocation = (
@@ -225,6 +279,9 @@ const moveToLocation = (
 				if (intraPage) {
 					window.dispatchEvent(new PopStateEvent('popstate'));
 				}
+			}
+			if (!intraPage) {
+				queueHashScrollCorrection(to.hash);
 			}
 		} else {
 			if (!scrolledToTop) {
@@ -326,6 +383,7 @@ async function updateDOM(
 }
 
 function abortAndRecreateMostRecentNavigation(): Navigation {
+	stopHashScrollCorrection?.();
 	mostRecentNavigation?.controller.abort();
 	return (mostRecentNavigation = {
 		controller: new AbortController(),


### PR DESCRIPTION
## Summary
- keep cross-page ClientRouter fragment navigation aligned by reapplying the hash scroll during the first bounded burst of post-swap layout changes
- add a preview-only regression that reproduces a late layout shift above a fragment target after navigation
- ship the stro patch changeset for the runtime fix

## Testing
- corepack pnpm exec playwright test e2e/view-transitions-preview.test.js --project="Chrome Stable"
- corepack pnpm exec playwright test e2e/view-transitions.test.js --project="Chrome Stable" --grep "Moving within a page without ClientRouter does not trigger a full page navigation|Fragment scroll position restored on back button|Scroll position restored when transitioning back to fragment|Fragment scroll position restored on forward button|Hash part of the target URL is preserved during server redirect"
- corepack pnpm exec prettier --check packages/astro/src/transitions/router.ts packages/astro/e2e/view-transitions-preview.test.js packages/astro/e2e/fixtures/view-transitions/src/pages/fragment-shift-from.astro packages/astro/e2e/fixtures/view-transitions/src/pages/fragment-shift-to.astro .changeset/fix-view-transitions-fragment-scroll.md
- git diff --check

Closes #16130.