### PR TITLE
refactor(astro): correct Fixture type signatures in test-utils

### DIFF
--- a/packages/astro/test/custom-404-implicit-rerouting.test.ts
+++ b/packages/astro/test/custom-404-implicit-rerouting.test.ts
@@ -20,7 +20,7 @@ for (const caseNumber of [1, 2, 3, 4, 5]) {
 			let devServer: DevServer;
 
 			before(async () => {
-				await fixture.build({});
+				await fixture.build();
 				devServer = await fixture.startDevServer();
 			});
 

--- a/packages/astro/test/custom-404-injected-from-dep.test.ts
+++ b/packages/astro/test/custom-404-injected-from-dep.test.ts
@@ -11,7 +11,7 @@ describe('Custom 404 with injectRoute from dependency', () => {
 				root: './fixtures/custom-404-injected-from-dep/',
 				site: 'http://example.com',
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('Build succeeds', async () => {

--- a/packages/astro/test/custom-404-static.test.ts
+++ b/packages/astro/test/custom-404-static.test.ts
@@ -47,7 +47,7 @@ describe('Custom 404 with Static', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('builds to 404.html', async () => {

--- a/packages/astro/test/error-bad-js.test.ts
+++ b/packages/astro/test/error-bad-js.test.ts
@@ -43,7 +43,7 @@ describe('Errors in JavaScript', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('in nested components, does not crash server', async () => {

--- a/packages/astro/test/error-build-location.test.ts
+++ b/packages/astro/test/error-build-location.test.ts
@@ -12,7 +12,7 @@ describe('Errors information in build', () => {
 
 		let errorContent: any;
 		try {
-			await fixture.build({});
+			await fixture.build();
 		} catch (e) {
 			errorContent = e;
 		}

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -30,7 +30,7 @@ process.env.ASTRO_TELEMETRY_DISABLED = true;
  *
  *
  * @typedef {Object} Fixture
- * @property {typeof build} build
+ * @property {(extraInlineConfig?: Parameters<typeof build>[0], options?: Parameters<typeof build>[1]) => Promise<void>} build
  * @property {(url: string) => string} resolveUrl
  * @property {(path: string) => Promise<boolean>} pathExists
  * @property {(url: string, opts?: Parameters<typeof fetch>[1]) => Promise<Response>} fetch
@@ -39,7 +39,7 @@ process.env.ASTRO_TELEMETRY_DISABLED = true;
  * @property {(path: string) => Promise<string[]>} readdir
  * @property {(pattern: string) => Promise<string[]>} glob
  * @property {(inlineConfig?: Parameters<typeof dev>[0]) => ReturnType<typeof dev>} startDevServer
- * @property {typeof preview} preview
+ * @property {(extraInlineConfig?: Parameters<typeof preview>[0]) => Promise<PreviewServer>} preview
  * @property {() => Promise<void>} clean
  * @property {(streaming?: boolean) => Promise<App>} loadTestAdapterApp
  * @property {(streaming?: boolean) => Promise<App>} loadSelfAdapterApp

--- a/packages/integrations/markdoc/test/content-collections.test.ts
+++ b/packages/integrations/markdoc/test/content-collections.test.ts
@@ -61,7 +61,7 @@ describe('Markdoc - Content Collections', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await baseFixture.build({});
+			await baseFixture.build();
 		});
 
 		it('loads entry', async () => {

--- a/packages/integrations/markdoc/test/content-layer.test.ts
+++ b/packages/integrations/markdoc/test/content-layer.test.ts
@@ -42,7 +42,7 @@ describe('Markdoc - Content Layer', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('renders content - with components', async () => {

--- a/packages/integrations/markdoc/test/headings.test.ts
+++ b/packages/integrations/markdoc/test/headings.test.ts
@@ -63,7 +63,7 @@ describe('Markdoc - Headings', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('applies IDs to headings', async () => {
@@ -142,7 +142,7 @@ describe('Markdoc - Headings with custom Astro renderer', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('applies IDs to headings', async () => {

--- a/packages/integrations/markdoc/test/image-assets.test.ts
+++ b/packages/integrations/markdoc/test/image-assets.test.ts
@@ -76,7 +76,7 @@ describe('Markdoc - Image assets', () => {
 
 			describe('build', () => {
 				before(async () => {
-					await baseFixture.build({});
+					await baseFixture.build();
 				});
 
 				it('uses public/ image paths unchanged', async () => {

--- a/packages/integrations/markdoc/test/propagated-assets.test.ts
+++ b/packages/integrations/markdoc/test/propagated-assets.test.ts
@@ -23,7 +23,7 @@ describe('Markdoc - propagated assets', () => {
 
 			before(async () => {
 				if (mode === 'prod') {
-					await fixture.build({});
+					await fixture.build();
 					stylesDocument = parseHTML(await fixture.readFile('/styles/index.html')).document;
 					scriptsDocument = parseHTML(await fixture.readFile('/scripts/index.html')).document;
 				} else if (mode === 'dev') {

--- a/packages/integrations/markdoc/test/render-components.test.ts
+++ b/packages/integrations/markdoc/test/render-components.test.ts
@@ -42,7 +42,7 @@ describe('Markdoc - render components', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('renders content - with components', async () => {

--- a/packages/integrations/markdoc/test/render-extends-components.test.ts
+++ b/packages/integrations/markdoc/test/render-extends-components.test.ts
@@ -35,7 +35,7 @@ describe('Markdoc - render components defined in `extends`', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('renders content - with components', async () => {

--- a/packages/integrations/markdoc/test/render-html.test.ts
+++ b/packages/integrations/markdoc/test/render-html.test.ts
@@ -65,7 +65,7 @@ describe('Markdoc - render html', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('renders content - simple', async () => {

--- a/packages/integrations/markdoc/test/render-indented-components.test.ts
+++ b/packages/integrations/markdoc/test/render-indented-components.test.ts
@@ -35,7 +35,7 @@ describe('Markdoc - render indented components', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('renders content - with indented components', async () => {

--- a/packages/integrations/markdoc/test/render-table-attrs.test.ts
+++ b/packages/integrations/markdoc/test/render-table-attrs.test.ts
@@ -13,7 +13,7 @@ describe('Markdoc - table attributes', () => {
 	describe('build', () => {
 		it('renders table with custom attributes without validation errors', async () => {
 			const fixture = await getFixture();
-			await fixture.build({});
+			await fixture.build();
 
 			const html = await fixture.readFile('/index.html');
 			const { document } = parseHTML(html);

--- a/packages/integrations/markdoc/test/render-with-transform.test.ts
+++ b/packages/integrations/markdoc/test/render-with-transform.test.ts
@@ -38,7 +38,7 @@ describe('Markdoc - render with transform override', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('uses custom render component instead of built-in transform', async () => {

--- a/packages/integrations/markdoc/test/render.test.ts
+++ b/packages/integrations/markdoc/test/render.test.ts
@@ -75,7 +75,7 @@ describe('Markdoc - render', () => {
 	describe('build', () => {
 		it('renders content - simple', async () => {
 			const fixture = await getFixture('render-simple');
-			await fixture.build({});
+			await fixture.build();
 
 			const html = await fixture.readFile('/index.html');
 
@@ -84,7 +84,7 @@ describe('Markdoc - render', () => {
 
 		it('renders content - with partials', async () => {
 			const fixture = await getFixture('render-partials');
-			await fixture.build({});
+			await fixture.build();
 
 			const html = await fixture.readFile('/index.html');
 
@@ -93,7 +93,7 @@ describe('Markdoc - render', () => {
 
 		it('renders content - with config', async () => {
 			const fixture = await getFixture('render-with-config');
-			await fixture.build({});
+			await fixture.build();
 
 			const html = await fixture.readFile('/index.html');
 
@@ -102,7 +102,7 @@ describe('Markdoc - render', () => {
 
 		it('renders content - with `render: null` in document', async () => {
 			const fixture = await getFixture('render-null');
-			await fixture.build({});
+			await fixture.build();
 
 			const html = await fixture.readFile('/index.html');
 
@@ -111,7 +111,7 @@ describe('Markdoc - render', () => {
 
 		it('renders content - with root folder containing space', async () => {
 			const fixture = await getFixture('render with-space');
-			await fixture.build({});
+			await fixture.build();
 
 			const html = await fixture.readFile('/index.html');
 
@@ -120,7 +120,7 @@ describe('Markdoc - render', () => {
 
 		it('renders content - with typographer option', async () => {
 			const fixture = await getFixture('render-typographer');
-			await fixture.build({});
+			await fixture.build();
 
 			const html = await fixture.readFile('/index.html');
 

--- a/packages/integrations/markdoc/test/variables.test.ts
+++ b/packages/integrations/markdoc/test/variables.test.ts
@@ -39,7 +39,7 @@ describe('Markdoc - Variables', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await baseFixture.build({});
+			await baseFixture.build();
 		});
 
 		it('has expected entry properties', async () => {

--- a/packages/integrations/react/test/react-19-preloads.test.ts
+++ b/packages/integrations/react/test/react-19-preloads.test.ts
@@ -7,7 +7,7 @@ test.describe('React 19 SSR integration', () => {
 		const fixture = await loadFixture({
 			root: new URL('./fixtures/react-19-preloads/', import.meta.url),
 		});
-		await fixture.build({});
+		await fixture.build();
 
 		const html = await fixture.readFile('/index.html');
 		const islandPattern = /<astro-island[^>]*>([\s\S]*?)<\/astro-island>/;

--- a/packages/integrations/react/test/react-component.test.ts
+++ b/packages/integrations/react/test/react-component.test.ts
@@ -19,7 +19,7 @@ describe('React Components', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('Can load React', async () => {

--- a/packages/integrations/sitemap/test/base-path.test.ts
+++ b/packages/integrations/sitemap/test/base-path.test.ts
@@ -12,7 +12,7 @@ describe('URLs with base path', () => {
 				root: './fixtures/ssr/',
 				base: '/base',
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('Base path is concatenated correctly', async () => {
@@ -34,7 +34,7 @@ describe('URLs with base path', () => {
 				root: './fixtures/static/',
 				base: '/base',
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('Base path is concatenated correctly', async () => {

--- a/packages/integrations/sitemap/test/chunks-files.test.ts
+++ b/packages/integrations/sitemap/test/chunks-files.test.ts
@@ -42,7 +42,7 @@ describe('Sitemap with chunked files', () => {
 				}),
 			],
 		});
-		await fixture.build({});
+		await fixture.build();
 		const flatMapUrls = async (file: string) => {
 			const data = await readXML(fixture.readFile(file));
 			return data.urlset.url.map((url: { loc: string[] }) => url.loc[0]);

--- a/packages/integrations/sitemap/test/config.test.ts
+++ b/packages/integrations/sitemap/test/config.test.ts
@@ -18,7 +18,7 @@ describe('Config', () => {
 					}),
 				],
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('filter: Just one page is added', async () => {
@@ -55,7 +55,7 @@ describe('Config', () => {
 					}),
 				],
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('filter: Just one page is added', async () => {
@@ -92,7 +92,7 @@ describe('Config', () => {
 					}),
 				],
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('filenameBase: Sets the generated sitemap filename', async () => {
@@ -119,7 +119,7 @@ describe('Config', () => {
 					}),
 				],
 			});
-			await assert.rejects(fixture.build({}), /^Error: filter error$/);
+			await assert.rejects(fixture.build(), /^Error: filter error$/);
 		});
 	});
 });

--- a/packages/integrations/sitemap/test/custom-pages.test.ts
+++ b/packages/integrations/sitemap/test/custom-pages.test.ts
@@ -17,7 +17,7 @@ describe('Sitemap with custom pages', () => {
 				}),
 			],
 		});
-		await fixture.build({});
+		await fixture.build();
 		const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 		urls = data.urlset.url.map((url: { loc: string[] }) => url.loc[0]);
 	});

--- a/packages/integrations/sitemap/test/custom-sitemaps.test.ts
+++ b/packages/integrations/sitemap/test/custom-sitemaps.test.ts
@@ -18,7 +18,7 @@ describe('Custom sitemaps', () => {
 				}),
 			],
 		});
-		await fixture.build({});
+		await fixture.build();
 		const data = await readXML(fixture.readFile('/sitemap-index.xml'));
 		sitemaps = data.sitemapindex.sitemap.map((s: { loc: string[]; lastmod: string[] }) => ({
 			loc: s.loc[0],

--- a/packages/integrations/sitemap/test/dynamic-path.test.ts
+++ b/packages/integrations/sitemap/test/dynamic-path.test.ts
@@ -10,7 +10,7 @@ describe('Dynamic with rest parameter', () => {
 		fixture = await loadFixture({
 			root: './fixtures/dynamic',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('Should generate correct urls', async () => {

--- a/packages/integrations/sitemap/test/i18n-fallback.test.ts
+++ b/packages/integrations/sitemap/test/i18n-fallback.test.ts
@@ -11,7 +11,7 @@ describe('i18n fallback', () => {
 		fixture = await loadFixture({
 			root: './fixtures/i18n-fallback/',
 		});
-		await fixture.build({});
+		await fixture.build();
 		const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 		urls = data.urlset.url.map((url: { loc: string[] }) => url.loc[0]);
 	});

--- a/packages/integrations/sitemap/test/namespaces.test.ts
+++ b/packages/integrations/sitemap/test/namespaces.test.ts
@@ -13,7 +13,7 @@ describe('Namespaces Configuration', () => {
 				root: './fixtures/static/',
 				integrations: [sitemap()],
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('includes all default namespaces', async () => {
@@ -37,7 +37,7 @@ describe('Namespaces Configuration', () => {
 					}),
 				],
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('excludes news namespace but includes others', async () => {
@@ -64,7 +64,7 @@ describe('Namespaces Configuration', () => {
 					}),
 				],
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('excludes all optional namespaces', async () => {

--- a/packages/integrations/sitemap/test/routes.test.ts
+++ b/packages/integrations/sitemap/test/routes.test.ts
@@ -11,7 +11,7 @@ describe('routes', () => {
 		fixture = await loadFixture({
 			root: './fixtures/static/',
 		});
-		await fixture.build({});
+		await fixture.build();
 		const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 		urls = data.urlset.url.map((url: { loc: string[] }) => url.loc[0]);
 	});

--- a/packages/integrations/sitemap/test/ssr.test.ts
+++ b/packages/integrations/sitemap/test/ssr.test.ts
@@ -10,7 +10,7 @@ describe('SSR support', () => {
 		fixture = await loadFixture({
 			root: './fixtures/ssr/',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('SSR pages require zero config', async () => {

--- a/packages/integrations/sitemap/test/staticPaths.test.ts
+++ b/packages/integrations/sitemap/test/staticPaths.test.ts
@@ -12,7 +12,7 @@ describe('getStaticPaths support', () => {
 			root: './fixtures/static/',
 			trailingSlash: 'always',
 		});
-		await fixture.build({});
+		await fixture.build();
 
 		const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 		urls = data.urlset.url.map((url: { loc: string[] }) => url.loc[0]);

--- a/packages/integrations/sitemap/test/trailing-slash.test.ts
+++ b/packages/integrations/sitemap/test/trailing-slash.test.ts
@@ -16,7 +16,7 @@ describe('Trailing slash', () => {
 						format: 'directory',
 					},
 				});
-				await fixture.build({});
+				await fixture.build();
 			});
 
 			it('URLs end with trailing slash', async () => {
@@ -38,7 +38,7 @@ describe('Trailing slash', () => {
 						format: 'file',
 					},
 				});
-				await fixture.build({});
+				await fixture.build();
 			});
 
 			it('URLs do not end with trailing slash', async () => {
@@ -58,7 +58,7 @@ describe('Trailing slash', () => {
 				root: './fixtures/trailing-slash/',
 				trailingSlash: 'never',
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('URLs do not end with trailing slash', async () => {
@@ -76,7 +76,7 @@ describe('Trailing slash', () => {
 					trailingSlash: 'never',
 					base: '/base',
 				});
-				await fixture.build({});
+				await fixture.build();
 			});
 
 			it('URLs do not end with trailing slash', async () => {
@@ -95,7 +95,7 @@ describe('Trailing slash', () => {
 				root: './fixtures/trailing-slash/',
 				trailingSlash: 'always',
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('URLs end with trailing slash', async () => {
@@ -112,7 +112,7 @@ describe('Trailing slash', () => {
 					trailingSlash: 'always',
 					base: '/base',
 				});
-				await fixture.build({});
+				await fixture.build();
 			});
 
 			it('URLs end with trailing slash', async () => {

--- a/packages/integrations/svelte/test/async-rendering.test.ts
+++ b/packages/integrations/svelte/test/async-rendering.test.ts
@@ -16,7 +16,7 @@ describe.skip('Async rendering', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('Can render async components', async () => {

--- a/packages/integrations/svelte/test/conditional-rendering.test.ts
+++ b/packages/integrations/svelte/test/conditional-rendering.test.ts
@@ -22,7 +22,7 @@ describe('Conditional rendering styles', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('includes styles for conditionally rendered Svelte components', async () => {

--- a/packages/integrations/svelte/test/empty-class-attribute.test.ts
+++ b/packages/integrations/svelte/test/empty-class-attribute.test.ts
@@ -19,7 +19,7 @@ describe('Empty class attribute', () => {
 			fixture = await loadFixture({
 				root: new URL('./fixtures/empty-class/', import.meta.url),
 			});
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('should not render empty class attribute when class prop is not provided', async () => {

--- a/packages/integrations/vue/test/app-entrypoint-css.test.ts
+++ b/packages/integrations/vue/test/app-entrypoint-css.test.ts
@@ -14,7 +14,7 @@ describe('App Entrypoint CSS', () => {
 
 	describe('build', () => {
 		before(async () => {
-			await fixture.build({});
+			await fixture.build();
 		});
 
 		it('injects styles referenced in appEntrypoint', async () => {

--- a/packages/integrations/vue/test/app-entrypoint.test.ts
+++ b/packages/integrations/vue/test/app-entrypoint.test.ts
@@ -11,7 +11,7 @@ describe('App Entrypoint', () => {
 		fixture = await loadFixture({
 			root: './fixtures/app-entrypoint/',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('loads during SSR', async () => {
@@ -80,7 +80,7 @@ describe('App Entrypoint no export default', () => {
 		fixture = await loadFixture({
 			root: './fixtures/app-entrypoint-no-export-default/',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('loads during SSR', async () => {
@@ -117,7 +117,7 @@ describe('App Entrypoint relative', () => {
 		fixture = await loadFixture({
 			root: './fixtures/app-entrypoint-relative/',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('loads during SSR', async () => {
@@ -147,7 +147,7 @@ describe('App Entrypoint /src/absolute', () => {
 		fixture = await loadFixture({
 			root: './fixtures/app-entrypoint-src-absolute/',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('loads during SSR', async () => {
@@ -177,7 +177,7 @@ describe('App Entrypoint async', () => {
 		fixture = await loadFixture({
 			root: './fixtures/app-entrypoint-async/',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('loads during SSR', async () => {

--- a/packages/integrations/vue/test/basics.test.ts
+++ b/packages/integrations/vue/test/basics.test.ts
@@ -10,7 +10,7 @@ describe('Basics', () => {
 		fixture = await loadFixture({
 			root: './fixtures/basics/',
 		});
-		await fixture.build({});
+		await fixture.build();
 	});
 
 	it('Slots are added without the slot attribute', async () => {


### PR DESCRIPTION
## Changes


`fixture.build()` and `fixture.preview()` can accept no arguments in their implementation. This PR corrects their types to match the implementation.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

CI should pass

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
