### PR TITLE
fix: normalize path casing for style resolution in dev mode

### DIFF
--- a/.changeset/gold-owl-soft-net.md
+++ b/.changeset/gold-owl-soft-net.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes style resolution in dev mode on case-insensitive file systems (macOS, Windows) where path casing differences between the working directory and the actual filesystem caused styles not to be found.

--- a/packages/astro/src/vite-plugin-astro-server/vite.ts
+++ b/packages/astro/src/vite-plugin-astro-server/vite.ts
@@ -13,6 +13,29 @@ const fileExtensionsToSSR = new Set(['.astro', '.mdoc', ...SUPPORTED_MARKDOWN_FI
 
 const STRIP_QUERY_PARAMS_REGEX = /\?.*$/;
 
+/**
+ * Case-insensitive fallback for `moduleGraph.getModulesByFile()`.
+ * On case-insensitive file systems (macOS, Windows), the working directory
+ * casing may differ from the actual filesystem casing (e.g. `d:\` vs `D:\`),
+ * causing exact-match lookups to fail. When the exact match returns nothing,
+ * we fall back to a case-insensitive comparison against the known file keys.
+ */
+function getModulesByFileCaseInsensitive(
+	environment: RunnableDevEnvironment,
+	file: string,
+): Set<EnvironmentModuleNode> | undefined {
+	const exact = environment.moduleGraph.getModulesByFile(file);
+	if (exact) return exact;
+
+	const fileLower = file.toLowerCase();
+	for (const mod of environment.moduleGraph.idToModuleMap.values()) {
+		if (mod.file && mod.file.toLowerCase() === fileLower) {
+			return environment.moduleGraph.getModulesByFile(mod.file);
+		}
+	}
+	return undefined;
+}
+
 /** recursively crawl the module graph to get all style files imported by parent id */
 export async function* crawlGraph(
 	environment: RunnableDevEnvironment,
@@ -27,7 +50,9 @@ export async function* crawlGraph(
 		? // "getModulesByFile" pulls from a delayed module cache (fun implementation detail),
 			// So we can get up-to-date info on initial server load.
 			// Needed for slower CSS preprocessing like Tailwind
-			(environment.moduleGraph.getModulesByFile(id) ?? new Set())
+			// Uses case-insensitive fallback for systems where CWD casing may differ from
+			// the filesystem (e.g. Windows drive letter or macOS case-insensitive volumes).
+			(getModulesByFileCaseInsensitive(environment, id) ?? new Set())
 		: // For non-root files, we're safe to pull from "getModuleById" based on testing.
 			// TODO: Find better invalidation strategy to use "getModuleById" in all cases!
 			new Set([environment.moduleGraph.getModuleById(id)]);
@@ -39,7 +64,7 @@ export async function* crawlGraph(
 		if (!entry) {
 			continue;
 		}
-		if (id === entry.id) {
+		if (id === entry.id || id.toLowerCase() === entry.id?.toLowerCase()) {
 			scanned.add(id);
 
 			// NOTE: It may be worth revisiting if we can crawl direct imports of the module since
@@ -119,7 +144,7 @@ export async function* crawlGraph(
 // a real import.
 function isImportedBy(parent: string, entry: EnvironmentModuleNode) {
 	for (const importer of entry.importers) {
-		if (importer.id === parent) {
+		if (importer.id === parent || importer.id?.toLowerCase() === parent.toLowerCase()) {
 			return true;
 		}
 	}

--- a/packages/astro/test/units/vite-plugin-astro-server/crawl-graph.test.ts
+++ b/packages/astro/test/units/vite-plugin-astro-server/crawl-graph.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { crawlGraph } from '../../../dist/vite-plugin-astro-server/vite.js';
+
+/**
+ * Creates a minimal mock of RunnableDevEnvironment for testing crawlGraph.
+ */
+function createMockEnvironment(modules: Array<{
+	id: string;
+	file?: string;
+	importedModules?: Array<{ id: string; importers: Array<{ id: string }> }>;
+}>) {
+	const idToModuleMap = new Map<string, any>();
+	const fileToModulesMap = new Map<string, Set<any>>();
+
+	for (const mod of modules) {
+		const moduleNode = {
+			id: mod.id,
+			file: mod.file ?? mod.id,
+			importedModules: new Set(
+				(mod.importedModules ?? []).map((imp) => ({
+					id: imp.id,
+					importers: new Set(imp.importers.map((i) => ({ id: i.id }))),
+					importedModules: new Set(),
+				})),
+			),
+			importers: new Set(),
+			ssrModule: {},
+		};
+		idToModuleMap.set(mod.id, moduleNode);
+
+		const file = mod.file ?? mod.id;
+		if (!fileToModulesMap.has(file)) {
+			fileToModulesMap.set(file, new Set());
+		}
+		fileToModulesMap.get(file)!.add(moduleNode);
+	}
+
+	return {
+		moduleGraph: {
+			getModulesByFile(file: string) {
+				return fileToModulesMap.get(file);
+			},
+			getModuleById(id: string) {
+				return idToModuleMap.get(id);
+			},
+			idToModuleMap,
+		},
+		runner: {
+			async import(_id: string) {},
+		},
+	} as any;
+}
+
+describe('crawlGraph', () => {
+	it('resolves styles when path casing matches exactly', async () => {
+		const env = createMockEnvironment([
+			{
+				id: '/projects/my-app/src/pages/index.astro',
+				importedModules: [
+					{
+						id: '/projects/my-app/src/styles/global.css',
+						importers: [{ id: '/projects/my-app/src/pages/index.astro' }],
+					},
+				],
+			},
+		]);
+
+		const results: any[] = [];
+		for await (const mod of crawlGraph(
+			env,
+			'/projects/my-app/src/pages/index.astro',
+			true,
+		)) {
+			results.push(mod);
+		}
+
+		assert.equal(results.length, 1);
+		assert.equal(results[0].id, '/projects/my-app/src/styles/global.css');
+	});
+
+	it('resolves styles when path casing differs (case-insensitive filesystem)', async () => {
+		// Simulate: CWD gives lowercase path, but module graph has uppercase
+		// e.g. on Windows: d:\projects vs D:\Projects
+		const env = createMockEnvironment([
+			{
+				id: 'D:/Projects/my-app/src/pages/index.astro',
+				file: 'D:/Projects/my-app/src/pages/index.astro',
+				importedModules: [
+					{
+						id: 'D:/Projects/my-app/src/styles/global.css',
+						importers: [{ id: 'D:/Projects/my-app/src/pages/index.astro' }],
+					},
+				],
+			},
+		]);
+
+		// Query with different casing (simulating CWD with different drive letter case)
+		const results: any[] = [];
+		for await (const mod of crawlGraph(
+			env,
+			'd:/projects/my-app/src/pages/index.astro',
+			true,
+		)) {
+			results.push(mod);
+		}
+
+		assert.equal(results.length, 1, 'Should find CSS module despite path casing difference');
+		assert.equal(results[0].id, 'D:/Projects/my-app/src/styles/global.css');
+	});
+
+	it('returns no results when path does not match even case-insensitively', async () => {
+		const env = createMockEnvironment([
+			{
+				id: '/projects/my-app/src/pages/index.astro',
+				importedModules: [],
+			},
+		]);
+
+		const results: any[] = [];
+		for await (const mod of crawlGraph(
+			env,
+			'/completely/different/path.astro',
+			true,
+		)) {
+			results.push(mod);
+		}
+
+		assert.equal(results.length, 0);
+	});
+});


### PR DESCRIPTION
## Changes

Fixes #14013

- Styles were missing in dev mode when the import path casing differed from the actual file path (e.g., `d:\projects` vs `D:\Projects`). This affected case-insensitive file systems (macOS, Windows).
- Added `getModulesByFileCaseInsensitive()` helper that falls back to case-insensitive comparison when exact-match lookup returns nothing.
- Normalized path comparison in `crawlGraph()` and `isImportedBy()` to be case-insensitive.

## Testing

- Added unit tests in `packages/astro/test/units/vite-plugin-astro-server/crawl-graph.test.ts`
  - Tests exact-match path resolution still works
  - Tests case-insensitive fallback when path casing differs (e.g., Windows drive letter case)
  - Tests that unrelated paths return no results

## Docs

No docs changes needed — this is an internal bug fix with no user-facing API changes.