### PR TITLE
fix: support remote build manifest paths on Windows

### DIFF
--- a/.changeset/tame-schools-fix.md
+++ b/.changeset/tame-schools-fix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix remote builds on Windows when serialized manifest directories are plain filesystem paths instead of file URLs.

--- a/packages/astro/src/core/app/manifest.ts
+++ b/packages/astro/src/core/app/manifest.ts
@@ -12,6 +12,75 @@ import type {
 
 export type { SerializedRouteData } from '../../types/astro.js';
 
+const WINDOWS_DRIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
+const WINDOWS_UNC_PATH_RE = /^\\\\[^\\]/;
+
+const SERIALIZED_DIRECTORY_FIELDS = [
+	'rootDir',
+	'srcDir',
+	'publicDir',
+	'outDir',
+	'cacheDir',
+	'buildClientDir',
+	'buildServerDir',
+] as const;
+
+type SerializedDirectoryField = (typeof SERIALIZED_DIRECTORY_FIELDS)[number];
+
+function toFileDirectoryURL(serializedDirectory: string): URL {
+	const normalizedDirectory = serializedDirectory.replace(/\\/g, '/');
+	const directoryWithTrailingSlash = normalizedDirectory.endsWith('/')
+		? normalizedDirectory
+		: `${normalizedDirectory}/`;
+
+	if (WINDOWS_DRIVE_PATH_RE.test(serializedDirectory)) {
+		return new URL(`file:///${encodeURI(directoryWithTrailingSlash)}`);
+	}
+
+	if (WINDOWS_UNC_PATH_RE.test(serializedDirectory)) {
+		return new URL(`file:${encodeURI(directoryWithTrailingSlash)}`);
+	}
+
+	return new URL(`file://${encodeURI(directoryWithTrailingSlash)}`);
+}
+
+function deserializeDirectoryPath(serializedDirectory: string): URL {
+	if (serializedDirectory.startsWith('file:')) {
+		return new URL(serializedDirectory);
+	}
+
+	if (
+		serializedDirectory.startsWith('/') ||
+		WINDOWS_DRIVE_PATH_RE.test(serializedDirectory) ||
+		WINDOWS_UNC_PATH_RE.test(serializedDirectory)
+	) {
+		return toFileDirectoryURL(serializedDirectory);
+	}
+
+	return new URL(serializedDirectory);
+}
+
+function getSerializedDirectoryPath(
+	serializedManifest: SerializedSSRManifest,
+	fieldName: SerializedDirectoryField,
+): string {
+	const serializedDirectory = serializedManifest[fieldName];
+
+	if (typeof serializedDirectory === 'string') {
+		return serializedDirectory;
+	}
+
+	const manifestType =
+		serializedManifest === null ? 'null' : Array.isArray(serializedManifest) ? 'array' : typeof serializedManifest;
+	const manifestValue =
+		manifestType === 'string'
+			? ` Manifest value: ${JSON.stringify(serializedManifest)}.`
+			: '';
+	throw new TypeError(
+		`Expected virtual:astro:manifest.${fieldName} to be a string, received ${typeof serializedDirectory}. Manifest type: ${manifestType}.${manifestValue}`,
+	);
+}
+
 export function deserializeManifest(
 	serializedManifest: SerializedSSRManifest,
 	routesList?: RoutesList,
@@ -51,13 +120,17 @@ export function deserializeManifest(
 			return { onRequest: NOOP_MIDDLEWARE_FN };
 		},
 		...serializedManifest,
-		rootDir: new URL(serializedManifest.rootDir),
-		srcDir: new URL(serializedManifest.srcDir),
-		publicDir: new URL(serializedManifest.publicDir),
-		outDir: new URL(serializedManifest.outDir),
-		cacheDir: new URL(serializedManifest.cacheDir),
-		buildClientDir: new URL(serializedManifest.buildClientDir),
-		buildServerDir: new URL(serializedManifest.buildServerDir),
+		rootDir: deserializeDirectoryPath(getSerializedDirectoryPath(serializedManifest, 'rootDir')),
+		srcDir: deserializeDirectoryPath(getSerializedDirectoryPath(serializedManifest, 'srcDir')),
+		publicDir: deserializeDirectoryPath(getSerializedDirectoryPath(serializedManifest, 'publicDir')),
+		outDir: deserializeDirectoryPath(getSerializedDirectoryPath(serializedManifest, 'outDir')),
+		cacheDir: deserializeDirectoryPath(getSerializedDirectoryPath(serializedManifest, 'cacheDir')),
+		buildClientDir: deserializeDirectoryPath(
+			getSerializedDirectoryPath(serializedManifest, 'buildClientDir'),
+		),
+		buildServerDir: deserializeDirectoryPath(
+			getSerializedDirectoryPath(serializedManifest, 'buildServerDir'),
+		),
 		assets,
 		componentMetadata,
 		inlinedScripts,

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -43,6 +43,7 @@ export function serializedManifestPlugin({
 	sync: boolean;
 }): Plugin {
 	const normalizedSrcDir = normalizePath(fileURLToPath(settings.config.srcDir));
+	let viteCommand: 'serve' | 'build';
 	let encodedKeyPromise: Promise<string> | undefined;
 
 	function getEncodedKey() {
@@ -66,6 +67,9 @@ export function serializedManifestPlugin({
 	return {
 		name: SERIALIZED_MANIFEST_ID,
 		enforce: 'pre',
+		configResolved(config) {
+			viteCommand = config.command;
+		},
 		configureServer(server) {
 			server.watcher.on('add', (path) => reloadManifest(path, server));
 			server.watcher.on('unlink', (path) => reloadManifest(path, server));
@@ -97,7 +101,7 @@ export function serializedManifestPlugin({
 			},
 			async handler() {
 				let manifestData: string;
-				if (command === 'build' && !sync) {
+				if (command === 'build' && viteCommand === 'build' && !sync) {
 					// Emit placeholder token that will be replaced by plugin-manifest.ts in build:post
 					// See plugin-manifest.ts for full architecture explanation
 					manifestData = `'${MANIFEST_REPLACE}'`;

--- a/packages/astro/test/units/app/manifest.test.js
+++ b/packages/astro/test/units/app/manifest.test.js
@@ -1,0 +1,59 @@
+import * as assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { createKey, encodeKey } from '../../../dist/core/encryption.js';
+import { deserializeManifest } from '../../../dist/core/app/manifest.js';
+import { createManifest } from './test-helpers.js';
+
+function toSerializedDirectoryPath(...segments) {
+	if (process.platform === 'win32') {
+		return `C:/astro-test/${segments.join('/')}${segments.length ? '/' : ''}`;
+	}
+
+	return `/astro-test/${segments.join('/')}${segments.length ? '/' : ''}`;
+}
+
+describe('deserializeManifest', () => {
+	it('normalizes absolute filesystem directory strings to file URLs', async () => {
+		const key = await encodeKey(await createKey());
+		const serializedManifest = {
+			...createManifest(),
+			rootDir: toSerializedDirectoryPath(),
+			srcDir: toSerializedDirectoryPath('src'),
+			publicDir: toSerializedDirectoryPath('public'),
+			outDir: toSerializedDirectoryPath('dist'),
+			cacheDir: toSerializedDirectoryPath('.astro'),
+			buildClientDir: toSerializedDirectoryPath('dist', 'client'),
+			buildServerDir: toSerializedDirectoryPath('dist', 'server'),
+			assets: [],
+			componentMetadata: [],
+			inlinedScripts: [],
+			clientDirectives: [],
+			routes: [],
+			key,
+		};
+
+		const manifest = deserializeManifest(serializedManifest);
+
+		assert.equal(path.normalize(fileURLToPath(manifest.rootDir)), path.normalize(toSerializedDirectoryPath()));
+		assert.equal(path.normalize(fileURLToPath(manifest.srcDir)), path.normalize(toSerializedDirectoryPath('src')));
+		assert.equal(
+			path.normalize(fileURLToPath(manifest.publicDir)),
+			path.normalize(toSerializedDirectoryPath('public')),
+		);
+		assert.equal(path.normalize(fileURLToPath(manifest.outDir)), path.normalize(toSerializedDirectoryPath('dist')));
+		assert.equal(
+			path.normalize(fileURLToPath(manifest.cacheDir)),
+			path.normalize(toSerializedDirectoryPath('.astro')),
+		);
+		assert.equal(
+			path.normalize(fileURLToPath(manifest.buildClientDir)),
+			path.normalize(toSerializedDirectoryPath('dist', 'client')),
+		);
+		assert.equal(
+			path.normalize(fileURLToPath(manifest.buildServerDir)),
+			path.normalize(toSerializedDirectoryPath('dist', 'server')),
+		);
+	});
+});

--- a/packages/db/test/fixtures/static-remote/package.json
+++ b/packages/db/test/fixtures/static-remote/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@astrojs/cloudflare": "workspace:*",
     "@astrojs/db": "workspace:*",
     "astro": "workspace:*"
   }

--- a/packages/db/test/remote-build-cloudflare.test.js
+++ b/packages/db/test/remote-build-cloudflare.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import cloudflare from '../../integrations/cloudflare/dist/index.js';
+import { loadFixture } from '../../astro/test/test-utils.js';
+import { clearEnvironment } from './test-utils.js';
+
+describe('astro:db remote build with Cloudflare adapter', () => {
+	let fixture;
+	let resetIndexPage;
+	let resetRunPage;
+
+	before(async () => {
+		process.env.ASTRO_DB_REMOTE_URL = 'libsql://example.turso.io';
+		process.env.ASTRO_DB_APP_TOKEN = 'test-token';
+		process.env.ASTRO_INTERNAL_TEST_REMOTE = 'true';
+
+		fixture = await loadFixture({
+			root: new URL('./fixtures/static-remote/', import.meta.url),
+			output: 'static',
+			adapter: cloudflare(),
+		});
+
+		resetIndexPage = await fixture.editFile(
+			'/src/pages/index.astro',
+			`<html>
+	<head>
+		<title>Remote Build</title>
+	</head>
+	<body>
+		<h1>Cloudflare remote build works</h1>
+	</body>
+</html>
+`,
+			false,
+		);
+		resetRunPage = await fixture.editFile(
+			'/src/pages/run.astro',
+			`<html>
+	<head>
+		<title>Remote Build</title>
+	</head>
+	<body>
+		<h1>Cloudflare remote build works</h1>
+	</body>
+</html>
+`,
+			false,
+		);
+	});
+
+	after(async () => {
+		resetRunPage?.();
+		resetIndexPage?.();
+		clearEnvironment();
+		await fixture?.clean();
+	});
+
+	it('builds without throwing an invalid manifest URL error', async () => {
+		await assert.doesNotReject(async () => {
+			await fixture.build();
+		});
+
+		const html = await fixture.readFile('/client/index.html');
+		assert.match(html, /Cloudflare remote build works/);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4654,6 +4654,9 @@ importers:
 
   packages/db/test/fixtures/static-remote:
     dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../../../integrations/cloudflare
       '@astrojs/db':
         specifier: workspace:*
         version: link:../../..


### PR DESCRIPTION
## Summary
- keep `virtual:astro:manifest` concrete during `astro:build:setup` temp-server runs
- accept absolute filesystem directory strings when deserializing serialized manifests on Windows
- add focused remote-build and manifest regressions for the Cloudflare adapter path

## Testing
- `node node_modules/astro-scripts/index.js test "test/units/app/manifest.test.js" --teardown ./test/units/teardown.js`
- `node node_modules/astro-scripts/index.js test --force-exit "test/remote-build-cloudflare.test.js"` in `packages/db` (previous local validation on this branch passed; this cycle's rerun hung in the fixture harness after mutating `.wrangler`, so I killed the stray processes and restored the fixture before publishing)

Closes #16114