### PR TITLE
fix(astro): preserve quoted import specifiers when appending asset query params

### DIFF
--- a/.changeset/fresh-ravens-cough.md
+++ b/.changeset/fresh-ravens-cough.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix inter-chunk import query rewriting to preserve valid syntax and prevent Netlify/Vercel build failures.

--- a/packages/astro/src/core/build/plugins/plugin-chunk-imports.ts
+++ b/packages/astro/src/core/build/plugins/plugin-chunk-imports.ts
@@ -15,7 +15,26 @@ export function pluginChunkImports(options: StaticBuildOptions): VitePlugin | un
 	if (!assetQueryParams || assetQueryParams.toString() === '') {
 		return undefined;
 	}
-	const queryString = assetQueryParams.toString();
+	// Snapshot adapter-provided params once so each rewrite reuses stable key/value pairs.
+	const paramsToAppend = Array.from(assetQueryParams.entries());
+
+	function appendQueryParams(specifier: string): string {
+		const hashIndex = specifier.indexOf('#');
+		const hash = hashIndex >= 0 ? specifier.slice(hashIndex) : '';
+		const withoutHash = hashIndex >= 0 ? specifier.slice(0, hashIndex) : specifier;
+
+		const queryIndex = withoutHash.indexOf('?');
+		const pathname = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+		const existingQuery = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : '';
+
+		const mergedQueryParams = new URLSearchParams(existingQuery);
+		for (const [key, value] of paramsToAppend) {
+			mergedQueryParams.append(key, value);
+		}
+
+		const mergedQueryString = mergedQueryParams.toString();
+		return `${pathname}${mergedQueryString ? `?${mergedQueryString}` : ''}${hash}`;
+	}
 
 	return {
 		name: '@astro/plugin-chunk-imports',
@@ -47,8 +66,21 @@ export function pluginChunkImports(options: StaticBuildOptions): VitePlugin | un
 			let rewritten = code;
 			for (let i = relativeImports.length - 1; i >= 0; i--) {
 				const imp = relativeImports[i];
-				// imp.s and imp.e are the start/end offsets of the module specifier (without quotes)
-				rewritten = rewritten.slice(0, imp.e) + '?' + queryString + rewritten.slice(imp.e);
+				const specifier = imp.n;
+				if (!specifier) {
+					continue;
+				}
+
+				// imp.s and imp.e are the start/end offsets of the full quoted specifier,
+				// while imp.n is the unquoted specifier value.
+				const quoteChar = rewritten[imp.s];
+				if (quoteChar !== '"' && quoteChar !== "'") {
+					continue;
+				}
+
+				const start = imp.s + 1;
+				const end = imp.e - 1;
+				rewritten = rewritten.slice(0, start) + appendQueryParams(specifier) + rewritten.slice(end);
 			}
 
 			return { code: rewritten, map: null };


### PR DESCRIPTION
Fixes #16196 

This seems likely connected to #16110, which introduced inter-chunk import rewriting for adapter asset query params.

## Deployment Failure on Netlify

```text
[ERROR] [vite] ✗ Build failed in 360ms
Syntax error "c"
  Location:
    _astro/page.!~{007}~.js:17:50
```

## Changes
- Fix `plugin-chunk-imports` rewrite logic to preserve valid JS import syntax when appending `assetQueryParams`.
- Rewrite only the module specifier content (inside quotes) using `es-module-lexer` offsets, instead of inserting blindly at the previous end offset.
- Merge adapter-provided query params with existing `?query` and `#hash` in relative inter-chunk JS imports.
- Add clarifying inline comments around specifier offsets and param snapshot behavior.
- This addresses cloud-only build failures (e.g. Netlify/Vercel) where generated `_astro/*.js` could become syntactically invalid in downstream bundling.

## Testing

- Reproduced the issue on Netlify before this fix (deployment build failed with syntax errors in generated `_astro/*.js` chunks).
- After applying this fix, redeployed the same project on Netlify and confirmed the build now succeeds.
