### PR TITLE
refactor(language-tools): migrate tests to typescript

### DIFF
--- a/packages/language-tools/ts-plugin/.vscode-test.js
+++ b/packages/language-tools/ts-plugin/.vscode-test.js
@@ -3,12 +3,13 @@ const { defineConfig } = require('@vscode/test-cli');
 module.exports = defineConfig([
 	{
 		label: 'unitTests',
-		files: 'test/**/*.test.js',
+		files: 'test/**/*.test.ts',
 		extensionDevelopmentPath: '../vscode',
 		version: 'stable',
 		mocha: {
 			ui: 'tdd',
 			timeout: 20000,
+			require: 'tsx/cjs',
 		},
 	},
 ]);

--- a/packages/language-tools/ts-plugin/package.json
+++ b/packages/language-tools/ts-plugin/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "typecheck:tests": "tsc --build tsconfig.test.json"
   },
   "author": "withastro",
   "license": "MIT",
@@ -39,9 +40,11 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.9.0",
     "@types/semver": "^7.7.1",
+    "@types/vscode": "^1.92.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "mocha": "^11.7.5",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vscode-uri": "^3.1.0"
   }

--- a/packages/language-tools/ts-plugin/test/suite/extension.test.ts
+++ b/packages/language-tools/ts-plugin/test/suite/extension.test.ts
@@ -1,14 +1,18 @@
-const assert = require('node:assert');
-const path = require('node:path');
-const vscode = require('vscode');
+import assert from 'node:assert';
+import path from 'node:path';
+import * as vscode from 'vscode';
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
 	// TypeScript takes a while to wake up and there's unfortunately no good way to wait for it
-	async function waitForTS(command, commandArgs, condition) {
+	async function waitForTS<T>(
+		command: string,
+		commandArgs: unknown[],
+		condition: (result: T) => boolean,
+	): Promise<T> {
 		for (let i = 0; i < 2000; i++) {
-			const commandResult = await vscode.commands.executeCommand(command, ...commandArgs);
+			const commandResult = await vscode.commands.executeCommand<T>(command, ...commandArgs);
 			if (condition(commandResult)) {
 				return commandResult;
 			}
@@ -24,7 +28,7 @@ suite('Extension Test Suite', () => {
 			vscode.Uri.file(path.join(__dirname, '../fixtures/script.ts')),
 		);
 
-		const references = await waitForTS(
+		const references = await waitForTS<vscode.Location[]>(
 			'vscode.executeReferenceProvider',
 			[doc.uri, new vscode.Position(0, 18)],
 			(result) => result.length > 1,
@@ -39,7 +43,7 @@ suite('Extension Test Suite', () => {
 			vscode.Uri.file(path.join(__dirname, '../fixtures/script.ts')),
 		);
 
-		const completions = await waitForTS(
+		const completions = await waitForTS<vscode.CompletionList>(
 			'vscode.executeCompletionItemProvider',
 			[doc.uri, new vscode.Position(4, 12)],
 			(result) => result.items.length > 0,
@@ -56,7 +60,7 @@ suite('Extension Test Suite', () => {
 			vscode.Uri.file(path.join(__dirname, '../fixtures/script.ts')),
 		);
 
-		const implementations = await waitForTS(
+		const implementations = await waitForTS<vscode.Location[]>(
 			'vscode.executeImplementationProvider',
 			[doc.uri, new vscode.Position(6, 15)],
 			(result) => result.length > 1,

--- a/packages/language-tools/ts-plugin/tsconfig.test.json
+++ b/packages/language-tools/ts-plugin/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["test/**/*.ts"],
+  "exclude": ["test/fixtures/**"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "types": ["node", "mocha", "vscode"]
+  }
+}

--- a/packages/language-tools/vscode/.vscode-test.js
+++ b/packages/language-tools/vscode/.vscode-test.js
@@ -3,11 +3,12 @@ const { defineConfig } = require('@vscode/test-cli');
 module.exports = defineConfig([
 	{
 		label: 'unitTests',
-		files: 'test/**/*.test.js',
+		files: 'test/**/*.test.ts',
 		version: 'stable',
 		mocha: {
 			ui: 'tdd',
 			timeout: 20000,
+			require: 'tsx/cjs',
 		},
 	},
 ]);

--- a/packages/language-tools/vscode/package.json
+++ b/packages/language-tools/vscode/package.json
@@ -243,7 +243,8 @@
     "test": "pnpm test:vscode && pnpm test:grammar",
     "test:vscode": "vscode-test",
     "test:grammar": "pnpm build:grammar && node ./test/grammar/test.mjs",
-    "update-grammar-snapshots": "node ./test/grammar/test.mjs --updateSnapshot"
+    "update-grammar-snapshots": "node ./test/grammar/test.mjs --updateSnapshot",
+    "typecheck:tests": "tsc --build tsconfig.test.json"
   },
   "devDependencies": {
     "@astrojs/language-server": "^2.16.6",
@@ -262,6 +263,7 @@
     "kleur": "^4.1.5",
     "mocha": "^11.7.5",
     "ovsx": "^0.10.10",
+    "tsx": "^4.21.0",
     "vscode-languageclient": "^9.0.1",
     "vscode-tmgrammar-test": "^0.1.3"
   },

--- a/packages/language-tools/vscode/test/extension.test.ts
+++ b/packages/language-tools/vscode/test/extension.test.ts
@@ -1,5 +1,5 @@
-const assert = require('node:assert');
-const vscode = require('vscode');
+import assert from 'node:assert';
+import * as vscode from 'vscode';
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');

--- a/packages/language-tools/vscode/tsconfig.test.json
+++ b/packages/language-tools/vscode/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["test/**/*.ts"],
+  "exclude": ["test/fixtures/**", "test/grammar/**"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "types": ["node", "mocha", "vscode"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1921,18 +1921,6 @@ importers:
         specifier: ^5.54.0
         version: 5.55.3
 
-  packages/astro/test/fixtures/alias-tsconfig-baseurl-only:
-    dependencies:
-      '@astrojs/svelte':
-        specifier: workspace:*
-        version: link:../../../../integrations/svelte
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-      svelte:
-        specifier: ^5.54.0
-        version: 5.55.3
-
   packages/astro/test/fixtures/alias-tsconfig-no-baseurl:
     dependencies:
       astro:
@@ -2447,12 +2435,6 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2
 
-  packages/astro/test/fixtures/astro-sitemap-rss:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/astro-slot-with-client:
     dependencies:
       '@astrojs/preact':
@@ -2637,12 +2619,6 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
-  packages/astro/test/fixtures/config-path:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/config-vite:
     dependencies:
       astro:
@@ -2730,12 +2706,6 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
-  packages/astro/test/fixtures/content-collections-cache-invalidation:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/content-collections-empty-dir:
     dependencies:
       astro:
@@ -2765,12 +2735,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-
-  packages/astro/test/fixtures/content-collections-same-contents:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
 
   packages/astro/test/fixtures/content-collections-type-inference:
     dependencies:
@@ -3191,12 +3155,6 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
-  packages/astro/test/fixtures/custom-500-middleware:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/custom-assets-name:
     dependencies:
       '@astrojs/node':
@@ -3320,12 +3278,6 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
-  packages/astro/test/fixtures/feature-support-message-suppresion:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/fetch:
     dependencies:
       '@astrojs/preact':
@@ -3375,12 +3327,6 @@ importers:
         version: link:../../..
 
   packages/astro/test/fixtures/glob-pages-css:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
-  packages/astro/test/fixtures/head-injection:
     dependencies:
       astro:
         specifier: workspace:*
@@ -3597,19 +3543,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
-  packages/astro/test/fixtures/middleware-sequence-request-clone:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/middleware-sequence-rewrite:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
-  packages/astro/test/fixtures/middleware-ssg:
     dependencies:
       astro:
         specifier: workspace:*
@@ -3626,12 +3560,6 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
-
-  packages/astro/test/fixtures/middleware-virtual:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
 
   packages/astro/test/fixtures/minification-html:
     dependencies:
@@ -4230,21 +4158,6 @@ importers:
         specifier: ^10.29.0
         version: 10.29.0
 
-  packages/astro/test/fixtures/ssr-split-manifest:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
-  packages/astro/test/fixtures/ssr-trailing-slash:
-    dependencies:
-      '@astrojs/node':
-        specifier: workspace:*
-        version: link:../../../../integrations/node
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/static-build:
     dependencies:
       '@astrojs/preact':
@@ -4447,24 +4360,6 @@ importers:
       vue:
         specifier: ^3.5.30
         version: 3.5.30(typescript@5.9.3)
-
-  packages/astro/test/fixtures/with-endpoint-routes:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
-  packages/astro/test/fixtures/with-subpath-no-trailing-slash:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
-  packages/astro/test/fixtures/without-site-config:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
 
   packages/create-astro:
     dependencies:
@@ -6873,6 +6768,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
+      '@types/vscode':
+        specifier: ^1.92.0
+        version: 1.109.0
       '@vscode/test-cli':
         specifier: ^0.0.12
         version: 0.0.12
@@ -6882,6 +6780,9 @@ importers:
       mocha:
         specifier: ^11.7.5
         version: 11.7.5
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -6949,6 +6850,9 @@ importers:
       ovsx:
         specifier: ^0.10.10
         version: 0.10.10
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       vscode-languageclient:
         specifier: ^9.0.1
         version: 9.0.1


### PR DESCRIPTION
Migrates the VS Code extension tests (`vscode` and `ts-plugin` packages) from JavaScript to TypeScript.

Since these tests are executed by `@vscode/test-cli` + mocha inside an Electron VS Code instance, they cannot use the repo's usual `node --experimental-strip-types` runner. Instead, `tsx/cjs` is registered as a mocha `require` hook so the `.ts` test files are transformed on the fly.

## Changes

- Rename `extension.test.js` → `extension.test.ts` in both packages
- `require()` → ES imports with proper `vscode` types
- Add `tsconfig.test.json` for each package (typechecking only, `noEmit: true`)
- Add `typecheck:tests` script for each package
- Add `tsx` devDep in both packages, plus `@types/vscode` in `ts-plugin`
- Update `.vscode-test.js` glob to `*.test.ts` and set `mocha.require: 'tsx/cjs'`

## Verification

- `pnpm run typecheck:tests` passes for both `ts-plugin` and `vscode`
- `pnpm test` inside each package runs the tests via real VS Code successfully