### PR TITLE
Apply trailingSlash config to extensionless endpoints in static builds

### DIFF
--- a/.changeset/fix-endpoint-trailing-slash-static-build.md
+++ b/.changeset/fix-endpoint-trailing-slash-static-build.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `trailingSlash: "always"` producing redirect HTML instead of the actual response for extensionless endpoints during static builds

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -10,7 +10,9 @@ import {
 	prepareAssetsGenerationEnv,
 } from '../../assets/build/generate.js';
 import {
+	appendForwardSlash,
 	collapseDuplicateTrailingSlashes,
+	hasFileExtension,
 	joinPaths,
 	removeLeadingForwardSlash,
 	removeTrailingForwardSlash,
@@ -618,7 +620,13 @@ function getUrlForPath(
 		}
 	} else if (routeType === 'endpoint') {
 		const buildPathRelative = removeLeadingForwardSlash(pathname);
-		buildPathname = joinPaths(base, buildPathRelative);
+		let endpointPathname = joinPaths(base, buildPathRelative);
+		if (trailingSlash === 'always' && !hasFileExtension(pathname)) {
+			endpointPathname = appendForwardSlash(endpointPathname);
+		} else if (trailingSlash === 'never') {
+			endpointPathname = removeTrailingForwardSlash(endpointPathname);
+		}
+		buildPathname = endpointPathname;
 	} else {
 		const buildPathRelative =
 			removeTrailingForwardSlash(removeLeadingForwardSlash(pathname)) + ending;

--- a/packages/astro/test/units/build/generate.test.js
+++ b/packages/astro/test/units/build/generate.test.js
@@ -211,6 +211,44 @@ describe('renderPath()', () => {
 		assert.ok(errors.length > 0, 'error should be logged before re-throwing');
 	});
 
+	// Regression: #16185 — extensionless endpoints with trailingSlash: 'always'
+	// must have a trailing slash in the prerender request URL so that BaseApp.render()
+	// does not emit a redirect instead of the endpoint's actual response.
+	it('sends a trailing-slash request URL for extensionless endpoints when trailingSlash is always', async () => {
+		const endpointOptions = await createStaticBuildOptions({
+			inlineConfig: { trailingSlash: 'always' },
+		});
+
+		let capturedUrl;
+		const prerenderer = createMockPrerenderer({ '/demo': 'hello' });
+		const originalRender = prerenderer.render.bind(prerenderer);
+		prerenderer.render = async (request, opts) => {
+			capturedUrl = new URL(request.url);
+			return originalRender(request, opts);
+		};
+
+		const route = createRouteData({
+			route: '/demo',
+			type: 'endpoint',
+			trailingSlash: 'always',
+			component: 'src/pages/demo.ts',
+		});
+
+		await renderPath({
+			prerenderer,
+			pathname: '/demo',
+			route,
+			options: endpointOptions,
+			logger: endpointOptions.logger,
+		});
+
+		assert.ok(capturedUrl, 'prerenderer.render should have been called');
+		assert.ok(
+			capturedUrl.pathname.endsWith('/'),
+			`expected trailing slash in request URL pathname, got "${capturedUrl.pathname}"`,
+		);
+	});
+
 	it('writes the rendered body to the filesystem (integration smoke)', async () => {
 		const html = '<html><body>Written to disk</body></html>';
 		const prerenderer = createMockPrerenderer({ '/disk-test': html });


### PR DESCRIPTION
## Changes

- Extensionless endpoints (e.g. `src/pages/demo.ts`) with `trailingSlash: "always"` now produce their actual response instead of redirect HTML during `astro build`. The bug was in `getUrlForPath()` in `generate.ts`, which skipped trailing slash handling for all endpoints. The route manifest correctly applied `trailingSlash` to extensionless endpoints, but the prerender request URL did not, causing `BaseApp.render()` to emit a 301 redirect instead of calling the endpoint.
- Endpoints with file extensions (e.g. `/feed.xml`, `/data.json`) remain exempt from trailing slash enforcement, matching the documented v6 behavior.

## Testing

- Added a unit test in `generate.test.js` that verifies the prerender request URL includes a trailing slash for extensionless endpoints when `trailingSlash: "always"` is configured. The test intercepts the URL passed to the prerenderer and asserts it ends with `/`.
- All existing `generate.test.js` and `trailing-slash.test.js` tests continue to pass.

## Docs

- No docs update needed — this restores the behavior that the docs already describe.

Closes #16185