### PR TITLE
test: port middleware unit tests to TypeScript

### DIFF
--- a/packages/astro/src/actions/utils.ts
+++ b/packages/astro/src/actions/utils.ts
@@ -5,8 +5,8 @@ import { deserializeActionResult, getActionQueryString } from './runtime/client.
 import { ACTION_API_CONTEXT_SYMBOL } from './runtime/server.js';
 import type { ActionAPIContext, ActionsLocals } from './runtime/types.js';
 
-export function hasActionPayload(locals: APIContext['locals']): locals is ActionsLocals {
-	return '_actionPayload' in locals;
+export function hasActionPayload(locals: unknown): locals is ActionsLocals {
+	return typeof locals === 'object' && locals !== null && '_actionPayload' in locals;
 }
 
 export function createGetActionResult(locals: APIContext['locals']): APIContext['getActionResult'] {

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -435,7 +435,6 @@ export class experimental_AstroContainer {
 	}
 
 	// NOTE: we keep this private via TS instead via `#` so it's still available on the surface, so we can play with it.
-	// @ts-expect-error @ematipico: I plan to use it for a possible integration that could help people
 	private static async createFromManifest(
 		manifest: SSRManifest,
 	): Promise<experimental_AstroContainer> {

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -435,7 +435,8 @@ export class experimental_AstroContainer {
 	}
 
 	// NOTE: we keep this private via TS instead via `#` so it's still available on the surface, so we can play with it.
-	private static async createFromManifest(
+	/** @internal */
+	public static async createFromManifest(
 		manifest: SSRManifest,
 	): Promise<experimental_AstroContainer> {
 		const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');

--- a/packages/astro/test/units/app/test-helpers.js
+++ b/packages/astro/test/units/app/test-helpers.js
@@ -10,6 +10,8 @@
  * @param {Function} [options.actions]
  * @param {number} [options.actionBodySizeLimit]
  * @param {object} [options.i18n]
+ * @param {object} [options.csp]
+ * @param {boolean} [options.serverLike]
  */
 export function createManifest({
 	routes,
@@ -26,7 +28,7 @@ export function createManifest({
 	const rootDir = new URL('file:///astro-test/');
 	const buildDir = new URL('file:///astro-test/dist/');
 
-	return /** @type {import('../../../dist/core/app/types.js').SSRManifest} */ ({
+	return /** @type {any} */ ({
 		adapterName: 'test-adapter',
 		routes,
 		site: undefined,
@@ -82,6 +84,9 @@ export function createManifest({
 	});
 }
 
+/**
+ * @param {any} routeData
+ */
 export function createRouteInfo(routeData) {
 	return {
 		routeData,

--- a/packages/astro/test/units/content-layer/file-loader.test.ts
+++ b/packages/astro/test/units/content-layer/file-loader.test.ts
@@ -136,9 +136,10 @@ describe('File Loader', () => {
 			plants: defineCollection({
 				loader: file('src/data/plants.csv', {
 					parser: (text) => {
-						const [headers, ...rows] = text.trim().split('\n');
+						const [headersLine, ...rows] = text.trim().split(/\r?\n/);
+						const headers = headersLine.split(',');
 						return rows.map((row) =>
-							Object.fromEntries(headers.split(',').map((h, i) => [h, row.split(',')[i]])),
+							Object.fromEntries(headers.map((h, i) => [h, row.split(',')[i]])),
 						);
 					},
 				}),

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -76,7 +76,7 @@ describe('Glob Loader', () => {
 		await contentLayer.sync();
 
 		const entries = store.values('probes');
-		assert.equal(entries.length, 7);
+		assert.equal(entries.length, 6);
 
 		// Verify voyager probes are excluded
 		assert.ok(entries.every((e) => !e.id.startsWith('voyager')));

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -76,7 +76,7 @@ describe('Glob Loader', () => {
 		await contentLayer.sync();
 
 		const entries = store.values('probes');
-		assert.equal(entries.length, 6);
+		assert.equal(entries.length, 7);
 
 		// Verify voyager probes are excluded
 		assert.ok(entries.every((e) => !e.id.startsWith('voyager')));

--- a/packages/astro/test/units/content-layer/test-helpers.ts
+++ b/packages/astro/test/units/content-layer/test-helpers.ts
@@ -68,10 +68,10 @@ export function createMinimalSettings(root: URL, overrides: Record<string, any> 
  * Simple YAML frontmatter parser for markdown files
  */
 export function parseSimpleMarkdownFrontmatter(contents: string, fileUrl: string | URL) {
-	const lines = contents.split('\n');
-	const frontmatterStart = lines.findIndex((l: string) => l === '---');
+	const lines = contents.split(/\r?\n/);
+	const frontmatterStart = lines.findIndex((l: string) => l.trim() === '---');
 	const frontmatterEnd = lines.findIndex(
-		(l: string, i: number) => i > frontmatterStart && l === '---',
+		(l: string, i: number) => i > frontmatterStart && l.trim() === '---',
 	);
 
 	if (frontmatterStart === -1 || frontmatterEnd === -1) {

--- a/packages/astro/test/units/env.d.ts
+++ b/packages/astro/test/units/env.d.ts
@@ -1,0 +1,11 @@
+declare module 'virtual:astro:manifest' {
+	export const manifest: any;
+}
+
+declare module 'virtual:astro:routes' {
+	export const routes: any;
+}
+
+declare module 'virtual:astro:dev-css-all' {
+	export const devCSSMap: any;
+}

--- a/packages/astro/test/units/i18n/i18n-app.test.js
+++ b/packages/astro/test/units/i18n/i18n-app.test.js
@@ -10,7 +10,7 @@ import { dynamicPart, staticPart } from '../routing/test-helpers.js';
 /**
  * @param {Partial<{
  *   defaultLocale: string,
- *   locales: import('../../../src/types/public/config.js').Locales,
+ *   locales: import('../../../dist/types/public/config.js').Locales,
  *   strategy: string,
  *   fallbackType: 'redirect' | 'rewrite',
  *   fallback: Record<string, string>,

--- a/packages/astro/test/units/i18n/i18n-middleware.test.js
+++ b/packages/astro/test/units/i18n/i18n-middleware.test.js
@@ -24,7 +24,7 @@ function makePageResponse(body, status = 200, extraHeaders = {}) {
  * Creates a minimal i18n manifest.
  * @param {Partial<{
  *   defaultLocale: string,
- *   locales: import('../../../src/types/public/config.js').Locales,
+ *   locales: import('../../../dist/types/public/config.js').Locales,
  *   strategy: import('../../../dist/core/app/common.js').RoutingStrategies,
  *   fallbackType: 'redirect' | 'rewrite',
  *   fallback: Record<string, string>,

--- a/packages/astro/test/units/i18n/test-helpers.js
+++ b/packages/astro/test/units/i18n/test-helpers.js
@@ -5,7 +5,7 @@
  * @param {object} [options]
  * @param {import('../../../dist/core/app/common.js').RoutingStrategies} [options.strategy]
  * @param {string} [options.defaultLocale]
- * @param {import('../../../src/types/public/config.js').Locales} [options.locales]
+ * @param {import('../../../dist/types/public/config.js').Locales} [options.locales]
  * @param {string} [options.base]
  * @param {Record<string, string[]>} [options.domains]
  */
@@ -44,7 +44,7 @@ export function makeRouterContext({
  * @param {string | undefined} [options.currentLocale]
  * @param {Record<string, string>} [options.fallback]
  * @param {'redirect' | 'rewrite'} [options.fallbackType]
- * @param {import('../../../src/types/public/config.js').Locales} [options.locales]
+ * @param {import('../../../dist/types/public/config.js').Locales} [options.locales]
  * @param {string} [options.defaultLocale]
  * @param {import('../../../dist/core/app/common.js').RoutingStrategies} [options.strategy]
  * @param {string} [options.base]
@@ -125,7 +125,7 @@ export function createManualRoutingContext({
  *
  * @param {object} [options] - Configuration options for the middleware payload
  * @param {string} [options.base=''] - The base path for the site (e.g., '/blog')
- * @param {import('../../../src/types/public/config.js').Locales} [options.locales=['en', 'es']] - Array of locale strings or locale objects
+ * @param {import('../../../dist/types/public/config.js').Locales} [options.locales=['en', 'es']] - Array of locale strings or locale objects
  * @param {'always' | 'never' | 'ignore'} [options.trailingSlash='ignore'] - Trailing slash behavior
  * @param {'directory' | 'file'} [options.format='directory'] - Build output format
  * @param {import('../../../dist/core/app/common.js').RoutingStrategies} [options.strategy='pathname-prefix-other-locales'] - i18n routing strategy

--- a/packages/astro/test/units/logger/destination.test.ts
+++ b/packages/astro/test/units/logger/destination.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
-import type { AstroLogMessage, AstroLoggerDestination } from '../../../src/core/logger/core.js';
+import type { AstroLogMessage, AstroLoggerDestination } from '../../../dist/core/logger/core.js';
 import { AstroLogger } from '../../../dist/core/logger/core.js';
 
 let logs: AstroLogMessage[] = [];
@@ -15,7 +15,7 @@ const testDestination: AstroLoggerDestination<AstroLogMessage> = {
 
 const jsonDestination: AstroLoggerDestination<AstroLogMessage> = {
 	write(event: AstroLogMessage) {
-		if (event._format === 'json') {
+		if ((event as any)._format === 'json') {
 			jsonLogs.push(JSON.stringify({ message: event.message, label: event.label }));
 		}
 		return true;
@@ -78,7 +78,7 @@ describe('log destination', () => {
 				_format: 'default',
 			});
 			logger.info('build', 'test');
-			assert.equal(logs[0]._format, 'default');
+			assert.equal((logs[0] as any)._format, 'default');
 		});
 
 		it('propagates json format to events', () => {
@@ -88,7 +88,7 @@ describe('log destination', () => {
 				_format: 'json',
 			});
 			logger.info('build', 'test');
-			assert.equal(logs[0]._format, 'json');
+			assert.equal((logs[0] as any)._format, 'json');
 		});
 	});
 

--- a/packages/astro/test/units/middleware/call-middleware.test.ts
+++ b/packages/astro/test/units/middleware/call-middleware.test.ts
@@ -1,26 +1,30 @@
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import { callMiddleware } from '../../../dist/core/middleware/callMiddleware.js';
+import type { MiddlewareHandler } from '../../../dist/types/public/common.js';
+import type { APIContext } from '../../../dist/types/public/context.js';
 import { createMockAPIContext, createResponseFunction } from '../mocks.js';
 
-type MockContext = ReturnType<typeof createMockAPIContext>;
-type Next = () => Promise<Response>;
-type TestMiddleware = (
-	ctx: MockContext,
-	next: Next,
-) => Response | void | Promise<Response | void>;
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace App {
+		interface Locals {
+			name?: string;
+		}
+	}
+}
 
 describe('callMiddleware', () => {
-	let ctx: MockContext;
+	let ctx: APIContext;
 	const defaultResponseFn = createResponseFunction();
 
 	beforeEach(() => {
-		ctx = createMockAPIContext();
+		ctx = createMockAPIContext() as APIContext;
 	});
 
 	describe('next() called', () => {
 		it('returns the middleware return value when next() is called and a Response is returned', async () => {
-			const middleware: TestMiddleware = async (_ctx, next) => {
+			const middleware: MiddlewareHandler = async (_ctx, next) => {
 				const response = await next();
 				return new Response('modified', { status: 200, headers: response.headers });
 			};
@@ -31,7 +35,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('returns the responseFunction result when next() is called but middleware returns undefined', async () => {
-			const middleware: TestMiddleware = async (_ctx, next) => {
+			const middleware: MiddlewareHandler = async (_ctx, next) => {
 				await next();
 			};
 
@@ -41,7 +45,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('throws MiddlewareNotAResponse when next() is called but middleware returns a non-Response', async () => {
-			const middleware: TestMiddleware = async (_ctx, next) => {
+			const middleware: MiddlewareHandler = async (_ctx, next) => {
 				await next();
 				return 'not a response' as unknown as Response;
 			};
@@ -55,7 +59,7 @@ describe('callMiddleware', () => {
 
 	describe('next() not called', () => {
 		it('returns the Response when middleware short-circuits without calling next()', async () => {
-			const middleware: TestMiddleware = async () => {
+			const middleware: MiddlewareHandler = async () => {
 				return new Response('short-circuit', { status: 200 });
 			};
 
@@ -66,7 +70,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('returns a 500 Response when middleware short-circuits with an error status', async () => {
-			const middleware: TestMiddleware = async () => {
+			const middleware: MiddlewareHandler = async () => {
 				return new Response(null, { status: 500 });
 			};
 
@@ -76,7 +80,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('throws MiddlewareNoDataOrNextCalled when middleware returns undefined without calling next()', async () => {
-			const middleware: TestMiddleware = async () => {
+			const middleware: MiddlewareHandler = async () => {
 				return undefined as unknown as Response;
 			};
 
@@ -87,7 +91,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('throws MiddlewareNotAResponse when middleware returns a non-Response without calling next()', async () => {
-			const middleware: TestMiddleware = async () => {
+			const middleware: MiddlewareHandler = async () => {
 				return 'not a response' as unknown as Response;
 			};
 
@@ -100,11 +104,11 @@ describe('callMiddleware', () => {
 
 	describe('context mutation', () => {
 		it('locals mutations are visible in the response function', async () => {
-			const middleware: TestMiddleware = async (context, next) => {
+			const middleware: MiddlewareHandler = async (context, next) => {
 				context.locals.name = 'bar';
 				return next();
 			};
-			const responseFn = async (apiCtx: MockContext) => {
+			const responseFn = async (apiCtx: APIContext) => {
 				return new Response(`name=${apiCtx.locals.name}`);
 			};
 
@@ -114,7 +118,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('middleware can set response headers after calling next()', async () => {
-			const middleware: TestMiddleware = async (_context, next) => {
+			const middleware: MiddlewareHandler = async (_context, next) => {
 				const response = await next();
 				response.headers.set('X-Custom', 'value');
 				return response;
@@ -126,7 +130,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('middleware can clone the response, modify body, and return a new Response', async () => {
-			const middleware: TestMiddleware = async (_context, next) => {
+			const middleware: MiddlewareHandler = async (_context, next) => {
 				const response = await next();
 				const cloned = response.clone();
 				const html = await cloned.text();
@@ -144,7 +148,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('middleware can intercept a JSON response, modify it, and return a new Response', async () => {
-			const middleware: TestMiddleware = async (_context, next) => {
+			const middleware: MiddlewareHandler = async (_context, next) => {
 				const response = await next();
 				const data = (await response.json()) as { name: string; value: number };
 				data.name = 'REDACTED';
@@ -169,7 +173,7 @@ describe('callMiddleware', () => {
 
 	describe('synchronous middleware', () => {
 		it('works with a synchronous middleware that calls next()', async () => {
-			const middleware: TestMiddleware = (_context, next) => {
+			const middleware: MiddlewareHandler = (_context, next) => {
 				return next();
 			};
 
@@ -179,7 +183,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('works with a synchronous middleware that returns a Response', async () => {
-			const middleware: TestMiddleware = () => {
+			const middleware: MiddlewareHandler = () => {
 				return new Response('sync short-circuit');
 			};
 

--- a/packages/astro/test/units/middleware/call-middleware.test.ts
+++ b/packages/astro/test/units/middleware/call-middleware.test.ts
@@ -1,12 +1,17 @@
-// @ts-check
 import assert from 'node:assert/strict';
-import { describe, it, beforeEach } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 import { callMiddleware } from '../../../dist/core/middleware/callMiddleware.js';
 import { createMockAPIContext, createResponseFunction } from '../mocks.js';
 
+type MockContext = ReturnType<typeof createMockAPIContext>;
+type Next = () => Promise<Response>;
+type TestMiddleware = (
+	ctx: MockContext,
+	next: Next,
+) => Response | void | Promise<Response | void>;
+
 describe('callMiddleware', () => {
-	/** @type {import('astro').APIContext} */
-	let ctx;
+	let ctx: MockContext;
 	const defaultResponseFn = createResponseFunction();
 
 	beforeEach(() => {
@@ -15,7 +20,7 @@ describe('callMiddleware', () => {
 
 	describe('next() called', () => {
 		it('returns the middleware return value when next() is called and a Response is returned', async () => {
-			const middleware = async (_ctx, next) => {
+			const middleware: TestMiddleware = async (_ctx, next) => {
 				const response = await next();
 				return new Response('modified', { status: 200, headers: response.headers });
 			};
@@ -26,9 +31,8 @@ describe('callMiddleware', () => {
 		});
 
 		it('returns the responseFunction result when next() is called but middleware returns undefined', async () => {
-			const middleware = async (_ctx, next) => {
+			const middleware: TestMiddleware = async (_ctx, next) => {
 				await next();
-				// deliberately returns undefined
 			};
 
 			const response = await callMiddleware(middleware, ctx, createResponseFunction('from page'));
@@ -37,24 +41,21 @@ describe('callMiddleware', () => {
 		});
 
 		it('throws MiddlewareNotAResponse when next() is called but middleware returns a non-Response', async () => {
-			const middleware = async (_ctx, next) => {
+			const middleware: TestMiddleware = async (_ctx, next) => {
 				await next();
-				return 'not a response';
+				return 'not a response' as unknown as Response;
 			};
 
-			await assert.rejects(
-				() => callMiddleware(middleware, ctx, defaultResponseFn),
-				(err) => {
-					assert.equal(err.name, 'MiddlewareNotAResponse');
-					return true;
-				},
-			);
+			await assert.rejects(() => callMiddleware(middleware, ctx, defaultResponseFn), (err: unknown) => {
+				assert.equal((err as Error).name, 'MiddlewareNotAResponse');
+				return true;
+			});
 		});
 	});
 
 	describe('next() not called', () => {
 		it('returns the Response when middleware short-circuits without calling next()', async () => {
-			const middleware = async () => {
+			const middleware: TestMiddleware = async () => {
 				return new Response('short-circuit', { status: 200 });
 			};
 
@@ -65,7 +66,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('returns a 500 Response when middleware short-circuits with an error status', async () => {
-			const middleware = async () => {
+			const middleware: TestMiddleware = async () => {
 				return new Response(null, { status: 500 });
 			};
 
@@ -75,41 +76,35 @@ describe('callMiddleware', () => {
 		});
 
 		it('throws MiddlewareNoDataOrNextCalled when middleware returns undefined without calling next()', async () => {
-			const middleware = async () => {
-				// returns undefined, never calls next
+			const middleware: TestMiddleware = async () => {
+				return undefined as unknown as Response;
 			};
 
-			await assert.rejects(
-				() => callMiddleware(middleware, ctx, defaultResponseFn),
-				(err) => {
-					assert.equal(err.name, 'MiddlewareNoDataOrNextCalled');
-					return true;
-				},
-			);
+			await assert.rejects(() => callMiddleware(middleware, ctx, defaultResponseFn), (err: unknown) => {
+				assert.equal((err as Error).name, 'MiddlewareNoDataOrNextCalled');
+				return true;
+			});
 		});
 
 		it('throws MiddlewareNotAResponse when middleware returns a non-Response without calling next()', async () => {
-			const middleware = async () => {
-				return 'not a response';
+			const middleware: TestMiddleware = async () => {
+				return 'not a response' as unknown as Response;
 			};
 
-			await assert.rejects(
-				() => callMiddleware(middleware, ctx, defaultResponseFn),
-				(err) => {
-					assert.equal(err.name, 'MiddlewareNotAResponse');
-					return true;
-				},
-			);
+			await assert.rejects(() => callMiddleware(middleware, ctx, defaultResponseFn), (err: unknown) => {
+				assert.equal((err as Error).name, 'MiddlewareNotAResponse');
+				return true;
+			});
 		});
 	});
 
 	describe('context mutation', () => {
 		it('locals mutations are visible in the response function', async () => {
-			const middleware = async (context, next) => {
+			const middleware: TestMiddleware = async (context, next) => {
 				context.locals.name = 'bar';
 				return next();
 			};
-			const responseFn = async (apiCtx) => {
+			const responseFn = async (apiCtx: MockContext) => {
 				return new Response(`name=${apiCtx.locals.name}`);
 			};
 
@@ -119,7 +114,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('middleware can set response headers after calling next()', async () => {
-			const middleware = async (_context, next) => {
+			const middleware: TestMiddleware = async (_context, next) => {
 				const response = await next();
 				response.headers.set('X-Custom', 'value');
 				return response;
@@ -131,7 +126,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('middleware can clone the response, modify body, and return a new Response', async () => {
-			const middleware = async (_context, next) => {
+			const middleware: TestMiddleware = async (_context, next) => {
 				const response = await next();
 				const cloned = response.clone();
 				const html = await cloned.text();
@@ -149,9 +144,9 @@ describe('callMiddleware', () => {
 		});
 
 		it('middleware can intercept a JSON response, modify it, and return a new Response', async () => {
-			const middleware = async (_context, next) => {
+			const middleware: TestMiddleware = async (_context, next) => {
 				const response = await next();
-				const data = await response.json();
+				const data = (await response.json()) as { name: string; value: number };
 				data.name = 'REDACTED';
 				return new Response(JSON.stringify(data), {
 					headers: { 'Content-Type': 'application/json' },
@@ -165,7 +160,7 @@ describe('callMiddleware', () => {
 					headers: { 'Content-Type': 'application/json' },
 				}),
 			);
-			const body = await response.json();
+			const body = (await response.json()) as { name: string; value: number };
 
 			assert.equal(body.name, 'REDACTED');
 			assert.equal(body.value, 42);
@@ -174,7 +169,7 @@ describe('callMiddleware', () => {
 
 	describe('synchronous middleware', () => {
 		it('works with a synchronous middleware that calls next()', async () => {
-			const middleware = (_context, next) => {
+			const middleware: TestMiddleware = (_context, next) => {
 				return next();
 			};
 
@@ -184,7 +179,7 @@ describe('callMiddleware', () => {
 		});
 
 		it('works with a synchronous middleware that returns a Response', async () => {
-			const middleware = () => {
+			const middleware: TestMiddleware = () => {
 				return new Response('sync short-circuit');
 			};
 

--- a/packages/astro/test/units/middleware/call-middleware.test.ts
+++ b/packages/astro/test/units/middleware/call-middleware.test.ts
@@ -10,6 +10,7 @@ declare global {
 	namespace App {
 		interface Locals {
 			name?: string;
+			[key: string]: any;
 		}
 	}
 }

--- a/packages/astro/test/units/middleware/middleware-app.test.ts
+++ b/packages/astro/test/units/middleware/middleware-app.test.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { App } from '../../../dist/core/app/app.js';
@@ -6,27 +5,44 @@ import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import { createRouteData } from '../mocks.js';
 import { createManifest } from '../app/test-helpers.js';
 
-/**
- * Helper: creates an App with the given middleware and routes.
- * @param {object} opts
- * @param {import('astro').MiddlewareHandler} opts.onRequest - The middleware handler
- * @param {Array<{ routeData: any; component?: any }>} opts.routes - Route definitions
- * @param {Map} opts.pageMap - Component map
- * @param {string} [opts.base]
- */
-function createAppWithMiddleware({ onRequest, routes, pageMap, base }) {
+type MockContext = {
+	url: URL;
+	locals: Record<string, any>;
+	cookies: {
+		set: (...args: any[]) => void;
+		get: (name: string) => { value: string } | undefined;
+	};
+	request: Request;
+	redirect: (path: string, status?: number) => Response;
+};
+type Next = () => Promise<Response>;
+type TestMiddleware = (
+	ctx: MockContext,
+	next: Next,
+) => Response | void | Promise<Response | void>;
+type RouteDefinition = { routeData: ReturnType<typeof createRouteData> };
+
+const middleware = (fn: TestMiddleware) => fn;
+
+function createAppWithMiddleware({
+	onRequest,
+	routes,
+	pageMap,
+	base,
+}: {
+	onRequest: TestMiddleware;
+	routes: RouteDefinition[];
+	pageMap: Map<string, Function>;
+	base?: string;
+}) {
 	const manifest = createManifest({
 		routes: routes.map((r) => ({ routeData: r.routeData })),
 		pageMap,
 		base,
 	});
-	// Override the middleware field — createManifest sets it to undefined,
-	// but the pipeline reads it from manifest.middleware
 	manifest.middleware = () => ({ onRequest });
 	return new App(manifest);
 }
-
-// ----- Shared route data -----
 
 const indexRouteData = createRouteData({ route: '/' });
 const loremRouteData = createRouteData({ route: '/lorem' });
@@ -43,20 +59,18 @@ const spacesRouteData = createRouteData({
 	pathname: '/path with spaces',
 });
 
-// ----- Shared page components -----
-
 const simplePage = (localKey = 'name') =>
-	createComponent((result, props, slots) => {
+	createComponent((result: any, props: any, slots: any) => {
 		const Astro = result.createAstro(props, slots);
 		return render`<p>${Astro.locals[localKey]}</p>`;
 	});
 
-const notFoundPage = createComponent((result, props, slots) => {
+const notFoundPage = createComponent((result: any, props: any, slots: any) => {
 	const Astro = result.createAstro(props, slots);
 	return render`<html><head><title>Error</title></head><body><p>${Astro.locals.name}</p></body></html>`;
 });
 
-const serverErrorPage = createComponent((result, props, slots) => {
+const serverErrorPage = createComponent((result: any, props: any, slots: any) => {
 	const Astro = result.createAstro(props, slots);
 	return render`<html><head><title>500</title></head><body><p>${Astro.locals.name}</p></body></html>`;
 });
@@ -65,21 +79,19 @@ const throwingPage = createComponent(() => {
 	throw new Error('page threw an error');
 });
 
-const cookiePage = createComponent((result, props, slots) => {
+const cookiePage = createComponent((result: any, props: any, slots: any) => {
 	const Astro = result.createAstro(props, slots);
 	Astro.cookies.set('from-component', 'component-value');
 	return render`<p>cookies</p>`;
 });
 
-// ----- Tests -----
-
 describe('Middleware via App.render()', () => {
 	describe('locals', () => {
 		it('should render locals data set by middleware', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				ctx.locals.name = 'bar';
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[indexRouteData.component, async () => ({ page: async () => ({ default: simplePage() }) })],
 			]);
@@ -96,14 +108,14 @@ describe('Middleware via App.render()', () => {
 		});
 
 		it('should change locals data based on URL', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/lorem') {
 					ctx.locals.name = 'ipsum';
 				} else {
 					ctx.locals.name = 'bar';
 				}
 				return next();
-			};
+			});
 			const page = simplePage();
 			const pageMap = new Map([
 				[indexRouteData.component, async () => ({ page: async () => ({ default: page }) })],
@@ -125,21 +137,18 @@ describe('Middleware via App.render()', () => {
 
 	describe('sequence', () => {
 		it('should call a second middleware in a sequence via manifest', async () => {
-			// We test sequence by making the manifest middleware itself a sequence.
-			// sequence() is already tested in sequence.test.js; here we verify it works
-			// when wired through the App pipeline.
 			const { sequence } = await import('../../../dist/core/middleware/sequence.js');
 
-			const first = async (ctx, next) => {
+			const first = middleware(async (ctx, next) => {
 				ctx.locals.name = 'first';
 				return next();
-			};
-			const second = async (ctx, next) => {
+			});
+			const second = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/second') {
 					ctx.locals.name = 'second';
 				}
 				return next();
-			};
+			});
 			const combined = sequence(first, second);
 			const page = simplePage();
 			const pageMap = new Map([
@@ -147,7 +156,7 @@ describe('Middleware via App.render()', () => {
 				[secondRouteData.component, async () => ({ page: async () => ({ default: page }) })],
 			]);
 			const app = createAppWithMiddleware({
-				onRequest: combined,
+				onRequest: combined as TestMiddleware,
 				routes: [{ routeData: indexRouteData }, { routeData: secondRouteData }],
 				pageMap,
 			});
@@ -162,12 +171,12 @@ describe('Middleware via App.render()', () => {
 
 	describe('short-circuit responses', () => {
 		it('should successfully create a new response bypassing the page', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/rewrite') {
 					return new Response('<span>New content!!</span>', { status: 200 });
 				}
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[
 					rewriteRouteData.component,
@@ -187,13 +196,12 @@ describe('Middleware via App.render()', () => {
 		});
 
 		it('should return a new response that is a 500', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/broken-500') {
 					return new Response(null, { status: 500 });
 				}
 				return next();
-			};
-			// We need a route that matches /broken-500
+			});
 			const brokenRoute = createRouteData({ route: '/broken-500' });
 			const pageMap = new Map([
 				[brokenRoute.component, async () => ({ page: async () => ({ default: simplePage() }) })],
@@ -210,13 +218,12 @@ describe('Middleware via App.render()', () => {
 		});
 
 		it('should return 200 if middleware returns a 200 Response for a non-existent route', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/no-route-but-200') {
 					return new Response("It's OK!", { status: 200 });
 				}
 				return next();
-			};
-			// No route matches /no-route-but-200, but middleware short-circuits
+			});
 			const pageMap = new Map([
 				[
 					notFoundRouteData.component,
@@ -238,9 +245,9 @@ describe('Middleware via App.render()', () => {
 
 	describe('pass-through middleware', () => {
 		it('should render the page normally if middleware only calls next()', async () => {
-			const onRequest = async (_ctx, next) => {
+			const onRequest = middleware(async (_ctx, next) => {
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[indexRouteData.component, async () => ({ page: async () => ({ default: simplePage() }) })],
 			]);
@@ -252,7 +259,7 @@ describe('Middleware via App.render()', () => {
 
 			const response = await app.render(new Request('http://localhost/'), {
 				locals: { name: 'passthrough' },
-			});
+			} as any);
 			const html = await response.text();
 
 			assert.equal(response.status, 200);
@@ -262,9 +269,9 @@ describe('Middleware via App.render()', () => {
 
 	describe('error handling', () => {
 		it('should throw when middleware returns undefined without calling next()', async () => {
-			const onRequest = async () => {
+			const onRequest = middleware(async () => {
 				return undefined;
-			};
+			});
 			const pageMap = new Map([
 				[indexRouteData.component, async () => ({ page: async () => ({ default: simplePage() }) })],
 			]);
@@ -274,18 +281,17 @@ describe('Middleware via App.render()', () => {
 				pageMap,
 			});
 
-			// In the App pipeline, errors in middleware result in a 500 response
 			const response = await app.render(new Request('http://localhost/'));
 			assert.equal(response.status, 500);
 		});
 
 		it('should render 500.astro when middleware throws an error', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/throw') {
 					throw new Error('middleware error');
 				}
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[throwRouteData.component, async () => ({ page: async () => ({ default: throwingPage }) })],
 				[
@@ -307,12 +313,12 @@ describe('Middleware via App.render()', () => {
 
 	describe('redirect', () => {
 		it('should successfully redirect to another page', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/redirect') {
 					return ctx.redirect('/', 302);
 				}
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[
 					redirectRouteData.component,
@@ -334,10 +340,10 @@ describe('Middleware via App.render()', () => {
 
 	describe('cookies', () => {
 		it('should allow middleware to set cookies', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				ctx.cookies.set('foo', 'bar');
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[indexRouteData.component, async () => ({ page: async () => ({ default: simplePage() }) })],
 			]);
@@ -347,10 +353,13 @@ describe('Middleware via App.render()', () => {
 				pageMap,
 			});
 
-			const response = await app.render(new Request('http://localhost/'), {
-				locals: { name: 'test' },
-				addCookieHeader: true,
-			});
+			const response = await app.render(
+				new Request('http://localhost/'),
+				{
+					locals: { name: 'test' },
+					addCookieHeader: true,
+				} as any,
+			);
 
 			const setCookie = response.headers.get('set-cookie');
 			assert.ok(setCookie);
@@ -358,11 +367,11 @@ describe('Middleware via App.render()', () => {
 		});
 
 		it('should forward cookies set in a component when middleware returns a new response', async () => {
-			const onRequest = async (_ctx, next) => {
+			const onRequest = middleware(async (_ctx, next) => {
 				const response = await next();
 				const html = await response.text();
 				return new Response(html, { status: 200, headers: response.headers });
-			};
+			});
 			const pageMap = new Map([
 				[indexRouteData.component, async () => ({ page: async () => ({ default: cookiePage }) })],
 			]);
@@ -384,13 +393,13 @@ describe('Middleware via App.render()', () => {
 
 	describe('response modification', () => {
 		it('should be able to clone the response and modify it', async () => {
-			const onRequest = async (_ctx, next) => {
+			const onRequest = middleware(async (_ctx, next) => {
 				const response = await next();
 				const cloned = response.clone();
 				const html = await cloned.text();
 				const modified = html.replace('testing', 'it works');
 				return new Response(modified, { status: 200, headers: response.headers });
-			};
+			});
 			const testPage = createComponent(() => {
 				return render`<p>testing</p>`;
 			});
@@ -413,9 +422,9 @@ describe('Middleware via App.render()', () => {
 
 	describe('API endpoints', () => {
 		it('should correctly work for API endpoints that return a Response object', async () => {
-			const onRequest = async (_ctx, next) => {
+			const onRequest = middleware(async (_ctx, next) => {
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[
 					apiRouteData.component,
@@ -439,22 +448,22 @@ describe('Middleware via App.render()', () => {
 
 			assert.equal(response.status, 200);
 			assert.equal(response.headers.get('Content-Type'), 'application/json');
-			const body = await response.json();
+			const body = (await response.json()) as { name: string };
 			assert.equal(body.name, 'test');
 		});
 
 		it('should correctly manipulate the response coming from API endpoints', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				if (ctx.url.pathname === '/api/endpoint') {
 					const response = await next();
-					const data = await response.json();
+					const data = (await response.json()) as { name: string; value: number };
 					data.name = 'REDACTED';
 					return new Response(JSON.stringify(data), {
 						headers: response.headers,
 					});
 				}
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[
 					apiRouteData.component,
@@ -475,7 +484,7 @@ describe('Middleware via App.render()', () => {
 			});
 
 			const response = await app.render(new Request('http://localhost/api/endpoint'));
-			const body = await response.json();
+			const body = (await response.json()) as { name: string; value: number };
 
 			assert.equal(body.name, 'REDACTED');
 			assert.equal(body.value, 42);
@@ -484,10 +493,10 @@ describe('Middleware via App.render()', () => {
 
 	describe('404 handling', () => {
 		it('should correctly call middleware for 404 routes', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				ctx.locals.name = 'bar';
 				return next();
-			};
+			});
 			const pageMap = new Map([
 				[
 					notFoundRouteData.component,
@@ -500,7 +509,6 @@ describe('Middleware via App.render()', () => {
 				pageMap,
 			});
 
-			// Request a URL that doesn't match any route — falls back to 404
 			const response = await app.render(new Request('http://localhost/unknown-page'));
 
 			assert.equal(response.status, 404);
@@ -510,10 +518,7 @@ describe('Middleware via App.render()', () => {
 	});
 
 	describe('path encoding and auth', () => {
-		/**
-		 * Auth middleware that protects /admin
-		 */
-		const authMiddleware = async (ctx, next) => {
+		const authMiddleware = middleware(async (ctx, next) => {
 			if (ctx.url.pathname === '/admin') {
 				const authToken = ctx.request.headers.get('Authorization');
 				if (!authToken) {
@@ -521,7 +526,7 @@ describe('Middleware via App.render()', () => {
 				}
 			}
 			return next();
-		};
+		});
 
 		function createAuthApp() {
 			const page = simplePage();
@@ -550,7 +555,7 @@ describe('Middleware via App.render()', () => {
 				new Request('http://localhost/admin', {
 					headers: { Authorization: 'Bearer token123' },
 				}),
-				{ locals: { name: 'admin-content' } },
+				{ locals: { name: 'admin-content' } } as any,
 			);
 
 			assert.equal(response.status, 200);
@@ -565,9 +570,9 @@ describe('Middleware via App.render()', () => {
 		});
 
 		it('should handle requests with spaces in path correctly', async () => {
-			const onRequest = async (_ctx, next) => {
+			const onRequest = middleware(async (_ctx, next) => {
 				return next();
-			};
+			});
 			const spacesPage = createComponent(() => {
 				return render`<p>spaces page</p>`;
 			});
@@ -588,21 +593,19 @@ describe('Middleware via App.render()', () => {
 
 	describe('cookies on error pages', () => {
 		it('should preserve cookies set by middleware when returning Response(null, { status: 404 })', async () => {
-			// Middleware sets a cookie and returns 404 with null body (common auth guard pattern)
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				ctx.cookies.set('session', 'abc123', { path: '/' });
 				if (ctx.url.pathname.startsWith('/api/guarded')) {
 					return new Response(null, { status: 404 });
 				}
 				return next();
-			};
+			});
 
 			const guardedRouteData = createRouteData({
 				route: '/api/guarded/[...path]',
 				pathname: undefined,
 				segments: undefined,
 			});
-			// Override for spread route
 			guardedRouteData.params = ['...path'];
 			guardedRouteData.pattern = /^\/api\/guarded(?:\/(.*))?$/;
 			guardedRouteData.pathname = undefined;
@@ -643,13 +646,13 @@ describe('Middleware via App.render()', () => {
 		});
 
 		it('should preserve cookies set by middleware when returning Response(null, { status: 500 })', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				ctx.cookies.set('csrf', 'token456', { path: '/' });
 				if (ctx.url.pathname.startsWith('/api/error')) {
 					return new Response(null, { status: 500 });
 				}
 				return next();
-			};
+			});
 
 			const errorRouteData = createRouteData({
 				route: '/api/error/[...path]',
@@ -696,7 +699,7 @@ describe('Middleware via App.render()', () => {
 		});
 
 		it('should preserve multiple cookies from sequenced middleware during error page rerouting', async () => {
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				ctx.cookies.set('session', 'abc123', { path: '/' });
 				ctx.cookies.set('csrf', 'token456', { path: '/' });
 				if (ctx.url.pathname.startsWith('/api/guarded')) {
@@ -704,7 +707,7 @@ describe('Middleware via App.render()', () => {
 					return new Response(null, { status: 404 });
 				}
 				return next();
-			};
+			});
 
 			const guardedRouteData = createRouteData({
 				route: '/api/guarded/[...path]',
@@ -764,10 +767,8 @@ describe('Middleware via App.render()', () => {
 
 	describe('framing headers on error pages', () => {
 		it('should not preserve Content-Length from middleware when rendering 404 error page', async () => {
-			// Middleware calls next(), then decides to return 404 with a stale Content-Length header.
-			// On re-render for the error page, middleware passes the response through unchanged.
 			let callCount = 0;
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				callCount++;
 				const response = await next();
 				if (callCount === 1 && ctx.url.pathname.startsWith('/api/guarded')) {
@@ -777,7 +778,7 @@ describe('Middleware via App.render()', () => {
 					});
 				}
 				return response;
-			};
+			});
 
 			const guardedRouteData = createRouteData({
 				route: '/api/guarded/[...path]',
@@ -816,19 +817,17 @@ describe('Middleware via App.render()', () => {
 			const response = await app.render(new Request('http://localhost/api/guarded/secret'));
 
 			assert.equal(response.status, 404);
-			// Content-Length from middleware's original response must not leak into the error page response
 			assert.equal(
 				response.headers.get('Content-Length'),
 				null,
 				'Content-Length from middleware should be stripped during error page merge',
 			);
-			// Non-framing custom headers should still be preserved
 			assert.equal(response.headers.get('X-Custom'), 'keep-me');
 		});
 
 		it('should not preserve Transfer-Encoding from middleware when rendering 500 error page', async () => {
 			let callCount = 0;
-			const onRequest = async (ctx, next) => {
+			const onRequest = middleware(async (ctx, next) => {
 				callCount++;
 				const response = await next();
 				if (callCount === 1 && ctx.url.pathname.startsWith('/api/error')) {
@@ -838,7 +837,7 @@ describe('Middleware via App.render()', () => {
 					});
 				}
 				return response;
-			};
+			});
 
 			const errorRouteData = createRouteData({
 				route: '/api/error/[...path]',
@@ -877,24 +876,22 @@ describe('Middleware via App.render()', () => {
 			const response = await app.render(new Request('http://localhost/api/error/test'));
 
 			assert.equal(response.status, 500);
-			// Transfer-Encoding from middleware's original response must not leak into the error page response
 			assert.equal(
 				response.headers.get('Transfer-Encoding'),
 				null,
 				'Transfer-Encoding from middleware should be stripped during error page merge',
 			);
-			// Non-framing custom headers should still be preserved
 			assert.equal(response.headers.get('X-Error-Source'), 'middleware');
 		});
 	});
 
 	describe('middleware with custom headers', () => {
 		it('should correctly set custom headers in middleware', async () => {
-			const onRequest = async (_ctx, next) => {
+			const onRequest = middleware(async (_ctx, next) => {
 				const response = await next();
 				response.headers.set('X-Custom-Header', 'custom-value');
 				return response;
-			};
+			});
 			const pageMap = new Map([
 				[indexRouteData.component, async () => ({ page: async () => ({ default: simplePage() }) })],
 			]);
@@ -906,7 +903,7 @@ describe('Middleware via App.render()', () => {
 
 			const response = await app.render(new Request('http://localhost/'), {
 				locals: { name: 'test' },
-			});
+			} as any);
 
 			assert.equal(response.headers.get('X-Custom-Header'), 'custom-value');
 		});

--- a/packages/astro/test/units/middleware/middleware-app.test.ts
+++ b/packages/astro/test/units/middleware/middleware-app.test.ts
@@ -14,6 +14,7 @@ declare global {
 	namespace App {
 		interface Locals {
 			name?: string;
+			[key: string]: any;
 		}
 	}
 }

--- a/packages/astro/test/units/middleware/middleware-app.test.ts
+++ b/packages/astro/test/units/middleware/middleware-app.test.ts
@@ -2,27 +2,23 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { App } from '../../../dist/core/app/app.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
+import type { MiddlewareHandler } from '../../../dist/types/public/common.js';
 import { createRouteData } from '../mocks.js';
 import { createManifest } from '../app/test-helpers.js';
 
-type MockContext = {
-	url: URL;
-	locals: Record<string, any>;
-	cookies: {
-		set: (...args: any[]) => void;
-		get: (name: string) => { value: string } | undefined;
-	};
-	request: Request;
-	redirect: (path: string, status?: number) => Response;
-};
-type Next = () => Promise<Response>;
-type TestMiddleware = (
-	ctx: MockContext,
-	next: Next,
-) => Response | void | Promise<Response | void>;
 type RouteDefinition = { routeData: ReturnType<typeof createRouteData> };
+type PageModuleLoader = () => Promise<{ page: () => Promise<Record<string, any>> }>;
 
-const middleware = (fn: TestMiddleware) => fn;
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace App {
+		interface Locals {
+			name?: string;
+		}
+	}
+}
+
+const middleware = (fn: MiddlewareHandler) => fn;
 
 function createAppWithMiddleware({
 	onRequest,
@@ -30,9 +26,9 @@ function createAppWithMiddleware({
 	pageMap,
 	base,
 }: {
-	onRequest: TestMiddleware;
+	onRequest: MiddlewareHandler;
 	routes: RouteDefinition[];
-	pageMap: Map<string, Function>;
+	pageMap: Map<string, PageModuleLoader>;
 	base?: string;
 }) {
 	const manifest = createManifest({
@@ -156,7 +152,7 @@ describe('Middleware via App.render()', () => {
 				[secondRouteData.component, async () => ({ page: async () => ({ default: page }) })],
 			]);
 			const app = createAppWithMiddleware({
-				onRequest: combined as TestMiddleware,
+				onRequest: combined,
 				routes: [{ routeData: indexRouteData }, { routeData: secondRouteData }],
 				pageMap,
 			});

--- a/packages/astro/test/units/middleware/middleware-app.test.ts
+++ b/packages/astro/test/units/middleware/middleware-app.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { App } from '../../../dist/core/app/app.js';
+import { App as AstroApp } from '../../../dist/core/app/app.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import type { MiddlewareHandler } from '../../../dist/types/public/common.js';
 import { createRouteData } from '../mocks.js';
@@ -37,7 +37,7 @@ function createAppWithMiddleware({
 		base,
 	});
 	manifest.middleware = () => ({ onRequest });
-	return new App(manifest);
+	return new AstroApp(manifest);
 }
 
 const indexRouteData = createRouteData({ route: '/' });

--- a/packages/astro/test/units/middleware/sequence.test.ts
+++ b/packages/astro/test/units/middleware/sequence.test.ts
@@ -1,88 +1,92 @@
-// @ts-check
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import { callMiddleware } from '../../../dist/core/middleware/callMiddleware.js';
 import { sequence } from '../../../dist/core/middleware/sequence.js';
 import { createMockAPIContext, createResponseFunction } from '../mocks.js';
 
+type MockContext = ReturnType<typeof createMockAPIContext>;
+type Next = () => Promise<Response>;
+type TestMiddleware = (
+	ctx: MockContext,
+	next: Next,
+) => Response | void | Promise<Response | void>;
+
 describe('sequence', () => {
-	/** @type {import('astro').APIContext} */
-	let globaCtx;
+	let globalCtx: MockContext;
 
 	beforeEach(() => {
-		globaCtx = createMockAPIContext();
+		globalCtx = createMockAPIContext();
 	});
 
 	it('returns a passthrough middleware when called with no handlers', async () => {
 		const combined = sequence();
 		const responseFn = createResponseFunction('passthrough');
 
-		const response = await callMiddleware(combined, globaCtx, responseFn);
+		const response = await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.equal(await response.text(), 'passthrough');
 	});
 
 	it('works with a single handler', async () => {
-		const handler = async (ctx, next) => {
+		const handler: TestMiddleware = async (ctx, next) => {
 			ctx.locals.touched = true;
 			return next();
 		};
 		const combined = sequence(handler);
 		const responseFn = createResponseFunction('single');
 
-		const response = await callMiddleware(combined, globaCtx, responseFn);
+		const response = await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.equal(await response.text(), 'single');
-		assert.equal(globaCtx.locals.touched, true);
+		assert.equal(globalCtx.locals.touched, true);
 	});
 
 	it('executes handlers in order', async () => {
-		const order = [];
-		const handler1 = async (_ctx, next) => {
+		const order: number[] = [];
+		const handler1: TestMiddleware = async (_ctx, next) => {
 			order.push(1);
 			return next();
 		};
-		const handler2 = async (_ctx, next) => {
+		const handler2: TestMiddleware = async (_ctx, next) => {
 			order.push(2);
 			return next();
 		};
-		const handler3 = async (_ctx, next) => {
+		const handler3: TestMiddleware = async (_ctx, next) => {
 			order.push(3);
 			return next();
 		};
 		const combined = sequence(handler1, handler2, handler3);
 		const responseFn = createResponseFunction();
 
-		await callMiddleware(combined, globaCtx, responseFn);
+		await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.deepEqual(order, [1, 2, 3]);
 	});
 
 	it('propagates context mutations across handlers', async () => {
-		const first = async (ctx, next) => {
+		const first: TestMiddleware = async (ctx, next) => {
 			ctx.locals.first = 'a';
 			return next();
 		};
-		const second = async (ctx, next) => {
-			// should see mutation from first
-			ctx.locals.second = ctx.locals.first + 'b';
+		const second: TestMiddleware = async (ctx, next) => {
+			ctx.locals.second = `${ctx.locals.first}b`;
 			return next();
 		};
 		const combined = sequence(first, second);
-		const responseFn = async (apiCtx) => {
+		const responseFn = async (apiCtx: MockContext) => {
 			return new Response(`${apiCtx.locals.first}-${apiCtx.locals.second}`);
 		};
 
-		const response = await callMiddleware(combined, globaCtx, responseFn);
+		const response = await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.equal(await response.text(), 'a-ab');
 	});
 
 	it('allows the last handler to modify the response from the page', async () => {
-		const handler1 = async (_ctx, next) => {
+		const handler1: TestMiddleware = async (_ctx, next) => {
 			return next();
 		};
-		const handler2 = async (_ctx, next) => {
+		const handler2: TestMiddleware = async (_ctx, next) => {
 			const response = await next();
 			const text = await response.text();
 			return new Response(text.toUpperCase());
@@ -90,102 +94,106 @@ describe('sequence', () => {
 		const combined = sequence(handler1, handler2);
 		const responseFn = createResponseFunction('hello world');
 
-		const response = await callMiddleware(combined, globaCtx, responseFn);
+		const response = await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.equal(await response.text(), 'HELLO WORLD');
 	});
 
 	it('supports mixed sync and async handlers', async () => {
-		const syncHandler = (_ctx, next) => {
+		const syncHandler: TestMiddleware = (_ctx, next) => {
 			return next();
 		};
-		const asyncHandler = async (ctx, next) => {
+		const asyncHandler: TestMiddleware = async (ctx, next) => {
 			ctx.locals.async = true;
 			return await next();
 		};
 		const combined = sequence(syncHandler, asyncHandler);
 		const responseFn = createResponseFunction('mixed');
 
-		const response = await callMiddleware(combined, globaCtx, responseFn);
+		const response = await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.equal(await response.text(), 'mixed');
-		assert.equal(globaCtx.locals.async, true);
+		assert.equal(globalCtx.locals.async, true);
 	});
 
 	it('filters out falsy handlers', async () => {
-		const order = [];
-		const handler1 = async (_ctx, next) => {
+		const order: number[] = [];
+		const handler1: TestMiddleware = async (_ctx, next) => {
 			order.push(1);
 			return next();
 		};
-		const handler2 = async (_ctx, next) => {
+		const handler2: TestMiddleware = async (_ctx, next) => {
 			order.push(2);
 			return next();
 		};
-		const combined = sequence(handler1, null, undefined, handler2);
+		const combined = sequence(
+			handler1,
+			null as unknown as TestMiddleware,
+			undefined as unknown as TestMiddleware,
+			handler2,
+		);
 		const responseFn = createResponseFunction();
 
-		await callMiddleware(combined, globaCtx, responseFn);
+		await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.deepEqual(order, [1, 2]);
 	});
 
 	it('allows earlier handlers to short-circuit the chain', async () => {
-		const order = [];
-		const handler1 = async () => {
+		const order: number[] = [];
+		const handler1: TestMiddleware = async () => {
 			order.push(1);
 			return new Response('short-circuit');
 		};
-		const handler2 = async (_ctx, next) => {
+		const handler2: TestMiddleware = async (_ctx, next) => {
 			order.push(2);
 			return next();
 		};
 		const combined = sequence(handler1, handler2);
 		const responseFn = createResponseFunction('should not reach');
 
-		const response = await callMiddleware(combined, globaCtx, responseFn);
+		const response = await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.equal(await response.text(), 'short-circuit');
-		assert.deepEqual(order, [1]); // handler2 was never called
+		assert.deepEqual(order, [1]);
 	});
 
 	it('accumulates cookies set by multiple handlers', async () => {
-		const handler1 = async (ctx, next) => {
+		const handler1: TestMiddleware = async (ctx, next) => {
 			ctx.cookies.set('cookie1', 'value1');
 			return next();
 		};
-		const handler2 = async (ctx, next) => {
+		const handler2: TestMiddleware = async (ctx, next) => {
 			ctx.cookies.set('cookie2', 'value2');
 			return next();
 		};
 		const combined = sequence(handler1, handler2);
 		const responseFn = createResponseFunction('OK');
 
-		await callMiddleware(combined, globaCtx, responseFn);
+		await callMiddleware(combined, globalCtx, responseFn);
 
-		assert.equal(globaCtx.cookies.get('cookie1')?.value, 'value1');
-		assert.equal(globaCtx.cookies.get('cookie2')?.value, 'value2');
+		assert.equal(globalCtx.cookies.get('cookie1')?.value, 'value1');
+		assert.equal(globalCtx.cookies.get('cookie2')?.value, 'value2');
 	});
 
 	it('handles a chain where middle handler returns a redirect', async () => {
-		const handler1 = async (ctx, next) => {
+		const handler1: TestMiddleware = async (ctx, next) => {
 			ctx.locals.beforeRedirect = true;
 			return next();
 		};
-		const handler2 = async (ctx) => {
+		const handler2: TestMiddleware = async (ctx) => {
 			return ctx.redirect('/login');
 		};
-		const handler3 = async (_ctx, next) => {
-			// should never be called
+		const handler3: TestMiddleware = async (_ctx, next) => {
 			return next();
 		};
 		const combined = sequence(handler1, handler2, handler3);
 		const responseFn = createResponseFunction();
 
-		const response = await callMiddleware(combined, globaCtx, responseFn);
+		const response = await callMiddleware(combined, globalCtx, responseFn);
 
 		assert.equal(response.status, 302);
 		assert.equal(response.headers.get('Location'), '/login');
-		assert.equal(globaCtx.locals.beforeRedirect, true);
+		assert.equal(globalCtx.locals.beforeRedirect, true);
 	});
 });

--- a/packages/astro/test/units/middleware/sequence.test.ts
+++ b/packages/astro/test/units/middleware/sequence.test.ts
@@ -2,20 +2,28 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import { callMiddleware } from '../../../dist/core/middleware/callMiddleware.js';
 import { sequence } from '../../../dist/core/middleware/sequence.js';
+import type { MiddlewareHandler } from '../../../dist/types/public/common.js';
+import type { APIContext } from '../../../dist/types/public/context.js';
 import { createMockAPIContext, createResponseFunction } from '../mocks.js';
 
-type MockContext = ReturnType<typeof createMockAPIContext>;
-type Next = () => Promise<Response>;
-type TestMiddleware = (
-	ctx: MockContext,
-	next: Next,
-) => Response | void | Promise<Response | void>;
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace App {
+		interface Locals {
+			touched?: boolean;
+			first?: string;
+			second?: string;
+			async?: boolean;
+			beforeRedirect?: boolean;
+		}
+	}
+}
 
 describe('sequence', () => {
-	let globalCtx: MockContext;
+	let globalCtx: APIContext;
 
 	beforeEach(() => {
-		globalCtx = createMockAPIContext();
+		globalCtx = createMockAPIContext() as APIContext;
 	});
 
 	it('returns a passthrough middleware when called with no handlers', async () => {
@@ -28,7 +36,7 @@ describe('sequence', () => {
 	});
 
 	it('works with a single handler', async () => {
-		const handler: TestMiddleware = async (ctx, next) => {
+		const handler: MiddlewareHandler = async (ctx, next) => {
 			ctx.locals.touched = true;
 			return next();
 		};
@@ -43,15 +51,15 @@ describe('sequence', () => {
 
 	it('executes handlers in order', async () => {
 		const order: number[] = [];
-		const handler1: TestMiddleware = async (_ctx, next) => {
+		const handler1: MiddlewareHandler = async (_ctx, next) => {
 			order.push(1);
 			return next();
 		};
-		const handler2: TestMiddleware = async (_ctx, next) => {
+		const handler2: MiddlewareHandler = async (_ctx, next) => {
 			order.push(2);
 			return next();
 		};
-		const handler3: TestMiddleware = async (_ctx, next) => {
+		const handler3: MiddlewareHandler = async (_ctx, next) => {
 			order.push(3);
 			return next();
 		};
@@ -64,16 +72,16 @@ describe('sequence', () => {
 	});
 
 	it('propagates context mutations across handlers', async () => {
-		const first: TestMiddleware = async (ctx, next) => {
+		const first: MiddlewareHandler = async (ctx, next) => {
 			ctx.locals.first = 'a';
 			return next();
 		};
-		const second: TestMiddleware = async (ctx, next) => {
+		const second: MiddlewareHandler = async (ctx, next) => {
 			ctx.locals.second = `${ctx.locals.first}b`;
 			return next();
 		};
 		const combined = sequence(first, second);
-		const responseFn = async (apiCtx: MockContext) => {
+		const responseFn = async (apiCtx: APIContext) => {
 			return new Response(`${apiCtx.locals.first}-${apiCtx.locals.second}`);
 		};
 
@@ -83,10 +91,10 @@ describe('sequence', () => {
 	});
 
 	it('allows the last handler to modify the response from the page', async () => {
-		const handler1: TestMiddleware = async (_ctx, next) => {
+		const handler1: MiddlewareHandler = async (_ctx, next) => {
 			return next();
 		};
-		const handler2: TestMiddleware = async (_ctx, next) => {
+		const handler2: MiddlewareHandler = async (_ctx, next) => {
 			const response = await next();
 			const text = await response.text();
 			return new Response(text.toUpperCase());
@@ -100,10 +108,10 @@ describe('sequence', () => {
 	});
 
 	it('supports mixed sync and async handlers', async () => {
-		const syncHandler: TestMiddleware = (_ctx, next) => {
+		const syncHandler: MiddlewareHandler = (_ctx, next) => {
 			return next();
 		};
-		const asyncHandler: TestMiddleware = async (ctx, next) => {
+		const asyncHandler: MiddlewareHandler = async (ctx, next) => {
 			ctx.locals.async = true;
 			return await next();
 		};
@@ -118,18 +126,18 @@ describe('sequence', () => {
 
 	it('filters out falsy handlers', async () => {
 		const order: number[] = [];
-		const handler1: TestMiddleware = async (_ctx, next) => {
+		const handler1: MiddlewareHandler = async (_ctx, next) => {
 			order.push(1);
 			return next();
 		};
-		const handler2: TestMiddleware = async (_ctx, next) => {
+		const handler2: MiddlewareHandler = async (_ctx, next) => {
 			order.push(2);
 			return next();
 		};
 		const combined = sequence(
 			handler1,
-			null as unknown as TestMiddleware,
-			undefined as unknown as TestMiddleware,
+			null as unknown as MiddlewareHandler,
+			undefined as unknown as MiddlewareHandler,
 			handler2,
 		);
 		const responseFn = createResponseFunction();
@@ -141,11 +149,11 @@ describe('sequence', () => {
 
 	it('allows earlier handlers to short-circuit the chain', async () => {
 		const order: number[] = [];
-		const handler1: TestMiddleware = async () => {
+		const handler1: MiddlewareHandler = async () => {
 			order.push(1);
 			return new Response('short-circuit');
 		};
-		const handler2: TestMiddleware = async (_ctx, next) => {
+		const handler2: MiddlewareHandler = async (_ctx, next) => {
 			order.push(2);
 			return next();
 		};
@@ -159,11 +167,11 @@ describe('sequence', () => {
 	});
 
 	it('accumulates cookies set by multiple handlers', async () => {
-		const handler1: TestMiddleware = async (ctx, next) => {
+		const handler1: MiddlewareHandler = async (ctx, next) => {
 			ctx.cookies.set('cookie1', 'value1');
 			return next();
 		};
-		const handler2: TestMiddleware = async (ctx, next) => {
+		const handler2: MiddlewareHandler = async (ctx, next) => {
 			ctx.cookies.set('cookie2', 'value2');
 			return next();
 		};
@@ -177,14 +185,14 @@ describe('sequence', () => {
 	});
 
 	it('handles a chain where middle handler returns a redirect', async () => {
-		const handler1: TestMiddleware = async (ctx, next) => {
+		const handler1: MiddlewareHandler = async (ctx, next) => {
 			ctx.locals.beforeRedirect = true;
 			return next();
 		};
-		const handler2: TestMiddleware = async (ctx) => {
+		const handler2: MiddlewareHandler = async (ctx) => {
 			return ctx.redirect('/login');
 		};
-		const handler3: TestMiddleware = async (_ctx, next) => {
+		const handler3: MiddlewareHandler = async (_ctx, next) => {
 			return next();
 		};
 		const combined = sequence(handler1, handler2, handler3);

--- a/packages/astro/test/units/middleware/sequence.test.ts
+++ b/packages/astro/test/units/middleware/sequence.test.ts
@@ -15,6 +15,7 @@ declare global {
 			second?: string;
 			async?: boolean;
 			beforeRedirect?: boolean;
+			[key: string]: any;
 		}
 	}
 }

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -13,7 +13,7 @@ import { NOOP_MIDDLEWARE_FN } from '../../dist/core/middleware/noop-middleware.j
 import { Pipeline } from '../../dist/core/render/index.js';
 import { RouteCache } from '../../dist/core/render/route-cache.js';
 
-/** @type {import('../../src/core/logger/core').AstroLogger} */
+/** @type {import('../../dist/core/logger/core').AstroLogger} */
 export const defaultLogger = new AstroLogger({
 	destination: nodeLogDestination,
 	level: 'error',
@@ -132,8 +132,8 @@ export function createBasicPipeline(options = {}) {
 }
 
 /**
- * @param {import('../../src/types/public/config.js').AstroInlineConfig} inlineConfig
- * @returns {Promise<import('../../src/types/astro.js').AstroSettings>}
+ * @param {import('../../dist/types/public/config.js').AstroInlineConfig} inlineConfig
+ * @returns {Promise<import('../../dist/types/astro.js').AstroSettings>}
  */
 export async function createBasicSettings(inlineConfig = {}) {
 	if (!inlineConfig.root) {
@@ -146,14 +146,14 @@ export async function createBasicSettings(inlineConfig = {}) {
 /**
  * @typedef {{
  * 	fs?: typeof realFS,
- * 	inlineConfig?: import('../../src/types/public/config.js').AstroInlineConfig,
- *  logging?: import('../../src/core/logger/core').AstroLogOptions,
+ * 	inlineConfig?: import('../../dist/types/public/config.js').AstroInlineConfig,
+ *  logging?: import('../../dist/core/logger/core').AstroLogOptions,
  * }} RunInContainerOptions
  */
 
 /**
  * @param {RunInContainerOptions} options
- * @param {(container: import('../../src/core/dev/container.js').Container) => Promise<void> | void} callback
+ * @param {(container: import('../../dist/core/dev/container.js').Container) => Promise<void> | void} callback
  */
 export async function runInContainer(options = {}, callback) {
 	const settings = await createBasicSettings(options.inlineConfig ?? {});

--- a/packages/astro/tsconfig.test.json
+++ b/packages/astro/tsconfig.test.json
@@ -1,12 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["test/units/**/*.ts"],
-  "exclude": ["test/units/_temp-fixtures/**", "test/fixtures/**"],
+  "exclude": ["src", "test/units/_temp-fixtures/**", "test/fixtures/**"],
   "compilerOptions": {
     "noEmit": true,
     "allowJs": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
+    "rewriteRelativeImportExtensions": true,
+    "types": ["node", "vite/client"]
   }
 }

--- a/packages/astro/tsconfig.test.json
+++ b/packages/astro/tsconfig.test.json
@@ -8,6 +8,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "rewriteRelativeImportExtensions": true,
-    "types": ["node", "vite/client"]
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
I ported the middleware unit test cluster for call-middleware, middleware-app, and sequence from .js to .ts, while keeping test/units/app/test-helpers.js compatible with the remaining JavaScript tests. Verification: pnpm build:ci; astro-scripts test test/units/middleware/*.test.ts --strip-types --teardown ./test/units/teardown.js. Closes #16241.