### PR TITLE
refactor: remove PRERENDER env variable in tests

### DIFF
--- a/packages/integrations/node/test/node-middleware-listener-cleanup.test.js
+++ b/packages/integrations/node/test/node-middleware-listener-cleanup.test.js
@@ -13,7 +13,6 @@ describe('Node middleware socket listener cleanup', () => {
 	let server;
 
 	before(async () => {
-		process.env.PRERENDER = true;
 		fixture = await loadFixture({
 			root: './fixtures/node-middleware/',
 			output: 'static',
@@ -36,7 +35,6 @@ describe('Node middleware socket listener cleanup', () => {
 	after(async () => {
 		server.close();
 		await fixture.clean();
-		delete process.env.PRERENDER;
 	});
 
 	it('should not leak socket listeners when serving static files', async () => {

--- a/packages/integrations/node/test/node-middleware.test.js
+++ b/packages/integrations/node/test/node-middleware.test.js
@@ -19,7 +19,6 @@ describe('behavior from middleware, standalone', () => {
 	let server;
 
 	before(async () => {
-		process.env.PRERENDER = false;
 		fixture = await loadFixture({
 			root: './fixtures/node-middleware/',
 			output: 'server',
@@ -35,8 +34,6 @@ describe('behavior from middleware, standalone', () => {
 	after(async () => {
 		await server.stop();
 		await fixture.clean();
-
-		delete process.env.PRERENDER;
 	});
 
 	describe('404', async () => {
@@ -60,7 +57,6 @@ describe('behavior from middleware, middleware with express', () => {
 	let server;
 
 	before(async () => {
-		process.env.PRERENDER = false;
 		fixture = await loadFixture({
 			root: './fixtures/node-middleware/',
 			output: 'server',
@@ -76,8 +72,6 @@ describe('behavior from middleware, middleware with express', () => {
 	after(async () => {
 		server.close();
 		await fixture.clean();
-
-		delete process.env.PRERENDER;
 	});
 
 	it('should render the endpoint', async () => {
@@ -145,7 +139,6 @@ describe('behavior from middleware, middleware with fastify', () => {
 	let server;
 
 	before(async () => {
-		process.env.PRERENDER = false;
 		fixture = await loadFixture({
 			root: './fixtures/node-middleware/',
 			output: 'server',
@@ -169,8 +162,6 @@ describe('behavior from middleware, middleware with fastify', () => {
 	after(async () => {
 		server.close();
 		await fixture.clean();
-
-		delete process.env.PRERENDER;
 	});
 
 	it('should render the endpoint', async () => {

--- a/packages/integrations/node/test/prerender-404-500.test.js
+++ b/packages/integrations/node/test/prerender-404-500.test.js
@@ -15,8 +15,6 @@ describe('Prerender 404', () => {
 
 	describe('With base', async () => {
 		before(async () => {
-			process.env.PRERENDER = true;
-
 			fixture = await loadFixture({
 				// inconsequential config that differs between tests
 				// to bust cache and prevent modules and their state
@@ -38,7 +36,6 @@ describe('Prerender 404', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-			process.env.PRERENDER = undefined;
 		});
 
 		it('Can render SSR route', async () => {
@@ -102,8 +99,6 @@ describe('Prerender 404', () => {
 
 	describe('Without base', async () => {
 		before(async () => {
-			process.env.PRERENDER = true;
-
 			fixture = await loadFixture({
 				// inconsequential config that differs between tests
 				// to bust cache and prevent modules and their state
@@ -124,7 +119,6 @@ describe('Prerender 404', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-			process.env.PRERENDER = undefined;
 		});
 
 		it('Can render SSR route', async () => {
@@ -167,7 +161,6 @@ describe('Hybrid 404', () => {
 
 	describe('With base', async () => {
 		before(async () => {
-			process.env.PRERENDER = false;
 			fixture = await loadFixture({
 				// inconsequential config that differs between tests
 				// to bust cache and prevent modules and their state
@@ -189,7 +182,6 @@ describe('Hybrid 404', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-			process.env.PRERENDER = undefined;
 		});
 
 		it('Can render SSR route', async () => {
@@ -226,7 +218,6 @@ describe('Hybrid 404', () => {
 
 	describe('Without base', async () => {
 		before(async () => {
-			process.env.PRERENDER = false;
 			fixture = await loadFixture({
 				// inconsequential config that differs between tests
 				// to bust cache and prevent modules and their state
@@ -247,7 +238,6 @@ describe('Hybrid 404', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-			process.env.PRERENDER = undefined;
 		});
 
 		it('Can render SSR route', async () => {

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -15,8 +15,6 @@ describe('Prerendering', () => {
 
 	describe('With base', async () => {
 		before(async () => {
-			process.env.PRERENDER = true;
-
 			fixture = await loadFixture({
 				base: '/some-base',
 				root: './fixtures/prerender/',
@@ -34,8 +32,6 @@ describe('Prerendering', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-
-			delete process.env.PRERENDER;
 		});
 
 		it('Can render SSR route', async () => {
@@ -103,8 +99,6 @@ describe('Prerendering', () => {
 
 	describe('Without base', async () => {
 		before(async () => {
-			process.env.PRERENDER = true;
-
 			fixture = await loadFixture({
 				root: './fixtures/prerender/',
 				output: 'server',
@@ -121,8 +115,6 @@ describe('Prerendering', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-
-			delete process.env.PRERENDER;
 		});
 
 		it('Can render SSR route', async () => {
@@ -180,7 +172,6 @@ describe('Prerendering', () => {
 
 	describe('Via integration', () => {
 		before(async () => {
-			process.env.PRERENDER = false;
 			fixture = await loadFixture({
 				root: './fixtures/prerender/',
 				output: 'server',
@@ -209,8 +200,6 @@ describe('Prerendering', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-
-			delete process.env.PRERENDER;
 		});
 
 		it('Can render SSR route', async () => {
@@ -237,8 +226,6 @@ describe('Prerendering', () => {
 		let devServer;
 
 		before(async () => {
-			process.env.PRERENDER = true;
-
 			fixture = await loadFixture({
 				root: './fixtures/prerender/',
 				output: 'server',
@@ -250,8 +237,6 @@ describe('Prerendering', () => {
 
 		after(async () => {
 			await devServer.stop();
-
-			delete process.env.PRERENDER;
 		});
 
 		it('Can render SSR route', async () => {
@@ -281,7 +266,6 @@ describe('Hybrid rendering', () => {
 
 	describe('With base', () => {
 		before(async () => {
-			process.env.PRERENDER = false;
 			fixture = await loadFixture({
 				base: '/some-base',
 				root: './fixtures/prerender/',
@@ -299,8 +283,6 @@ describe('Hybrid rendering', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-
-			delete process.env.PRERENDER;
 		});
 
 		it('Can render SSR route', async () => {
@@ -367,7 +349,6 @@ describe('Hybrid rendering', () => {
 
 	describe('Without base', () => {
 		before(async () => {
-			process.env.PRERENDER = false;
 			fixture = await loadFixture({
 				root: './fixtures/prerender/',
 				output: 'static',
@@ -384,8 +365,6 @@ describe('Hybrid rendering', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-
-			delete process.env.PRERENDER;
 		});
 
 		it('Can render SSR route', async () => {
@@ -443,8 +422,6 @@ describe('Hybrid rendering', () => {
 
 	describe('Shared modules', () => {
 		before(async () => {
-			process.env.PRERENDER = false;
-
 			fixture = await loadFixture({
 				root: './fixtures/prerender/',
 				output: 'static',
@@ -461,8 +438,6 @@ describe('Hybrid rendering', () => {
 		after(async () => {
 			await server.stop();
 			await fixture.clean();
-
-			delete process.env.PRERENDER;
 		});
 
 		it('Can render SSR route', async () => {

--- a/packages/integrations/node/test/trailing-slash.test.js
+++ b/packages/integrations/node/test/trailing-slash.test.js
@@ -16,7 +16,6 @@ describe('Trailing slash', () => {
 		describe('With base', async () => {
 			before(async () => {
 				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
-				process.env.PRERENDER = true;
 
 				fixture = await loadFixture({
 					root: './fixtures/trailing-slash/',
@@ -36,8 +35,6 @@ describe('Trailing slash', () => {
 			after(async () => {
 				await server.stop();
 				await fixture.clean();
-
-				delete process.env.PRERENDER;
 			});
 
 			it('Can render prerendered base route', async () => {
@@ -96,7 +93,6 @@ describe('Trailing slash', () => {
 		describe('Without base', async () => {
 			before(async () => {
 				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
-				process.env.PRERENDER = true;
 
 				fixture = await loadFixture({
 					root: './fixtures/trailing-slash/',
@@ -115,8 +111,6 @@ describe('Trailing slash', () => {
 			after(async () => {
 				await server.stop();
 				await fixture.clean();
-
-				delete process.env.PRERENDER;
 			});
 
 			it('Can render prerendered base route', async () => {
@@ -214,7 +208,6 @@ describe('Trailing slash', () => {
 		describe('With base', async () => {
 			before(async () => {
 				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
-				process.env.PRERENDER = true;
 
 				fixture = await loadFixture({
 					root: './fixtures/trailing-slash/',
@@ -234,8 +227,6 @@ describe('Trailing slash', () => {
 			after(async () => {
 				await server.stop();
 				await fixture.clean();
-
-				delete process.env.PRERENDER;
 			});
 
 			it('Can render prerendered base route', async () => {
@@ -276,7 +267,6 @@ describe('Trailing slash', () => {
 		describe('Without base', async () => {
 			before(async () => {
 				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
-				process.env.PRERENDER = true;
 
 				fixture = await loadFixture({
 					root: './fixtures/trailing-slash/',
@@ -295,8 +285,6 @@ describe('Trailing slash', () => {
 			after(async () => {
 				await server.stop();
 				await fixture.clean();
-
-				delete process.env.PRERENDER;
 			});
 
 			it('Can render prerendered base route', async () => {
@@ -339,7 +327,6 @@ describe('Trailing slash', () => {
 		describe('With base', async () => {
 			before(async () => {
 				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
-				process.env.PRERENDER = true;
 
 				fixture = await loadFixture({
 					root: './fixtures/trailing-slash/',
@@ -359,8 +346,6 @@ describe('Trailing slash', () => {
 			after(async () => {
 				await server.stop();
 				await fixture.clean();
-
-				delete process.env.PRERENDER;
 			});
 
 			it('Can render prerendered base route', async () => {
@@ -419,7 +404,6 @@ describe('Trailing slash', () => {
 		describe('Without base', async () => {
 			before(async () => {
 				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
-				process.env.PRERENDER = true;
 
 				fixture = await loadFixture({
 					root: './fixtures/trailing-slash/',
@@ -438,8 +422,6 @@ describe('Trailing slash', () => {
 			after(async () => {
 				await server.stop();
 				await fixture.clean();
-
-				delete process.env.PRERENDER;
 			});
 
 			it('Can render prerendered base route', async () => {

--- a/packages/integrations/vercel/test/path-override-security.test.ts
+++ b/packages/integrations/vercel/test/path-override-security.test.ts
@@ -18,7 +18,6 @@ describe('Vercel serverless path override security', () => {
 	let fixture: Fixture;
 
 	before(async () => {
-		process.env.PRERENDER = 'true';
 		fixture = await loadFixture({
 			root: './fixtures/serverless-with-dynamic-routes/',
 			output: 'server',

--- a/packages/integrations/vercel/test/serverless-prerender.test.ts
+++ b/packages/integrations/vercel/test/serverless-prerender.test.ts
@@ -6,7 +6,6 @@ describe('Serverless prerender', () => {
 	let fixture: Fixture;
 
 	before(async () => {
-		process.env.PRERENDER = 'true';
 		fixture = await loadFixture({
 			root: './fixtures/serverless-prerender/',
 		});
@@ -43,7 +42,6 @@ describe('Serverless hybrid rendering', () => {
 	let fixture: Fixture;
 
 	before(async () => {
-		process.env.PRERENDER = 'true';
 		fixture = await loadFixture({
 			root: './fixtures/serverless-prerender/',
 			output: 'static',

--- a/packages/integrations/vercel/test/serverless-with-dynamic-routes.test.ts
+++ b/packages/integrations/vercel/test/serverless-with-dynamic-routes.test.ts
@@ -6,7 +6,6 @@ describe('Serverless with dynamic routes', () => {
 	let fixture: Fixture;
 
 	before(async () => {
-		process.env.PRERENDER = 'true';
 		fixture = await loadFixture({
 			root: './fixtures/serverless-with-dynamic-routes/',
 			output: 'server',


### PR DESCRIPTION
## Changes

Remove redundant `process.env.PRERENDER` from test files. It was used [here](https://github.com/withastro/astro/blob/d3d99fba269da9e812e748539a11dfed785ef8a4/packages/integrations/node/test/fixtures/prerender/src/pages/two.astro#L2), but this usage has been removed since Astro 4.14.0 (see [changeset file](https://github.com/withastro/astro/blob/a23c69d0d0bed229bee52a32e61f135f9ebf9122/.changeset/eleven-pens-glow.md))

Part of https://github.com/withastro/astro/issues/16241 


## Testing

CI all green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
