### PR TITLE
refactor: migrate custom 404 tests to typescript

### DIFF
--- a/packages/astro/test/custom-404-html.test.ts
+++ b/packages/astro/test/custom-404-html.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer } from './test-utils.js';
 
 describe('Custom 404.html', () => {
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -14,7 +14,7 @@ describe('Custom 404.html', () => {
 	});
 
 	describe('dev', () => {
-		let devServer;
+		let devServer: DevServer;
 		let $;
 
 		before(async () => {

--- a/packages/astro/test/custom-404-implicit-rerouting.test.ts
+++ b/packages/astro/test/custom-404-implicit-rerouting.test.ts
@@ -1,12 +1,11 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer, type App } from './test-utils.js';
 
 for (const caseNumber of [1, 2, 3, 4, 5]) {
 	describe(`Custom 404 with implicit rerouting - Case #${caseNumber}`, () => {
-		/** @type {import('./test-utils.js').Fixture} */
-		let fixture;
+		let fixture: Fixture;
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -18,11 +17,10 @@ for (const caseNumber of [1, 2, 3, 4, 5]) {
 		});
 
 		describe('dev server', () => {
-			/** @type {import('./test-utils.js').DevServer} */
-			let devServer;
+			let devServer: DevServer;
 
 			before(async () => {
-				await fixture.build();
+				await fixture.build({});
 				devServer = await fixture.startDevServer();
 			});
 
@@ -44,8 +42,7 @@ for (const caseNumber of [1, 2, 3, 4, 5]) {
 		});
 
 		describe('prod server', () => {
-			/** @type {import('./test-utils.js').App} */
-			let app;
+			let app: App;
 
 			before(async () => {
 				app = await fixture.loadTestAdapterApp();

--- a/packages/astro/test/custom-404-injected-from-dep.test.ts
+++ b/packages/astro/test/custom-404-injected-from-dep.test.ts
@@ -1,18 +1,17 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture } from './test-utils.js';
 
 describe('Custom 404 with injectRoute from dependency', () => {
 	describe('build', () => {
-		/** @type {import('./test-utils.js').Fixture} */
-		let fixture;
+		let fixture: Fixture;
 
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/custom-404-injected-from-dep/',
 				site: 'http://example.com',
 			});
-			await fixture.build();
+			await fixture.build({});
 		});
 
 		it('Build succeeds', async () => {

--- a/packages/astro/test/custom-404-injected.test.ts
+++ b/packages/astro/test/custom-404-injected.test.ts
@@ -1,20 +1,20 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer } from './test-utils.js';
 
-describe('Custom 404 locals', () => {
-	let fixture;
+describe('Custom 404 with injectRoute', () => {
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
-			root: './fixtures/custom-404-locals/',
+			root: './fixtures/custom-404-injected/',
 			site: 'http://example.com',
 		});
 	});
 
 	describe('dev', () => {
-		let devServer;
+		let devServer: DevServer;
 		let $;
 
 		before(async () => {
@@ -40,20 +40,7 @@ describe('Custom 404 locals', () => {
 			$ = cheerio.load(html);
 
 			assert.equal($('h1').text(), 'Page not found');
-			assert.equal($('p.message').text(), 'This 404 is a dynamic HTML file.');
-			assert.equal($('p.runtime').text(), 'locals');
-		});
-
-		it('renders 404 for /404-return', async () => {
-			const res = await fixture.fetch('/404-return');
-			assert.equal(res.status, 404);
-
-			const html = await res.text();
-			$ = cheerio.load(html);
-
-			assert.equal($('h1').text(), 'Page not found');
-			assert.equal($('p.message').text(), 'This 404 is a dynamic HTML file.');
-			assert.equal($('p.runtime').text(), 'locals');
+			assert.equal($('p').text(), '/a');
 		});
 	});
 });

--- a/packages/astro/test/custom-404-locals.test.ts
+++ b/packages/astro/test/custom-404-locals.test.ts
@@ -1,20 +1,20 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer } from './test-utils.js';
 
-describe('Custom 404 with injectRoute', () => {
-	let fixture;
+describe('Custom 404 locals', () => {
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
-			root: './fixtures/custom-404-injected/',
+			root: './fixtures/custom-404-locals/',
 			site: 'http://example.com',
 		});
 	});
 
 	describe('dev', () => {
-		let devServer;
+		let devServer: DevServer;
 		let $;
 
 		before(async () => {
@@ -40,7 +40,20 @@ describe('Custom 404 with injectRoute', () => {
 			$ = cheerio.load(html);
 
 			assert.equal($('h1').text(), 'Page not found');
-			assert.equal($('p').text(), '/a');
+			assert.equal($('p.message').text(), 'This 404 is a dynamic HTML file.');
+			assert.equal($('p.runtime').text(), 'locals');
+		});
+
+		it('renders 404 for /404-return', async () => {
+			const res = await fixture.fetch('/404-return');
+			assert.equal(res.status, 404);
+
+			const html = await res.text();
+			$ = cheerio.load(html);
+
+			assert.equal($('h1').text(), 'Page not found');
+			assert.equal($('p.message').text(), 'This 404 is a dynamic HTML file.');
+			assert.equal($('p.runtime').text(), 'locals');
 		});
 	});
 });

--- a/packages/astro/test/custom-404-md.test.ts
+++ b/packages/astro/test/custom-404-md.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer } from './test-utils.js';
 
 describe('Custom 404 Markdown', () => {
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -13,7 +13,7 @@ describe('Custom 404 Markdown', () => {
 	});
 
 	describe('dev', () => {
-		let devServer;
+		let devServer: DevServer;
 		let $;
 
 		before(async () => {

--- a/packages/astro/test/custom-404-static.test.ts
+++ b/packages/astro/test/custom-404-static.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer } from './test-utils.js';
 
 describe('Custom 404 with Static', () => {
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -14,7 +14,7 @@ describe('Custom 404 with Static', () => {
 	});
 
 	describe('dev', () => {
-		let devServer;
+		let devServer: DevServer;
 		let $;
 
 		before(async () => {
@@ -47,7 +47,7 @@ describe('Custom 404 with Static', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build();
+			await fixture.build({});
 		});
 
 		it('builds to 404.html', async () => {

--- a/packages/astro/tsconfig.test.json
+++ b/packages/astro/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": [
     "test/units/**/*.ts",
+    "test/*.ts",
     "test/test-adapter.js",
     "test/test-image-service.js",
     "test/test-plugins.js",


### PR DESCRIPTION
Part of https://github.com/withastro/astro/issues/16241

This PR shows how to migrate integration tests `packages/astro/test/*.js` to TypeScript. Only a few tests are migrated. I just want to verify that these TS files are actually picked up by CI for both testing and type checking.

<img width="1102" height="625" alt="image" src="https://github.com/user-attachments/assets/c34e1d96-f909-4215-ad9d-a8bf008e4bcc" />
