### PR TITLE
test: port render/ssr-elements unit test to TypeScript

### DIFF
--- a/packages/astro/test/units/render/ssr-elements.test.ts
+++ b/packages/astro/test/units/render/ssr-elements.test.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {


### PR DESCRIPTION
Ports `packages/astro/test/units/render/ssr-elements.test.js` to TypeScript as part of #16241.

The file only imports from `dist/` and uses no shared local helpers, so it moves cleanly without touching neighbouring tests. The pre-existing `// @ts-check` directive is removed since the strict tsconfig.test.json covers the file now.

## Verification

- `pnpm run typecheck:tests` → 0 errors
- `pnpm exec astro-scripts test test/units/render/ssr-elements.test.ts --strip-types` → 20/20 pass