### PR TITLE
Respect schema-transformed slugs in glob content IDs

### DIFF
--- a/.changeset/fix-slugify-glob-id.md
+++ b/.changeset/fix-slugify-glob-id.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes content collection `glob()` loader IDs to respect schema-transformed frontmatter `slug` values such as `z.string().slugify()`

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -87,6 +87,7 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 	}
 
 	const isLegacy = !!globOptions[secretLegacyFlag];
+	const hasCustomGenerateId = typeof globOptions?.generateId === 'function';
 	const generateId =
 		globOptions?.generateId ?? ((opts: GenerateIdOptions) => generateIdDefault(opts, isLegacy));
 
@@ -136,7 +137,32 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 					fileUrl,
 				});
 
-				const id = generateId({ entry, base, data });
+				const generatedId = generateId({ entry, base, data });
+
+				const digest = generateDigest(contents);
+				const filePath = fileURLToPath(fileUrl);
+				const relativePath = posixRelative(fileURLToPath(config.root), filePath);
+
+				let parsedData: Record<string, unknown> | undefined;
+				let id = generatedId;
+
+				// When using the default ID generation (based on frontmatter slug), allow schema transforms
+				// such as `z.string().slugify()` to update the final entry ID.
+				if (!hasCustomGenerateId && typeof data.slug === 'string' && data.slug.length > 0) {
+					parsedData = await parseData({
+						id,
+						data,
+						filePath,
+					});
+
+					if (
+						typeof parsedData.slug === 'string' &&
+						parsedData.slug.length > 0 &&
+						parsedData.slug !== id
+					) {
+						id = parsedData.slug;
+					}
+				}
 
 				if (oldId && oldId !== id) {
 					store.delete(oldId);
@@ -145,9 +171,6 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 				untouchedEntries.delete(id);
 
 				const existingEntry = store.get(id);
-
-				const digest = generateDigest(contents);
-				const filePath = fileURLToPath(fileUrl);
 
 				if (existingEntry && existingEntry.digest === digest && existingEntry.filePath) {
 					if (existingEntry.deferredRender) {
@@ -162,10 +185,7 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 					fileToIdMap.set(filePath, id);
 					return;
 				}
-
-				const relativePath = posixRelative(fileURLToPath(config.root), filePath);
-
-				const parsedData = await parseData({
+				parsedData ??= await parseData({
 					id,
 					data,
 					filePath,

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -353,10 +353,10 @@ describe('Glob Loader', () => {
 	});
 
 	it('uses schema-transformed slug as entry id for default generateId', async () => {
-		const root = createTempDir('astro-glob-loader-slugify-');
-		await fs.mkdir(new URL('./src/content/posts/', root), { recursive: true });
+		const tempRoot = createTempDir('astro-glob-loader-slugify-');
+		await fs.mkdir(new URL('./src/content/posts/', tempRoot), { recursive: true });
 		await fs.writeFile(
-			new URL('./src/content/posts/post.md', root),
+			new URL('./src/content/posts/post.md', tempRoot),
 			`---
 slug: Fancy One!!!
 ---
@@ -365,7 +365,7 @@ slug: Fancy One!!!
 		);
 
 		const store = new MutableDataStore();
-		const settings = createMinimalSettings(root, {
+		const settings = createMinimalSettings(tempRoot, {
 			contentEntryTypes: [createMarkdownEntryType()],
 		});
 		const logger = new AstroLogger({
@@ -398,10 +398,10 @@ slug: Fancy One!!!
 	});
 
 	it('does not override id when slug is empty', async () => {
-		const root = createTempDir('astro-glob-loader-empty-slug-');
-		await fs.mkdir(new URL('./src/content/posts/', root), { recursive: true });
+		const tempRoot = createTempDir('astro-glob-loader-empty-slug-');
+		await fs.mkdir(new URL('./src/content/posts/', tempRoot), { recursive: true });
 		await fs.writeFile(
-			new URL('./src/content/posts/post.md', root),
+			new URL('./src/content/posts/post.md', tempRoot),
 			`---
 slug: ""
 ---
@@ -410,7 +410,7 @@ slug: ""
 		);
 
 		const store = new MutableDataStore();
-		const settings = createMinimalSettings(root, {
+		const settings = createMinimalSettings(tempRoot, {
 			contentEntryTypes: [createMarkdownEntryType()],
 		});
 		const logger = new AstroLogger({
@@ -443,10 +443,10 @@ slug: ""
 	});
 
 	it('keeps custom generateId output unchanged', async () => {
-		const root = createTempDir('astro-glob-loader-custom-generate-id-');
-		await fs.mkdir(new URL('./src/content/posts/', root), { recursive: true });
+		const tempRoot = createTempDir('astro-glob-loader-custom-generate-id-');
+		await fs.mkdir(new URL('./src/content/posts/', tempRoot), { recursive: true });
 		await fs.writeFile(
-			new URL('./src/content/posts/post.md', root),
+			new URL('./src/content/posts/post.md', tempRoot),
 			`---
 slug: Fancy One!!!
 ---
@@ -455,7 +455,7 @@ slug: Fancy One!!!
 		);
 
 		const store = new MutableDataStore();
-		const settings = createMinimalSettings(root, {
+		const settings = createMinimalSettings(tempRoot, {
 			contentEntryTypes: [createMarkdownEntryType()],
 		});
 		const logger = new AstroLogger({

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -1,11 +1,14 @@
 import { strict as assert } from 'node:assert';
+import { promises as fs } from 'node:fs';
 import { describe, it } from 'node:test';
+import { z } from 'zod';
 import { glob } from '../../../dist/content/loaders/glob.js';
 import { defineCollection } from '../../../dist/content/config.js';
 import { ContentLayer } from '../../../dist/content/content-layer.js';
 import { MutableDataStore } from '../../../dist/content/mutable-data-store.js';
 import { AstroLogger } from '../../../dist/core/logger/core.js';
 import {
+	createTempDir,
 	createTestConfigObserver,
 	createMinimalSettings,
 	createMarkdownEntryType,
@@ -347,5 +350,144 @@ describe('Glob Loader', () => {
 		await contentLayer.sync();
 
 		assert.ok(warnings.some((w) => w.includes('No files found matching')));
+	});
+
+	it('uses schema-transformed slug as entry id for default generateId', async () => {
+		const root = createTempDir('astro-glob-loader-slugify-');
+		await fs.mkdir(new URL('./src/content/posts/', root), { recursive: true });
+		await fs.writeFile(
+			new URL('./src/content/posts/post.md', root),
+			`---
+slug: Fancy One!!!
+---
+
+# Hello`,
+		);
+
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root, {
+			contentEntryTypes: [createMarkdownEntryType()],
+		});
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'silent',
+		});
+
+		const collections = {
+			posts: defineCollection({
+				loader: glob({ pattern: '*.md', base: 'src/content/posts' }),
+				schema: z.object({
+					slug: z.string().slugify().optional(),
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		const entries = store.values('posts');
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].id, 'fancy-one');
+		assert.equal(entries[0].data.slug, 'fancy-one');
+	});
+
+	it('does not override id when slug is empty', async () => {
+		const root = createTempDir('astro-glob-loader-empty-slug-');
+		await fs.mkdir(new URL('./src/content/posts/', root), { recursive: true });
+		await fs.writeFile(
+			new URL('./src/content/posts/post.md', root),
+			`---
+slug: ""
+---
+
+# Hello`,
+		);
+
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root, {
+			contentEntryTypes: [createMarkdownEntryType()],
+		});
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'silent',
+		});
+
+		const collections = {
+			posts: defineCollection({
+				loader: glob({ pattern: '*.md', base: 'src/content/posts' }),
+				schema: z.object({
+					slug: z.string().slugify().optional(),
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		const entries = store.values('posts');
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].id, 'post');
+		assert.equal(entries[0].data.slug, '');
+	});
+
+	it('keeps custom generateId output unchanged', async () => {
+		const root = createTempDir('astro-glob-loader-custom-generate-id-');
+		await fs.mkdir(new URL('./src/content/posts/', root), { recursive: true });
+		await fs.writeFile(
+			new URL('./src/content/posts/post.md', root),
+			`---
+slug: Fancy One!!!
+---
+
+# Hello`,
+		);
+
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root, {
+			contentEntryTypes: [createMarkdownEntryType()],
+		});
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'silent',
+		});
+
+		const collections = {
+			posts: defineCollection({
+				loader: glob({
+					pattern: '*.md',
+					base: 'src/content/posts',
+					generateId: ({ entry }) => `custom-${entry.replace(/\.md$/, '')}`,
+				}),
+				schema: z.object({
+					slug: z.string().slugify().optional(),
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		const entries = store.values('posts');
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].id, 'custom-post');
+		assert.equal(entries[0].data.slug, 'fancy-one');
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes `glob()` content loader ID generation so frontmatter `slug` values transformed by content schemas (for example `z.string().slugify()`) are reflected in the final entry `id` when using the default ID generator.
- Keeps custom `generateId` behavior unchanged and adds guards so empty slug values do not override the filename-derived fallback ID.

## Testing

- Added unit coverage in `packages/astro/test/units/content-layer/glob-loader.test.ts` for transformed slug IDs, empty-slug fallback behavior, and unchanged custom `generateId` behavior.
- I could not run the test suite in this environment because `pnpm`/`corepack` are unavailable here; tests should be executed in a standard Astro dev setup.

## Docs

- No docs update needed, because this is a bug fix to existing content collection slug behavior with no API changes.
