### PR TITLE
Pre-optimize @preact/signals in dev to fix E2E flakiness

### DIFF
--- a/.changeset/preact-optimize-signals.md
+++ b/.changeset/preact-optimize-signals.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/preact': patch
+---
+
+Pre-optimizes `@preact/signals` and `preact/hooks` in the Vite dep optimizer to prevent late discovery triggering full page reloads during dev

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -126,6 +126,8 @@ function configEnvironmentPlugin(compat: boolean | undefined): Plugin {
 					'@astrojs/preact/client.js',
 					'preact',
 					'preact/jsx-runtime',
+					'preact/hooks',
+					'@astrojs/preact > @preact/signals',
 				];
 			}
 


### PR DESCRIPTION
## Changes

- Adds `preact/hooks` and `@preact/signals` to the Preact integration's client `optimizeDeps.include` so Vite pre-bundles them upfront instead of discovering them late after the first page load
- Without this, Vite discovers `@preact/signals` on first request, re-optimizes, and sends a full page reload that races with test interactions

## Testing

- Ran `e2e/namespaced-component.test.js` 10 times with cache cleared before each run: 10/10 passed. Previously failed ~3/5 on main.

## Docs

- No docs needed — internal dep optimization change with no user-facing API