### PR TITLE
test: port assets/fonts/{infra,e2e} unit tests to TypeScript

### DIFF
--- a/packages/astro/test/units/assets/fonts/e2e.test.ts
+++ b/packages/astro/test/units/assets/fonts/e2e.test.ts
@@ -30,12 +30,9 @@ import { fontProviders } from '../../../../dist/assets/fonts/providers/index.js'
 import { AstroLogger } from '../../../../dist/core/logger/core.js';
 import { nodeLogDestination } from '../../../../dist/core/logger/node.js';
 
-/**
- * @param {{ fonts: Array<import('../../../../dist/assets/fonts/types.js').FontFamily> }} param0
- */
-async function run({ fonts: _fonts }) {
+async function run({ fonts: _fonts }: { fonts: any[] }) {
 	const hasher = await XxhashHasher.create();
-	const resolvedFamilies = _fonts.map((family) => resolveFamily({ family, hasher }));
+	const resolvedFamilies = _fonts.map((family: any) => resolveFamily({ family, hasher }));
 	const defaults = DEFAULTS;
 	const { bold } = colors;
 	const logger = new AstroLogger({

--- a/packages/astro/test/units/assets/fonts/infra.test.ts
+++ b/packages/astro/test/units/assets/fonts/infra.test.ts
@@ -61,17 +61,11 @@ describe('fonts infra', () => {
 	});
 
 	describe('CachedFontFetcher', () => {
-		/**
-		 *
-		 * @param {{ ok: boolean }} param0
-		 */
-		function createReadFileMock({ ok }) {
-			/** @type {Array<string>} */
-			const filesUrls = [];
+		function createReadFileMock({ ok }: { ok: boolean }) {
+			const filesUrls: string[] = [];
 			return {
 				filesUrls,
-				/** @type {(url: string) => Promise<Buffer>} */
-				readFile: async (url) => {
+				readFile: async (url: string): Promise<Buffer> => {
 					filesUrls.push(url);
 					if (!ok) {
 						throw 'fs error';
@@ -81,25 +75,18 @@ describe('fonts infra', () => {
 			};
 		}
 
-		/**
-		 *
-		 * @param {{ ok: boolean }} param0
-		 */
-		function createFetchMock({ ok }) {
-			/** @type {Array<string>} */
-			const fetchUrls = [];
+		function createFetchMock({ ok }: { ok: boolean }) {
+			const fetchUrls: string[] = [];
 			return {
 				fetchUrls,
-				/** @type {(url: string) => Promise<Response>} */
-				fetch: async (url) => {
+				fetch: (async (url: string) => {
 					fetchUrls.push(url);
-					// @ts-expect-error
 					return {
 						ok,
 						status: ok ? 200 : 500,
-						arrayBuffer: async () => new ArrayBuffer(),
+						arrayBuffer: async () => new ArrayBuffer(0),
 					};
-				},
+				}) as unknown as typeof fetch,
 			};
 		}
 
@@ -236,7 +223,7 @@ describe('fonts infra', () => {
 
 		for (const [input, check] of data) {
 			try {
-				const res = fontTypeExtractor.extract(input);
+				const res = fontTypeExtractor.extract(input as string);
 				if (check) {
 					assert.equal(res, check);
 				} else {
@@ -421,12 +408,7 @@ describe('fonts infra', () => {
 	});
 
 	describe('UnifontFontResolver', () => {
-		/**
-		 * @param {string} name
-		 * @param {any} [config]
-		 * @returns {import('../../../../dist/index.js').FontProvider}
-		 * */
-		const createProvider = (name, config) => ({
+		const createProvider = (name: string, config?: any): any => ({
 			name,
 			config,
 			resolveFont: () => undefined,
@@ -597,17 +579,15 @@ describe('fonts infra', () => {
 						listFonts: () => ['a', 'b', 'c'],
 					};
 				});
-				/** @returns {import('../../../../dist/index.js').FontProvider} */
-				const astroProvider = () => {
+				const astroProvider = (): any => {
 					const provider = unifontProvider();
-					/** @type {import('unifont').InitializedProvider | undefined} */
-					let initializedProvider;
+					let initializedProvider: any;
 					return {
 						name: provider._name,
-						async init(context) {
+						async init(context: any) {
 							initializedProvider = await provider(context);
 						},
-						async resolveFont({ familyName, ...rest }) {
+						async resolveFont({ familyName, ...rest }: any) {
 							return await initializedProvider?.resolveFont(familyName, rest);
 						},
 						async listFonts() {

--- a/packages/astro/test/units/assets/fonts/utils.js
+++ b/packages/astro/test/units/assets/fonts/utils.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @import { Hasher, FontMetricsResolver, Storage, FontResolver, StringMatcher } from '../../../../dist/assets/fonts/definitions'
+ * @import { Hasher, FontMetricsResolver, Storage, FontResolver, StringMatcher } from '../../../../dist/assets/fonts/definitions.js'
  */
 
 /** @implements {Storage} */
@@ -88,7 +88,7 @@ export class FakeFontMetricsResolver {
 	}
 
 	/**
-	 * @param {Parameters<import('../../../../dist/assets/fonts/definitions').FontMetricsResolver['generateFontFace']>[0]} input
+	 * @param {Parameters<import('../../../../dist/assets/fonts/definitions.js').FontMetricsResolver['generateFontFace']>[0]} input
 	 */
 	generateFontFace(input) {
 		return JSON.stringify(input, null, 2) + `,`;
@@ -116,7 +116,7 @@ export class PassthroughFontResolver {
 	}
 
 	/**
-	 * @param {{ families: Array<import('../../../../dist/assets/fonts/types').ResolvedFontFamily>; hasher: Hasher }} param0
+	 * @param {{ families: Array<import('../../../../dist/assets/fonts/types.js').ResolvedFontFamily>; hasher: Hasher }} param0
 	 */
 	static async create({ families, hasher }) {
 		/** @type {Map<string, import('../../../../dist/index.js').FontProvider<Record<string, any>>>} */


### PR DESCRIPTION
Ports two larger `assets/fonts/` unit test files to TypeScript as part of #16241:

- `packages/astro/test/units/assets/fonts/infra.test.js` (778 lines)
- `packages/astro/test/units/assets/fonts/e2e.test.js` (388 lines)

JSDoc `@param` annotations on internal helper functions become explicit TypeScript parameter types. Mock `fetch` / `readFile` signatures use `as unknown as typeof fetch` to bridge partial responses with the real DOM type.

The shared `utils.js` helper in the same directory needed three `.js` extensions added to its JSDoc `@import` paths so the new `.ts` files can transitively type-check it through `allowJs`. Without that, `tsconfig.test.json`'s NodeNext module resolution flags `@import` paths as missing extensions.

## Verification

- `pnpm run typecheck:tests` → 0 errors
- `infra.test.ts` → 31/31 pass
- `e2e.test.ts` → 2/2 pass