### PR TITLE
Remove bogus Node.js import breaking actions-blog E2E tests

### DIFF
--- a/packages/astro/e2e/fixtures/actions-blog/src/components/PostComment.tsx
+++ b/packages/astro/e2e/fixtures/actions-blog/src/components/PostComment.tsx
@@ -1,6 +1,5 @@
 import { actions, isInputError } from 'astro:actions';
 import { useState } from 'react';
-import {createLoggerFromFlags} from "../../../../../src/cli/flags.ts";
 
 export function PostComment({
 	postId,


### PR DESCRIPTION
## Changes

- A sync commit accidentally introduced an unused `import {createLoggerFromFlags} from "../../../../../src/cli/flags.ts"` into the client-side `PostComment.tsx` test fixture. This Node.js-only import broke React hydration, preventing the `onSubmit` handler from attaching. The "Comment action - success" and "Logout action redirects" E2E tests failed as a result.

## Testing

- Ran the full `actions-blog.test.js` suite with `--repeat-each=10` (76/76 passed) to confirm the fix is stable and not flaky.

## Docs

- No docs update needed — this is a test fixture change only.