### PR TITLE
Use redirect: manual in Cloudflare image binding transform

### DIFF
--- a/.changeset/cloudflare-image-binding-no-redirect-follow.md
+++ b/.changeset/cloudflare-image-binding-no-redirect-follow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Uses `redirect: 'manual'` for remote image fetches in the Cloudflare binding image transform, consistent with all other image fetch paths

--- a/packages/integrations/cloudflare/src/utils/image-binding-transform.ts
+++ b/packages/integrations/cloudflare/src/utils/image-binding-transform.ts
@@ -25,7 +25,14 @@ export async function transform(
 	}
 
 	const imageSrc = new URL(href, url.origin);
-	const content = await (isRemotePath(href) ? fetch(imageSrc) : assets.fetch(imageSrc));
+	const content = await (isRemotePath(href)
+		? fetch(imageSrc, { redirect: 'manual' })
+		: assets.fetch(imageSrc));
+
+	if (content.status >= 300 && content.status < 400) {
+		return new Response('Not Found', { status: 404 });
+	}
+
 	if (!content.body) {
 		return new Response(null, { status: 404 });
 	}

--- a/packages/integrations/cloudflare/test/binding-image-service.test.js
+++ b/packages/integrations/cloudflare/test/binding-image-service.test.js
@@ -1,12 +1,28 @@
 import * as assert from 'node:assert/strict';
+import { createServer } from 'node:http';
 import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './_test-utils.js';
 
 describe('BindingImageService', () => {
 	let fixture;
 	let previewServer;
+	let redirectServer;
+	let redirectServerPort;
 
 	before(async () => {
+		// Start a local HTTP server that always responds with a 302 redirect.
+		// Used to test that the image transform endpoint does not follow redirects.
+		redirectServer = createServer((req, res) => {
+			res.writeHead(302, { Location: 'http://example.com/secret' });
+			res.end();
+		});
+		await new Promise((resolve) => {
+			redirectServer.listen(0, () => {
+				redirectServerPort = redirectServer.address().port;
+				resolve();
+			});
+		});
+
 		fixture = await loadFixture({
 			root: './fixtures/binding-image-service/',
 		});
@@ -16,6 +32,7 @@ describe('BindingImageService', () => {
 
 	after(async () => {
 		await previewServer.stop();
+		await new Promise((resolve) => redirectServer.close(resolve));
 	});
 
 	it('returns 403 for missing href parameter', async () => {
@@ -51,5 +68,11 @@ describe('BindingImageService', () => {
 		const res = await fixture.fetch('/_image?href=/placeholder.jpg&f=avif&w=100');
 		assert.equal(res.status, 200);
 		assert.equal(res.headers.get('content-type'), 'image/avif');
+	});
+
+	it('does not follow redirects for remote images', async () => {
+		const href = `http://localhost:${redirectServerPort}/image.jpg`;
+		const res = await fixture.fetch(`/_image?href=${encodeURIComponent(href)}&f=webp`);
+		assert.equal(res.status, 404);
 	});
 });

--- a/packages/integrations/cloudflare/test/binding-image-service.test.js
+++ b/packages/integrations/cloudflare/test/binding-image-service.test.js
@@ -12,7 +12,7 @@ describe('BindingImageService', () => {
 	before(async () => {
 		// Start a local HTTP server that always responds with a 302 redirect.
 		// Used to test that the image transform endpoint does not follow redirects.
-		redirectServer = createServer((req, res) => {
+		redirectServer = createServer((_req, res) => {
 			res.writeHead(302, { Location: 'http://example.com/secret' });
 			res.end();
 		});

--- a/packages/integrations/cloudflare/test/fixtures/binding-image-service/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/binding-image-service/astro.config.mjs
@@ -5,5 +5,8 @@ export default defineConfig({
 	adapter: cloudflare({
 		imageService: 'cloudflare-binding',
 	}),
+	image: {
+		domains: ['localhost'],
+	},
 	output: 'server',
 });


### PR DESCRIPTION
## Changes

- The fetch() call for remote images in the Cloudflare binding image transform (image-binding-transform.ts) now uses `{ redirect: 'manual' }` and rejects 3xx responses with a 404, consistent with every other remote image fetch path in core Astro and the Cloudflare integration.
- Previously this was the only image fetch path that used the default `redirect: 'follow'` behavior, which meant the worker would follow HTTP redirects to whatever destination the remote server specified, bypassing the `isRemoteAllowed()` domain check that only validated the initial URL.

## Testing

- Added a test that spins up a local HTTP server returning a 302 redirect, requests `/_image` with that URL (which passes the domain allowlist), and asserts a 404 is returned instead of following the redirect.
- All existing binding image service tests continue to pass.

## Docs

- No docs update needed — this is an internal behavior change with no new API surface.