### PR TITLE
fix(partytown): bump @qwik.dev/partytown to ^0.13.2

### DIFF
--- a/.changeset/bump-partytown.md
+++ b/.changeset/bump-partytown.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/partytown": patch
+---
+
+Bumps @qwik.dev/partytown from ^0.11.2 to ^0.13.2

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -32,7 +32,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@qwik.dev/partytown": "^0.11.2",
+    "@qwik.dev/partytown": "^0.13.2",
     "mrmime": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Bumps `@qwik.dev/partytown` from `^0.11.2` to `^0.13.2`.

This update includes fixes for deprecated Chromium APIs (`SharedStorage` and `AttributionReporting`) that were causing Lighthouse warnings in sites using Partytown.

Related: https://github.com/QwikDev/partytown/pull/697
Related: https://github.com/withastro/astro/issues/15494

## Changes

- Bumps `@qwik.dev/partytown` dependency from `^0.11.2` to `^0.13.2`
- Resolves Lighthouse deprecation warnings for `SharedStorage` and `AttributionReporting` APIs in the Partytown sandbox service worker

## Testing

Tested locally by overriding `@qwik.dev/partytown` to `0.13.2` in a production Astro 6 project. Full build completes successfully and Partytown functions as expected.

## Docs

No docs needed, this is a dependency version bump with no documented API changes.
