### PR TITLE
Include injected routes when checking if renderers are needed in SSR builds

### DIFF
--- a/.changeset/ssr-renderers-injected-routes.md
+++ b/.changeset/ssr-renderers-injected-routes.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes SSR builds failing with "No matching renderer found" when a project only has injected routes and no `src/pages/` directory

--- a/packages/astro/src/actions/integration.ts
+++ b/packages/astro/src/actions/integration.ts
@@ -1,6 +1,6 @@
 import { AstroError } from '../core/errors/errors.js';
 import { ActionsWithoutServerOutputError } from '../core/errors/errors-data.js';
-import { hasNonPrerenderedProjectRoute } from '../core/routing/helpers.js';
+import { hasNonPrerenderedRoute } from '../core/routing/helpers.js';
 import { viteID } from '../core/util.js';
 import type { AstroSettings } from '../types/astro.js';
 import type { AstroIntegration } from '../types/public/integrations.js';
@@ -41,7 +41,7 @@ export default function astroIntegrationActionsRouteHandler({
 				});
 			},
 			'astro:routes:resolved': ({ routes }) => {
-				if (!hasNonPrerenderedProjectRoute(routes)) {
+				if (!hasNonPrerenderedRoute(routes)) {
 					const error = new AstroError(ActionsWithoutServerOutputError);
 					error.stack = undefined;
 					throw error;

--- a/packages/astro/src/core/routing/helpers.ts
+++ b/packages/astro/src/core/routing/helpers.ts
@@ -75,26 +75,28 @@ export function routeHasHtmlExtension(route: RouteData): boolean {
 	);
 }
 
-export function hasNonPrerenderedProjectRoute(
+export function hasNonPrerenderedRoute(
 	routes: Array<Pick<RouteData, 'type' | 'origin' | 'prerender'>>,
-	options?: { includeEndpoints?: boolean },
+	options?: { includeEndpoints?: boolean; includeExternal?: boolean },
 ): boolean;
-export function hasNonPrerenderedProjectRoute(
+export function hasNonPrerenderedRoute(
 	routes: Array<Pick<IntegrationResolvedRoute, 'type' | 'origin' | 'isPrerendered'>>,
-	options?: { includeEndpoints?: boolean },
+	options?: { includeEndpoints?: boolean; includeExternal?: boolean },
 ): boolean;
-export function hasNonPrerenderedProjectRoute(
+export function hasNonPrerenderedRoute(
 	routes: Array<
 		| Pick<RouteData, 'type' | 'origin' | 'prerender'>
 		| Pick<IntegrationResolvedRoute, 'type' | 'origin' | 'isPrerendered'>
 	>,
-	options?: { includeEndpoints?: boolean },
+	options?: { includeEndpoints?: boolean; includeExternal?: boolean },
 ): boolean {
 	const includeEndpoints = options?.includeEndpoints ?? true;
+	const includeExternal = options?.includeExternal ?? false;
 	const routeTypes: ReadonlyArray<string> = includeEndpoints ? ['page', 'endpoint'] : ['page'];
+	const origins: ReadonlyArray<string> = includeExternal ? ['project', 'external'] : ['project'];
 
 	return routes.some((route) => {
 		const isPrerendered = 'isPrerendered' in route ? route.isPrerendered : route.prerender;
-		return routeTypes.includes(route.type) && route.origin === 'project' && !isPrerendered;
+		return routeTypes.includes(route.type) && origins.includes(route.origin) && !isPrerendered;
 	});
 }

--- a/packages/astro/src/vite-plugin-renderers/index.ts
+++ b/packages/astro/src/vite-plugin-renderers/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigEnv, Plugin as VitePlugin } from 'vite';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
-import { hasNonPrerenderedProjectRoute } from '../core/routing/helpers.js';
+import { hasNonPrerenderedRoute } from '../core/routing/helpers.js';
 import type { ServerIslandsState } from '../core/server-islands/shared-state.js';
 import type { AstroSettings, RoutesList } from '../types/astro.js';
 
@@ -40,8 +40,9 @@ export default function vitePluginRenderers(options: PluginOptions): VitePlugin 
 					this.environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr &&
 					renderers.length > 0 &&
 					!options.serverIslandsState.hasIslands() &&
-					!hasNonPrerenderedProjectRoute(options.routesList.routes, {
+					!hasNonPrerenderedRoute(options.routesList.routes, {
 						includeEndpoints: false,
+						includeExternal: true,
 					})
 				) {
 					return { code: `export const renderers = [];` };

--- a/packages/astro/test/units/routing/routing-helpers.test.js
+++ b/packages/astro/test/units/routing/routing-helpers.test.js
@@ -1,0 +1,28 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { hasNonPrerenderedRoute } from '../../../dist/core/routing/helpers.js';
+
+describe('hasNonPrerenderedRoute', () => {
+	it('returns true when a non-prerendered project page exists', () => {
+		const routes = [{ type: 'page', origin: 'project', prerender: false }];
+		assert.equal(hasNonPrerenderedRoute(routes), true);
+	});
+
+	it('returns false when all project pages are prerendered', () => {
+		const routes = [{ type: 'page', origin: 'project', prerender: true }];
+		assert.equal(hasNonPrerenderedRoute(routes), false);
+	});
+
+	it('excludes endpoints when includeEndpoints is false', () => {
+		const routes = [{ type: 'endpoint', origin: 'project', prerender: false }];
+		assert.equal(hasNonPrerenderedRoute(routes, { includeEndpoints: false }), false);
+		assert.equal(hasNonPrerenderedRoute(routes, { includeEndpoints: true }), true);
+	});
+
+	it('returns true for injected (external) non-prerendered pages when includeExternal is true', () => {
+		const routes = [{ type: 'page', origin: 'external', prerender: false }];
+		assert.equal(hasNonPrerenderedRoute(routes, { includeExternal: true }), true);
+		assert.equal(hasNonPrerenderedRoute(routes), false);
+	});
+});


### PR DESCRIPTION
## Changes

- SSR builds with only injected routes (no `src/pages/` directory) were failing at runtime with `No matching renderer found.`
- The renderer plugin's build optimization strips renderers from the SSR bundle when it determines no SSR pages need them. The way it determines this was not accounting for injected routes. This fixes it.

## Testing

- Added unit tests for `hasNonPrerenderedRoute` covering: project pages, prerendered pages, endpoint exclusion, and the new `includeExternal` option with injected routes.
- Verified end-to-end against [HiDeoo's reproduction](https://github.com/HiDeoo/astro-ssr-only-injected-route-repro)

## Docs

- N/A, bug fix