### PR TITLE
Fix static asset error responses including immutable cache headers

### DIFF
--- a/.changeset/fix-node-cache-poisoning.md
+++ b/.changeset/fix-node-cache-poisoning.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes a cache poisoning vulnerability where conditional request errors (e.g. malformed `If-Match` header) returned immutable far-future cache headers, allowing CDN caches to serve error responses instead of static assets

--- a/.changeset/fix-node-cache-poisoning.md
+++ b/.changeset/fix-node-cache-poisoning.md
@@ -2,4 +2,4 @@
 '@astrojs/node': patch
 ---
 
-Fixes a cache poisoning vulnerability where conditional request errors (e.g. malformed `If-Match` header) returned immutable far-future cache headers, allowing CDN caches to serve error responses instead of static assets
+Fixes static asset error responses incorrectly including immutable cache headers. Conditional request failures (e.g. `If-Match` mismatch) now return the correct status code without far-future cache directives.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -130,25 +130,32 @@ export function createStaticHandler(
 
 			stream.on('error', (err) => {
 				if (forwardError) {
-					console.error(err.toString());
-					res.writeHead(500);
-					res.end('Internal server error');
+					// The `send` library emits errors with a `statusCode` property
+					// (e.g. 412 for precondition failures from If-Match / If-Unmodified-Since).
+					// Use the real status when available instead of always returning 500.
+					const status = 'statusCode' in err ? (err as any).statusCode : 500;
+					if (status >= 500) {
+						console.error(err.toString());
+					}
+					res.writeHead(status);
+					res.end(status >= 500 ? 'Internal server error' : '');
 					return;
 				}
 				// File not found, forward to the SSR handler
 				ssr();
 			});
-			stream.on('headers', (_res: ServerResponse) => {
-				// assets in dist/_astro are hashed and should get the immutable header
-				if (normalizedPathname.startsWith(`/${app.manifest.assetsDir}/`)) {
-					// This is the "far future" cache header, used for static files whose name includes their digest hash.
-					// 1 year (31,536,000 seconds) is convention.
-					// Taken from https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#immutable
-					_res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-				}
-			});
 			stream.on('file', () => {
 				forwardError = true;
+			});
+			// The `stream` event fires only when `send` is actually going to stream
+			// the file content (i.e. after all precondition checks like If-Match and
+			// If-Unmodified-Since have passed). Setting cache headers here instead of
+			// in the `headers` event ensures error responses (e.g. 412) are never
+			// sent with immutable cache headers, which would poison CDN caches.
+			stream.on('stream', () => {
+				if (normalizedPathname.startsWith(`/${app.manifest.assetsDir}/`)) {
+					res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+				}
 			});
 			stream.pipe(res);
 		} else {

--- a/packages/integrations/node/test/assets.test.js
+++ b/packages/integrations/node/test/assets.test.js
@@ -44,4 +44,26 @@ describe('Assets', () => {
 		cacheControl = response.headers.get('cache-control');
 		assert.equal(cacheControl, 'public, max-age=31536000, immutable');
 	});
+
+	it('Malformed If-Match header should return 412 without immutable cache headers', async () => {
+		// First, get a valid asset URL from the page
+		let response = await fixture.fetch('/text-file');
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		const fileURL = $('a').attr('href');
+
+		// Send a request with a malformed If-Match header that won't match the ETag
+		response = await fixture.fetch(fileURL, {
+			headers: { 'If-Match': 'xxx' },
+		});
+
+		// Should return 412 Precondition Failed, not 500
+		assert.equal(response.status, 412);
+
+		// Must NOT include the immutable far-future cache header on error responses,
+		// as that would allow CDN cache poisoning. The `send` library may still set
+		// its own default `public, max-age=0` which is harmless (not cached).
+		const cacheControl = response.headers.get('cache-control');
+		assert.notEqual(cacheControl, 'public, max-age=31536000, immutable');
+	});
 });


### PR DESCRIPTION
## Changes

- Moves the immutable `Cache-Control` header from `send`'s `headers` event to the `stream` event, which only fires on the success path (after precondition checks pass). Previously, conditional request failures (e.g. `If-Match` mismatch) on hashed `/_astro/` assets returned error responses with `Cache-Control: public, max-age=31536000, immutable`, causing CDNs to cache the error.
- Propagates the real HTTP status code from `send`'s error object (e.g. 412 for precondition failure) instead of always returning 500.

## Testing

- Added integration test in `test/assets.test.js` that sends a request with `If-Match: xxx` to a hashed asset and asserts it returns 412 without the immutable cache header.
- Existing test for immutable headers on successful asset requests continues to pass.

## Docs

- No docs update needed — this is a bugfix with no user-facing API change.