### PR TITLE
fix(cloudflare): exclude queue consumers from prerender worker

### DIFF
--- a/.changeset/fix-cf-prerender-queue-consumers.md
+++ b/.changeset/fix-cf-prerender-queue-consumers.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes `ERR_MULTIPLE_CONSUMERS` error when using Cloudflare Queues with prerendered pages. The prerender worker config callback now excludes `queues.consumers` from the entry worker config, since the prerender worker only renders static HTML and should not register as a queue consumer. Queue producers (bindings) are preserved.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -181,11 +181,15 @@ export default function createIntegration({
 						experimental: {
 							prerenderWorker: {
 								config(_, { entryWorkerConfig }) {
+									const { queues, ...restWorkerConfig } = entryWorkerConfig;
 									return {
-										...entryWorkerConfig,
+										...restWorkerConfig,
 										name: 'prerender',
+										...(queues?.producers?.length && {
+											queues: { producers: queues.producers },
+										}),
 										...(needsImagesBinding &&
-											!entryWorkerConfig.images && {
+											!restWorkerConfig.images && {
 												images: { binding: imagesBindingName },
 											}),
 									};

--- a/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/astro.config.mjs
@@ -1,0 +1,7 @@
+import cloudflare from '@astrojs/cloudflare';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	adapter: cloudflare(),
+	output: 'server',
+});

--- a/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-cloudflare-prerender-queue-consumers",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/cloudflare": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/src/pages/api.ts
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/src/pages/api.ts
@@ -1,0 +1,9 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+	return new Response(JSON.stringify({ ok: true }), {
+		headers: { 'Content-Type': 'application/json' },
+	});
+};

--- a/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+// This page is prerendered by default (output: 'server' with no opt-out)
+// Actually, in output: 'server' mode, pages are server-rendered by default.
+// We explicitly mark this as prerendered.
+export const prerender = true;
+---
+<html>
+<head><title>Prerendered</title></head>
+<body><h1>Prerendered Page</h1></body>
+</html>

--- a/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/wrangler.jsonc
+++ b/packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+  "name": "prerender-queue-consumers",
+  "main": "@astrojs/cloudflare/entrypoints/server",
+  "compatibility_date": "2026-01-28",
+  "queues": {
+    "consumers": [
+      {
+        "queue": "my-queue"
+      }
+    ],
+    "producers": [
+      {
+        "binding": "MY_QUEUE",
+        "queue": "my-queue"
+      }
+    ]
+  }
+}

--- a/packages/integrations/cloudflare/test/prerender-queue-consumers.test.js
+++ b/packages/integrations/cloudflare/test/prerender-queue-consumers.test.js
@@ -1,0 +1,33 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { loadFixture } from './_test-utils.js';
+
+describe('Prerender with queue consumers', () => {
+	let fixture;
+	let previewServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/prerender-queue-consumers/',
+		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
+
+	after(async () => {
+		previewServer.stop();
+	});
+
+	it('builds and previews without ERR_MULTIPLE_CONSUMERS', async () => {
+		// The prerendered page should be accessible
+		const res = await fixture.fetch('/');
+		const html = await res.text();
+		assert.ok(html.includes('Prerendered Page'));
+	});
+
+	it('serves the SSR endpoint', async () => {
+		const res = await fixture.fetch('/api');
+		const json = await res.json();
+		assert.deepEqual(json, { ok: true });
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4976,6 +4976,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/cloudflare/test/fixtures/prerender-queue-consumers:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/cloudflare/test/fixtures/prerender-styles:
     dependencies:
       '@astrojs/cloudflare':


### PR DESCRIPTION
## Summary

Fixes #16199. The `@astrojs/cloudflare` adapter's prerender worker config callback spreads the entire `entryWorkerConfig` into the prerender worker, including `queues.consumers`. When Miniflare sees two workers both registered as consumers of the same queue, it rejects with `ERR_MULTIPLE_CONSUMERS`. The prerender worker only renders static HTML and has no need for queue consumer registrations.

## Changes

- Destructure `queues` from `entryWorkerConfig` in the prerender worker `config()` callback
- Spread `restWorkerConfig` (without queues) instead of the full config
- Preserve `queues.producers` (bindings) when present, since producers are just bindings and don't cause conflicts
- Drop `queues.consumers` entirely from the prerender worker
- Add test fixture with a hybrid site (prerendered page + SSR endpoint) that defines both `queues.consumers` and `queues.producers` in `wrangler.jsonc`
- Add test verifying the build succeeds and both routes work in preview

## Test plan

- [x] New test `prerender-queue-consumers.test.js` passes (2/2 assertions)
- [x] Existing `wrangler-preview-platform.test.js` still passes (4/4 assertions)
- [x] Changeset included