### PR TITLE
refactor(astro): migrate error tests to typescript

### DIFF
--- a/packages/astro/test/error-bad-js.test.ts
+++ b/packages/astro/test/error-bad-js.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer } from './test-utils.js';
 
 describe('Errors in JavaScript', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -19,8 +18,7 @@ describe('Errors in JavaScript', () => {
 	});
 
 	describe('dev', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
+		let devServer: DevServer;
 
 		before(async () => {
 			devServer = await fixture.startDevServer();
@@ -45,7 +43,7 @@ describe('Errors in JavaScript', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build();
+			await fixture.build({});
 		});
 
 		it('in nested components, does not crash server', async () => {

--- a/packages/astro/test/error-build-location.test.ts
+++ b/packages/astro/test/error-build-location.test.ts
@@ -1,23 +1,23 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture } from './test-utils.js';
 
 describe('Errors information in build', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	it('includes the file where the error happened', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/error-build-location',
 		});
 
-		let errorContent;
+		let errorContent: any;
 		try {
-			await fixture.build();
+			await fixture.build({});
 		} catch (e) {
 			errorContent = e;
 		}
 
 		assert.equal(errorContent.id, 'src/pages/index.astro');
+		assert.equal(errorContent.message, `I'm happening in build!`);
 	});
 });

--- a/packages/astro/test/error-map.test.ts
+++ b/packages/astro/test/error-map.test.ts
@@ -73,15 +73,11 @@ describe('Content Collections - error map', () => {
 	});
 });
 
-/**
- * @param {z.ZodError} error
- * @returns string[]
- */
-function messages(error) {
+function messages(error: z.ZodError): string[] {
 	return error.issues.map((e) => e.message);
 }
 
-function getParseError(schema, entry, parseOpts = { error: errorMap }) {
+function getParseError(schema: z.Schema, entry: unknown, parseOpts = { error: errorMap }) {
 	const res = schema.safeParse(entry, parseOpts);
 	assert.equal(res.success, false, 'Schema should raise error');
 	return res.error;

--- a/packages/astro/test/error-non-error.test.ts
+++ b/packages/astro/test/error-non-error.test.ts
@@ -1,13 +1,11 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, type Fixture, type DevServer } from './test-utils.js';
 
 describe('Can handle errors that are not instanceof Error', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
-	/** @type {import('./test-utils').DevServer} */
-	let devServer;
+	let devServer: DevServer;
 
 	before(async () => {
 		fixture = await loadFixture({


### PR DESCRIPTION
Part of https://github.com/withastro/astro/issues/16241 