### PR TITLE
fix(core): fix append of assetQueryParams to inter-chunk JS *dynamic* imports (#16258)

### DIFF
--- a/.changeset/twelve-sloths-kiss.md
+++ b/.changeset/twelve-sloths-kiss.md
@@ -2,6 +2,4 @@
 'astro': patch
 ---
 
-Fixes Vercel build errors for skew protection query parameters appended to inter-chunk Javascript using dynamic imports in client bundles.
-
-NOTE: Fix was written by https://github.com/leifmarcus in issue comment https://github.com/withastro/astro/issues/16258#issuecomment-4222396413
+Fixes build errors on platforms with skew protection enabled (e.g. Vercel, Netlify) for inter-chunk Javascript using dynamic imports

--- a/.changeset/twelve-sloths-kiss.md
+++ b/.changeset/twelve-sloths-kiss.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes Vercel build errors for skew protection query parameters appended to inter-chunk Javascript using dynamic imports in client bundles.
+
+NOTE: Fix was written by https://github.com/leifmarcus in issue comment https://github.com/withastro/astro/issues/16258#issuecomment-4222396413

--- a/packages/astro/src/core/build/plugins/plugin-chunk-imports.ts
+++ b/packages/astro/src/core/build/plugins/plugin-chunk-imports.ts
@@ -47,8 +47,11 @@ export function pluginChunkImports(options: StaticBuildOptions): VitePlugin | un
 			let rewritten = code;
 			for (let i = relativeImports.length - 1; i >= 0; i--) {
 				const imp = relativeImports[i];
-				// imp.s and imp.e are the start/end offsets of the module specifier (without quotes)
-				rewritten = rewritten.slice(0, imp.e) + '?' + queryString + rewritten.slice(imp.e);
+				// imp.s and imp.e are the start/end offsets of the module specifier.
+				// Static imports: e points after the specifier text, before the quote.
+				// Dynamic string imports: e points after the closing quote.
+				const insertAt = imp.d > -1 ? imp.e - 1 : imp.e;
+				rewritten = rewritten.slice(0, insertAt) + '?' + queryString + rewritten.slice(insertAt);
 			}
 
 			return { code: rewritten, map: null };

--- a/packages/astro/test/asset-query-params.test.js
+++ b/packages/astro/test/asset-query-params.test.js
@@ -173,29 +173,46 @@ describe('Asset Query Parameters in Inter-Chunk JS Imports', () => {
 		const scripts = $('script[src]');
 		assert.ok(scripts.length > 0, 'Should have at least one external script');
 
-		let foundRelativeImport = false;
+		let foundStaticImport = false;
+		let foundDynamicImport = false;
 		// Read all client JS files and check inter-chunk imports have query params
 		const jsFiles = await fixture.glob('client/**/*.js');
 		for (const file of jsFiles) {
 			const code = await fixture.readFile(`/${file}`);
-			// Match relative imports: from"./chunk.js", from "./chunk.js", import("./chunk.js")
-			const allImports = [
+			// Match static imports: from "./chunk.js", from "./chunk.js"
+			const staticImports = [
 				...code.matchAll(/(from\s*["'])(\.\.?\/[^"']+\.(?:js|mjs)(?:\?[^"']*)?)(["'])/g),
+			];
+			// Match dynamic imports: import("./chunk.js")
+			const dynamicImports = [
 				...code.matchAll(/(import\s*\(\s*["'])(\.\.?\/[^"']+\.(?:js|mjs)(?:\?[^"']*)?)(["'])/g),
 			];
-			for (const match of allImports) {
-				foundRelativeImport = true;
+			for (const match of staticImports) {
+				foundStaticImport = true;
 				const importPath = match[2];
 				assert.match(
 					importPath,
 					/\?dpl=test-deploy-id/,
-					`Inter-chunk import should include assetQueryParams: ${match[0]}`,
+					`Static inter-chunk import should include assetQueryParams: ${match[0]}`,
+				);
+			}
+			for (const match of dynamicImports) {
+				foundDynamicImport = true;
+				const importPath = match[2];
+				assert.match(
+					importPath,
+					/\?dpl=test-deploy-id/,
+					`Dynamic inter-chunk import should include assetQueryParams: ${match[0]}`,
 				);
 			}
 		}
 		assert.ok(
-			foundRelativeImport,
-			'Expected at least one relative inter-chunk import in client JS files',
+			foundStaticImport,
+			'Expected at least one static relative inter-chunk import in client JS files',
+		);
+		assert.ok(
+			foundDynamicImport,
+			'Expected at least one dynamic relative inter-chunk import in client JS files',
 		);
 	});
 });

--- a/packages/astro/test/fixtures/asset-query-params-chunks/src/components/CounterB.astro
+++ b/packages/astro/test/fixtures/asset-query-params-chunks/src/components/CounterB.astro
@@ -1,6 +1,8 @@
 <div id="counter-b">Counter B</div>
 <script>
-	import { farewell, MESSAGES } from './shared.js';
+	// Dynamic import here instead of static to test both kinds of import
+	const { farewell, MESSAGES } = (await import('./shared.js'));
+
 	const el = document.getElementById('counter-b');
 	if (el) el.textContent = farewell('B') + ' ' + MESSAGES.success;
 </script>

--- a/packages/astro/test/fixtures/asset-query-params-chunks/src/components/CounterB.astro
+++ b/packages/astro/test/fixtures/asset-query-params-chunks/src/components/CounterB.astro
@@ -1,8 +1,6 @@
 <div id="counter-b">Counter B</div>
 <script>
-	// Dynamic import here instead of static to test both kinds of import
-	const { farewell, MESSAGES } = (await import('./shared.js'));
-
+	import { farewell, MESSAGES } from './shared.js';
 	const el = document.getElementById('counter-b');
 	if (el) el.textContent = farewell('B') + ' ' + MESSAGES.success;
 </script>

--- a/packages/astro/test/fixtures/asset-query-params-chunks/src/components/DynamicLoader.astro
+++ b/packages/astro/test/fixtures/asset-query-params-chunks/src/components/DynamicLoader.astro
@@ -1,0 +1,6 @@
+<div id="dynamic-loader">Dynamic Loader</div>
+<script>
+	const { greet, MESSAGES } = await import('./shared.js');
+	const el = document.getElementById('dynamic-loader');
+	if (el) el.textContent = greet('Dynamic') + ' ' + MESSAGES.loading;
+</script>

--- a/packages/astro/test/fixtures/asset-query-params-chunks/src/pages/index.astro
+++ b/packages/astro/test/fixtures/asset-query-params-chunks/src/pages/index.astro
@@ -1,11 +1,13 @@
 ---
 import CounterA from '../components/CounterA.astro';
 import CounterB from '../components/CounterB.astro';
+import DynamicLoader from '../components/DynamicLoader.astro';
 ---
 <html>
 	<head><title>Chunk Imports Test</title></head>
 	<body>
 		<CounterA />
 		<CounterB />
+		<DynamicLoader />
 	</body>
 </html>


### PR DESCRIPTION
## Changes

Fix build errors in Vercel deployments caused by assetQueryParams being applied incorrectly to inter-chunk JS dynamic imports e.g. `const shared = await import('./shared.js');`

Build error is: `Expected ":" but found ")"`

NOTE: this fix should be credited to @leifmarcus because they suggested it in https://github.com/withastro/astro/issues/16258#issuecomment-4222396413 – this PR just tests and applies that suggestion.

## Testing

Build errors are normally only seen in Vercel deployments, but can be triggered locally by providing the same deployment ID environment variable provided in the Vercel environment when skew protection is enabled:

    VERCEL_DEPLOYMENT_ID=testing pnpm run build

Updated test `appends assetQueryParams to relative imports inside client JS chunks` to include a dynamic import – not just static imports – so it will trigger the build error if run at the commit 4f772eb0 that precedes the fix commit.

I also confirmed the fix by linking the patched Astro to a project that previously failed to build locally using the command above. However I have not yet tested a real Vercel deployment with the fix applied: I'm not sure how to go about doing that?

## Docs

No docs changes needed.