### PR TITLE
fix(astro, cloudflare): pass server.allowedHosts to adapter preview entrypoints

### DIFF
--- a/.changeset/fix-allowedhosts-preview-adapter.md
+++ b/.changeset/fix-allowedhosts-preview-adapter.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/cloudflare': patch
+---
+
+Pass `server.allowedHosts` to adapter preview entrypoints so non-localhost Host headers are no longer blocked with 403 when using `astro preview` with the Cloudflare adapter

--- a/.changeset/fix-allowedhosts-preview-adapter.md
+++ b/.changeset/fix-allowedhosts-preview-adapter.md
@@ -1,6 +1,19 @@
 ---
-'astro': patch
-'@astrojs/cloudflare': patch
+'astro': minor
+'@astrojs/cloudflare': minor
 ---
 
-Pass `server.allowedHosts` to adapter preview entrypoints so non-localhost Host headers are no longer blocked with 403 when using `astro preview` with the Cloudflare adapter
+Adds `allowedHosts` to the `PreviewServerParams` interface, making the `server.allowedHosts` configuration available to adapter preview entrypoints.
+
+Previously, `server.allowedHosts` was only applied to the static preview server and the dev server. When using `astro preview` with an adapter like `@astrojs/cloudflare`, requests with non-localhost `Host` headers were always blocked with a `403 Forbidden` response, regardless of your configuration.
+
+You can now configure `server.allowedHosts` and it will be respected during `astro preview` with any adapter that supports it:
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  server: {
+    allowedHosts: ['staging.example.com'],
+  },
+});
+```

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -89,6 +89,7 @@ export default async function preview(inlineConfig: AstroInlineConfig): Promise<
 		base: settings.config.base,
 		logger: new AstroIntegrationLogger(logger.options, settings.adapter.name),
 		headers: settings.config.server.headers,
+		allowedHosts: settings.config.server.allowedHosts,
 		root: settings.config.root,
 	});
 

--- a/packages/astro/src/types/public/preview.ts
+++ b/packages/astro/src/types/public/preview.ts
@@ -18,6 +18,7 @@ export interface PreviewServerParams {
 	base: string;
 	logger: AstroIntegrationLogger;
 	headers?: OutgoingHttpHeaders;
+	allowedHosts?: string[] | true;
 	root: URL;
 }
 

--- a/packages/astro/test/fixtures/ssr-preview-allowed-hosts/package.json
+++ b/packages/astro/test/fixtures/ssr-preview-allowed-hosts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/ssr-preview-allowed-hosts",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-preview-allowed-hosts/preview.mjs
+++ b/packages/astro/test/fixtures/ssr-preview-allowed-hosts/preview.mjs
@@ -1,0 +1,43 @@
+import { preview } from 'vite';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A minimal adapter preview entrypoint that mirrors the Cloudflare adapter pattern:
+ * it starts a Vite preview server and forwards `allowedHosts` from the Astro config.
+ *
+ * This lets us test that the core preview entrypoint actually passes `allowedHosts`
+ * through to adapter preview modules.
+ */
+export default async function ({ host, port, headers, base, root, server, allowedHosts }) {
+	const previewServer = await preview({
+		configFile: false,
+		base,
+		appType: 'mpa',
+		build: {
+			outDir: fileURLToPath(server),
+		},
+		root: fileURLToPath(root),
+		preview: {
+			host,
+			port,
+			headers,
+			open: false,
+			allowedHosts: allowedHosts ?? [],
+		},
+	});
+
+	function closed() {
+		return new Promise((resolve, reject) => {
+			previewServer.httpServer.addListener('close', resolve);
+			previewServer.httpServer.addListener('error', reject);
+		});
+	}
+
+	return {
+		host,
+		port,
+		closed,
+		server: previewServer.httpServer,
+		stop: previewServer.close.bind(previewServer),
+	};
+}

--- a/packages/astro/test/fixtures/ssr-preview-allowed-hosts/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-preview-allowed-hosts/src/pages/index.astro
@@ -1,0 +1,6 @@
+<html>
+  <head></head>
+  <body>
+    <h1>Hello world!</h1>
+  </body>
+</html>

--- a/packages/astro/test/ssr-preview-allowed-hosts.test.js
+++ b/packages/astro/test/ssr-preview-allowed-hosts.test.js
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { after, before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
+
+/**
+ * Make a raw HTTP request with a custom Host header.
+ * Node's built-in fetch ignores Host header overrides, so we use node:http directly.
+ */
+function fetchWithHost(port, hostHeader) {
+	return new Promise((resolve, reject) => {
+		const req = http.request(
+			{
+				hostname: 'localhost',
+				port,
+				path: '/',
+				method: 'GET',
+				headers: { host: hostHeader },
+			},
+			(res) => {
+				res.resume();
+				resolve(res);
+			},
+		);
+		req.on('error', reject);
+		req.end();
+	});
+}
+
+function getBoundPort(previewServer) {
+	return previewServer.server.address().port;
+}
+
+describe('adapter preview - server.allowedHosts is passed to adapter', () => {
+	let fixture;
+	let previewServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-preview-allowed-hosts/',
+			output: 'server',
+			adapter: testAdapter({
+				extendAdapter: {
+					previewEntrypoint: './preview.mjs',
+				},
+			}),
+			server: {
+				allowedHosts: ['example.com'],
+			},
+		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
+
+	after(async () => {
+		await previewServer.stop();
+		await fixture.clean();
+	});
+
+	it('allows requests from a host listed in server.allowedHosts', async () => {
+		const res = await fetchWithHost(getBoundPort(previewServer), 'example.com');
+		// The SSR server build output doesn't serve static HTML, so we may get 404.
+		// The important assertion is that it's NOT 403 (host validation passed).
+		assert.notEqual(res.statusCode, 403);
+	});
+
+	it('blocks requests from a host not in server.allowedHosts', async () => {
+		const res = await fetchWithHost(getBoundPort(previewServer), 'evil.com');
+		assert.equal(res.statusCode, 403);
+	});
+});
+
+describe('adapter preview - server.allowedHosts: true allows all hosts', () => {
+	let fixture;
+	let previewServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-preview-allowed-hosts/',
+			outDir: './dist-allow-all/',
+			output: 'server',
+			adapter: testAdapter({
+				extendAdapter: {
+					previewEntrypoint: './preview.mjs',
+				},
+			}),
+			server: {
+				allowedHosts: true,
+			},
+		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
+
+	after(async () => {
+		await previewServer.stop();
+		await fixture.clean();
+	});
+
+	it('allows requests from any host when server.allowedHosts is true', async () => {
+		const res = await fetchWithHost(getBoundPort(previewServer), 'any-host.example');
+		assert.notEqual(res.statusCode, 403);
+	});
+});
+
+describe('adapter preview - allowedHosts defaults to empty when not configured', () => {
+	let fixture;
+	let previewServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-preview-allowed-hosts/',
+			outDir: './dist-default/',
+			output: 'server',
+			adapter: testAdapter({
+				extendAdapter: {
+					previewEntrypoint: './preview.mjs',
+				},
+			}),
+			// No server.allowedHosts configured — should default to []
+		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
+
+	after(async () => {
+		await previewServer.stop();
+		await fixture.clean();
+	});
+
+	it('allows localhost requests when no allowedHosts is configured', async () => {
+		const res = await fetchWithHost(getBoundPort(previewServer), 'localhost');
+		assert.notEqual(res.statusCode, 403);
+	});
+});

--- a/packages/integrations/cloudflare/src/entrypoints/preview.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/preview.ts
@@ -21,6 +21,7 @@ const createPreviewServer: CreatePreviewServer = async ({
 	port,
 	host,
 	root,
+	allowedHosts,
 }) => {
 	const wranglerConfigPath = resolvePath(fileURLToPath(root), '.wrangler/deploy/config.json');
 	if (!existsSync(wranglerConfigPath)) {
@@ -45,7 +46,7 @@ const createPreviewServer: CreatePreviewServer = async ({
 				port,
 				headers,
 				open: false,
-				allowedHosts: [],
+				allowedHosts: allowedHosts ?? [],
 			},
 			plugins: [
 				cfVitePlugin({ ...globalThis.astroCloudflareOptions, viteEnvironment: { name: 'ssr' } }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4274,6 +4274,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/ssr-preview-allowed-hosts:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/ssr-renderers-static-vue:
     dependencies:
       '@astrojs/vue':


### PR DESCRIPTION
## Changes

- Added `allowedHosts` to the `PreviewServerParams` interface so adapter preview entrypoints can receive the user's `server.allowedHosts` configuration
- Pass `settings.config.server.allowedHosts` from the core preview entrypoint (`packages/astro/src/core/preview/index.ts`) to adapter preview modules
- Update the Cloudflare adapter's preview entrypoint to use the passed `allowedHosts` value (`allowedHosts ?? []`) instead of hardcoding an empty array

**Before:** `astro preview` with `@astrojs/cloudflare` always returns 403 for non-localhost Host headers, regardless of `server.allowedHosts` config.

**After:** `server.allowedHosts` is respected, matching the behavior of `astro dev` and the static preview server.

Fixes #16198

## Testing

- Existing tests in `test/astro-preview-allowed-hosts.test.js` pass (5/5 tests, 3 suites)
- TypeScript compilation passes for both `astro` and `@astrojs/cloudflare` with 0 errors
- Both packages build cleanly (0 errors, 0 warnings)
- Biome lint passes on all changed files
- Manual verification: the static preview server already handles `allowedHosts` correctly via the same pattern (see `static-preview-server.ts`); this fix extends that to adapter preview entrypoints

## Docs

No docs changes needed. `server.allowedHosts` is already documented — this fix makes it work correctly with adapter preview entrypoints as users would expect.
