### PR TITLE
Allow Actions with static output when an adapter is configured

### DIFF
--- a/.changeset/actions-static-with-adapter.md
+++ b/.changeset/actions-static-with-adapter.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Actions failing with `ActionsWithoutServerOutputError` when using `output: 'static'` with an adapter

--- a/packages/astro/src/actions/integration.ts
+++ b/packages/astro/src/actions/integration.ts
@@ -41,7 +41,7 @@ export default function astroIntegrationActionsRouteHandler({
 				});
 			},
 			'astro:routes:resolved': ({ routes }) => {
-				if (!hasNonPrerenderedRoute(routes)) {
+				if (!settings.config.adapter && !hasNonPrerenderedRoute(routes)) {
 					const error = new AstroError(ActionsWithoutServerOutputError);
 					error.stack = undefined;
 					throw error;

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -476,6 +476,25 @@ describe('Astro Actions in static mode with prerender = false routes', () => {
 	});
 });
 
+it('Works with adapter and all pages prerendered', async () => {
+	const fixture = await loadFixture({
+		root: './fixtures/actions/',
+		output: 'static',
+		adapter: testAdapter(),
+	});
+	const devServer = await fixture.startDevServer();
+	const res = await fixture.fetch('/_actions/subscribe', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ channel: 'bholmesdev' }),
+	});
+
+	assert.equal(res.ok, true);
+	await devServer.stop();
+});
+
 it('Base path should be used', async () => {
 	const fixture = await loadFixture({
 		root: './fixtures/actions/',


### PR DESCRIPTION
## Changes

- Skips the `ActionsWithoutServerOutputError` validation when an adapter is present. PR #15890 moved this check from `astro:config:done` to `astro:routes:resolved` but lost adapter-awareness — the old check was naturally bypassed because adapters override `buildOutput` to `'server'`. The new check only inspects resolved routes, so `output: 'static'` with all pages prerendered + an adapter (Netlify, Cloudflare, etc.) incorrectly throws.

## Testing

- Added a test that starts a dev server with the `actions` fixture, `output: 'static'`, and `testAdapter()`, confirming the action endpoint responds successfully.
- Full `actions.test.js` suite passes (26/26).

## Docs

- No docs change needed — this restores previously documented Astro 5 behavior.

Closes #16103