### PR TITLE
VSCode extension: use JSX comments instead of HTML comments for comment toggle

### DIFF
--- a/.changeset/vscode-use-jsx-comments-instead-of-html.md
+++ b/.changeset/vscode-use-jsx-comments-instead-of-html.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+use JSX comments instead of HTML comments for comment toggle

--- a/packages/language-tools/vscode/languages/astro-language-configuration.json
+++ b/packages/language-tools/vscode/languages/astro-language-configuration.json
@@ -1,6 +1,6 @@
 {
   "comments": {
-    "blockComment": ["<!--", "-->"]
+    "blockComment": ["{/* ", " */}"]
   },
   "brackets": [["<!--", "-->"], ["<", ">"], ["{", "}"]],
   "autoClosingPairs": [


### PR DESCRIPTION
Changes the default comment toggle (`Cmd+/` / `Ctrl+/`) in Astro template sections from HTML comments (`<!-- -->`) to JSX comments (`{/* */}`).

**Why:** HTML comments leak to the rendered output, which is a security concern — developers using the comment hotkey expect their comments to be stripped, but `<!-- -->` is visible to anyone viewing page source. JSX comments (`{/* */}`) are stripped by the Astro compiler and never reach the consumer.

**What changed:** One line in `packages/language-tools/vscode/languages/astro-language-configuration.json` — `blockComment` from `["<!--", "-->"]` to `["{/* ", " */}"]`.

**Note:** This PR is intentionally minimal to serve as a discussion starter. The tradeoffs are real and the team may prefer a different approach (see alternatives below). The goal is to reopen the conversation from withastro/language-tools#274 with a concrete proposal.

## Context

This was discussed in withastro/language-tools#274 by @Princesseuh. The ideal solution would be context-aware comments (HTML outside elements, JSX inside), but VSCode's `blockComment` in language configuration is a single static value — it can't switch based on cursor position. The `embeddedLanguages` mapping already handles frontmatter (`//` via `source.ts`) and expressions (`//` via `source.tsx`), but the template section is all one scope (`source.astro`).

Related issues and discussions:
- withastro/language-tools#274 — RFC: Use JSX syntax for the template instead of HTML?
- withastro/language-tools#123 — Commenting with Ctrl+/ in the frontmatter uses HTML-style comment
- withastro/roadmap#747 — Option to remove HTML comments
- withastro/astro#8717 — HTML comment inside JS expression in template causes crash
- withastro/astro#9120 — JS `//` comments inside JSX-like component template error

Given that choice, `{/* */}` is the safer default:
- Accidental comment leaks are a silent security issue. The comments may leak sensitive information about how the code works, or even secrets like API keys or database credentials. Developers expect comments to be stripped and may not realize that `<!-- -->` is visible to end users.
- Intentional HTML comments in output are rare and can still be typed manually
- Astro is a rendering framework, not raw HTML — HTML comments only exist in plain HTML because there's no other way to comment things out (rare exceptions like Angular's comment bindings aside). In a rendering framework, comments are a developer concern and should not leak to the output by default
- For the rare case where someone intentionally wants an HTML comment in the output, there are better explicit options: `<Fragment set:html="<!-- my comment -->" />`, or Astro could provide a built-in component like `<HTMLComment>` similar to how `<Fragment>` already exists

## Alternative

If changing the default for all users is too opinionated, the extension could expose a user-configurable setting (e.g. `astro.comments.style: "jsx" | "html"`) and use `vscode.languages.setLanguageConfiguration()` in the extension's activation to programmatically set the `blockComment` based on the user's preference. The static `language-configuration.json` would serve as the fallback default, but the programmatic call would override it at runtime. This would let users who rely on HTML comments opt back in while keeping the safe default.

## Personal note

In all my time using Astro, I have never once wanted an HTML comment in the output. Every single time I hit the comment shortcut and get `<!-- -->` instead of `{/* */}`, I have to undo and retype it manually. I suspect most Astro developers share this frustration — we reach for the comment hotkey to temporarily disable code or leave notes for ourselves, not to ship comments to the browser.