### PR TITLE
fix(core): svg via f=svg

### DIFF
--- a/.changeset/fix-image-endpoint-svg-format-validation.md
+++ b/.changeset/fix-image-endpoint-svg-format-validation.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the `/_image` endpoint accepting an arbitrary `f=svg` query parameter and serving non-SVG content as `image/svg+xml`. The endpoint now validates that the source is actually SVG before honoring `f=svg`, matching the same guard already enforced on the `<Image>` component path.

--- a/packages/astro/src/assets/endpoint/shared.ts
+++ b/packages/astro/src/assets/endpoint/shared.ts
@@ -5,6 +5,7 @@ import { isRemoteAllowed } from '@astrojs/internal-helpers/remote';
 import * as mime from 'mrmime';
 import { getConfiguredImageService } from '../internal.js';
 import { etag } from '../utils/etag.js';
+import { inferSourceFormat } from '../utils/inferSourceFormat.js';
 
 export async function loadRemoteImage(src: URL): Promise<Buffer | undefined> {
 	try {
@@ -42,6 +43,15 @@ export const handleImageRequest = async ({
 
 	if (!transform?.src) {
 		return new Response('Invalid request', { status: 400 });
+	}
+
+	// Reject requests that attempt to convert a non-SVG source to SVG output.
+	// This mirrors the same guard in verifyOptions() that protects the <Image> component path.
+	if (transform.format === 'svg') {
+		const sourceFormat = inferSourceFormat(transform.src);
+		if (sourceFormat !== 'svg') {
+			return new Response('Cannot convert non-SVG source to SVG format', { status: 403 });
+		}
 	}
 
 	let inputBuffer: Buffer | undefined = undefined;

--- a/packages/astro/src/assets/utils/inferSourceFormat.ts
+++ b/packages/astro/src/assets/utils/inferSourceFormat.ts
@@ -1,6 +1,6 @@
 import { removeQueryString } from '@astrojs/internal-helpers/path';
 
-const DATA_PREFIX = 'data';
+const DATA_PREFIX = 'data:';
 
 /**
  * Infer the image format from a source path or URL by examining

--- a/packages/astro/src/assets/utils/inferSourceFormat.ts
+++ b/packages/astro/src/assets/utils/inferSourceFormat.ts
@@ -1,0 +1,29 @@
+import { removeQueryString } from '@astrojs/internal-helpers/path';
+
+const DATA_PREFIX = 'data';
+
+/**
+ * Infer the image format from a source path or URL by examining
+ * the file extension. For data: URIs, the MIME type is extracted.
+ * Returns undefined if the format cannot be determined.
+ */
+export function inferSourceFormat(src: string): string | undefined {
+	// data: URIs encode the MIME type directly, e.g. "data:image/svg+xml;base64,..."
+	if (src.startsWith(DATA_PREFIX)) {
+		const mime = src.slice(DATA_PREFIX.length, src.indexOf(';'));
+		if (mime === 'image/svg+xml') return 'svg';
+		const sub = mime.split('/')[1];
+		return sub || undefined;
+	}
+
+	// For regular URLs/paths, extract the extension from the pathname
+	try {
+		// Strip query string and hash before extracting extension
+		const cleanSrc = removeQueryString(src).split('#')[0];
+		const lastDot = cleanSrc.lastIndexOf('.');
+		if (lastDot === -1) return undefined;
+		return cleanSrc.slice(lastDot + 1).toLowerCase();
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -529,6 +529,24 @@ describe('astro:image', () => {
 					const imageRequest = await fixture.fetch(src);
 					assert.ok(imageRequest.status >= 400);
 				});
+
+				it('rejects f=svg for a non-SVG data: URI', async () => {
+					// A PNG data: URI with f=svg should be rejected — the endpoint must not
+					// serve non-SVG content with an image/svg+xml content type
+					const pngDataUri =
+						'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+					const src = `/_image?href=${encodeURIComponent(pngDataUri)}&f=svg`;
+					const response = await fixture.fetch(src);
+					assert.equal(response.status, 403, 'should reject f=svg for a data:image/png source');
+				});
+
+				it('allows f=svg for an actual SVG data: URI', async () => {
+					const svgDataUri =
+						'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz48L3N2Zz4=';
+					const src = `/_image?href=${encodeURIComponent(svgDataUri)}&f=svg`;
+					const response = await fixture.fetch(src);
+					assert.equal(response.status, 200, 'should allow f=svg for a data:image/svg+xml source');
+				});
 			});
 
 			it('error if no width and height', async () => {
@@ -1300,6 +1318,14 @@ describe('astro:image', () => {
 			const html = await res.text();
 			assert.equal(html, 'An image: "image.png"');
 		});
+
+		it('rejects f=svg when source is not SVG in dev mode', async () => {
+			const params = new URLSearchParams();
+			params.set('href', '/src/assets/penguin1.jpg?origWidth=207&origHeight=243&origFormat=jpg');
+			params.set('f', 'svg');
+			const response = await fixture.fetch('/some-base/_image?' + String(params));
+			assert.equal(response.status, 403, 'should reject f=svg for a .jpg source in dev');
+		});
 	});
 
 	describe('prod ssr', () => {
@@ -1449,6 +1475,73 @@ describe('astro:image', () => {
 			let response = await app.render(request);
 			assert.equal(response.status, 200);
 			assert.equal(response.headers.get('content-type'), 'image/webp');
+		});
+
+		it('rejects f=svg when source is not SVG', async () => {
+			const app = await fixture.loadTestAdapterApp();
+
+			// Attempt to request a non-SVG source with f=svg — this should be rejected
+			let request = new Request('http://example.com/_image?href=/penguin3.jpg&f=svg');
+			let response = await app.render(request);
+			assert.equal(response.status, 403, 'should reject f=svg for a .jpg source');
+			const body = await response.text();
+			assert.ok(
+				body.includes('Cannot convert non-SVG source to SVG format'),
+				'should include descriptive error message',
+			);
+		});
+	});
+
+	describe('prod ssr - SVG format validation', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/core-image-ssr/',
+				output: 'server',
+				outDir: './dist/server-prod-svg-validation',
+				adapter: testAdapter(),
+				image: {
+					endpoint: { entrypoint: 'astro/assets/endpoint/node' },
+					service: testImageService(),
+					remotePatterns: [{ protocol: 'data' }],
+				},
+			});
+			await fixture.build();
+		});
+
+		it('rejects f=svg for a non-SVG data: URI in production build', async () => {
+			const app = await fixture.loadTestAdapterApp();
+			const pngDataUri =
+				'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+			const request = new Request(
+				'http://example.com/_image?href=' + encodeURIComponent(pngDataUri) + '&f=svg',
+			);
+			const response = await app.render(request);
+			assert.equal(response.status, 403, 'should reject f=svg for a data:image/png source');
+			const body = await response.text();
+			assert.ok(
+				body.includes('Cannot convert non-SVG source to SVG format'),
+				'should include descriptive error message',
+			);
+		});
+
+		it('allows f=svg for an actual SVG data: URI in production build', async () => {
+			const app = await fixture.loadTestAdapterApp();
+			const svgDataUri =
+				'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz48L3N2Zz4=';
+			const request = new Request(
+				'http://example.com/_image?href=' + encodeURIComponent(svgDataUri) + '&f=svg',
+			);
+			const response = await app.render(request);
+			assert.equal(response.status, 200, 'should allow f=svg for a data:image/svg+xml source');
+			assert.equal(response.headers.get('content-type'), 'image/svg+xml');
+		});
+
+		it('rejects f=svg for a remote-style non-SVG URL in production build', async () => {
+			const app = await fixture.loadTestAdapterApp();
+			// Local path with .jpg extension — should be rejected when f=svg
+			const request = new Request('http://example.com/_image?href=/penguin3.jpg&f=svg');
+			const response = await app.render(request);
+			assert.equal(response.status, 403, 'should reject f=svg for a .jpg source');
 		});
 	});
 

--- a/packages/astro/test/units/assets/endpoint-svg-reject.test.ts
+++ b/packages/astro/test/units/assets/endpoint-svg-reject.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { inferSourceFormat } from '../../../dist/assets/utils/inferSourceFormat.js';
+
+describe('inferSourceFormat', () => {
+	it('detects svg from file extension', () => {
+		assert.equal(inferSourceFormat('/images/logo.svg'), 'svg');
+	});
+
+	it('detects svg from remote URL', () => {
+		assert.equal(inferSourceFormat('https://example.com/icon.svg'), 'svg');
+	});
+
+	it('detects svg from remote URL with query string', () => {
+		assert.equal(inferSourceFormat('https://example.com/icon.svg?v=2'), 'svg');
+	});
+
+	it('detects svg from remote URL with hash', () => {
+		assert.equal(inferSourceFormat('https://example.com/icon.svg#fragment'), 'svg');
+	});
+
+	it('detects svg from data: URI with image/svg+xml', () => {
+		assert.equal(inferSourceFormat('data:image/svg+xml;base64,PHN2Zz4='), 'svg');
+	});
+
+	it('detects png from file extension', () => {
+		assert.equal(inferSourceFormat('/images/photo.png'), 'png');
+	});
+
+	it('detects jpg from file extension', () => {
+		assert.equal(inferSourceFormat('/images/photo.jpg'), 'jpg');
+	});
+
+	it('detects webp from remote URL', () => {
+		assert.equal(inferSourceFormat('https://cdn.example.com/img.webp'), 'webp');
+	});
+
+	it('detects png from data: URI', () => {
+		assert.equal(inferSourceFormat('data:image/png;base64,iVBOR'), 'png');
+	});
+
+	it('returns undefined for extensionless path', () => {
+		assert.equal(inferSourceFormat('/images/photo'), undefined);
+	});
+
+	it('is case-insensitive for extensions', () => {
+		assert.equal(inferSourceFormat('/images/logo.SVG'), 'svg');
+		assert.equal(inferSourceFormat('/images/photo.PNG'), 'png');
+	});
+
+	it('handles paths with multiple dots', () => {
+		assert.equal(inferSourceFormat('/images/my.photo.jpg'), 'jpg');
+	});
+
+	it('detects format from Astro internal query string paths', () => {
+		assert.equal(
+			inferSourceFormat('/src/assets/penguin.jpg?origWidth=207&origHeight=243&origFormat=jpg'),
+			'jpg',
+		);
+	});
+});


### PR DESCRIPTION
## Changes

This PR fixes a bug where non-SVG images can be converted to SVG output.

## Testing

Added various tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
