### PR TITLE
perf(core): cache crawl result

### DIFF
--- a/.changeset/bright-kids-sip.md
+++ b/.changeset/bright-kids-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Slightly improved the performance of the dev server by caching the internal crawling of the dependencies of a project.

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -1,6 +1,7 @@
 import nodeFs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import * as vite from 'vite';
+import type { CrawlFrameworkPkgsResult } from 'vitefu';
 import { crawlFrameworkPkgs } from 'vitefu';
 import { vitePluginActions } from '../actions/vite-plugin-actions.js';
 import { getAssetsPrefix } from '../assets/utils/getAssetsPrefix.js';
@@ -71,42 +72,79 @@ type CreateViteOptions = {
 	  }
 );
 
+// In-process cache for crawlFrameworkPkgs results. The crawl walks the entire
+// node_modules tree reading package.json files, which is expensive and produces
+// the same result for a given (root, isBuild) pair within a single process lifetime.
+const _crawlCache = new Map<string, CrawlFrameworkPkgsResult>();
+
+function cloneCrawlResult(result: CrawlFrameworkPkgsResult): CrawlFrameworkPkgsResult {
+	return {
+		optimizeDeps: {
+			include: [...result.optimizeDeps.include],
+			exclude: [...result.optimizeDeps.exclude],
+		},
+		ssr: {
+			noExternal: [...result.ssr.noExternal],
+			external: [...result.ssr.external],
+		},
+	};
+}
+
+/**
+ * Clear the crawlFrameworkPkgs cache. Call this when node_modules may have
+ * changed (e.g. after a dev server restart triggered by config/lockfile change).
+ */
+export function clearCrawlCache(): void {
+	_crawlCache.clear();
+}
+
 /** Return a base vite config as a common starting point for all Vite commands. */
 export async function createVite(
 	commandConfig: vite.InlineConfig,
 	{ settings, logger, mode, command, fs = nodeFs, sync, routesList }: CreateViteOptions,
 ): Promise<vite.InlineConfig> {
-	const astroPkgsConfig = await crawlFrameworkPkgs({
-		root: fileURLToPath(settings.config.root),
-		isBuild: command === 'build',
-		viteUserConfig: settings.config.vite,
-		isFrameworkPkgByJson(pkgJson) {
-			// Certain packages will trigger the checks below, but need to be external. A common example are SSR adapters
-			// for node-based platforms, as we need to control the order of the import paths to make sure polyfills are applied in time.
-			if (pkgJson?.astro?.external === true) {
-				return false;
-			}
+	const root = fileURLToPath(settings.config.root);
+	const isBuild = command === 'build';
+	const crawlCacheKey = `${root}:${isBuild}`;
 
-			return (
-				// Attempt: package relies on `astro`. ✅ Definitely an Astro package
-				pkgJson.peerDependencies?.astro ||
-				pkgJson.dependencies?.astro ||
-				// Attempt: package is tagged with `astro` or `astro-component`. ✅ Likely a community package
-				pkgJson.keywords?.includes('astro') ||
-				pkgJson.keywords?.includes('astro-component') ||
-				// Attempt: package is named `astro-something` or `@scope/astro-something`. ✅ Likely a community package
-				/^(?:@[^/]+\/)?astro-/.test(pkgJson.name)
-			);
-		},
-		isFrameworkPkgByName(pkgName) {
-			const isNotAstroPkg = isCommonNotAstro(pkgName);
-			if (isNotAstroPkg) {
-				return false;
-			} else {
-				return undefined;
-			}
-		},
-	});
+	let astroPkgsConfig = _crawlCache.get(crawlCacheKey);
+	if (!astroPkgsConfig) {
+		astroPkgsConfig = await crawlFrameworkPkgs({
+			root,
+			isBuild,
+			viteUserConfig: settings.config.vite,
+			isFrameworkPkgByJson(pkgJson) {
+				// Certain packages will trigger the checks below, but need to be external. A common example are SSR adapters
+				// for node-based platforms, as we need to control the order of the import paths to make sure polyfills are applied in time.
+				if (pkgJson?.astro?.external === true) {
+					return false;
+				}
+
+				return (
+					// Attempt: package relies on `astro`. ✅ Definitely an Astro package
+					pkgJson.peerDependencies?.astro ||
+					pkgJson.dependencies?.astro ||
+					// Attempt: package is tagged with `astro` or `astro-component`. ✅ Likely a community package
+					pkgJson.keywords?.includes('astro') ||
+					pkgJson.keywords?.includes('astro-component') ||
+					// Attempt: package is named `astro-something` or `@scope/astro-something`. ✅ Likely a community package
+					/^(?:@[^/]+\/)?astro-/.test(pkgJson.name)
+				);
+			},
+			isFrameworkPkgByName(pkgName) {
+				const isNotAstroPkg = isCommonNotAstro(pkgName);
+				if (isNotAstroPkg) {
+					return false;
+				} else {
+					return undefined;
+				}
+			},
+		});
+		_crawlCache.set(crawlCacheKey, astroPkgsConfig);
+	}
+
+	// Return a clone so consumers can't mutate the cached result
+	astroPkgsConfig = cloneCrawlResult(astroPkgsConfig);
 
 	const envLoader = createEnvLoader({
 		mode,

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -10,7 +10,7 @@ import { getPrerenderDefault } from '../../prerender/utils.js';
 import type { AstroSettings } from '../../types/astro.js';
 import type { AstroInlineConfig } from '../../types/public/config.js';
 import { createSettings, resolveConfig } from '../config/index.js';
-import { createVite } from '../create-vite.js';
+import { clearCrawlCache, createVite } from '../create-vite.js';
 import { collectErrorMetadata } from '../errors/dev/utils.js';
 import { isAstroConfigZodError } from '../errors/errors.js';
 import { createSafeError } from '../errors/index.js';
@@ -68,6 +68,8 @@ function shouldRestartContainer(
 async function restartContainerInPlace(container: Container): Promise<AstroSettings | Error> {
 	const { logger, settings: existingSettings, inlineConfig, fs } = container;
 	container.restartInFlight = true;
+	// Clear the crawlFrameworkPkgs cache since node_modules may have changed
+	clearCrawlCache();
 
 	try {
 		const { astroConfig } = await resolveConfig(inlineConfig, 'dev', fs);


### PR DESCRIPTION
Closes AST-70

## Changes

This change was mostly driven to improve tests, but it has some slight improvements to the dev server too. 

The tests hit the cache ~58% of the time, which means:
- less system calls
- less crawling

## Testing

Green CI

## Docs

No docs update needed — internal performance optimization with no user-facing behavior change.