### PR TITLE
Fix Starlight dev crashes with the Cloudflare adapter

### DIFF
--- a/.changeset/bright-bulldogs-flash.md
+++ b/.changeset/bright-bulldogs-flash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a dev-mode crash loop in the Cloudflare adapter when using Starlight by excluding `@astrojs/starlight` from SSR dependency optimization

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -271,6 +271,7 @@ export default function createIntegration({
 													'virtual:astro:*',
 													'virtual:astro-cloudflare:*',
 													'virtual:@astrojs/*',
+													'@astrojs/starlight',
 												],
 												esbuildOptions: {
 													// Suppress Vite's `createRequire(import.meta.url)` banner to work around


### PR DESCRIPTION
## Changes

- Fixes a dev-mode optimizer crash loop for Starlight projects using `@astrojs/cloudflare` by excluding `@astrojs/starlight` from server-side dependency optimization.
- Keeps Starlight modules on normal Vite resolution paths instead of esbuild prebundling, which avoids unresolved `virtual:starlight/*` and related internal-loader failures.

## Testing

- Reproduced the loop in a minimal Starlight + Cloudflare app and confirmed repeated optimizer failures on page request.
- Verified that excluding `@astrojs/starlight` in SSR optimizer config resolves the loop after clearing `node_modules/.vite` and restarting dev.

## Docs

- No docs update needed because this is an internal adapter bug fix; user-facing behavior now matches expected dev stability.