### PR TITLE
fix(router): handle dotted directory routes with trailing slash

### DIFF
--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -43,6 +43,11 @@ import { type AstroSession, PERSIST_SYMBOL } from '../session/runtime.js';
 import type { AppPipeline } from './pipeline.js';
 import type { SSRManifest } from './types.js';
 
+function shouldTreatAsFilePath(pathname: string) {
+	// Paths ending with / are directory-like and should not be treated as file requests.
+	return !pathname.endsWith('/') && hasFileExtension(pathname);
+}
+
 export interface DevMatch {
 	routeData: RouteData;
 	resolvedPathname: string;
@@ -365,7 +370,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 			return pathname;
 		}
 
-		if (trailingSlash === 'always' && !hasFileExtension(pathname)) {
+		if (trailingSlash === 'always' && !shouldTreatAsFilePath(pathname)) {
 			return appendForwardSlash(pathname);
 		}
 		if (trailingSlash === 'never') {

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -432,7 +432,9 @@ const trailingSlashForPath = (
 	pathname: string | null,
 	config: AstroConfig,
 ): AstroConfig['trailingSlash'] =>
-	pathname && hasFileExtension(pathname) ? 'never' : config.trailingSlash;
+	pathname && !pathname.endsWith('/') && hasFileExtension(pathname)
+		? 'never'
+		: config.trailingSlash;
 
 function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): RouteData[] {
 	const { config } = settings;

--- a/packages/astro/src/vite-plugin-astro-server/trailing-slash.ts
+++ b/packages/astro/src/vite-plugin-astro-server/trailing-slash.ts
@@ -8,6 +8,11 @@ import { trailingSlashMismatchTemplate } from '../template/4xx.js';
 import type { AstroSettings } from '../types/astro.js';
 import { writeHtmlResponse, writeRedirectResponse } from './response.js';
 
+function shouldTreatAsFilePath(pathname: string) {
+	// Paths ending with / are directory-like and should not be treated as file requests.
+	return !pathname.endsWith('/') && hasFileExtension(pathname);
+}
+
 export function trailingSlashMiddleware(settings: AstroSettings): vite.Connect.NextHandleFunction {
 	const { trailingSlash } = settings.config;
 
@@ -31,7 +36,9 @@ export function trailingSlashMiddleware(settings: AstroSettings): vite.Connect.N
 
 		if (
 			(trailingSlash === 'never' && pathname.endsWith('/') && pathname !== '/') ||
-			(trailingSlash === 'always' && !pathname.endsWith('/') && !hasFileExtension(pathname))
+			(trailingSlash === 'always' &&
+				!pathname.endsWith('/') &&
+				!shouldTreatAsFilePath(pathname))
 		) {
 			const html = trailingSlashMismatchTemplate(pathname, trailingSlash);
 			return writeHtmlResponse(res, 404, html);

--- a/packages/astro/test/units/app/trailing-slash.test.js
+++ b/packages/astro/test/units/app/trailing-slash.test.js
@@ -41,6 +41,7 @@ const notFoundPage = createComponent(() => {
 const anotherRouteData = createRouteData('/another');
 const subPathRouteData = createRouteData('/sub/path');
 const dotPathRouteData = createRouteData('/dot.in.directory/path');
+const dottedFinalSegmentRouteData = createRouteData('/dot.in.directory');
 const notFoundRouteData = {
 	...createRouteData('/404'),
 	component: 'src/pages/404.astro',
@@ -72,6 +73,14 @@ const pageMap = new Map([
 		}),
 	],
 	[
+		dottedFinalSegmentRouteData.component,
+		async () => ({
+			page: async () => ({
+				default: okPage,
+			}),
+		}),
+	],
+	[
 		notFoundRouteData.component,
 		async () => ({
 			page: async () => ({
@@ -90,6 +99,7 @@ describe('Redirecting trailing slashes in SSR', () => {
 					{ routeData: anotherRouteData },
 					{ routeData: subPathRouteData },
 					{ routeData: dotPathRouteData },
+					{ routeData: dottedFinalSegmentRouteData },
 					{ routeData: notFoundRouteData },
 				],
 				pageMap,
@@ -172,6 +182,13 @@ describe('Redirecting trailing slashes in SSR', () => {
 			const response = await app.render(request);
 			assert.equal(response.status, 301);
 			assert.equal(response.headers.get('Location'), '/dot.in.directory/path/');
+		});
+
+		it('Does redirect when the final segment includes a dot and is a route', async () => {
+			const request = new Request('http://example.com/dot.in.directory');
+			const response = await app.render(request);
+			assert.equal(response.status, 301);
+			assert.equal(response.headers.get('Location'), '/dot.in.directory/');
 		});
 
 		it('Does not redirect internal paths', async () => {

--- a/packages/astro/test/units/routing/trailing-slash.test.js
+++ b/packages/astro/test/units/routing/trailing-slash.test.js
@@ -44,6 +44,10 @@ describe('trailingSlash', () => {
 								pattern: '/injected.json',
 								entrypoint: './src/pages/api.ts',
 							});
+							injectRoute({
+								pattern: '/dot.in.directory',
+								entrypoint: './src/pages/api.ts',
+							});
 						},
 					},
 				},
@@ -169,6 +173,27 @@ describe('trailingSlash', () => {
 		container.handle(req, res);
 		const json = await text();
 		assert.equal(json, '{"success":true}');
+	});
+
+	it('should match a dotted injected route when request has a trailing slash', async () => {
+		const { req, res, text } = createRequestAndResponse({
+			method: 'GET',
+			url: '/dot.in.directory/',
+		});
+		container.handle(req, res);
+		const json = await text();
+		assert.equal(json, '{"success":true}');
+	});
+
+	it('should NOT match a dotted injected route when request lacks a trailing slash', async () => {
+		const { req, res, text } = createRequestAndResponse({
+			method: 'GET',
+			url: '/dot.in.directory',
+		});
+		container.handle(req, res);
+		const html = await text();
+		assert.equal(html.includes(`<span class="statusMessage">Not found</span>`), true);
+		assert.equal(res.statusCode, 404);
 	});
 
 	it('should NOT match the API route when request has a trailing slash, with a file extension', async () => {


### PR DESCRIPTION
Issue ID : #16140

Description: Fixes trailing-slash route classification for dotted final path segments so directory-like routes such as /dot.in.directory/ are not treated as file paths; includes routing and app regression tests.