### PR TITLE
Fix .svelte files in node_modules with Cloudflare prerenderEnvironment: node

### DIFF
--- a/.changeset/fix-svelte-prerender-node.md
+++ b/.changeset/fix-svelte-prerender-node.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/svelte': patch
+---
+
+Fixes `.svelte` files in `node_modules` failing with `Unknown file extension ".svelte"` when using the Cloudflare adapter with `prerenderEnvironment: 'node'`

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -306,7 +306,6 @@ export default function createIntegration({
 									if (conf.ssr) {
 										// Cloudflare does not support externalizing modules in server environments
 										conf.ssr.external = undefined;
-										conf.ssr.noExternal = true;
 									}
 								},
 							},

--- a/packages/integrations/cloudflare/src/vite-plugin-dev-server-prerender-middleware.ts
+++ b/packages/integrations/cloudflare/src/vite-plugin-dev-server-prerender-middleware.ts
@@ -18,14 +18,6 @@ export function createNodePrerenderPlugin(): vite.Plugin {
 			};
 		},
 
-		// Disable dep optimization for the `prerender` environment so dependencies
-		// are loaded via native import() with correct import.meta.url semantics.
-		configEnvironment(environmentName) {
-			if (environmentName === 'prerender') {
-				return { optimizeDeps: { noDiscovery: true, include: [] } };
-			}
-		},
-
 		configureServer(server) {
 			(server as any)[devPrerenderMiddlewareSymbol] = true;
 		},

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/astro.config.mjs
@@ -1,3 +1,6 @@
 import { defineConfig } from 'astro/config';
+import svelte from '@astrojs/svelte';
 
-export default defineConfig({});
+export default defineConfig({
+	integrations: [svelte()],
+});

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./src/index.js"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fake-svelte-pkg",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "peerDependencies": {
+    "svelte": "^5.0.0"
+  }
+}

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/src/FakeComponent.svelte
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/src/FakeComponent.svelte
@@ -1,0 +1,1 @@
+<p>Hello from fake svelte component</p>

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/src/index.js
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg/src/index.js
@@ -1,0 +1,1 @@
+export { default as FakeComponent } from './FakeComponent.svelte';

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "dependencies": {
     "@astrojs/cloudflare": "workspace:*",
-    "astro": "workspace:*"
+    "@astrojs/svelte": "workspace:*",
+    "astro": "workspace:*",
+    "svelte": "^5.0.0",
+    "fake-svelte-pkg": "file:./fake-svelte-pkg"
   }
 }

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/components/SvelteWrapper.svelte
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/components/SvelteWrapper.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { FakeComponent } from 'fake-svelte-pkg';
+</script>
+
+<div id="svelte-wrapper">
+  <FakeComponent />
+</div>

--- a/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/pages/svelte.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-node-env/src/pages/svelte.astro
@@ -1,0 +1,15 @@
+---
+export const prerender = true;
+
+import SvelteWrapper from '../components/SvelteWrapper.svelte';
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Svelte Prerender Test</title>
+	</head>
+	<body>
+		<SvelteWrapper />
+	</body>
+</html>

--- a/packages/integrations/cloudflare/test/prerender-node-env.test.js
+++ b/packages/integrations/cloudflare/test/prerender-node-env.test.js
@@ -41,8 +41,8 @@ describe('prerenderEnvironment: node', () => {
 
 	it('renders svelte component that imports .svelte files from node_modules', async () => {
 		const res = await fixture.fetch('/svelte');
-		assert.equal(res.status, 200);
 		const html = await res.text();
+		assert.equal(res.status, 200, `Expected 200 but got ${res.status}. Body: ${html.slice(0, 500)}`);
 		assert.ok(
 			html.includes('id="svelte-wrapper"'),
 			'Expected the prerendered page to contain the svelte wrapper',

--- a/packages/integrations/cloudflare/test/prerender-node-env.test.js
+++ b/packages/integrations/cloudflare/test/prerender-node-env.test.js
@@ -41,8 +41,8 @@ describe('prerenderEnvironment: node', () => {
 
 	it('renders svelte component that imports .svelte files from node_modules', async () => {
 		const res = await fixture.fetch('/svelte');
+		assert.equal(res.status, 200);
 		const html = await res.text();
-		assert.equal(res.status, 200, `Expected 200 but got ${res.status}. Body: ${html.slice(0, 500)}`);
 		assert.ok(
 			html.includes('id="svelte-wrapper"'),
 			'Expected the prerendered page to contain the svelte wrapper',

--- a/packages/integrations/cloudflare/test/prerender-node-env.test.js
+++ b/packages/integrations/cloudflare/test/prerender-node-env.test.js
@@ -39,6 +39,20 @@ describe('prerenderEnvironment: node', () => {
 		);
 	});
 
+	it('renders svelte component that imports .svelte files from node_modules', async () => {
+		const res = await fixture.fetch('/svelte');
+		assert.equal(res.status, 200);
+		const html = await res.text();
+		assert.ok(
+			html.includes('id="svelte-wrapper"'),
+			'Expected the prerendered page to contain the svelte wrapper',
+		);
+		assert.ok(
+			html.includes('Hello from fake svelte component'),
+			'Expected the fake svelte component to be rendered',
+		);
+	});
+
 	it('includes styles in prerendered page', async () => {
 		const res = await fixture.fetch('/');
 		const html = await res.text();

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "svelte2tsx": "^0.7.52",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitefu": "^1.1.2"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -2,6 +2,7 @@ import type { Options } from '@sveltejs/vite-plugin-svelte';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import type { AstroIntegration, AstroRenderer } from 'astro';
 import type { Plugin } from 'vite';
+import { crawlFrameworkPkgs } from 'vitefu';
 import { createSvelteOptimizeEsbuildPlugins } from './optimize-esbuild-plugins.js';
 
 function getRenderer(): AstroRenderer {
@@ -18,11 +19,20 @@ export default function svelteIntegration(options?: Options): AstroIntegration {
 	return {
 		name: '@astrojs/svelte',
 		hooks: {
-			'astro:config:setup': async ({ updateConfig, addRenderer }) => {
+			'astro:config:setup': async ({ config, updateConfig, addRenderer }) => {
 				addRenderer(getRenderer());
+
+				const sveltePackages = await crawlFrameworkPkgs({
+					root: config.root.pathname,
+					isBuild: false,
+					isFrameworkPkgByJson(pkgJson) {
+						return !!pkgJson.peerDependencies?.svelte;
+					},
+				});
+
 				updateConfig({
 					vite: {
-						plugins: [svelte(options), configEnvironmentPlugin()],
+						plugins: [svelte(options), configEnvironmentPlugin(sveltePackages.ssr.noExternal)],
 					},
 				});
 			},
@@ -30,16 +40,42 @@ export default function svelteIntegration(options?: Options): AstroIntegration {
 	};
 }
 
-function configEnvironmentPlugin(): Plugin {
+function configEnvironmentPlugin(svelteNoExternal: string[]): Plugin {
 	return {
 		name: '@astrojs/svelte:config-environment',
 		configEnvironment(environmentName, options) {
+			const isServer = environmentName !== 'client';
+
+			if (isServer && svelteNoExternal.length > 0) {
+				// Add svelte framework packages to noExternal so they go through
+				// Vite's transform pipeline (Node can't import .svelte files natively).
+				const result: any = {
+					resolve: {
+						noExternal: svelteNoExternal,
+					},
+				};
+
+				if (
+					(environmentName === 'ssr' || environmentName === 'prerender') &&
+					options.optimizeDeps?.noDiscovery === false
+				) {
+					result.optimizeDeps = {
+						include: ['svelte/server', 'svelte/internal/server'],
+						exclude: ['@astrojs/svelte/server.js'],
+						esbuildOptions: {
+							plugins: createSvelteOptimizeEsbuildPlugins('server'),
+						},
+					};
+				}
+
+				return result;
+			}
+
 			if (
 				environmentName === 'client' ||
 				((environmentName === 'ssr' || environmentName === 'prerender') &&
 					options.optimizeDeps?.noDiscovery === false)
 			) {
-				const isServer = environmentName !== 'client';
 				return {
 					optimizeDeps: {
 						include: isServer

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -1,6 +1,7 @@
 import type { Options } from '@sveltejs/vite-plugin-svelte';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import type { AstroIntegration, AstroRenderer } from 'astro';
+import { fileURLToPath } from 'node:url';
 import type { Plugin } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
 import { createSvelteOptimizeEsbuildPlugins } from './optimize-esbuild-plugins.js';
@@ -23,7 +24,7 @@ export default function svelteIntegration(options?: Options): AstroIntegration {
 				addRenderer(getRenderer());
 
 				const sveltePackages = await crawlFrameworkPkgs({
-					root: config.root.pathname,
+					root: fileURLToPath(config.root),
 					isBuild: false,
 					isFrameworkPkgByJson(pkgJson) {
 						return !!pkgJson.peerDependencies?.svelte;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4972,9 +4972,20 @@ importers:
       '@astrojs/cloudflare':
         specifier: workspace:*
         version: link:../../..
+      '@astrojs/svelte':
+        specifier: workspace:*
+        version: link:../../../../svelte
       astro:
         specifier: workspace:*
         version: link:../../../../../astro
+      fake-svelte-pkg:
+        specifier: file:./fake-svelte-pkg
+        version: file:packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg(svelte@5.54.1)
+      svelte:
+        specifier: ^5.0.0
+        version: 5.54.1
+
+  packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg: {}
 
   packages/integrations/cloudflare/test/fixtures/prerender-styles:
     dependencies:
@@ -6313,6 +6324,9 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu:
+        specifier: ^1.1.2
+        version: 1.1.2(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       astro:
         specifier: workspace:*
@@ -7179,6 +7193,15 @@ importers:
         specifier: ^3.1.6
         version: 3.1.6(typescript@5.9.3)
 
+  triage/current:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: ^10.0.0-beta.4
+        version: link:../../packages/integrations/vercel
+      astro:
+        specifier: 6.0.0-beta.11
+        version: 6.0.0-beta.11(@azure/identity@4.13.0)(@netlify/blobs@10.7.0)(@types/node@25.2.3)(@vercel/functions@3.4.3)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.1)(sass@1.98.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+
 packages:
 
   '@antfu/utils@0.7.10':
@@ -7289,6 +7312,16 @@ packages:
   '@astrojs/compiler@3.0.1':
     resolution: {integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==}
 
+  '@astrojs/internal-helpers@0.8.0-beta.1':
+    resolution: {integrity: sha512-nX39HmVNrto0AwlGnk6Vj8fQ35v4VVIuSxsbvaANGeAIK7uAjOY3ca7xz+gejWeqGbY7vkGk6vsz3i0jTClCSQ==}
+
+  '@astrojs/markdown-remark@7.0.0-beta.6':
+    resolution: {integrity: sha512-6SRUg3feMrLUyKdjPXrrzE1Gmb+x1jDKqoUmZZcbMzByipCZKAi82DmbuZmRqg7Bb49xGW+iS/F8urOPz8/L+A==}
+
+  '@astrojs/prism@4.0.0-beta.2':
+    resolution: {integrity: sha512-3snR85nTXnXvgmFJ43AacCQcylk+mpsiQ5Gmr9hcR5IrEA6+EvaYfaF9jlxZqJIZYey/9ubSRmaERtwDhV/FeA==}
+    engines: {node: ^20.19.1 || >=22.12.0}
+
   '@astrojs/solid-js@5.1.3':
     resolution: {integrity: sha512-KxfYt4y1d7BuSw6EsN1EaPoGYsIES7bEI6AtTbncuabRUUMZs+mOWOeOdmgnwVLj+jbNbhBjUZsqr77eUviZdw==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
@@ -7298,6 +7331,10 @@ packages:
     peerDependenciesMeta:
       solid-devtools:
         optional: true
+
+  '@astrojs/telemetry@3.3.0':
+    resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/vue@5.1.4':
     resolution: {integrity: sha512-srE+3tgSnGG4FVr7Bs9JAgLcUAg1mtGrbBFdwlj++Y05Awwlc967WCcmOK6rnxQ6q5PcK5+WL2x2tKoWh5SN7A==}
@@ -9877,17 +9914,29 @@ packages:
     resolution: {integrity: sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==}
     engines: {node: '>=20.0.0'}
 
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
   '@shikijs/engine-javascript@4.0.2':
     resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
     engines: {node: '>=20'}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
   '@shikijs/engine-oniguruma@4.0.2':
     resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
     engines: {node: '>=20'}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.0.2':
     resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
@@ -9901,6 +9950,9 @@ packages:
     resolution: {integrity: sha512-cmPlKLD8JeojasNFoY64162ScpEdEdQUMuVodPCrv1nx1z3bjmGwoKWDruQWa/ejSznImlaeB0Ty6Q3zPaVQAA==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
   '@shikijs/themes@4.0.2':
     resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
     engines: {node: '>=20'}
@@ -9910,6 +9962,9 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       typescript: '>=5.5.0'
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.0.2':
     resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
@@ -10737,6 +10792,9 @@ packages:
   alpinejs@3.15.8:
     resolution: {integrity: sha512-zxIfCRTBGvF1CCLIOMQOxAyBuqibxSEwS6Jm1a3HGA9rgrJVcjEWlwLcQTVGAWGS8YhAsTRLVrtQ5a5QT9bSSQ==}
 
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -10844,6 +10902,11 @@ packages:
     resolution: {integrity: sha512-jL5skNQLA0YBc1R3bVGXyHew3FqGqsT7AgLzWAVeTLzFkwVMUYvs4/lKJSmS7ygcF1GnHnoKG6++8GL9VtWwGQ==}
     engines: {node: '>=18.14.1'}
 
+  astro@6.0.0-beta.11:
+    resolution: {integrity: sha512-kQvgIJnjgnVgkAOcSXB9/iRHvw437/40dnvi+7J1RQxPAWVahh9fhNPjbCWqcQV4bblzG3SAQLSJCf7FcKnV8g==}
+    engines: {node: ^20.19.1 || >=22.12.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
+    hasBin: true
+
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
 
@@ -10926,6 +10989,9 @@ packages:
       bare-abort-controller:
         optional: true
 
+  base-64@1.0.0:
+    resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -10982,6 +11048,10 @@ packages:
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
+
+  boxen@8.0.1:
+    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
+    engines: {node: '>=18'}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -11064,6 +11134,10 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
@@ -11150,6 +11224,10 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
 
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
@@ -11577,6 +11655,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       typescript: ^5.4.4
+
+  deterministic-object-hash@2.0.2:
+    resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
+    engines: {node: '>=18'}
 
   dettle@1.0.5:
     resolution: {integrity: sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==}
@@ -12033,6 +12115,11 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  fake-svelte-pkg@file:packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg:
+    resolution: {directory: packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg, type: directory}
+    peerDependencies:
+      svelte: ^5.0.0
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -12884,6 +12971,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -14251,6 +14342,10 @@ packages:
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -14699,6 +14794,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
@@ -15872,6 +15970,10 @@ packages:
   wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
@@ -15913,6 +16015,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -16041,6 +16147,10 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  yocto-spinner@1.1.0:
+    resolution: {integrity: sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA==}
+    engines: {node: '>=18.19'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -16175,6 +16285,37 @@ snapshots:
 
   '@astrojs/compiler@3.0.1': {}
 
+  '@astrojs/internal-helpers@0.8.0-beta.1': {}
+
+  '@astrojs/markdown-remark@7.0.0-beta.6':
+    dependencies:
+      '@astrojs/internal-helpers': 0.8.0-beta.1
+      '@astrojs/prism': 4.0.0-beta.2
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      js-yaml: 4.1.1
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      shiki: 3.23.0
+      smol-toml: 1.6.1
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@astrojs/prism@4.0.0-beta.2':
+    dependencies:
+      prismjs: 1.30.0
+
   '@astrojs/solid-js@5.1.3(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(solid-js@1.9.11)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
       solid-js: 1.9.11
@@ -16194,6 +16335,18 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/telemetry@3.3.0':
+    dependencies:
+      ci-info: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dlv: 1.1.3
+      dset: 3.1.4
+      is-docker: 3.0.0
+      is-wsl: 3.1.1
+      which-pm-runs: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@astrojs/vue@5.1.4(@types/node@25.2.3)(astro@packages+astro)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.1)(sass@1.98.0)(tsx@4.21.0)(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
@@ -18777,6 +18930,13 @@ snapshots:
 
   '@secretlint/types@10.2.2': {}
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -18785,16 +18945,31 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.4
+
   '@shikijs/engine-javascript@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.4
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.0.2':
     dependencies:
@@ -18815,6 +18990,10 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.1.0
 
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
   '@shikijs/themes@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
@@ -18827,6 +19006,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/types@4.0.2':
     dependencies:
@@ -19870,6 +20054,10 @@ snapshots:
     dependencies:
       '@vue/reactivity': 3.1.5
 
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@5.0.0:
@@ -19975,6 +20163,103 @@ snapshots:
       marked-smartypants: 1.1.11(marked@12.0.2)
       ultrahtml: 1.6.0
 
+  astro@6.0.0-beta.11(@azure/identity@4.13.0)(@netlify/blobs@10.7.0)(@types/node@25.2.3)(@vercel/functions@3.4.3)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.1)(sass@1.98.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+    dependencies:
+      '@astrojs/compiler': 3.0.1
+      '@astrojs/internal-helpers': 0.8.0-beta.1
+      '@astrojs/markdown-remark': 7.0.0-beta.6
+      '@astrojs/telemetry': 3.3.0
+      '@capsizecss/unpack': 4.0.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.1)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      boxen: 8.0.1
+      ci-info: 4.4.0
+      clsx: 2.1.1
+      common-ancestor-path: 2.0.0
+      cookie: 1.1.1
+      cssesc: 3.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      deterministic-object-hash: 2.0.2
+      devalue: 5.6.4
+      diff: 8.0.3
+      dlv: 1.1.3
+      dset: 3.1.4
+      es-module-lexer: 2.0.0
+      esbuild: 0.25.5
+      flattie: 1.1.1
+      fontace: 0.4.1
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      js-yaml: 4.1.1
+      magic-string: 0.30.21
+      magicast: 0.5.2
+      mrmime: 2.0.1
+      neotraverse: 0.6.18
+      p-limit: 7.3.0
+      p-queue: 9.1.0
+      package-manager-detector: 1.6.0
+      piccolore: 0.1.3
+      picomatch: 4.0.4
+      prompts: 2.4.2
+      rehype: 13.0.2
+      semver: 7.7.4
+      shiki: 3.23.0
+      smol-toml: 1.6.1
+      svgo: 4.0.1
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tsconfck: 3.1.6(typescript@5.9.3)
+      ultrahtml: 1.6.0
+      unifont: 0.7.4
+      unist-util-visit: 5.1.0
+      unstorage: 1.17.4(@azure/identity@4.13.0)(@netlify/blobs@10.7.0)(@vercel/functions@3.4.3)
+      vfile: 6.0.3
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 22.0.0
+      yocto-spinner: 1.1.0
+      zod: 4.3.6
+    optionalDependencies:
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - yaml
+
   async-sema@3.1.1: {}
 
   async@3.2.6: {}
@@ -20070,6 +20355,8 @@ snapshots:
 
   bare-events@2.8.2: {}
 
+  base-64@1.0.0: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.19: {}
@@ -20133,6 +20420,17 @@ snapshots:
   bottleneck@2.19.5: {}
 
   boundary@2.0.0: {}
+
+  boxen@8.0.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 8.0.0
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -20216,6 +20514,8 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
+
+  camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001774: {}
 
@@ -20309,6 +20609,8 @@ snapshots:
       consola: 3.4.2
 
   cjs-module-lexer@1.4.3: {}
+
+  cli-boxes@3.0.0: {}
 
   cli-cursor@4.0.0:
     dependencies:
@@ -20679,6 +20981,10 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  deterministic-object-hash@2.0.2:
+    dependencies:
+      base-64: 1.0.0
 
   dettle@1.0.5: {}
 
@@ -21199,6 +21505,10 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fake-svelte-pkg@file:packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg(svelte@5.54.1):
+    dependencies:
+      svelte: 5.54.1
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -22167,6 +22477,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -23912,6 +24224,11 @@ snapshots:
 
   promise-limit@2.7.0: {}
 
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
@@ -24535,6 +24852,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   shiki@4.0.2:
     dependencies:
@@ -25749,6 +26077,10 @@ snapshots:
 
   wicked-good-xpath@1.3.0: {}
 
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
+
   winston-transport@4.9.0:
     dependencies:
       logform: 2.7.0
@@ -25814,6 +26146,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
+      strip-ansi: 7.1.2
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
@@ -25936,6 +26274,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yocto-spinner@1.1.0:
+    dependencies:
+      yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
 


### PR DESCRIPTION
## Changes

- Packages that ship `.svelte` files (e.g. `bits-ui`) now work with the Cloudflare adapter's `prerenderEnvironment: 'node'` option. Previously they failed with `Unknown file extension ".svelte"` because the prerender environment's `resolve.noExternal` was missing these packages, so they were loaded via Node's native `import()` instead of Vite's transform pipeline.
- **`@astrojs/cloudflare`**: Removed top-level `ssr.noExternal = true` from the `cf-externals` plugin. This was poisoning `vitefu`'s `crawlFrameworkPkgs` into returning an empty list, since it assumed all packages were already noExternal. The `ssr` environment still gets `resolve.noExternal: true` from `@cloudflare/vite-plugin` directly. Also removed the `configEnvironment` hook that disabled dep optimization for the prerender environment.
- **`@astrojs/svelte`**: Uses `crawlFrameworkPkgs` to discover packages that peerDepend on `svelte` and adds them to `resolve.noExternal` for all server environments (including `prerender`) via `configEnvironment`.

## Testing

- Added a test to the existing `prerenderEnvironment: 'node'` test suite that renders a svelte component importing a `.svelte` file from a fake `node_modules` package.
- All 6 existing tests continue to pass, including workerd SSR, server islands, and Node.js API access.

## Docs

- No docs update needed — this fixes a bug, no new API surface.

Closes #15906
