### PR TITLE
chore: add rule for detecting incorrect imports

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -188,6 +188,26 @@
           }
         }
       }
+    },
+    {
+      "includes": ["**/astro/test/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["**/src/**"],
+                    "message": "The test should not import the source code. Import the code from the dist/ folder instead."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/astro/test/types/schemas.ts
+++ b/packages/astro/test/types/schemas.ts
@@ -1,9 +1,9 @@
 import { describe, it } from 'node:test';
 import { expectTypeOf } from 'expect-type';
 import type * as z from 'zod/v4';
-import { type FontProviderSchema, FontFamilySchema } from '../../src/assets/fonts/config.js';
-import type { FontProvider, FontFamily } from '../../src/assets/fonts/types.js';
-import type { CacheSchema, RouteRulesSchema } from '../../src/core/cache/config.js';
+import { type FontProviderSchema, FontFamilySchema } from '../../dist/assets/fonts/config.js';
+import type { FontProvider, FontFamily } from '../../dist/assets/fonts/types.js';
+import type { CacheSchema, RouteRulesSchema } from '../../dist/core/cache/config.js';
 import type { CacheProviderConfig, RouteRules } from '../../dist/core/cache/types.js';
 import type { SessionDriverConfigSchema } from '../../dist/core/session/config.js';
 import type { SessionDriverConfig } from '../../dist/core/session/types.js';


### PR DESCRIPTION
## Changes

This PR enables the rule `noRestrictedImports` so that it emits an error if tests try to import modules and types from the `src/` folders.

## Testing

Green CI (fixed a few things)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
