### PR TITLE
fix(dev): preserve --port flag after Vite-triggered server restart

### DIFF
--- a/.changeset/fix-dev-port-vite-restart.md
+++ b/.changeset/fix-dev-port-vite-restart.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `--port` flag being ignored after a Vite-triggered server restart (e.g. when a `.env` file changes)

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -53,7 +53,7 @@ export async function createContainer({
 
 	const {
 		base,
-		server: { host, headers, open: serverOpen, allowedHosts },
+		server: { host, headers, open: serverOpen, allowedHosts, port },
 	} = settings.config;
 
 	// serverOpen = true, isRestart = false
@@ -103,7 +103,7 @@ export async function createContainer({
 	);
 	const viteConfig = await createVite(
 		{
-			server: { host, headers, open, allowedHosts },
+			server: { host, headers, open, allowedHosts, port },
 			optimizeDeps: {
 				include: rendererClientEntries,
 			},


### PR DESCRIPTION
Closes #16278

## Changes

- This fix has been made by @astrobot-houston. I tested it, works great.
- Fix `astro dev --port` not being preserved after a Vite-triggered server restart (e.g. `.env` file change)
- `port` was missing from the destructured server config in `packages/astro/src/core/dev/container.ts` — all other server properties (`host`, `headers`, `open`, `allowedHosts`) were already forwarded to `createVite()`, but `port` was simply omitted

## Testing

Tested manually: started `astro dev --port 7000`, modified `.env`, confirmed the server restarts on port `7000` instead of falling back to Vite's default `5173`. Same as `astro dev` default `4321` port. It will restart properly with `4321`

No automated test added — this would require an integration test simulating a Vite restart, which is outside the scope of this fix.

## Docs

No docs change needed — `--port` is already documented as working. This restores the expected behavior.