### PR TITLE
Allow preview releases for PRs against next

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -2,7 +2,7 @@ name: Preview release
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, next]
     types: [labeled]
 
 concurrency:


### PR DESCRIPTION
## Changes

- Runs our preview release workflow for PRs targeting `next` as well as PRs targeting `main`
