### PR TITLE
fix: react 19 ssr aito injection preload link

### DIFF
--- a/.changeset/nine-jokes-sink.md
+++ b/.changeset/nine-jokes-sink.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Fix React 19 "Float" mechanism injecting <link rel="preload"> into Astro islands instead of the <head>. This PR adds a filter to @astrojs/react to strip these auto-generated resource from the island's HTML output, ensuring valid HTML structure.

--- a/packages/integrations/react/src/server.ts
+++ b/packages/integrations/react/src/server.ts
@@ -133,8 +133,8 @@ async function renderToStaticMarkup(
 	// These should be in <head>, not inside the island.
 	// See: https://github.com/facebook/react/issues/27910
 	html = html.replace(
-		/<link\s+[^>]*rel="(?:preload|modulepreload|stylesheet|preconnect|dns-prefetch)"[^>]*\/?>/g,
-		'',
+  	/<link\s[^>]*rel="(?:preload|modulepreload|stylesheet|preconnect|dns-prefetch)"[^>]*>/g,
+  	'',
 	);
 	return { html, attrs };
 }

--- a/packages/integrations/react/src/server.ts
+++ b/packages/integrations/react/src/server.ts
@@ -129,6 +129,13 @@ async function renderToStaticMarkup(
 	} else {
 		html = await renderToPipeableStreamAsync(vnode, renderOptions);
 	}
+	// Strip React 19 auto-injected resource hints (preloads, etc.) from island output.
+	// These should be in <head>, not inside the island.
+	// See: https://github.com/facebook/react/issues/27910
+	html = html.replace(
+		/<link\s+[^>]*rel="(?:preload|modulepreload|stylesheet|preconnect|dns-prefetch)"[^>]*\/?>/g,
+		'',
+	);
 	return { html, attrs };
 }
 

--- a/packages/integrations/react/test/fixtures/react-19-preloads/astro.config.mjs
+++ b/packages/integrations/react/test/fixtures/react-19-preloads/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+export default defineConfig({
+  integrations: [react()],
+});

--- a/packages/integrations/react/test/fixtures/react-19-preloads/package.json
+++ b/packages/integrations/react/test/fixtures/react-19-preloads/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixture/react-19-preloads",
+  "type": "module",
+  "dependencies": {
+    "astro": "latest",
+    "@astrojs/react": "latest",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/integrations/react/test/fixtures/react-19-preloads/src/components/ImageComponent.jsx
+++ b/packages/integrations/react/test/fixtures/react-19-preloads/src/components/ImageComponent.jsx
@@ -1,0 +1,8 @@
+export default function ImageComponent() {
+  return (
+    <div>
+      <h1>React 19 Island</h1>
+      <img src="/_astro/test-image.webp" alt="Test" />
+    </div>
+  );
+}

--- a/packages/integrations/react/test/fixtures/react-19-preloads/src/pages/index.astro
+++ b/packages/integrations/react/test/fixtures/react-19-preloads/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import ImageComponent from '../components/ImageComponent';
+---
+<html>
+<head>
+  <title>React 19 Test</title>
+</head>
+<body>
+  <ImageComponent client:load />
+</body>
+</html>

--- a/packages/integrations/react/test/react-19-preloads.test.js
+++ b/packages/integrations/react/test/react-19-preloads.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+test.describe('React 19 SSR integration', () => {
+	test('should strip preloads to prevent invalid HTML inside astro-islands', async () => {
+  	const fixture = await loadFixture({ root: new URL('./fixtures/react-19-preloads/', import.meta.url) });
+  	await fixture.build();
+
+  	const html = await fixture.readFile('/index.html');
+  	const islandPattern = /<astro-island[^>]*>([\s\S]*?)<\/astro-island>/;
+  	const match = islandPattern.exec(html);
+  	const island = match ? match[1] : '';
+
+  	assert.ok(!island.includes('rel="preload"'), 'React 19: preloads should be stripped');
+  	assert.ok(island.includes('<img'), 'Component content should be preserved');
+	});
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1893,6 +1893,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/actions-middleware-context: {}
+
   packages/astro/test/fixtures/alias:
     dependencies:
       '@astrojs/svelte':
@@ -6182,6 +6184,21 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+
+  packages/integrations/react/test/fixtures/react-19-preloads:
+    dependencies:
+      '@astrojs/react':
+        specifier: latest
+        version: link:../../..
+      astro:
+        specifier: latest
+        version: link:../../../../../astro
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
 
   packages/integrations/react/test/fixtures/react-component:
     dependencies:


### PR DESCRIPTION
## Changes
Fix React 19 "Float" mechanism injecting <link rel="preload"> into Astro islands instead of the <head>. This PR adds a filter to @astrojs/react to strip these auto-generated resource from the island's HTML output, ensuring valid HTML structure.

- issue : #16212

## Testing

Before Implemented:

<img width="992" height="466" alt="スクリーンショット 2026-04-05 10 00 14" src="https://github.com/user-attachments/assets/6d9e7797-100f-4c71-bb55-d5ea499583c9" />

After Implemented:

<img width="698" height="198" alt="スクリーンショット 2026-04-05 10 02 28" src="https://github.com/user-attachments/assets/05920116-485f-4b79-9245-82ac366e2a0c" />


## Docs
