### PR TITLE
Surface console output from workerd during Cloudflare prerendering

### DIFF
--- a/.changeset/cloudflare-prerender-console-output.md
+++ b/.changeset/cloudflare-prerender-console-output.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Surfaces `console.log` and `console.warn` output from workerd during prerendering

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -61,7 +61,7 @@ export function createCloudflarePrerenderer({
 					outDir: fileURLToPath(serverDir),
 				},
 				root: fileURLToPath(root),
-				logLevel: 'error',
+				logLevel: 'info',
 				preview: {
 					host: 'localhost',
 					port: 0, // Let the OS pick a free port

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -57,8 +57,9 @@ export function createCloudflarePrerenderer({
 			// from the Cloudflare vite plugin while still allowing user console.log output to pass through.
 			// We strip ANSI codes before testing because the Cloudflare vite plugin wraps messages in color codes.
 			const defaultLogger = createLogger('info');
+			// eslint-disable-next-line no-control-regex
 			const ansiRe = /\x1b\[[0-9;]*m/g;
-			const astroRequestLogRe = /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+\/__astro_/;
+			const astroRequestLogRe = /^(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+\/__astro_/;
 			const customLogger: ReturnType<typeof createLogger> = {
 				...defaultLogger,
 				info(msg, opts) {

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -53,16 +53,16 @@ export function createCloudflarePrerenderer({
 			// Ensure client dir exists (CF plugin expects it for assets)
 			await mkdir(clientDir, { recursive: true });
 
-			// Create a custom logger that filters out HTTP request logs (e.g. "POST /__astro_prerender 200 OK")
+			// Create a custom logger that filters out internal HTTP request logs (e.g. "POST /__astro_prerender 200 OK")
 			// from the Cloudflare vite plugin while still allowing user console.log output to pass through.
 			// We strip ANSI codes before testing because the Cloudflare vite plugin wraps messages in color codes.
 			const defaultLogger = createLogger('info');
 			const ansiRe = /\x1b\[[0-9;]*m/g;
-			const requestLogRe = /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+\S+\s+\d+\s+/;
+			const astroRequestLogRe = /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+\/__astro_/;
 			const customLogger: ReturnType<typeof createLogger> = {
 				...defaultLogger,
 				info(msg, opts) {
-					if (requestLogRe.test(msg.replace(ansiRe, ''))) return;
+					if (astroRequestLogRe.test(msg.replace(ansiRe, ''))) return;
 					defaultLogger.info(msg, opts);
 				},
 			};

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -4,7 +4,7 @@ import type {
 	AssetsGlobalStaticImagesList,
 	PathWithRoute,
 } from 'astro';
-import { preview, type PreviewServer as VitePreviewServer } from 'vite';
+import { preview, createLogger, type PreviewServer as VitePreviewServer } from 'vite';
 import { fileURLToPath } from 'node:url';
 import { mkdir } from 'node:fs/promises';
 import { cloudflare as cfVitePlugin, type PluginConfig } from '@cloudflare/vite-plugin';
@@ -53,6 +53,20 @@ export function createCloudflarePrerenderer({
 			// Ensure client dir exists (CF plugin expects it for assets)
 			await mkdir(clientDir, { recursive: true });
 
+			// Create a custom logger that filters out HTTP request logs (e.g. "POST /__astro_prerender 200 OK")
+			// from the Cloudflare vite plugin while still allowing user console.log output to pass through.
+			// We strip ANSI codes before testing because the Cloudflare vite plugin wraps messages in color codes.
+			const defaultLogger = createLogger('info');
+			const ansiRe = /\x1b\[[0-9;]*m/g;
+			const requestLogRe = /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+\S+\s+\d+\s+/;
+			const customLogger: ReturnType<typeof createLogger> = {
+				...defaultLogger,
+				info(msg, opts) {
+					if (requestLogRe.test(msg.replace(ansiRe, ''))) return;
+					defaultLogger.info(msg, opts);
+				},
+			};
+
 			previewServer = await preview({
 				configFile: false,
 				base,
@@ -61,7 +75,7 @@ export function createCloudflarePrerenderer({
 					outDir: fileURLToPath(serverDir),
 				},
 				root: fileURLToPath(root),
-				logLevel: 'info',
+				customLogger,
 				preview: {
 					host: 'localhost',
 					port: 0, // Let the OS pick a free port


### PR DESCRIPTION
## Changes

- Worker `console.log`/`console.warn` output during prerendering was silently swallowed because the internal Vite preview server in `@astrojs/cloudflare` used `logLevel: 'error'`. Changed to `logLevel: 'info'` so that console output from workerd is no longer suppressed.

Closes #16200

## Testing

- Tested manually

## Docs

- N/A, bug fix