### PR TITLE
test: port render unit tests to TypeScript

### DIFF
--- a/packages/astro/test/units/render/queue-rendering.test.ts
+++ b/packages/astro/test/units/render/queue-rendering.test.ts
@@ -5,13 +5,22 @@ import { renderQueue } from '../../../dist/runtime/server/render/queue/renderer.
 import { NodePool } from '../../../dist/runtime/server/render/queue/pool.js';
 import { renderPage } from '../../../dist/runtime/server/render/page.js';
 
+type QueueSSRResult = Parameters<typeof buildRenderQueue>[1];
+type RenderQueueNode = Awaited<ReturnType<typeof buildRenderQueue>>['nodes'][number];
+type RenderPageResult = Parameters<typeof renderPage>[0];
+type RenderPageComponent = Parameters<typeof renderPage>[1];
+type TestPageFactory = RenderPageComponent & {
+	(props: unknown): string;
+	'astro:html'?: boolean;
+	moduleId: string;
+};
+
 /**
  * Tests for the queue-based rendering engine
  * These are unit tests for the core queue building and rendering logic
  */
 describe('Queue-based rendering engine', () => {
-	// Create a minimal SSRResult mock for testing
-	function createMockResult() {
+	function createMockResult(): QueueSSRResult {
 		return {
 			_metadata: {
 				hasHydrationScript: false,
@@ -32,10 +41,9 @@ describe('Queue-based rendering engine', () => {
 			componentMetadata: new Map(),
 			cancelled: false,
 			compressHTML: false,
-		};
+		} as unknown as QueueSSRResult;
 	}
 
-	// Create a NodePool for testing
 	function createMockPool() {
 		return new NodePool(1000);
 	}
@@ -48,7 +56,7 @@ describe('Queue-based rendering engine', () => {
 
 			assert.ok(queue.nodes.length > 0);
 			assert.equal(queue.nodes[0].type, 'text');
-			assert.equal(queue.nodes[0].content, 'Hello, World!');
+			assert.equal(getTextContent(queue.nodes[0]), 'Hello, World!');
 		});
 
 		it('should handle numbers', async () => {
@@ -58,7 +66,7 @@ describe('Queue-based rendering engine', () => {
 
 			assert.ok(queue.nodes.length > 0);
 			assert.equal(queue.nodes[0].type, 'text');
-			assert.equal(queue.nodes[0].content, '42');
+			assert.equal(getTextContent(queue.nodes[0]), '42');
 		});
 
 		it('should handle booleans', async () => {
@@ -68,7 +76,7 @@ describe('Queue-based rendering engine', () => {
 
 			assert.ok(queue.nodes.length > 0);
 			assert.equal(queue.nodes[0].type, 'text');
-			assert.equal(queue.nodes[0].content, 'true');
+			assert.equal(getTextContent(queue.nodes[0]), 'true');
 		});
 
 		it('should handle arrays', async () => {
@@ -77,15 +85,16 @@ describe('Queue-based rendering engine', () => {
 			const queue = await buildRenderQueue(['Hello', ' ', 'World'], result, pool);
 
 			assert.equal(queue.nodes.length, 3);
-			assert.equal(queue.nodes[0].content, 'Hello');
-			assert.equal(queue.nodes[1].content, ' ');
-			assert.equal(queue.nodes[2].content, 'World');
+			assert.equal(getTextContent(queue.nodes[0]), 'Hello');
+			assert.equal(getTextContent(queue.nodes[1]), ' ');
+			assert.equal(getTextContent(queue.nodes[2]), 'World');
 		});
 
 		it('should handle null and undefined (skip them)', async () => {
 			const result = createMockResult();
-			const nullQueue = await buildRenderQueue(null, result);
-			const undefinedQueue = await buildRenderQueue(undefined, result);
+			const pool = createMockPool();
+			const nullQueue = await buildRenderQueue(null, result, pool);
+			const undefinedQueue = await buildRenderQueue(undefined, result, pool);
 
 			assert.equal(nullQueue.nodes.length, 0);
 			assert.equal(undefinedQueue.nodes.length, 0);
@@ -99,7 +108,7 @@ describe('Queue-based rendering engine', () => {
 
 			assert.equal(falseQueue.nodes.length, 0);
 			assert.equal(zeroQueue.nodes.length, 1);
-			assert.equal(zeroQueue.nodes[0].content, '0');
+			assert.equal(getTextContent(zeroQueue.nodes[0]), '0');
 		});
 
 		it('should handle promises', async () => {
@@ -109,7 +118,7 @@ describe('Queue-based rendering engine', () => {
 			const queue = await buildRenderQueue(promise, result, pool);
 
 			assert.equal(queue.nodes.length, 1);
-			assert.equal(queue.nodes[0].content, 'Resolved value');
+			assert.equal(getTextContent(queue.nodes[0]), 'Resolved value');
 		});
 
 		it('should handle nested arrays', async () => {
@@ -118,9 +127,9 @@ describe('Queue-based rendering engine', () => {
 			const queue = await buildRenderQueue([['Nested', ' '], 'Array'], result, pool);
 
 			assert.equal(queue.nodes.length, 3);
-			assert.equal(queue.nodes[0].content, 'Nested');
-			assert.equal(queue.nodes[1].content, ' ');
-			assert.equal(queue.nodes[2].content, 'Array');
+			assert.equal(getTextContent(queue.nodes[0]), 'Nested');
+			assert.equal(getTextContent(queue.nodes[1]), ' ');
+			assert.equal(getTextContent(queue.nodes[2]), 'Array');
 		});
 
 		it('should handle async iterables', async () => {
@@ -136,9 +145,9 @@ describe('Queue-based rendering engine', () => {
 			const queue = await buildRenderQueue(asyncGen(), result, pool);
 
 			assert.equal(queue.nodes.length, 3);
-			assert.equal(queue.nodes[0].content, 'First');
-			assert.equal(queue.nodes[1].content, 'Second');
-			assert.equal(queue.nodes[2].content, 'Third');
+			assert.equal(getTextContent(queue.nodes[0]), 'First');
+			assert.equal(getTextContent(queue.nodes[1]), 'Second');
+			assert.equal(getTextContent(queue.nodes[2]), 'Third');
 		});
 
 		it('should track parent relationships', async () => {
@@ -147,11 +156,10 @@ describe('Queue-based rendering engine', () => {
 			const pool = createMockPool();
 			const queue = await buildRenderQueue(nestedArray, result, pool);
 
-			// Verify correct node structure
 			assert.equal(queue.nodes.length, 3);
-			assert.equal(queue.nodes[0].content, 'child1');
-			assert.equal(queue.nodes[1].content, 'child2');
-			assert.equal(queue.nodes[2].content, 'sibling');
+			assert.equal(getTextContent(queue.nodes[0]), 'child1');
+			assert.equal(getTextContent(queue.nodes[1]), 'child2');
+			assert.equal(getTextContent(queue.nodes[2]), 'sibling');
 		});
 
 		it('should maintain correct rendering order', async () => {
@@ -159,9 +167,9 @@ describe('Queue-based rendering engine', () => {
 			const pool = createMockPool();
 			const queue = await buildRenderQueue(['A', 'B', 'C'], result, pool);
 
-			assert.equal(queue.nodes[0].content, 'A');
-			assert.equal(queue.nodes[1].content, 'B');
-			assert.equal(queue.nodes[2].content, 'C');
+			assert.equal(getTextContent(queue.nodes[0]), 'A');
+			assert.equal(getTextContent(queue.nodes[1]), 'B');
+			assert.equal(getTextContent(queue.nodes[2]), 'C');
 		});
 
 		it('should handle sync iterables (Set)', async () => {
@@ -171,8 +179,7 @@ describe('Queue-based rendering engine', () => {
 			const queue = await buildRenderQueue(set, result, pool);
 
 			assert.equal(queue.nodes.length, 3);
-			// Set iteration order is insertion order
-			const contents = queue.nodes.map((n) => n.content);
+			const contents = queue.nodes.map((node) => getTextContent(node));
 			assert.ok(contents.includes('One'));
 			assert.ok(contents.includes('Two'));
 			assert.ok(contents.includes('Three'));
@@ -187,7 +194,7 @@ describe('Queue-based rendering engine', () => {
 
 			let output = '';
 			const destination = {
-				write(chunk) {
+				write(chunk: unknown) {
 					output += String(chunk);
 				},
 			};
@@ -203,7 +210,7 @@ describe('Queue-based rendering engine', () => {
 
 			let output = '';
 			const destination = {
-				write(chunk) {
+				write(chunk: unknown) {
 					output += String(chunk);
 				},
 			};
@@ -219,7 +226,7 @@ describe('Queue-based rendering engine', () => {
 
 			let output = '';
 			const destination = {
-				write(chunk) {
+				write(chunk: unknown) {
 					output += String(chunk);
 				},
 			};
@@ -236,7 +243,7 @@ describe('Queue-based rendering engine', () => {
 
 			let output = '';
 			const destination = {
-				write(chunk) {
+				write(chunk: unknown) {
 					output += String(chunk);
 				},
 			};
@@ -252,7 +259,7 @@ describe('Queue-based rendering engine', () => {
 
 			let output = '';
 			const destination = {
-				write(chunk) {
+				write(chunk: unknown) {
 					output += String(chunk);
 				},
 			};
@@ -268,7 +275,7 @@ describe('Queue-based rendering engine', () => {
  * queuedRendering breaks .html pages by escaping their raw HTML string output.
  */
 describe('renderPage() with queuedRendering and .html pages', () => {
-	function createMockResultWithQueue() {
+	function createMockResultWithQueue(): RenderPageResult {
 		const pool = new NodePool(1000);
 		return {
 			_metadata: {
@@ -297,24 +304,22 @@ describe('renderPage() with queuedRendering and .html pages', () => {
 				enabled: true,
 				pool,
 			},
-		};
+		} as unknown as RenderPageResult;
 	}
 
 	it('does not escape HTML tags when rendering a .html page component', async () => {
 		// Simulate the component factory generated by vite-plugin-html for a .html file.
 		// These return a plain string and have `astro:html = true`.
-		const htmlPageFactory = function render(_props) {
+		const htmlPageFactory = function render(_props: unknown) {
 			return '<body>\n  <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>\n</body>';
-		};
+		} as TestPageFactory;
 		htmlPageFactory['astro:html'] = true;
 		htmlPageFactory.moduleId = 'src/pages/admin/index.html';
 
 		const result = createMockResultWithQueue();
-
 		const response = await renderPage(result, htmlPageFactory, {}, null, false);
 		const html = await response.text();
 
-		// The raw <script> tag must appear verbatim — not HTML-escaped
 		assert.ok(
 			html.includes('<script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>'),
 			`Expected unescaped <script> tag in output, got:\n${html}`,
@@ -328,14 +333,12 @@ describe('renderPage() with queuedRendering and .html pages', () => {
 	it('still escapes HTML in non-.html page components with queuedRendering', async () => {
 		// A regular (non-.html) component factory should NOT have astro:html = true,
 		// so raw string output from it should be treated as text and escaped.
-		const regularFactory = function render(_props) {
+		const regularFactory = function render(_props: unknown) {
 			return '<script>alert("xss")</script>';
-		};
-		// No astro:html flag set — this is the default for non-.html components
+		} as TestPageFactory;
 		regularFactory.moduleId = 'src/pages/regular.astro';
 
 		const result = createMockResultWithQueue();
-
 		const response = await renderPage(result, regularFactory, {}, null, false);
 		const html = await response.text();
 
@@ -343,3 +346,11 @@ describe('renderPage() with queuedRendering and .html pages', () => {
 		assert.ok(html.includes('&lt;script&gt;'), `Expected HTML-escaped output, got:\n${html}`);
 	});
 });
+
+function getTextContent(node: RenderQueueNode): string {
+	if (node.type !== 'text') {
+		assert.fail(`expected text node, got ${node.type}`);
+	}
+
+	return node.content;
+}

--- a/packages/astro/test/units/render/rendering.test.ts
+++ b/packages/astro/test/units/render/rendering.test.ts
@@ -9,14 +9,24 @@ import {
 	renderTemplate,
 } from '../../../dist/runtime/server/index.js';
 
-const DEFAULT_RESULT = {
-	clientDirectives: new Map(),
+type IdProps = {
+	id: string;
 };
 
-describe('rendering', () => {
-	const evaluated = [];
+type RenderResultContext = Parameters<typeof renderComponent>[0];
 
-	const Scalar = createComponent((_result, props) => {
+type Renderable = {
+	render(destination: { write(chunk: unknown): void }): void | Promise<void>;
+};
+
+const DEFAULT_RESULT = {
+	clientDirectives: new Map(),
+} as unknown as RenderResultContext;
+
+describe('rendering', () => {
+	const evaluated: string[] = [];
+
+	const Scalar = createComponent((_result: RenderResultContext, props: IdProps) => {
 		evaluated.push(props.id);
 		return renderTemplate`<scalar id="${props.id}"></scalar>`;
 	});
@@ -26,7 +36,7 @@ describe('rendering', () => {
 	});
 
 	it('components are evaluated and rendered depth-first', async () => {
-		const Root = createComponent((result, props) => {
+		const Root = createComponent((result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			return renderTemplate`<root id="${props.id}">
 				${renderComponent(result, '', Scalar, { id: `${props.id}/scalar_1` })}
@@ -35,7 +45,7 @@ describe('rendering', () => {
 			</root>`;
 		});
 
-		const Nested = createComponent((result, props) => {
+		const Nested = createComponent((result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			return renderTemplate`<nested id="${props.id}">
 				${renderComponent(result, '', Scalar, { id: `${props.id}/scalar` })}
@@ -63,7 +73,7 @@ describe('rendering', () => {
 	});
 
 	it('synchronous component trees are rendered without promises', () => {
-		const Root = createComponent((result, props) => {
+		const Root = createComponent((result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			return renderTemplate`<root id="${props.id}">
 				${() => renderComponent(result, '', Scalar, { id: `${props.id}/scalar_1` })}
@@ -77,6 +87,9 @@ describe('rendering', () => {
 
 		const result = renderToString(Root(DEFAULT_RESULT, { id: 'root' }, {}));
 		assert.ok(!isPromise(result));
+		if (isPromise(result)) {
+			assert.fail('expected synchronous render result');
+		}
 
 		const rendered = getRenderedIds(result);
 
@@ -98,7 +111,7 @@ describe('rendering', () => {
 	});
 
 	it('async component children are deferred', async () => {
-		const Root = createComponent((result, props) => {
+		const Root = createComponent((result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			return renderTemplate`<root id="${props.id}">
 				${renderComponent(result, '', AsyncNested, { id: `${props.id}/asyncnested` })}
@@ -106,7 +119,7 @@ describe('rendering', () => {
 			</root>`;
 		});
 
-		const AsyncNested = createComponent(async (result, props) => {
+		const AsyncNested = createComponent(async (result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			await new Promise((resolve) => setTimeout(resolve, 0));
 			return renderTemplate`<asyncnested id="${props.id}">
@@ -136,7 +149,7 @@ describe('rendering', () => {
 	it('adjacent async components are evaluated eagerly', async () => {
 		const resetEvent = new ManualResetEvent();
 
-		const Root = createComponent((result, props) => {
+		const Root = createComponent((result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			return renderTemplate`<root id="${props.id}">
 				${renderComponent(result, '', AsyncNested, { id: `${props.id}/asyncnested_1` })}
@@ -144,7 +157,7 @@ describe('rendering', () => {
 			</root>`;
 		});
 
-		const AsyncNested = createComponent(async (result, props) => {
+		const AsyncNested = createComponent(async (result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			await resetEvent.wait();
 			return renderTemplate`<asyncnested id="${props.id}">
@@ -188,11 +201,10 @@ describe('rendering', () => {
 		});
 
 		const renderInstance = await renderComponent(DEFAULT_RESULT, '', Root, {});
-
-		const chunks = [];
+		const chunks: HTMLString[] = [];
 		const destination = {
-			write: (chunk) => {
-				chunks.push(chunk);
+			write(chunk: unknown) {
+				chunks.push(chunk as HTMLString);
 			},
 		};
 
@@ -202,7 +214,7 @@ describe('rendering', () => {
 	});
 
 	it('all primitives are rendered in order', async () => {
-		const Root = createComponent((result, props) => {
+		const Root = createComponent((result: RenderResultContext, props: IdProps) => {
 			evaluated.push(props.id);
 			return renderTemplate`<root id="${props.id}">
 				${renderComponent(result, '', Scalar, { id: `${props.id}/first` })}
@@ -248,20 +260,20 @@ describe('rendering', () => {
 	});
 });
 
-function renderToString(item) {
+function renderToString(item: unknown): string | Promise<string> {
 	if (isPromise(item)) {
-		return item.then(renderToString);
+		return Promise.resolve(item).then((resolved) => renderToString(resolved));
 	}
 
 	let result = '';
 
 	const destination = {
-		write: (chunk) => {
-			result += chunk.toString();
+		write(chunk: unknown) {
+			result += String(chunk);
 		},
 	};
 
-	const renderResult = item.render(destination);
+	const renderResult = (item as Renderable).render(destination);
 
 	if (isPromise(renderResult)) {
 		return renderResult.then(() => result);
@@ -270,20 +282,20 @@ function renderToString(item) {
 	return result;
 }
 
-function getRenderedIds(html) {
+function getRenderedIds(html: string) {
 	return cheerio
 		.load(
 			html,
 			null,
 			false,
 		)('*')
-		.map((_, node) => node.attribs['id'])
+		.map((_, node) => ('attribs' in node ? node.attribs?.['id'] : undefined))
 		.toArray();
 }
 
 class ManualResetEvent {
-	#resolve;
-	#promise;
+	#resolve?: () => void;
+	#promise?: Promise<void>;
 	#done = false;
 
 	release() {
@@ -306,8 +318,8 @@ class ManualResetEvent {
 		if (!this.#promise) {
 			this.#promise = this.#done
 				? Promise.resolve()
-				: new Promise((resolve) => {
-						this.#resolve = resolve;
+				: new Promise<void>((resolve) => {
+						this.#resolve = () => resolve();
 					});
 		}
 

--- a/packages/astro/test/units/render/ssr-elements.test.ts
+++ b/packages/astro/test/units/render/ssr-elements.test.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {


### PR DESCRIPTION
Part of #16241.

## Summary
- port `render/ssr-elements`, `render/rendering`, and `render/queue-rendering` unit tests from `.js` to `.ts`
- keep the migration scoped to self-contained render tests without touching shared helpers
- preserve the existing assertions while adding the minimal local typing needed for the converted tests

## Testing
- pnpm exec astro-scripts test \"test/units/{render/ssr-elements,render/rendering,render/queue-rendering}.test.ts\" --strip-types --teardown ./test/units/teardown.js