### PR TITLE
feat(logger): cli flag and build

### DIFF
--- a/packages/astro/src/cli/flags.ts
+++ b/packages/astro/src/cli/flags.ts
@@ -1,6 +1,7 @@
 import type { Arguments } from 'yargs-parser';
 import type { AstroLogger } from '../core/logger/core.js';
-import { createNodeLogger } from '../core/logger/impls/node.js';
+import { createNodeLoggerFromFlags } from '../core/logger/impls/node.js';
+import { createJsonLoggerFromFlags } from '../core/logger/impls/json.js';
 import type { AstroInlineConfig } from '../types/public/config.js';
 
 // Alias for now, but allows easier migration to node's `parseArgs` in the future.
@@ -8,7 +9,7 @@ export type Flags = Arguments;
 
 /** @deprecated Use AstroConfigResolver instead */
 export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
-	return {
+	const inlineConfig: AstroInlineConfig = {
 		// Inline-only configs
 		configFile: typeof flags.config === 'string' ? flags.config : undefined,
 		mode: typeof flags.mode === 'string' ? flags.mode : undefined,
@@ -34,6 +35,16 @@ export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
 						: [],
 		},
 	};
+
+	if (flags.experimentalJson) {
+		inlineConfig.experimental = {
+			logger: {
+				entrypoint: 'astro/logger/json',
+			},
+		};
+	}
+
+	return inlineConfig;
 }
 
 /**
@@ -48,6 +59,9 @@ export function createLoggerFromFlags(flags: Flags): AstroLogger {
 	} else if (flags.silent) {
 		logLevel = 'silent';
 	}
-
-	return createNodeLogger({ logLevel });
+	if (flags.experimentalJson) {
+		return createJsonLoggerFromFlags({ logLevel });
+	} else {
+		return createNodeLoggerFromFlags({ logLevel });
+	}
 }

--- a/packages/astro/src/cli/help/index.ts
+++ b/packages/astro/src/cli/help/index.ts
@@ -28,6 +28,7 @@ export const DEFAULT_HELP_PAYLOAD: HelpPayload = {
 			['--silent', 'Disable all logging.'],
 			['--version', 'Show the version number and exit.'],
 			['--help', 'Show this help message.'],
+			['--experimental-json', 'Enables JSON logging.'],
 		],
 	},
 };

--- a/packages/astro/src/cli/preferences/index.ts
+++ b/packages/astro/src/cli/preferences/index.ts
@@ -10,7 +10,8 @@ import { DEFAULT_PREFERENCES } from '../../preferences/defaults.js';
 import dlv from '../../preferences/dlv.js';
 import { coerce, isValidKey, type PreferenceKey } from '../../preferences/index.js';
 import type { AstroSettings } from '../../types/astro.js';
-import { createLoggerFromFlags, type Flags, flagsToAstroInlineConfig } from '../flags.js';
+import { type Flags, flagsToAstroInlineConfig } from '../flags.js';
+import { loadOrCreateNodeLogger } from '../../core/logger/load.js';
 
 const { bgGreen, black, bold, dim, yellow } = colors;
 
@@ -68,8 +69,8 @@ export async function preferences(
 	}
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);
-	const logger = createLoggerFromFlags(flags);
 	const { astroConfig } = await resolveConfig(inlineConfig ?? {}, 'dev');
+	const logger = await loadOrCreateNodeLogger(astroConfig, inlineConfig ?? {});
 	const settings = await createSettings(
 		astroConfig,
 		inlineConfig.logLevel,

--- a/packages/astro/src/config/index.ts
+++ b/packages/astro/src/config/index.ts
@@ -1,7 +1,6 @@
+// Keep this imports free of possible runtime imports
 import type { UserConfig as ViteUserConfig, UserConfigFn as ViteUserConfigFn } from 'vite';
 import type { FontProvider } from '../assets/fonts/types.js';
-import { createRoutesList } from '../core/routing/create-manifest.js';
-import { getPrerenderDefault } from '../prerender/utils.js';
 import type { SessionDriverConfig, SessionDriverName } from '../core/session/types.js';
 import type { AstroInlineConfig, AstroUserConfig, Locales } from '../types/public/config.js';
 
@@ -32,19 +31,23 @@ export function getViteConfig(
 		// Use dynamic import to avoid pulling in deps unless used
 		const [
 			{ mergeConfig },
-			{ createNodeLogger },
+			{ loadOrCreateNodeLogger },
 			{ resolveConfig, createSettings },
 			{ createVite },
 			{ runHookConfigSetup, runHookConfigDone },
+			{ createRoutesList },
+			{ getPrerenderDefault },
 		] = await Promise.all([
 			import('vite'),
-			import('../core/logger/impls/node.js'),
+			import('../core/logger/load.js'),
 			import('../core/config/index.js'),
 			import('../core/create-vite.js'),
 			import('../integrations/hooks.js'),
+			import('../core/routing/create-manifest.js'),
+			import('../prerender/utils.js'),
 		]);
-		const logger = createNodeLogger(inlineAstroConfig);
 		const { astroConfig: config } = await resolveConfig(inlineAstroConfig, cmd);
+		const logger = await loadOrCreateNodeLogger(config, inlineAstroConfig);
 		let settings = await createSettings(config, inlineAstroConfig.logLevel, userViteConfig.root);
 		settings = await runHookConfigSetup({ settings, command: cmd, logger });
 		const routesList = await createRoutesList(

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -24,7 +24,7 @@ import type {
 	SSRResult,
 } from '../types/public/internal.js';
 import { ContainerPipeline } from './pipeline.js';
-import { createNodeLogger } from '../core/logger/impls/node.js';
+import { createConsoleLogger } from '../core/logger/impls/console.js';
 
 /**
  * Public type, used for integrations to define a renderer for the container API
@@ -300,7 +300,7 @@ export class experimental_AstroContainer {
 		astroConfig,
 	}: AstroContainerConstructor) {
 		this.#pipeline = ContainerPipeline.create({
-			logger: createNodeLogger({ logLevel: 'info' }),
+			logger: createConsoleLogger({ level: 'error' }),
 			manifest: createManifest(manifest, renderers),
 			streaming,
 			renderers: renderers ?? manifest?.renderers ?? [],

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -14,7 +14,7 @@ import {
 import type { AstroSettings, RoutesList } from '../../types/astro.js';
 import type { AstroInlineConfig, RuntimeMode } from '../../types/public/config.js';
 import { resolveConfig } from '../config/config.js';
-import { createNodeLogger } from '../logger/impls/node.js';
+import { loadOrCreateNodeLogger } from '../logger/load.js';
 import { createSettings } from '../config/settings.js';
 import { createVite } from '../create-vite.js';
 import { createKey, getEnvironmentKey, hasEnvironmentKey } from '../encryption.js';
@@ -62,8 +62,8 @@ export default async function build(
 	options: BuildOptions = {},
 ): Promise<void> {
 	ensureProcessNodeEnv(options.devOutput ? 'development' : 'production');
-	const logger = createNodeLogger(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig, 'build');
+	const logger = await loadOrCreateNodeLogger(astroConfig, inlineConfig ?? {});
 	telemetry.record(eventCliSession('build', userConfig));
 
 	warnIfCspWithShiki(astroConfig, logger);

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -558,8 +558,7 @@ export const AstroConfigSchema = z.object({
 					entrypoint: z.string(),
 					config: z.record(z.string(), z.any()).optional(),
 				})
-				.optional()
-				.prefault(ASTRO_CONFIG_DEFAULTS.experimental.logger),
+				.optional(),
 		})
 		.prefault({}),
 	legacy: z

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -14,12 +14,11 @@ import { createVite } from '../create-vite.js';
 import { collectErrorMetadata } from '../errors/dev/utils.js';
 import { isAstroConfigZodError } from '../errors/errors.js';
 import { createSafeError } from '../errors/index.js';
-import { createNodeLogger } from '../logger/impls/node.js';
+import { loadOrCreateNodeLogger } from '../logger/load.js';
 import { formatErrorMessage, warnIfCspWithShiki } from '../messages/runtime.js';
 import { createRoutesList } from '../routing/create-manifest.js';
 import type { Container } from './container.js';
 import { createContainer } from './container.js';
-import { loadLogger } from '../logger/load.js';
 
 const configRE = /.*astro.config.(?:mjs|mts|cjs|cts|js|ts)$/;
 
@@ -145,13 +144,9 @@ export async function createContainerWithAutomaticRestart({
 	inlineConfig,
 	fs,
 }: CreateContainerWithAutomaticRestart): Promise<Restart> {
-	const logger = createNodeLogger(inlineConfig ?? {});
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'dev', fs);
 	// For now, we override only when no inline config has been provided. This won't break tests
-	if (!inlineConfig && astroConfig.experimental.logger) {
-		const destination = await loadLogger(astroConfig.experimental.logger, fs, astroConfig.root);
-		logger.setDestination(destination);
-	}
+	const logger = await loadOrCreateNodeLogger(astroConfig, inlineConfig ?? {});
 
 	warnIfCspWithShiki(astroConfig, logger);
 	telemetry.record(eventCliSession('dev', userConfig));

--- a/packages/astro/src/core/logger/impls/json.ts
+++ b/packages/astro/src/core/logger/impls/json.ts
@@ -1,5 +1,11 @@
-import { type AstroLoggerDestination, type AstroLoggerMessage, levels } from '../core.js';
+import {
+	AstroLogger,
+	type AstroLoggerDestination,
+	type AstroLoggerMessage,
+	levels,
+} from '../core.js';
 import type { Writable } from 'node:stream';
+import type { AstroInlineConfig } from '../../../types/public/index.js';
 
 export type JonsHandlerConfig = {
 	pretty: boolean;
@@ -11,7 +17,9 @@ type ConsoleStream = Writable & {
 
 export const SGR_REGEX = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, 'g');
 
-export default function (config: JonsHandlerConfig): AstroLoggerDestination<AstroLoggerMessage> {
+export default function jsonLoggerDestination(
+	config: JonsHandlerConfig,
+): AstroLoggerDestination<AstroLoggerMessage> {
 	return {
 		write(event) {
 			let dest: ConsoleStream = process.stderr;
@@ -28,4 +36,11 @@ export default function (config: JonsHandlerConfig): AstroLoggerDestination<Astr
 			}
 		},
 	};
+}
+
+export function createJsonLoggerFromFlags(config: AstroInlineConfig) {
+	return new AstroLogger({
+		destination: jsonLoggerDestination({ pretty: false }),
+		level: config.logLevel ?? 'info',
+	});
 }

--- a/packages/astro/src/core/logger/impls/node.ts
+++ b/packages/astro/src/core/logger/impls/node.ts
@@ -32,7 +32,7 @@ export default function (): AstroLoggerDestination<AstroLoggerMessage> {
 	return nodeLogDestination;
 }
 
-export function createNodeLogger(inlineConfig: AstroInlineConfig): AstroLogger {
+export function createNodeLoggerFromFlags(inlineConfig: AstroInlineConfig): AstroLogger {
 	if (inlineConfig.logger) return inlineConfig.logger;
 
 	return new AstroLogger({

--- a/packages/astro/src/core/logger/load.ts
+++ b/packages/astro/src/core/logger/load.ts
@@ -1,20 +1,22 @@
-import type { AstroLoggerDestination } from './core.js';
+import { AstroLogger, type AstroLoggerDestination, type AstroLoggerLevel } from './core.js';
 import loadFallbackPlugin from '../../vite-plugin-load-fallback/index.js';
 import { createMinimalViteDevServer } from '../createMinimalViteDevServer.js';
 import { isRunnableDevEnvironment, type RunnableDevEnvironment, type ViteDevServer } from 'vite';
-import type fsMod from 'node:fs';
+import fsMod from 'node:fs';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../constants.js';
 import { AstroError } from '../errors/index.js';
 import { UnableToLoadLogger } from '../errors/errors-data.js';
 import type { LoggerHandlerConfig } from './config.js';
-import type { AstroConfig } from '../../types/public/index.js';
+import type { AstroConfig, AstroInlineConfig } from '../../types/public/index.js';
 import { astroLoggerVitePlugin } from './vite.js';
+import { createNodeLoggerFromFlags } from './impls/node.js';
 
-export async function loadLogger(
+async function loadLogger(
 	config: LoggerHandlerConfig,
-	fs: typeof fsMod,
 	root: AstroConfig['root'],
-): Promise<AstroLoggerDestination> {
+	level: AstroLoggerLevel = 'info',
+	fs: typeof fsMod = fsMod,
+): Promise<AstroLogger> {
 	let server: ViteDevServer | undefined = undefined;
 	let cause: Error | undefined = undefined;
 
@@ -27,7 +29,10 @@ export async function loadLogger(
 				ASTRO_VITE_ENVIRONMENT_NAMES.ssr
 			] as RunnableDevEnvironment;
 			const mod = await environment.runner.import('virtual:astro:logger');
-			return mod.default as AstroLoggerDestination;
+			return new AstroLogger({
+				destination: mod.default as AstroLoggerDestination,
+				level,
+			});
 		}
 	} catch (e: unknown) {
 		if (e instanceof Error) {
@@ -47,4 +52,29 @@ export async function loadLogger(
 		error.cause = cause;
 	}
 	throw error;
+}
+
+/**
+ * It attempts to load a logger from the entrypoint.
+ * If not provided, it creates a new logger instance on the fly.
+ * @param astroConfig
+ * @param inlineAstroConfig
+ */
+export async function loadOrCreateNodeLogger(
+	astroConfig: AstroConfig,
+	inlineAstroConfig: AstroInlineConfig,
+) {
+	try {
+		if (astroConfig.experimental.logger) {
+			return await loadLogger(
+				astroConfig.experimental.logger,
+				astroConfig.root,
+				inlineAstroConfig.logLevel,
+			);
+		} else {
+			return createNodeLoggerFromFlags(inlineAstroConfig);
+		}
+	} catch {
+		return createNodeLoggerFromFlags(inlineAstroConfig);
+	}
 }

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -8,7 +8,7 @@ import { runHookConfigDone, runHookConfigSetup } from '../../integrations/hooks.
 import type { AstroInlineConfig } from '../../types/public/config.js';
 import type { PreviewModule, PreviewServer } from '../../types/public/preview.js';
 import { resolveConfig } from '../config/config.js';
-import { createNodeLogger } from '../logger/impls/node.js';
+import { loadOrCreateNodeLogger } from '../logger/load.js';
 import { createSettings } from '../config/settings.js';
 import { createRoutesList } from '../routing/create-manifest.js';
 import { getPrerenderDefault } from '../../prerender/utils.js';
@@ -24,8 +24,8 @@ import { getResolvedHostForHttpServer } from './util.js';
  */
 export default async function preview(inlineConfig: AstroInlineConfig): Promise<PreviewServer> {
 	ensureProcessNodeEnv('production');
-	const logger = createNodeLogger(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'preview');
+	const logger = await loadOrCreateNodeLogger(astroConfig, inlineConfig ?? {});
 	telemetry.record(eventCliSession('preview', userConfig));
 
 	const _settings = await createSettings(

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -19,7 +19,7 @@ import type { AstroSettings } from '../../types/astro.js';
 import type { AstroInlineConfig } from '../../types/public/config.js';
 import { getTimeStat } from '../build/util.js';
 import { resolveConfig } from '../config/config.js';
-import { createNodeLogger } from '../logger/impls/node.js';
+import { loadOrCreateNodeLogger } from '../logger/load.js';
 import { createSettings } from '../config/settings.js';
 import { createVite } from '../create-vite.js';
 import {
@@ -59,8 +59,8 @@ export default async function sync(
 	{ fs, telemetry: _telemetry = false }: { fs?: typeof fsMod; telemetry?: boolean } = {},
 ) {
 	ensureProcessNodeEnv('production');
-	const logger = createNodeLogger(inlineConfig);
 	const { astroConfig, userConfig } = await resolveConfig(inlineConfig ?? {}, 'sync');
+	const logger = await loadOrCreateNodeLogger(astroConfig, inlineConfig ?? {});
 	if (_telemetry) {
 		telemetry.record(eventCliSession('sync', userConfig));
 	}

--- a/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
+++ b/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
@@ -12,11 +12,11 @@ import { ProcessOperatingSystemProvider } from '../cli/infra/process-operating-s
 import { TinyexecCommandExecutor } from '../cli/infra/tinyexec-command-executor.js';
 import type { RouteInfo } from '../core/app/types.js';
 import type { AstroLogger } from '../core/logger/core.js';
-import { createNodeLogger } from '../core/logger/impls/node.js';
 import type { ModuleLoader } from '../core/module-loader/index.js';
 import type { AstroSettings, RoutesList } from '../types/astro.js';
 import type { DevServerController } from '../vite-plugin-astro-server/controller.js';
 import { AstroServerApp } from './app.js';
+import { loadOrCreateNodeLogger } from '../core/logger/load.js';
 
 export default async function createAstroServerApp(
 	controller: DevServerController,
@@ -24,7 +24,7 @@ export default async function createAstroServerApp(
 	loader: ModuleLoader,
 	logger?: AstroLogger,
 ) {
-	const actualLogger = logger ?? createNodeLogger({ logLevel: settings.logLevel });
+	const actualLogger = logger ?? (await loadOrCreateNodeLogger(settings.config, {}));
 
 	const routesList: RoutesList = { routes: routes.map((r: RouteInfo) => r.routeData) };
 

--- a/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
+++ b/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
@@ -16,7 +16,7 @@ import type { ModuleLoader } from '../core/module-loader/index.js';
 import type { AstroSettings, RoutesList } from '../types/astro.js';
 import type { DevServerController } from '../vite-plugin-astro-server/controller.js';
 import { AstroServerApp } from './app.js';
-import { loadOrCreateNodeLogger } from '../core/logger/load.js';
+import { createNodeLoggerFromFlags } from '../core/logger/impls/node.js';
 
 export default async function createAstroServerApp(
 	controller: DevServerController,
@@ -24,7 +24,7 @@ export default async function createAstroServerApp(
 	loader: ModuleLoader,
 	logger?: AstroLogger,
 ) {
-	const actualLogger = logger ?? (await loadOrCreateNodeLogger(settings.config, {}));
+	const actualLogger = logger ?? createNodeLoggerFromFlags({});
 
 	const routesList: RoutesList = { routes: routes.map((r: RouteInfo) => r.routeData) };
 

--- a/packages/astro/test/units/assets/fonts/e2e.test.js
+++ b/packages/astro/test/units/assets/fonts/e2e.test.js
@@ -27,7 +27,7 @@ import { UnifontFontResolver } from '../../../../dist/assets/fonts/infra/unifont
 import { UnstorageFsStorage } from '../../../../dist/assets/fonts/infra/unstorage-fs-storage.js';
 import { XxhashHasher } from '../../../../dist/assets/fonts/infra/xxhash-hasher.js';
 import { fontProviders } from '../../../../dist/assets/fonts/providers/index.js';
-import { createNodeLogger } from '../../../../dist/core/logger/impls/node.js';
+import { createNodeLoggerFromFlags } from '../../../../dist/core/logger/impls/node.js';
 
 /**
  * @param {{ fonts: Array<import('../../../../dist/assets/fonts/types.js').FontFamily> }} param0
@@ -37,7 +37,7 @@ async function run({ fonts: _fonts }) {
 	const resolvedFamilies = _fonts.map((family) => resolveFamily({ family, hasher }));
 	const defaults = DEFAULTS;
 	const { bold } = colors;
-	const logger = createNodeLogger({ level: 'silent' });
+	const logger = createNodeLoggerFromFlags({ logLevel: 'silent' });
 	const stringMatcher = new LevenshteinStringMatcher();
 	const base = new URL('./data/cache/', import.meta.url);
 	// Clear cache

--- a/packages/astro/test/units/compile/css-base-path.test.ts
+++ b/packages/astro/test/units/compile/css-base-path.test.ts
@@ -5,9 +5,9 @@ import { resolveConfig } from 'vite';
 import { compileAstro } from '../../../dist/vite-plugin-astro/compile.js';
 import type { AstroConfig } from '../../../dist/types/public/config.js';
 import type { CompileProps } from '../../../dist/core/compile/compile.js';
-import { createNodeLogger } from '../../../dist/core/logger/impls/node.js';
+import { createNodeLoggerFromFlags } from '../../../dist/core/logger/impls/node.js';
 
-const logger = createNodeLogger({ logLevel: 'silent' });
+const logger = createNodeLoggerFromFlags({ logLevel: 'silent' });
 
 /** Compile Astro source with a given base path. */
 async function compileWithBase(source: string, base = '/') {

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -8,13 +8,13 @@ import { resolveConfig } from '../../dist/core/config/index.js';
 import { createBaseSettings } from '../../dist/core/config/settings.js';
 import { createContainer } from '../../dist/core/dev/container.js';
 import { AstroIntegrationLogger, AstroLogger } from '../../dist/core/logger/core.js';
-import { createNodeLogger } from '../../dist/core/logger/impls/node.js';
+import { createNodeLoggerFromFlags } from '../../dist/core/logger/impls/node.js';
 import { NOOP_MIDDLEWARE_FN } from '../../dist/core/middleware/noop-middleware.js';
 import { Pipeline } from '../../dist/core/render/index.js';
 import { RouteCache } from '../../dist/core/render/route-cache.js';
 
 /** @type {import('../../src/core/logger/core').AstroLogger} */
-export const defaultLogger = createNodeLogger({ level: 'error' });
+export const defaultLogger = createNodeLoggerFromFlags({ logLevel: 'error' });
 
 const tempFixturesDir = fileURLToPath(new URL('./_temp-fixtures/', import.meta.url));
 


### PR DESCRIPTION
## Changes

This PR creates a new function called `loadOrCrateNodeLogger`, which is called in every place where we create a logger right before loading the configuration. 

It also adds a new `--experimental-json` (as per RFC) which creates a new JSON logger.

The loading of the logger has been implemented in:
- `dev`
- `build`
- `sync`
- `add`

## Testing

Mostly manual testing. Existing CI should stay green.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
