### PR TITLE
test: port assets/image-service unit test to TypeScript

### DIFF
--- a/packages/astro/test/units/assets/image-service.test.ts
+++ b/packages/astro/test/units/assets/image-service.test.ts
@@ -89,14 +89,14 @@ describe('sharp encoder options', async () => {
 describe('sharp image service', async () => {
 	const sharpService = (await import('../../../dist/assets/services/sharp.js')).default;
 
-	const config = { service: { entrypoint: '', config: {} } };
+	const config = { service: { entrypoint: '', config: {} } } as any;
 
-	let inputBuffer;
+	let inputBuffer: Uint8Array;
 	before(async () => {
 		inputBuffer = new Uint8Array(await readFile(FIXTURE_IMAGE));
 	});
 
-	async function transform(opts) {
+	async function transform(opts: any) {
 		const { data } = await sharpService.transform(
 			inputBuffer,
 			{ src: 'penguin.jpg', format: 'webp', ...opts },


### PR DESCRIPTION
Ports `packages/astro/test/units/assets/image-service.test.js` to TypeScript as part of #16241.

The file imports only from `dist/` and uses no shared local helpers. The mock `ImageConfig` and `transform` opts use `any` casts to bridge partial mocks with the strict tsconfig.test.json.

## Verification

- `pnpm run typecheck:tests` → 0 errors
- `pnpm exec astro-scripts test test/units/assets/image-service.test.ts --strip-types` → 13/13 pass