### PR TITLE
chore: refactor `dlv` util to use `.reduce`

### DIFF
--- a/packages/astro/src/preferences/dlv.ts
+++ b/packages/astro/src/preferences/dlv.ts
@@ -1,7 +1,3 @@
-export default function dlv(obj: Record<string, unknown>, key: string): any {
-	for (const k of key.split('.')) {
-		// @ts-expect-error: Type 'unknown' is not assignable to type 'Record<string, unknown>'.
-		obj = obj?.[k];
-	}
-	return obj;
+export default function dlv(obj: Record<string, any>, key: string): any {
+	return key.split('.').reduce((acc, k) => acc?.[k], obj);
 }


### PR DESCRIPTION
## Changes

Refactor `dlv` util to use a simpler `.reduce` instead of manual loop and assignment


## Testing

Tests still pass


## Docs

N/A
