### PR TITLE
fix: stabilize client build output filenames across runs

### DIFF
--- a/.changeset/deterministic-client-build.md
+++ b/.changeset/deterministic-client-build.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes non-deterministic client build output by sorting entry points before passing them to Rollup. Previously, consecutive builds of the same source code could produce different output filenames, breaking CDN caching.

--- a/.changeset/deterministic-client-build.md
+++ b/.changeset/deterministic-client-build.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Sort client build entry points for consistent Rollup chunk ordering. This prevents unnecessary output filename changes between builds.
+Fixes a bug where emitted assets during a client build would contain always fresh, new hashes in their name. Now the build should be more stable.

--- a/.changeset/deterministic-client-build.md
+++ b/.changeset/deterministic-client-build.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes non-deterministic client build output by sorting entry points before passing them to Rollup. Previously, consecutive builds of the same source code could produce different output filenames, breaking CDN caching.
+Sort client build entry points for consistent Rollup chunk ordering. This prevents unnecessary output filename changes between builds.

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -371,9 +371,12 @@ async function buildEnvironments(opts: StaticBuildOptions, internals: BuildInter
 					// So using the noop plugin here which will give us an input that just gets thrown away.
 					internals.clientInput.add(NOOP_MODULE_ID);
 				}
-				builder.environments.client.config.build.rollupOptions.input = Array.from(
-					internals.clientInput,
-				);
+				// Sort the client input to ensure deterministic Rollup entry point ordering.
+				// `internals.clientInput` is a Set whose iteration order depends on async module resolution
+				// timing during prerendering. Without sorting, consecutive builds of the same
+				// source code can produce different output filenames, breaking CDN caching.
+				const sortedClientInput = Array.from(internals.clientInput).sort();
+				builder.environments.client.config.build.rollupOptions.input = sortedClientInput;
 				settings.timer.start('Client build');
 				await builder.build(builder.environments.client);
 				settings.timer.end('Client build');


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/16347

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No new test is added because the issue is non-deterministic and hard to reproduce reliably in a test.

Verified manually by using the repo at https://github.com/withastro/astro/issues/16347.

All existing tests should pass.

## Docs

Changeset added. 
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
