### PR TITLE
fix(astro): handle case-insensitive paths when matching style modules

### DIFF
--- a/.changeset/fix-style-case-mismatch.md
+++ b/.changeset/fix-style-case-mismatch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix inline `<style>` blocks being silently dropped when running `npm run dev` from a path whose casing differs from the canonical filesystem path on Windows and macOS.

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -5,6 +5,13 @@ import { parseAstroRequest } from './query.js';
 import type { CompileMetadata } from './types.js';
 import { frontmatterRE } from './utils.js';
 
+// Case-insensitive filesystems (Windows, macOS) may report file paths with different
+// casing than the canonical path used to store metadata. Normalize for comparison.
+const isCaseInsensitiveFS = process.platform === 'win32' || process.platform === 'darwin';
+function normalizePathForComparison(path: string) {
+	return isCaseInsensitiveFS ? path.toLowerCase() : path;
+}
+
 interface HandleHotUpdateOptions {
 	logger: Logger;
 	compile: (code: string, filename: string) => Promise<CompileAstroResult>;
@@ -20,7 +27,13 @@ export async function handleHotUpdate(
 	// If any `ctx.file` is part of a CSS dependency of any Astro file, invalidate its `astroFileToCompileMetadata`
 	// so the next transform of the Astro file or Astro script/style virtual module will re-generate it
 	for (const [astroFile, compileData] of astroFileToCompileMetadata) {
-		const isUpdatedFileCssDep = compileData.css.some((css) => css.dependencies?.includes(ctx.file));
+		const isUpdatedFileCssDep = compileData.css.some((css) =>
+			css.dependencies?.some(
+				(dep) =>
+					normalizePathForComparison(dep) === normalizePathForComparison(ctx.file) ||
+					dep === ctx.file,
+			),
+			);
 		if (isUpdatedFileCssDep) {
 			astroFileToCompileMetadata.delete(astroFile);
 		}
@@ -31,7 +44,20 @@ export async function handleHotUpdate(
 	// If only the style code has changed, e.g. editing the `color`, then we can directly invalidate
 	// the Astro CSS virtual modules only. The main Astro module's JS result will be the same and doesn't
 	// need to be invalidated.
-	const oldCode = astroFileToCompileMetadata.get(ctx.file)?.originalCode;
+	// Look up compile metadata using the actual file path from Vite's watcher, which uses
+	// the canonical filesystem casing. Also try the ctx.file as-is to handle case-
+	// insensitive filesystem mismatches.
+	const normalizedFile = normalizePathForComparison(ctx.file);
+	let compileData = astroFileToCompileMetadata.get(ctx.file);
+	if (!compileData) {
+		for (const [key, value] of astroFileToCompileMetadata) {
+			if (normalizePathForComparison(key) === normalizedFile) {
+				compileData = value;
+				break;
+			}
+		}
+	}
+	const oldCode = compileData?.originalCode;
 	if (oldCode == null) return;
 	const newCode = await ctx.read();
 


### PR DESCRIPTION
On case-insensitive filesystems (Windows, macOS), running `npm run dev` from a path with different casing than the canonical filesystem path caused inline `<style>` blocks to be silently dropped.

## Root cause

The HMR handler in `vite-plugin-astro/hmr.ts` compared file paths using strict equality. When the casing of `ctx.file` (provided by Vite's watcher using the actual filesystem casing) differed from the key stored in the compile metadata map, lookups failed and CSS was never returned.

## Changes

- Normalize path casing for comparison when looking up compile metadata on `win32` and `darwin`.
- Normalize CSS dependency paths using the same approach when checking if an updated file is a CSS dependency.
- Add a changeset for the `astro` package.

## Testing

Existing HMR tests continue to pass. The fix is scoped to case-insensitive platforms so Linux behavior is unaffected.

Fixes #14013