### PR TITLE
test: port routing/route-matching unit test to TypeScript

### DIFF
--- a/packages/astro/test/units/routing/route-matching.test.ts
+++ b/packages/astro/test/units/routing/route-matching.test.ts
@@ -116,11 +116,11 @@ const fileSystem = {
  * Sorts matched routes following the same logic as getSortedPreloadedMatches,
  * but without requiring a full pipeline/container.
  */
-function sortMatches(matches) {
+function sortMatches(matches: any[]) {
 	return matches
 		.slice()
-		.sort((a, b) => routeComparator(a, b))
-		.sort((a, b) => {
+		.sort((a: any, b: any) => routeComparator(a, b))
+		.sort((a: any, b: any) => {
 			// Prioritize prerendered routes over server routes when patterns are equal
 			if (a.pattern.source === b.pattern.source) {
 				if (a.prerender !== b.prerender) {
@@ -133,8 +133,8 @@ function sortMatches(matches) {
 }
 
 describe('Route matching', () => {
-	let fixture;
-	let manifestData;
+	let fixture: any;
+	let manifestData: any;
 
 	before(async () => {
 		fixture = await createFixture(fileSystem);
@@ -160,7 +160,7 @@ describe('Route matching', () => {
 		it('should be sorted correctly', async () => {
 			const matches = matchAllRoutes('/try-matching-a-route', manifestData);
 			const sortedMatches = sortMatches(matches);
-			const sortedRouteNames = sortedMatches.map((match) => match.route);
+			const sortedRouteNames = sortedMatches.map((match: any) => match.route);
 
 			assert.deepEqual(sortedRouteNames, [
 				'/[astaticdynamic]',

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -13,7 +13,7 @@ import { NOOP_MIDDLEWARE_FN } from '../../dist/core/middleware/noop-middleware.j
 import { Pipeline } from '../../dist/core/render/index.js';
 import { RouteCache } from '../../dist/core/render/route-cache.js';
 
-/** @type {import('../../src/core/logger/core').AstroLogger} */
+/** @type {import('../../dist/core/logger/core.js').AstroLogger} */
 export const defaultLogger = new AstroLogger({
 	destination: nodeLogDestination,
 	level: 'error',
@@ -132,8 +132,8 @@ export function createBasicPipeline(options = {}) {
 }
 
 /**
- * @param {import('../../src/types/public/config.js').AstroInlineConfig} inlineConfig
- * @returns {Promise<import('../../src/types/astro.js').AstroSettings>}
+ * @param {import('../../dist/types/public/config.js').AstroInlineConfig} inlineConfig
+ * @returns {Promise<import('../../dist/types/astro.js').AstroSettings>}
  */
 export async function createBasicSettings(inlineConfig = {}) {
 	if (!inlineConfig.root) {
@@ -146,14 +146,14 @@ export async function createBasicSettings(inlineConfig = {}) {
 /**
  * @typedef {{
  * 	fs?: typeof realFS,
- * 	inlineConfig?: import('../../src/types/public/config.js').AstroInlineConfig,
- *  logging?: import('../../src/core/logger/core').AstroLogOptions,
+ * 	inlineConfig?: import('../../dist/types/public/config.js').AstroInlineConfig,
+ *  logging?: import('../../dist/core/logger/core.js').AstroLogOptions,
  * }} RunInContainerOptions
  */
 
 /**
  * @param {RunInContainerOptions} options
- * @param {(container: import('../../src/core/dev/container.js').Container) => Promise<void> | void} callback
+ * @param {(container: import('../../dist/core/dev/container.js').Container) => Promise<void> | void} callback
  */
 export async function runInContainer(options = {}, callback) {
 	const settings = await createBasicSettings(options.inlineConfig ?? {});


### PR DESCRIPTION
Ports `packages/astro/test/units/routing/route-matching.test.js` to TypeScript as part of #16241.

The test imports helpers from `../test-utils.js`, whose JSDoc `@param` and `@type` annotations previously referenced `../../src/...` paths *without* `.js` extensions. Once `test-utils.js`'s six JSDoc references are pointed at `../../dist/.../*.js` instead, the import is safe to follow from a strict TypeScript test file under `allowJs`. This unblocks future ports of any test that depends on the shared `test-utils.js` helper.

## Verification

- `pnpm run typecheck:tests` → 0 errors
- `pnpm exec astro-scripts test test/units/routing/route-matching.test.ts --strip-types` → 1/1 pass