### PR TITLE
refactor(astro): migrate core-image tests to typescript

### DIFF
--- a/packages/astro/test/api-routes.test.js
+++ b/packages/astro/test/api-routes.test.js
@@ -13,7 +13,7 @@ describe('API routes', () => {
 
 	describe('Binary data', () => {
 		it('can be returned from a response', async () => {
-			const dat = await fixture.readFile('/binary.dat', null);
+			const dat = await fixture.readBuffer('/binary.dat');
 			assert.equal(dat.length, 1);
 			assert.equal(dat[0], 0xff);
 		});

--- a/packages/astro/test/core-image-fs-config.test.ts
+++ b/packages/astro/test/core-image-fs-config.test.ts
@@ -2,12 +2,12 @@ import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('Image optimization with Vite fs config', () => {
 	describe('fs.allow and fs.deny', () => {
-		let fixture;
-		let devServer;
+		let fixture: Fixture;
+		let devServer: DevServer;
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -86,8 +86,8 @@ describe('Image optimization with Vite fs config', () => {
 	});
 
 	describe('safeModulePaths', () => {
-		let fixture;
-		let devServer;
+		let fixture: Fixture;
+		let devServer: DevServer;
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -111,7 +111,7 @@ describe('Image optimization with Vite fs config', () => {
 			const img = $('#sibling-image');
 			assert.ok(img.length > 0, 'Image element should be present');
 
-			const imgSrc = img.attr('src');
+			const imgSrc = img.attr('src')!;
 			assert.ok(imgSrc, 'Should have image src');
 			assert.ok(imgSrc.includes('/_image'), 'Should use image optimization endpoint');
 

--- a/packages/astro/test/core-image-infersize.test.ts
+++ b/packages/astro/test/core-image-infersize.test.ts
@@ -3,37 +3,36 @@ import { Writable } from 'node:stream';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 
-import { AstroLogger } from '../dist/core/logger/core.js';
+import { AstroLogger, type AstroLogMessage } from '../dist/core/logger/core.js';
 import { testImageService } from './test-image-service.js';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('astro:image:infersize', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 	const remoteAvatarUrl = 'https://avatars.githubusercontent.com/u/622227?s=64&v=4';
 
 	describe('dev', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
+		let devServer: DevServer;
+		const logs: Array<AstroLogMessage> = [];
 
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/core-image-infersize/',
 			});
 
-			devServer = await fixture.startDevServer({
-				logger: new AstroLogger({
-					level: 'error',
-					destination: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
+			const logger = new AstroLogger({
+				level: 'error',
+				destination: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						logs.push(event);
+						callback();
+					},
 				}),
+			});
+			devServer = await fixture.startDevServer({
+				// @ts-expect-error: `logger` is an internal API
+				logger,
 			});
 		});
 
@@ -42,39 +41,39 @@ describe('astro:image:infersize', () => {
 		});
 
 		describe('inferSize works', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
-				let res = await fixture.fetch('/');
-				let html = await res.text();
+				const res = await fixture.fetch('/');
+				const html = await res.text();
 				$ = cheerio.load(html);
 			});
 
 			it('Image component works', async () => {
-				let $img = $('img');
+				const $img = $('img');
 				assert.equal(
-					$img.attr('src').startsWith('/_image') && $img.attr('src').endsWith('f=webp'),
+					$img.attr('src')!.startsWith('/_image') && $img.attr('src')!.endsWith('f=webp'),
 					true,
 				);
 			});
 
 			it('Picture component works', async () => {
-				let $img = $('picture img');
+				const $img = $('picture img');
 				assert.equal(
-					$img.attr('src').startsWith('/_image') && $img.attr('src').endsWith('f=png'),
+					$img.attr('src')!.startsWith('/_image') && $img.attr('src')!.endsWith('f=png'),
 					true,
 				);
 			});
 
 			it('getImage works', async () => {
-				let $img = $('#getImage');
+				const $img = $('#getImage');
 				assert.equal(
-					$img.attr('src').startsWith('/_image') && $img.attr('src').endsWith('f=webp'),
+					$img.attr('src')!.startsWith('/_image') && $img.attr('src')!.endsWith('f=webp'),
 					true,
 				);
 			});
 
 			it('direct function call work', async () => {
-				let $dimensions = $('#direct');
+				const $dimensions = $('#direct');
 				assert.equal($dimensions.text().trim(), '64x64');
 			});
 		});
@@ -92,10 +91,8 @@ describe('astro:image:infersize', () => {
 	});
 
 	describe('dev with custom image service', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let customFixture;
-		/** @type {import('./test-utils').DevServer} */
-		let customDevServer;
+		let customFixture: Fixture;
+		let customDevServer: DevServer;
 
 		before(async () => {
 			customFixture = await loadFixture({

--- a/packages/astro/test/core-image-layout.test.ts
+++ b/packages/astro/test/core-image-layout.test.ts
@@ -6,15 +6,13 @@ import parseSrcset from 'parse-srcset';
 import { AstroLogger } from '../dist/core/logger/core.js';
 import { testImageService } from './test-image-service.js';
 import { testRemoteImageService } from './test-remote-image-service.js';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('astro:image:layout', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	describe('local image service', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
+		let devServer: DevServer;
 		const walrusImagePath =
 			'https://images.unsplash.com/photo-1690941380217-24dfa9a1d21f?q=80&w=1476&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
 		const imageScale = 2;
@@ -39,111 +37,111 @@ describe('astro:image:layout', () => {
 		});
 
 		describe('basics', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
-				let res = await fixture.fetch('/');
-				let html = await res.text();
+				const res = await fixture.fetch('/');
+				const html = await res.text();
 				$ = cheerio.load(html);
 			});
 
 			it('Adds the <img> tag', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.length, 1);
-				assert.equal($img.attr('src').startsWith('/_image'), true);
+				assert.equal($img.attr('src')!.startsWith('/_image'), true);
 			});
 
 			it('includes lazy loading attributes', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.attr('loading'), 'lazy');
 				assert.equal($img.attr('decoding'), 'async');
 				assert.equal($img.attr('fetchpriority'), undefined);
 			});
 
 			it('includes priority loading attributes', () => {
-				let $img = $('#local-priority img');
+				const $img = $('#local-priority img');
 				assert.equal($img.attr('loading'), 'eager');
 				assert.equal($img.attr('decoding'), 'sync');
 				assert.equal($img.attr('fetchpriority'), 'high');
 			});
 
 			it('has width and height - no dimensions set', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.attr('width'), '2316');
 				assert.equal($img.attr('height'), '1544');
 			});
 
 			it('has proper width and height - only width', () => {
-				let $img = $('#local-width img');
+				const $img = $('#local-width img');
 				assert.equal($img.attr('width'), '350');
 				assert.equal($img.attr('height'), '233');
 			});
 
 			it('has proper width and height - only height', () => {
-				let $img = $('#local-height img');
+				const $img = $('#local-height img');
 				assert.equal($img.attr('width'), '300');
 				assert.equal($img.attr('height'), '200');
 			});
 
 			it('has proper width and height - has both width and height', () => {
-				let $img = $('#local-both img');
+				const $img = $('#local-both img');
 				assert.equal($img.attr('width'), '300');
 				assert.equal($img.attr('height'), '400');
 			});
 
 			it('sets the style', () => {
-				let $img = $('#local-both img');
+				const $img = $('#local-both img');
 				assert.equal($img.data('astro-image'), 'constrained');
 			});
 
 			it('sets the style when no dimensions set', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.data('astro-image'), 'constrained');
 			});
 
 			it('sets style for fixed image', () => {
-				let $img = $('#local-fixed img');
+				const $img = $('#local-fixed img');
 				assert.equal($img.data('astro-image'), 'fixed');
 			});
 
 			it('sets style for full-width image', () => {
-				let $img = $('#local-full-width img');
+				const $img = $('#local-full-width img');
 				assert.equal($img.data('astro-image'), 'full-width');
 			});
 
 			it('passes in a parent class', () => {
-				let $img = $('#local-class img');
+				const $img = $('#local-class img');
 
-				assert.match($img.attr('class'), /green/);
+				assert.match($img.attr('class')!, /green/);
 			});
 
 			it('passes in a parent style', () => {
-				let $img = $('#local-style img');
-				assert.match($img.attr('style'), /border: 2px red solid/);
+				const $img = $('#local-style img');
+				assert.match($img.attr('style')!, /border: 2px red solid/);
 			});
 
 			it('passes in a parent style as an object', () => {
-				let $img = $('#local-style-object img');
-				assert.match($img.attr('style'), /border:2px red solid/);
+				const $img = $('#local-style-object img');
+				assert.match($img.attr('style')!, /border:2px red solid/);
 			});
 		});
 
 		describe('remote images', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
-				let res = await fixture.fetch('/remote');
-				let html = await res.text();
+				const res = await fixture.fetch('/remote');
+				const html = await res.text();
 				$ = cheerio.load(html);
 			});
 
 			describe('inferSize', () => {
 				it('default inferSize works', () => {
-					let $img = $('#infer-size img');
+					const $img = $('#infer-size img');
 					assert.equal($img.attr('width'), '2670');
 					assert.equal($img.attr('height'), '1780');
 				});
 
 				it('custom inferSize works', () => {
-					let $img = $('#infer-size-custom img');
+					const $img = $('#infer-size-custom img');
 					assert.equal($img.attr('width'), (1476 * imageScale).toString());
 					assert.equal($img.attr('height'), (978 * imageScale).toString());
 				});
@@ -151,28 +149,27 @@ describe('astro:image:layout', () => {
 		});
 
 		describe('picture component', () => {
-			/** Original image dimensions */
+			// Original image dimensions
 			const originalWidth = 2316;
 			const originalHeight = 1544;
 
-			/** @type {import("cheerio").CheerioAPI} */
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
-				let res = await fixture.fetch('/picture');
-				let html = await res.text();
+				const res = await fixture.fetch('/picture');
+				const html = await res.text();
 				$ = cheerio.load(html);
 			});
 
 			describe('basics', () => {
 				it('creates picture and img elements', () => {
-					let $picture = $('#picture-density-2-format picture');
-					let $img = $('#picture-density-2-format img');
+					const $picture = $('#picture-density-2-format picture');
+					const $img = $('#picture-density-2-format img');
 					assert.equal($picture.length, 1);
 					assert.equal($img.length, 1);
 				});
 
 				it('includes source elements for each format', () => {
-					let $sources = $('#picture-density-2-format source');
+					const $sources = $('#picture-density-2-format source');
 					assert.equal($sources.length, 2); // avif and webp formats
 
 					const types = $sources.map((_, el) => $(el).attr('type')).get();
@@ -180,15 +177,15 @@ describe('astro:image:layout', () => {
 				});
 
 				it('generates responsive srcset matching layout breakpoints', () => {
-					let $source = $('#picture-density-2-format source').first();
-					const srcset = parseSrcset($source.attr('srcset'));
+					const $source = $('#picture-density-2-format source').first();
+					const srcset = parseSrcset($source.attr('srcset')!);
 
 					const widths = srcset.map((s) => s.w);
 					assert.deepEqual(widths, [640, 750, 828, 1080, 1158, 1280, 1668, 2048, 2316]);
 				});
 
 				it('has proper width and height attributes', () => {
-					let $img = $('#picture-density-2-format img');
+					const $img = $('#picture-density-2-format img');
 					// Width is set to half of original in the component
 					const expectedWidth = Math.round(originalWidth / 2);
 					const expectedHeight = Math.round(originalHeight / 2);
@@ -200,59 +197,59 @@ describe('astro:image:layout', () => {
 
 			describe('responsive variants', () => {
 				it('constrained - has max of 2x requested size', () => {
-					let $source = $('#picture-constrained source').first();
-					const widths = parseSrcset($source.attr('srcset')).map((s) => s.w);
+					const $source = $('#picture-constrained source').first();
+					const widths = parseSrcset($source.attr('srcset')!).map((s) => s.w);
 					assert.equal(widths.at(-1), 1600); // Max should be 2x the 800px width
 
-					let $img = $('#picture-constrained img');
+					const $img = $('#picture-constrained img');
 					const aspectRatio = originalWidth / originalHeight;
 					assert.equal($img.attr('width'), '800');
 					assert.equal($img.attr('height'), Math.round(800 / aspectRatio).toString());
 				});
 
 				it('constrained - just has 1x and 2x when smaller than min breakpoint', () => {
-					let $source = $('#picture-both source').first();
-					const widths = parseSrcset($source.attr('srcset')).map((s) => s.w);
+					const $source = $('#picture-both source').first();
+					const widths = parseSrcset($source.attr('srcset')!).map((s) => s.w);
 					assert.deepEqual(widths, [300, 600]); // Just 1x and 2x for small images
 
-					let $img = $('#picture-both img');
+					const $img = $('#picture-both img');
 					assert.equal($img.attr('width'), '300');
 					assert.equal($img.attr('height'), '400');
 				});
 
 				it('fixed - has just 1x and 2x', () => {
-					let $source = $('#picture-fixed source').first();
-					const widths = parseSrcset($source.attr('srcset')).map((s) => s.w);
+					const $source = $('#picture-fixed source').first();
+					const widths = parseSrcset($source.attr('srcset')!).map((s) => s.w);
 					assert.deepEqual(widths, [400, 800]); // Fixed layout only needs 1x and 2x
 
-					let $img = $('#picture-fixed img');
+					const $img = $('#picture-fixed img');
 					assert.equal($img.attr('width'), '400');
 					assert.equal($img.attr('height'), '300');
 				});
 
 				it('full-width: has all breakpoints below image size', () => {
-					let $source = $('#picture-full-width source').first();
-					const widths = parseSrcset($source.attr('srcset')).map((s) => s.w);
+					const $source = $('#picture-full-width source').first();
+					const widths = parseSrcset($source.attr('srcset')!).map((s) => s.w);
 					assert.deepEqual(widths, [640, 750, 828, 1080, 1280, 1668, 2048]);
 				});
 			});
 
 			describe('fallback format', () => {
 				it('uses specified fallback format', () => {
-					let $img = $('#picture-fallback img');
-					const imageURL = new URL($img.attr('src'), 'http://localhost');
+					const $img = $('#picture-fallback img');
+					const imageURL = new URL($img.attr('src')!, 'http://localhost');
 					assert.equal(imageURL.searchParams.get('f'), 'jpeg');
 				});
 
 				it('does not add fallbackFormat as an attribute', () => {
-					let $img = $('#picture-fallback img');
+					const $img = $('#picture-fallback img');
 					assert.equal($img.attr('fallbackformat'), undefined);
 				});
 
 				it('maintains original aspect ratio', () => {
-					let $img = $('#picture-fallback img');
-					const width = Number.parseInt($img.attr('width'));
-					const height = Number.parseInt($img.attr('height'));
+					const $img = $('#picture-fallback img');
+					const width = Number.parseInt($img.attr('width')!);
+					const height = Number.parseInt($img.attr('height')!);
 					const imageAspectRatio = width / height;
 					const originalAspectRatio = originalWidth / originalHeight;
 
@@ -263,17 +260,17 @@ describe('astro:image:layout', () => {
 
 			describe('attributes', () => {
 				it('applies class to img element', () => {
-					let $img = $('#picture-attributes img');
-					assert.ok($img.attr('class').includes('img-comp'));
+					const $img = $('#picture-attributes img');
+					assert.ok($img.attr('class')!.includes('img-comp'));
 				});
 
 				it('applies pictureAttributes to picture element', () => {
-					let $picture = $('#picture-attributes picture');
-					assert.ok($picture.attr('class').includes('picture-comp'));
+					const $picture = $('#picture-attributes picture');
+					assert.ok($picture.attr('class')!.includes('picture-comp'));
 				});
 
 				it('adds data attributes instead of inline styles', () => {
-					let $img = $('#picture-attributes img');
+					const $img = $('#picture-attributes img');
 					// Should have data attributes for CSP compliance
 					assert.ok($img.attr('data-astro-image'));
 					// Should NOT have inline style CSS variables
@@ -285,14 +282,14 @@ describe('astro:image:layout', () => {
 				});
 
 				it('passing in style as an object', () => {
-					let $img = $('#picture-style-object img');
-					const style = $img.attr('style');
+					const $img = $('#picture-style-object img');
+					const style = $img.attr('style')!;
 					assert.match(style, /border:2px red solid/);
 				});
 
 				it('passing in style as a string', () => {
-					let $img = $('#picture-style img');
-					const style = $img.attr('style');
+					const $img = $('#picture-style img');
+					const style = $img.attr('style')!;
 					assert.match(style, /border: 2px red solid/);
 				});
 			});
@@ -327,7 +324,7 @@ describe('astro:image:layout', () => {
 					];
 
 					$sources.each((_, source) => {
-						const type = $(source).attr('type');
+						const type = $(source).attr('type')!;
 						assert.ok(
 							validMimeTypes.includes(type),
 							`Expected type attribute value to be a valid MIME type: ${type}`,
@@ -339,10 +336,8 @@ describe('astro:image:layout', () => {
 	});
 
 	describe('remote image service', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
+		let devServer: DevServer;
+		const logs: Array<{ type: any; level: 'error'; message: string }> = [];
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -353,17 +348,20 @@ describe('astro:image:layout', () => {
 				},
 			});
 
-			devServer = await fixture.startDevServer({
-				logger: new AstroLogger({
-					level: 'error',
-					destination: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
+			const logger = new AstroLogger({
+				level: 'error',
+				destination: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						logs.push(event);
+						callback();
+					},
 				}),
+			});
+			devServer = await fixture.startDevServer({
+				// `logger` is @internal in AstroInlineConfig so it's stripped from dist types
+				// @ts-expect-error
+				logger,
 			});
 		});
 
@@ -385,97 +383,97 @@ describe('astro:image:layout', () => {
 			await fixture.build();
 		});
 		describe('basics', () => {
-			let $;
-			let html;
+			let $: cheerio.CheerioAPI;
+			let html: string;
 			before(async () => {
 				html = await fixture.readFile('/index.html');
 				$ = cheerio.load(html);
 			});
 
 			it('Adds the <img> tag', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.length, 1);
-				assert.ok($img.attr('src').startsWith('/_astro'));
+				assert.ok($img.attr('src')!.startsWith('/_astro'));
 			});
 
 			it('includes lazy loading attributes', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.attr('loading'), 'lazy');
 				assert.equal($img.attr('decoding'), 'async');
 				assert.equal($img.attr('fetchpriority'), undefined);
 			});
 
 			it('includes priority loading attributes', () => {
-				let $img = $('#local-priority img');
+				const $img = $('#local-priority img');
 				assert.equal($img.attr('loading'), 'eager');
 				assert.equal($img.attr('decoding'), 'sync');
 				assert.equal($img.attr('fetchpriority'), 'high');
 			});
 
 			it('has width and height - no dimensions set', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.attr('width'), '2316');
 				assert.equal($img.attr('height'), '1544');
 			});
 
 			it('has proper width and height - only width', () => {
-				let $img = $('#local-width img');
+				const $img = $('#local-width img');
 				assert.equal($img.attr('width'), '350');
 				assert.equal($img.attr('height'), '233');
 			});
 
 			it('has proper width and height - only height', () => {
-				let $img = $('#local-height img');
+				const $img = $('#local-height img');
 				assert.equal($img.attr('width'), '300');
 				assert.equal($img.attr('height'), '200');
 			});
 
 			it('has proper width and height - has both width and height', () => {
-				let $img = $('#local-both img');
+				const $img = $('#local-both img');
 				assert.equal($img.attr('width'), '300');
 				assert.equal($img.attr('height'), '400');
 			});
 
 			it('sets the style', () => {
-				let $img = $('#local-both img');
+				const $img = $('#local-both img');
 				assert.equal($img.data('astro-image'), 'constrained');
 			});
 
 			it('sets the style when no dimensions set', () => {
-				let $img = $('#local img');
+				const $img = $('#local img');
 				assert.equal($img.data('astro-image'), 'constrained');
 			});
 
 			it('sets style for fixed image', () => {
-				let $img = $('#local-fixed img');
+				const $img = $('#local-fixed img');
 				assert.equal($img.data('astro-image'), 'fixed');
 			});
 
 			it('sets style for full-width image', () => {
-				let $img = $('#local-full-width img');
+				const $img = $('#local-full-width img');
 				assert.equal($img.data('astro-image'), 'full-width');
 			});
 
 			it('passes in a parent class', () => {
-				let $img = $('#local-class img');
+				const $img = $('#local-class img');
 				assert.equal($img.prop('class'), 'green');
 			});
 
 			it('only passes the class in once', () => {
 				// Check that class="green" only appears once
 				// We can't use cheerio because it normalises the DOM, so we have to use a regex
-				const matches = html.match(/class="green"/g);
+				const matches = html.match(/class="green"/g)!;
 				assert.equal(matches.length, 1);
 			});
 
 			it('passes in a parent style', () => {
-				let $img = $('#local-style img');
-				assert.match($img.attr('style'), /border: 2px red solid/);
+				const $img = $('#local-style img');
+				assert.match($img.attr('style')!, /border: 2px red solid/);
 			});
 
 			it('passes in a parent style as an object', () => {
-				let $img = $('#local-style-object img');
-				assert.match($img.attr('style'), /border:2px red solid/);
+				const $img = $('#local-style-object img');
+				assert.match($img.attr('style')!, /border:2px red solid/);
 			});
 
 			it('injects a style tag', () => {

--- a/packages/astro/test/core-image-picture-emit-file.test.ts
+++ b/packages/astro/test/core-image-picture-emit-file.test.ts
@@ -2,15 +2,14 @@ import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import parseSrcset from 'parse-srcset';
-import { loadFixture } from './test-utils.js';
+import { type Fixture, loadFixture } from './test-utils.js';
 
-function removeLeadingForwardSlash(path) {
+function removeLeadingForwardSlash(path: string) {
 	return path.startsWith('/') ? path.substring(1) : path;
 }
 
 describe('astro:image', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	describe('build', () => {
 		before(async () => {
@@ -22,7 +21,7 @@ describe('astro:image', () => {
 		});
 
 		describe('generated images', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
 				const html = await fixture.readFile('index.html');
 				$ = cheerio.load(html);
@@ -32,7 +31,7 @@ describe('astro:image', () => {
 				describe('normal', () => {
 					it('default format', async () => {
 						const $source = $('#picture source');
-						const srcset = parseSrcset($source.attr('srcset'));
+						const srcset = parseSrcset($source.attr('srcset')!);
 						const generatedImages = await fixture.glob('_astro/**/penguin.*.webp');
 
 						assert.deepEqual(generatedImages.length, 1);
@@ -44,7 +43,7 @@ describe('astro:image', () => {
 
 					it('fallback format', async () => {
 						const $img = $('#picture img');
-						const src = $img.attr('src');
+						const src = $img.attr('src')!;
 						const generatedFallbackImages = await fixture.glob('_astro/**/penguin.*.jpg');
 
 						assert.deepEqual(generatedFallbackImages.length, 1);
@@ -55,7 +54,7 @@ describe('astro:image', () => {
 				describe('with widths', () => {
 					it('default format', async () => {
 						const $source = $('#picture-widths source');
-						const srcset = parseSrcset($source.attr('srcset'));
+						const srcset = parseSrcset($source.attr('srcset')!);
 						const generatedImages = await fixture.glob('_astro/**/walrus.*.webp');
 
 						assert.deepEqual(generatedImages.length, 2);
@@ -67,8 +66,8 @@ describe('astro:image', () => {
 
 					it('fallback format', async () => {
 						const $img = $('#picture-widths img');
-						const src = $img.attr('src');
-						const srcset = parseSrcset($img.attr('srcset'));
+						const src = $img.attr('src')!;
+						const srcset = parseSrcset($img.attr('srcset')!);
 						const generatedFallbackImages = await fixture.glob('_astro/**/walrus.*.jpg');
 
 						assert.deepEqual(generatedFallbackImages.length, 3);
@@ -82,7 +81,7 @@ describe('astro:image', () => {
 				describe('with densities', () => {
 					it('default format', async () => {
 						const $source = $('#picture-densities source');
-						const srcset = parseSrcset($source.attr('srcset'));
+						const srcset = parseSrcset($source.attr('srcset')!);
 						const generatedImages = await fixture.glob('_astro/**/polarBear.*.webp');
 
 						assert.deepEqual(generatedImages.length, 3);
@@ -94,8 +93,8 @@ describe('astro:image', () => {
 
 					it('fallback format', async () => {
 						const $img = $('#picture-densities img');
-						const src = $img.attr('src');
-						const srcset = parseSrcset($img.attr('srcset'));
+						const src = $img.attr('src')!;
+						const srcset = parseSrcset($img.attr('srcset')!);
 						const generatedFallbackImages = await fixture.glob('_astro/**/polarBear.*.jpg');
 
 						assert.deepEqual(generatedFallbackImages.length, 3);

--- a/packages/astro/test/core-image-remark-imgattr.test.ts
+++ b/packages/astro/test/core-image-remark-imgattr.test.ts
@@ -4,34 +4,34 @@ import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 
 import { AstroLogger } from '../dist/core/logger/core.js';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('astro:image', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	describe('dev', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
+		let devServer: DevServer;
+		const logs: Array<{ type: any; level: 'error'; message: string }> = [];
 
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/core-image-remark-imgattr/',
 			});
 
-			devServer = await fixture.startDevServer({
-				logger: new AstroLogger({
-					level: 'error',
-					destination: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
+			const logger = new AstroLogger({
+				level: 'error',
+				destination: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						logs.push(event);
+						callback();
+					},
 				}),
+			});
+			devServer = await fixture.startDevServer({
+				// `logger` is @internal in AstroInlineConfig so it's stripped from dist types
+				// @ts-expect-error
+				logger,
 			});
 		});
 
@@ -40,21 +40,21 @@ describe('astro:image', () => {
 		});
 
 		describe('Test image attributes can be added by remark plugins', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
-				let res = await fixture.fetch('/');
-				let html = await res.text();
+				const res = await fixture.fetch('/');
+				const html = await res.text();
 				$ = cheerio.load(html);
 			});
 
 			it('Image has eager loading meaning getImage passed props it doesnt use through it', async () => {
-				let $img = $('img');
+				const $img = $('img');
 				assert.equal($img.attr('loading'), 'eager');
 			});
 
 			it('Image src contains w=50 meaning getImage correctly used props added through the remark plugin', async () => {
-				let $img = $('img');
-				assert.equal(new URL($img.attr('src'), 'http://example.com').searchParams.get('w'), '50');
+				const $img = $('img');
+				assert.equal(new URL($img.attr('src')!, 'http://example.com').searchParams.get('w'), '50');
 			});
 		});
 	});

--- a/packages/astro/test/core-image-svg-in-island.test.ts
+++ b/packages/astro/test/core-image-svg-in-island.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('astro:assets - SVG Components in Astro Islands', async () => {
-	/** @type {import('./test-utils.js').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -14,8 +13,7 @@ describe('astro:assets - SVG Components in Astro Islands', async () => {
 	});
 
 	describe('dev', () => {
-		/** @type {import('./test-utils.js').DevServer} */
-		let devServer;
+		let devServer: DevServer;
 
 		before(async () => {
 			devServer = await fixture.startDevServer();
@@ -27,14 +25,14 @@ describe('astro:assets - SVG Components in Astro Islands', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			const $ = cheerio.load(html, { xml: true });
 			const island = $('astro-island');
-			const componentUrl = island.attr('component-url');
+			const componentUrl = island.attr('component-url')!;
 			assert.ok(componentUrl, 'Expected component-url attribute to be present on astro-island.');
 			const componentModule = await fixture.fetch(componentUrl).then((res) => res.text());
 			const imports = componentModule
 				.split('\n')
 				.map((line) => line.trim())
 				.filter((line) => line.startsWith('import '));
-			const svgImportStatement = imports.find((imp) => imp.includes('src/components/astro.svg'));
+			const svgImportStatement = imports.find((imp) => imp.includes('src/components/astro.svg'))!;
 			assert.ok(svgImportStatement, 'Expected SVG to be imported in the component.');
 			const importPath = svgImportStatement.split('from')[1].trim().replace(/['";]/g, '');
 			const mod = await fixture.fetch(importPath).then((res) => res.text());
@@ -50,7 +48,7 @@ describe('astro:assets - SVG Components in Astro Islands', async () => {
 	});
 
 	describe('build', () => {
-		before(() => fixture.build({}));
+		before(() => fixture.build());
 
 		after(() => fixture.clean());
 

--- a/packages/astro/test/core-image-svg.test.ts
+++ b/packages/astro/test/core-image-svg.test.ts
@@ -3,34 +3,33 @@ import { Writable } from 'node:stream';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { AstroLogger } from '../dist/core/logger/core.js';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('astro:assets - SVG Components', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	describe('dev', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
+		let devServer: DevServer;
+		const logs: Array<{ type: any; level: 'error'; message: string }> = [];
 
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/core-image-svg/',
 			});
 
-			devServer = await fixture.startDevServer({
-				logger: new AstroLogger({
-					level: 'error',
-					destination: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
+			const logger = new AstroLogger({
+				level: 'error',
+				destination: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						logs.push(event);
+						callback();
+					},
 				}),
+			});
+			devServer = await fixture.startDevServer({
+				// @ts-expect-error: `logger` is @internal in AstroInlineConfig so it's stripped from dist types
+				logger,
 			});
 		});
 
@@ -39,10 +38,10 @@ describe('astro:assets - SVG Components', () => {
 		});
 
 		describe('basics', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
-				let res = await fixture.fetch('/');
-				let html = await res.text();
+				const res = await fixture.fetch('/');
+				const html = await res.text();
 				$ = cheerio.load(html, { xml: true });
 			});
 			it('Inlines the SVG by default', () => {
@@ -53,17 +52,17 @@ describe('astro:assets - SVG Components', () => {
 
 		describe('props', () => {
 			describe('strip', () => {
-				let $;
-				let html;
+				let $: cheerio.CheerioAPI;
+				let html: string;
 
 				before(async () => {
-					let res = await fixture.fetch('/strip');
+					const res = await fixture.fetch('/strip');
 					html = await res.text();
 					$ = cheerio.load(html, { xml: true });
 				});
 
 				it('removes unnecessary attributes', () => {
-					let $svg = $('#base svg');
+					const $svg = $('#base svg');
 					assert.equal($svg.length, 1);
 					assert.equal(!!$svg.attr('xmlns'), false);
 					assert.equal(!!$svg.attr('xmlns:xlink'), false);
@@ -73,7 +72,7 @@ describe('astro:assets - SVG Components', () => {
 					let $svg = $('#additionalNodes');
 					// Ensure we only have the svg node
 					assert.equal($svg.children().length, 1);
-					assert.equal($svg.children()[0].name, 'svg');
+					assert.equal(($svg.children()[0] as { name: string }).name, 'svg');
 					$svg = $svg.children('svg');
 					assert.equal($svg.length, 1);
 					assert.equal(!!$svg.attr('xmlns'), false);
@@ -85,15 +84,15 @@ describe('astro:assets - SVG Components', () => {
 				});
 			});
 			describe('additional props', () => {
-				let $;
+				let $: cheerio.CheerioAPI;
 				before(async () => {
-					let res = await fixture.fetch('/props');
-					let html = await res.text();
+					const res = await fixture.fetch('/props');
+					const html = await res.text();
 					$ = cheerio.load(html, { xml: true });
 				});
 
 				it('adds the props to the svg', () => {
-					let $svg = $('#base svg');
+					const $svg = $('#base svg');
 					assert.equal($svg.length, 1);
 					assert.equal($svg.attr('aria-hidden'), 'true');
 					assert.equal($svg.attr('id'), 'plus');
@@ -105,7 +104,7 @@ describe('astro:assets - SVG Components', () => {
 					assert.equal($path.length, 1);
 				});
 				it('allows specifying the role attribute', () => {
-					let $svg = $('#role svg');
+					const $svg = $('#role svg');
 					assert.equal($svg.length, 1);
 					assert.equal($svg.attr('role'), 'presentation');
 				});
@@ -114,8 +113,8 @@ describe('astro:assets - SVG Components', () => {
 
 		describe('markdown', () => {
 			it('Adds the <svg> tag with the definition', async () => {
-				let res = await fixture.fetch('/blog/basic');
-				let html = await res.text();
+				const res = await fixture.fetch('/blog/basic');
+				const html = await res.text();
 				const $ = cheerio.load(html, { xml: true });
 
 				const $svg = $('svg');
@@ -125,8 +124,8 @@ describe('astro:assets - SVG Components', () => {
 				assert.equal($path.length > 0, true);
 			});
 			it('Adds the <svg> tag that applies props', async () => {
-				let res = await fixture.fetch('/blog/props');
-				let html = await res.text();
+				const res = await fixture.fetch('/blog/props');
+				const html = await res.text();
 				const $ = cheerio.load(html, { xml: true });
 
 				const $svg = $('svg');
@@ -141,8 +140,8 @@ describe('astro:assets - SVG Components', () => {
 
 		describe('metadata', () => {
 			it('returns a serializable metadata object', async () => {
-				let res = await fixture.fetch('/serialize.json');
-				let json = await res.json();
+				const res = await fixture.fetch('/serialize.json');
+				const json = await res.json();
 				assert.equal(json.image.format, 'svg');
 				assert.equal(json.image.width, 85);
 				assert.equal(json.image.height, 107);
@@ -152,10 +151,8 @@ describe('astro:assets - SVG Components', () => {
 	});
 
 	describe('SVGO optimization', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let optimizedFixture;
-		/** @type {import('./test-utils').DevServer} */
-		let optimizedDevServer;
+		let optimizedFixture: Fixture;
+		let optimizedDevServer: DevServer;
 
 		before(async () => {
 			optimizedFixture = await loadFixture({
@@ -166,7 +163,6 @@ describe('astro:assets - SVG Components', () => {
 							'preset-default',
 							{
 								name: 'removeViewBox',
-								active: false,
 							},
 						],
 					},
@@ -181,11 +177,11 @@ describe('astro:assets - SVG Components', () => {
 		});
 
 		describe('with optimization enabled', () => {
-			let $;
-			let html;
+			let $: cheerio.CheerioAPI;
+			let html: string;
 
 			before(async () => {
-				let res = await optimizedFixture.fetch('/optimized');
+				const res = await optimizedFixture.fetch('/optimized');
 				html = await res.text();
 				$ = cheerio.load(html, { xml: true });
 			});

--- a/packages/astro/test/core-image-unconventional-settings.test.ts
+++ b/packages/astro/test/core-image-unconventional-settings.test.ts
@@ -3,14 +3,9 @@ import { describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 
 import { testImageService } from './test-image-service.js';
-import { loadFixture } from './test-utils.js';
+import { type AstroInlineConfig, type Fixture, loadFixture } from './test-utils.js';
 
-/**
- ** @typedef {import('../src/types/public/config.js').AstroInlineConfig & { root?: string | URL }} AstroInlineConfig
- */
-
-/** @type {AstroInlineConfig} */
-const defaultSettings = {
+const defaultSettings: AstroInlineConfig = {
 	root: './fixtures/core-image-unconventional-settings/',
 	image: {
 		service: testImageService(),
@@ -18,8 +13,7 @@ const defaultSettings = {
 };
 
 describe('astro:assets - Support unconventional build settings properly', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	it('supports assetsPrefix', async () => {
 		fixture = await loadFixture({
@@ -32,26 +26,24 @@ describe('astro:assets - Support unconventional build settings properly', () => 
 
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		const src = $('#walrus-img').attr('src');
+		const src = $('#walrus-img').attr('src')!;
 		assert.equal(src.startsWith('https://cdn.example.com/'), true);
 
-		const data = await fixture.readFile(src.replace('https://cdn.example.com/', ''), null);
+		const data = await fixture.readBuffer(src.replace('https://cdn.example.com/', ''));
 		assert.equal(data instanceof Buffer, true);
 	});
 
 	it('supports base', async () => {
 		fixture = await loadFixture({
 			...defaultSettings,
-			build: {
-				base: '/subdir/',
-			},
+			base: '/subdir/',
 		});
 		await fixture.build();
 
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		const src = $('#walrus-img').attr('src');
-		const data = await fixture.readFile(src.replace('/subdir/', ''), null);
+		const src = $('#walrus-img').attr('src')!;
+		const data = await fixture.readBuffer(src.replace('/subdir/', ''));
 		assert.equal(data instanceof Buffer, true);
 	});
 
@@ -59,19 +51,19 @@ describe('astro:assets - Support unconventional build settings properly', () => 
 	it('supports assetsPrefix + base', async () => {
 		fixture = await loadFixture({
 			...defaultSettings,
+			base: '/subdir/',
 			build: {
 				assetsPrefix: 'https://cdn.example.com/',
-				base: '/subdir/',
 			},
 		});
 		await fixture.build();
 
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		const src = $('#walrus-img').attr('src');
+		const src = $('#walrus-img').attr('src')!;
 		assert.equal(src.startsWith('https://cdn.example.com/'), true);
 
-		const data = await fixture.readFile(src.replace('https://cdn.example.com/', ''), null);
+		const data = await fixture.readBuffer(src.replace('https://cdn.example.com/', ''));
 		assert.equal(data instanceof Buffer, true);
 	});
 
@@ -87,11 +79,11 @@ describe('astro:assets - Support unconventional build settings properly', () => 
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
 
-		const unoptimizedSrc = $('#walrus-img-unoptimized').attr('src');
+		const unoptimizedSrc = $('#walrus-img-unoptimized').attr('src')!;
 		assert.equal(unoptimizedSrc.startsWith('/assets/'), true);
 
-		const src = $('#walrus-img').attr('src');
-		const data = await fixture.readFile(src, null);
+		const src = $('#walrus-img').attr('src')!;
+		const data = await fixture.readBuffer(src);
 
 		assert.equal(data instanceof Buffer, true);
 	});
@@ -123,8 +115,8 @@ describe('astro:assets - Support unconventional build settings properly', () => 
 		const unoptimizedSrc = $('#walrus-img-unoptimized').attr('src');
 		assert.equal(unoptimizedSrc, '/images/hello_light_walrus.avif');
 
-		const src = $('#walrus-img').attr('src');
-		const data = await fixture.readFile(src, null);
+		const src = $('#walrus-img').attr('src')!;
+		const data = await fixture.readBuffer(src);
 
 		assert.equal(data instanceof Buffer, true);
 	});
@@ -153,12 +145,12 @@ describe('astro:assets - Support unconventional build settings properly', () => 
 
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		const unoptimizedSrc = $('#walrus-img-unoptimized').attr('src');
-		const originalData = await fixture.readFile(unoptimizedSrc, null);
+		const unoptimizedSrc = $('#walrus-img-unoptimized').attr('src')!;
+		const originalData = await fixture.readBuffer(unoptimizedSrc);
 		assert.equal(originalData instanceof Buffer, true);
 
-		const src = $('#walrus-img').attr('src');
-		const data = await fixture.readFile(src, null);
+		const src = $('#walrus-img').attr('src')!;
+		const data = await fixture.readBuffer(src);
 
 		assert.equal(data instanceof Buffer, true);
 	});
@@ -188,19 +180,18 @@ describe('astro:assets - Support unconventional build settings properly', () => 
 
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		const unoptimizedSrc = $('#walrus-img-unoptimized').attr('src');
+		const unoptimizedSrc = $('#walrus-img-unoptimized').attr('src')!;
 		assert.equal(unoptimizedSrc, 'https://cdn.example.com/images/hello_light_walrus.avif');
 
-		const unoptimizedData = await fixture.readFile(
+		const unoptimizedData = await fixture.readBuffer(
 			unoptimizedSrc.replace('https://cdn.example.com/', ''),
-			null,
 		);
 		assert.equal(unoptimizedData instanceof Buffer, true);
 
-		const src = $('#walrus-img').attr('src');
+		const src = $('#walrus-img').attr('src')!;
 		assert.equal(src.startsWith('https://cdn.example.com/'), true);
 
-		const data = await fixture.readFile(src.replace('https://cdn.example.com/', ''), null);
+		const data = await fixture.readBuffer(src.replace('https://cdn.example.com/', ''));
 		assert.equal(data instanceof Buffer, true);
 	});
 });

--- a/packages/astro/test/core-image.test.ts
+++ b/packages/astro/test/core-image.test.ts
@@ -6,24 +6,19 @@ import { after, afterEach, before, describe, it } from 'node:test';
 import { removeDir } from '@astrojs/internal-helpers/fs';
 import * as cheerio from 'cheerio';
 import parseSrcset from 'parse-srcset';
-import { AstroLogger } from '../dist/core/logger/core.js';
+import { AstroLogger, type AstroLogMessage } from '../dist/core/logger/core.js';
 import testAdapter from './test-adapter.js';
 import { testImageService } from './test-image-service.js';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('astro:image', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	describe('dev', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
-		/** @type {import('node:http').Server | undefined} */
-		let redirectServer;
-		/** @type {string | undefined} */
-		let redirectUrl;
+		let devServer: DevServer;
+		const logs: Array<AstroLogMessage> = [];
+		let redirectServer: import('node:http').Server | undefined;
+		let redirectUrl: string | undefined;
 
 		before(async () => {
 			redirectServer = createServer((req, res) => {
@@ -38,7 +33,7 @@ describe('astro:image', () => {
 				res.end();
 			});
 
-			await new Promise((resolve) => redirectServer.listen(0, '127.0.0.1', resolve));
+			await new Promise<void>((resolve) => redirectServer!.listen(0, '127.0.0.1', () => resolve()));
 			const address = redirectServer.address();
 			if (address && typeof address === 'object') {
 				redirectUrl = `http://127.0.0.1:${address.port}/redirect`;
@@ -66,30 +61,32 @@ describe('astro:image', () => {
 				},
 			});
 
-			devServer = await fixture.startDevServer({
-				logger: new AstroLogger({
-					level: 'error',
-					destination: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
+			const logger = new AstroLogger({
+				level: 'error',
+				destination: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						logs.push(event);
+						callback();
+					},
 				}),
+			});
+			devServer = await fixture.startDevServer({
+				// @ts-expect-error: `logger` is an internal API
+				logger,
 			});
 		});
 
 		after(async () => {
 			await devServer.stop();
 			if (redirectServer) {
-				await new Promise((resolve) => redirectServer.close(resolve));
+				await new Promise<void>((resolve) => redirectServer!.close(() => resolve()));
 			}
 		});
 
 		describe('basics', () => {
-			let $;
-			let body;
+			let $: cheerio.CheerioAPI;
+			let body: string;
 			before(async () => {
 				let res = await fixture.fetch('/');
 				body = await res.text();
@@ -99,7 +96,7 @@ describe('astro:image', () => {
 			it('Adds the <img> tag', () => {
 				let $img = $('#local img');
 				assert.equal($img.length, 1);
-				assert.equal($img.attr('src').startsWith('/_image'), true);
+				assert.equal($img.attr('src')!.startsWith('/_image'), true);
 			});
 
 			it('does not inject responsive image styles when not enabled', () => {
@@ -142,14 +139,14 @@ describe('astro:image', () => {
 
 			it('middleware loads the file', async () => {
 				let $img = $('#local img');
-				let src = $img.attr('src');
+				let src = $img.attr('src')!;
 				let res = await fixture.fetch(src);
 				assert.equal(res.status, 200);
 			});
 
 			it('returns proper content-type', async () => {
 				let $img = $('#local img');
-				let src = $img.attr('src');
+				let src = $img.attr('src')!;
 				let res = await fixture.fetch(src);
 				assert.equal(res.headers.get('content-type'), 'image/webp');
 			});
@@ -169,7 +166,7 @@ describe('astro:image', () => {
 				let $img = $('img');
 				assert.equal($img.length, 1);
 
-				let src = $img.attr('src');
+				let src = $img.attr('src')!;
 				res = await fixture.fetch(src);
 				assert.equal(res.status, 200);
 			});
@@ -215,7 +212,7 @@ describe('astro:image', () => {
 				let $img = $('img');
 				assert.equal($img.length, 1);
 
-				let src = $img.attr('src');
+				let src = $img.attr('src')!;
 				res = await fixture.fetch(src);
 				assert.equal(res.status, 200);
 			});
@@ -228,7 +225,7 @@ describe('astro:image', () => {
 				let $img = $('img');
 				assert.equal($img.length, 1);
 
-				let src = $img.attr('src');
+				let src = $img.attr('src')!;
 				let loading = $img.attr('loading');
 				res = await fixture.fetch(src);
 				assert.equal(res.status, 200);
@@ -243,7 +240,7 @@ describe('astro:image', () => {
 				let $img = $('img');
 				assert.equal($img.length, 1);
 
-				let src = $img.attr('src');
+				let src = $img.attr('src')!;
 				res = await fixture.fetch(src);
 				assert.equal(res.status, 200);
 				assert.equal(res.headers.get('content-type'), 'image/avif');
@@ -258,7 +255,7 @@ describe('astro:image', () => {
 				let $img = $('#picture-fallback img');
 				assert.equal($img.length, 1);
 
-				const imageURL = new URL($img.attr('src'), 'http://localhost');
+				const imageURL = new URL($img.attr('src')!, 'http://localhost');
 				assert.equal(imageURL.searchParams.get('f'), 'jpeg');
 				assert.equal($img.attr('fallbackformat'), undefined);
 
@@ -270,7 +267,7 @@ describe('astro:image', () => {
 				assert.equal($picture.length, 1);
 				assert.equal($source.length, 2);
 
-				const srcset = parseSrcset($source.attr('srcset'));
+				const srcset = parseSrcset($source.attr('srcset')!);
 				assert.equal(
 					srcset.every((src) => src.url.startsWith('/_image')),
 					true,
@@ -292,7 +289,7 @@ describe('astro:image', () => {
 					'(max-width: 448px) 400px, (max-width: 810px) 750px, 1050px',
 				);
 
-				const srcset2 = parseSrcset($source.attr('srcset'));
+				const srcset2 = parseSrcset($source.attr('srcset')!);
 				assert.equal(
 					srcset2.every((src) => src.url.startsWith('/_image')),
 					true,
@@ -313,8 +310,8 @@ describe('astro:image', () => {
 				];
 
 				const $sources = $('#picture-mime-types picture source');
-				for ($source of $sources) {
-					const type = $source.attribs.type;
+				for (const sourceEl of $sources) {
+					const type = sourceEl.attribs.type;
 					assert.equal(
 						validMimeTypes.includes(type),
 						true,
@@ -330,10 +327,10 @@ describe('astro:image', () => {
 
 				// Should have scoped attribute
 				let $picture = $('#picture-attributes picture');
-				assert.ok(Object.keys($picture.attr()).find((a) => a.startsWith('data-astro-cid-')));
+				assert.ok(Object.keys($picture.attr()!).find((a) => a.startsWith('data-astro-cid-')));
 
 				let $img = $('#picture-attributes img');
-				assert.ok(Object.keys($img.attr()).find((a) => a.startsWith('data-astro-cid-')));
+				assert.ok(Object.keys($img.attr()!).find((a) => a.startsWith('data-astro-cid-')));
 			});
 
 			it('properly deduplicate srcset images', async () => {
@@ -344,7 +341,7 @@ describe('astro:image', () => {
 				let localImage = $('#local-3-images img');
 				assert.equal(
 					new Set([
-						...parseSrcset(localImage.attr('srcset')).map((src) => src.url),
+						...parseSrcset(localImage.attr('srcset')!).map((src) => src.url),
 						localImage.attr('src'),
 					]).size,
 					3,
@@ -353,7 +350,7 @@ describe('astro:image', () => {
 				let remoteImage = $('#remote-3-images img');
 				assert.equal(
 					new Set([
-						...parseSrcset(remoteImage.attr('srcset')).map((src) => src.url),
+						...parseSrcset(remoteImage.attr('srcset')!).map((src) => src.url),
 						remoteImage.attr('src'),
 					]).size,
 					3,
@@ -362,7 +359,7 @@ describe('astro:image', () => {
 				let local1x = $('#local-1x img');
 				assert.equal(
 					new Set([
-						...parseSrcset(local1x.attr('srcset')).map((src) => src.url),
+						...parseSrcset(local1x.attr('srcset')!).map((src) => src.url),
 						local1x.attr('src'),
 					]).size,
 					1,
@@ -371,7 +368,7 @@ describe('astro:image', () => {
 				let remote1x = $('#remote-1x img');
 				assert.equal(
 					new Set([
-						...parseSrcset(remote1x.attr('srcset')).map((src) => src.url),
+						...parseSrcset(remote1x.attr('srcset')!).map((src) => src.url),
 						remote1x.attr('src'),
 					]).size,
 					1,
@@ -380,7 +377,7 @@ describe('astro:image', () => {
 				let local2Widths = $('#local-2-widths img');
 				assert.equal(
 					new Set([
-						...parseSrcset(local2Widths.attr('srcset')).map((src) => src.url),
+						...parseSrcset(local2Widths.attr('srcset')!).map((src) => src.url),
 						local2Widths.attr('src'),
 					]).size,
 					2,
@@ -389,7 +386,7 @@ describe('astro:image', () => {
 				let remote2Widths = $('#remote-2-widths img');
 				assert.equal(
 					new Set([
-						...parseSrcset(remote2Widths.attr('srcset')).map((src) => src.url),
+						...parseSrcset(remote2Widths.attr('srcset')!).map((src) => src.url),
 						remote2Widths.attr('src'),
 					]).size,
 					2,
@@ -405,13 +402,13 @@ describe('astro:image', () => {
 				const originalHeight = 400;
 				const local2xOriginalWH = $('#local-2x-original-wh img');
 
-				const srcURL = new URL(local2xOriginalWH.attr('src'), 'http://localhost');
+				const srcURL = new URL(local2xOriginalWH.attr('src')!, 'http://localhost');
 				const srcParams = srcURL.searchParams;
 				assert.equal(srcParams.get('w'), (originalWidth / 2).toString());
 				assert.equal(srcParams.get('h'), (originalHeight / 2).toString());
 				assert.equal(srcParams.get('f'), 'webp');
 
-				const parsedSrcsets = parseSrcset(local2xOriginalWH.attr('srcset'));
+				const parsedSrcsets = parseSrcset(local2xOriginalWH.attr('srcset')!);
 				const srcset2x = parsedSrcsets.find((a) => a.d === 2);
 				assert(srcset2x);
 				const srcset2xURL = new URL(srcset2x.url, 'http://localhost');
@@ -430,13 +427,13 @@ describe('astro:image', () => {
 				const originalHeight = 400;
 				const local2xOriginalWHF = $('#local-2x-original-whf img');
 
-				const srcURL = new URL(local2xOriginalWHF.attr('src'), 'http://localhost');
+				const srcURL = new URL(local2xOriginalWHF.attr('src')!, 'http://localhost');
 				const srcParams = srcURL.searchParams;
 				assert.equal(srcParams.get('w'), (originalWidth / 2).toString());
 				assert.equal(srcParams.get('h'), (originalHeight / 2).toString());
 				assert.equal(srcParams.get('f'), 'jpg');
 
-				const parsedSrcsets = parseSrcset(local2xOriginalWHF.attr('srcset'));
+				const parsedSrcsets = parseSrcset(local2xOriginalWHF.attr('srcset')!);
 				const srcset2x = parsedSrcsets.find((a) => a.d === 2);
 				assert(srcset2x);
 				const srcset2xURL = new URL(srcset2x.url, 'http://localhost');
@@ -448,10 +445,7 @@ describe('astro:image', () => {
 		});
 
 		describe('vite-isms', () => {
-			/**
-			 * @type {cheerio.CheerioAPI}
-			 */
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
 				let res = await fixture.fetch('/vite');
 				let html = await res.text();
@@ -476,7 +470,7 @@ describe('astro:image', () => {
 
 		describe('remote', () => {
 			describe('working', () => {
-				let $;
+				let $: cheerio.CheerioAPI;
 				before(async () => {
 					let res = await fixture.fetch('/');
 					let html = await res.text();
@@ -486,7 +480,7 @@ describe('astro:image', () => {
 				it('has proper link and works', async () => {
 					let $img = $('#remote img');
 
-					let src = $img.attr('src');
+					let src = $img.attr('src')!;
 					assert.ok(src.startsWith('/_image?'));
 					const imageRequest = await fixture.fetch(src);
 					assert.equal(imageRequest.status, 200);
@@ -511,7 +505,7 @@ describe('astro:image', () => {
 
 				it('support data: URI', () => {
 					let $img = $('#data-uri img');
-					assert.ok($img.attr('src').startsWith('/_image?href=data'));
+					assert.ok($img.attr('src')!.startsWith('/_image?href=data'));
 					assert.ok($img.attr('width'));
 					assert.ok($img.attr('height'));
 				});
@@ -574,12 +568,12 @@ describe('astro:image', () => {
 
 				let $img = $('img');
 				assert.equal($img.length, 1);
-				assert.equal($img.attr('src').includes('penguin1.jpg'), true);
+				assert.equal($img.attr('src')!.includes('penguin1.jpg'), true);
 			});
 		});
 
 		describe('markdown', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
 				let res = await fixture.fetch('/post');
 				let html = await res.text();
@@ -592,7 +586,7 @@ describe('astro:image', () => {
 
 				// Verbose test for the full URL to make sure the image went through the full pipeline
 				assert.equal(
-					$img.attr('src').startsWith('/_image') && $img.attr('src').endsWith('f=webp'),
+					$img.attr('src')!.startsWith('/_image') && $img.attr('src')!.endsWith('f=webp'),
 					true,
 				);
 			});
@@ -609,7 +603,7 @@ describe('astro:image', () => {
 				$ = cheerio.load(html);
 
 				let $img = $('img');
-				assert.equal($img.attr('src').startsWith('/_image'), true);
+				assert.equal($img.attr('src')!.startsWith('/_image'), true);
 			});
 
 			it('Supports special characters in file name', async () => {
@@ -639,7 +633,7 @@ describe('astro:image', () => {
 		});
 
 		describe('getImage', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
 				let res = await fixture.fetch('/get-image');
 				let html = await res.text();
@@ -649,7 +643,7 @@ describe('astro:image', () => {
 			it('Adds the <img> tag', () => {
 				let $img = $('img');
 				assert.equal($img.length, 1);
-				assert.equal($img.attr('src').startsWith('/_image'), true);
+				assert.equal($img.attr('src')!.startsWith('/_image'), true);
 			});
 
 			it('includes the provided alt', () => {
@@ -659,7 +653,7 @@ describe('astro:image', () => {
 		});
 
 		describe('content collections', () => {
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
 				let res = await fixture.fetch('/blog/one');
 				let html = await res.text();
@@ -674,19 +668,21 @@ describe('astro:image', () => {
 			it('image in cc folder is processed', () => {
 				let $imgs = $('img');
 				let $blogfolderimg = $($imgs[6]);
-				assert.equal($blogfolderimg.attr('src').includes('blogfolder.jpg'), true);
-				assert.equal($blogfolderimg.attr('src').endsWith('f=webp'), true);
+				assert.equal($blogfolderimg.attr('src')!.includes('blogfolder.jpg'), true);
+				assert.equal($blogfolderimg.attr('src')!.endsWith('f=webp'), true);
 			});
 
 			it('has proper source for directly used image', () => {
 				let $img = $('#direct-image img');
-				assert.equal($img.attr('src').startsWith('/'), true);
+				assert.equal($img.attr('src')!.startsWith('/'), true);
 			});
 
 			it('has proper sources for array of images', () => {
-				let $img = $('#array-of-images img');
-				const imgsSrcs = [];
-				$img.each((_i, img) => imgsSrcs.push(img.attribs['src']));
+				const $img = $('#array-of-images img');
+				const imgsSrcs: string[] = [];
+				$img.each((_i, img) => {
+					imgsSrcs.push(img.attribs['src']);
+				});
 				assert.equal($img.length, 2);
 				assert.equal(
 					imgsSrcs.every((img) => img.startsWith('/')),
@@ -696,14 +692,14 @@ describe('astro:image', () => {
 
 			it('has proper attributes for optimized image through getImage', () => {
 				let $img = $('#optimized-image-get-image img');
-				assert.equal($img.attr('src').startsWith('/_image'), true);
+				assert.equal($img.attr('src')!.startsWith('/_image'), true);
 				assert.equal($img.attr('width'), '207');
 				assert.equal($img.attr('height'), '243');
 			});
 
 			it('has proper attributes for optimized image through Image component', () => {
 				let $img = $('#optimized-image-component img');
-				assert.equal($img.attr('src').startsWith('/_image'), true);
+				assert.equal($img.attr('src')!.startsWith('/_image'), true);
 				assert.equal($img.attr('width'), '207');
 				assert.equal($img.attr('height'), '243');
 				assert.equal($img.attr('alt'), 'A penguin!');
@@ -711,13 +707,12 @@ describe('astro:image', () => {
 
 			it('properly handles nested images', () => {
 				let $img = $('#nested-image img');
-				assert.equal($img.attr('src').startsWith('/'), true);
+				assert.equal($img.attr('src')!.startsWith('/'), true);
 			});
 		});
 
 		describe('regular img tag', () => {
-			/** @type {ReturnType<import('cheerio')['load']>} */
-			let $;
+			let $: cheerio.CheerioAPI;
 			before(async () => {
 				let res = await fixture.fetch('/regular-img');
 				let html = await res.text();
@@ -725,11 +720,11 @@ describe('astro:image', () => {
 			});
 
 			it('does not have a file url', async () => {
-				assert.equal($('img').attr('src').startsWith('file://'), false);
+				assert.equal($('img').attr('src')!.startsWith('file://'), false);
 			});
 
 			it('includes /src in the path', async () => {
-				assert.equal($('img').attr('src').includes('/src'), true);
+				assert.equal($('img').attr('src')!.includes('/src'), true);
 			});
 		});
 
@@ -760,17 +755,15 @@ describe('astro:image', () => {
 		});
 
 		describe('custom endpoint', async () => {
-			/** @type {import('./test-utils').DevServer} */
-			let customEndpointDevServer;
+			let customEndpointDevServer: DevServer;
 
-			/** @type {import('./test-utils.js').Fixture} */
-			let customEndpointFixture;
+			let customEndpointFixture: Fixture;
 
 			before(async () => {
 				customEndpointFixture = await loadFixture({
 					root: './fixtures/core-image/',
 					image: {
-						endpoint: { entrypoint: './src/custom-endpoint.ts' },
+						endpoint: { route: '/_image', entrypoint: './src/custom-endpoint.ts' },
 						service: testImageService({ foo: 'bar' }),
 						domains: ['avatars.githubusercontent.com'],
 					},
@@ -786,7 +779,7 @@ describe('astro:image', () => {
 				const html = await response.text();
 
 				const $ = cheerio.load(html);
-				const src = $('#local img').attr('src');
+				const src = $('#local img').attr('src')!;
 
 				let res = await customEndpointFixture.fetch(src);
 				assert.equal(res.status, 200);
@@ -803,10 +796,8 @@ describe('astro:image', () => {
 	});
 
 	describe('proper errors', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
+		let devServer: DevServer;
+		const logs: Array<AstroLogMessage> = [];
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -816,17 +807,19 @@ describe('astro:image', () => {
 				},
 			});
 
-			devServer = await fixture.startDevServer({
-				logger: new AstroLogger({
-					level: 'error',
-					destination: new Writable({
-						objectMode: true,
-						write(event, _, callback) {
-							logs.push(event);
-							callback();
-						},
-					}),
+			const logger = new AstroLogger({
+				level: 'error',
+				destination: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						logs.push(event);
+						callback();
+					},
 				}),
+			});
+			devServer = await fixture.startDevServer({
+				// @ts-expect-error: `logger` is an internal API
+				logger,
 			});
 		});
 
@@ -905,7 +898,7 @@ describe('astro:image', () => {
 		it('has base path prefix when using the Image component', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			const src = $('#local img').attr('src');
+			const src = $('#local img').attr('src')!;
 			assert.equal(src.length > 0, true);
 			assert.equal(src.startsWith('/blog'), true);
 		});
@@ -913,7 +906,7 @@ describe('astro:image', () => {
 		it('has base path prefix when using getImage', async () => {
 			const html = await fixture.readFile('/get-image/index.html');
 			const $ = cheerio.load(html);
-			const src = $('img').attr('src');
+			const src = $('img').attr('src')!;
 			assert.equal(src.length > 0, true);
 			assert.equal(src.startsWith('/blog'), true);
 		});
@@ -921,7 +914,7 @@ describe('astro:image', () => {
 		it('has base path prefix when using image directly', async () => {
 			const html = await fixture.readFile('/direct/index.html');
 			const $ = cheerio.load(html);
-			const src = $('img').attr('src');
+			const src = $('img').attr('src')!;
 			assert.equal(src.length > 0, true);
 			assert.equal(src.startsWith('/blog'), true);
 		});
@@ -929,7 +922,7 @@ describe('astro:image', () => {
 		it('has base path prefix in Markdown', async () => {
 			const html = await fixture.readFile('/post/index.html');
 			const $ = cheerio.load(html);
-			const src = $('img').attr('src');
+			const src = $('img').attr('src')!;
 			assert.equal(src.length > 0, true);
 			assert.equal(src.startsWith('/blog'), true);
 		});
@@ -937,7 +930,7 @@ describe('astro:image', () => {
 		it('has base path prefix in Content Collection frontmatter', async () => {
 			const html = await fixture.readFile('/blog/one/index.html');
 			const $ = cheerio.load(html);
-			const src = $('img').attr('src');
+			const src = $('img').attr('src')!;
 			assert.equal(src.length > 0, true);
 			assert.equal(src.startsWith('/blog'), true);
 		});
@@ -950,6 +943,7 @@ describe('astro:image', () => {
 				adapter: testAdapter(),
 				image: {
 					endpoint: {
+						route: '/_image',
 						entrypoint: 'astro/assets/endpoint/node',
 					},
 					service: testImageService(),
@@ -963,7 +957,7 @@ describe('astro:image', () => {
 			assert.equal(response.status, 200);
 			const html = await response.text();
 			const $ = cheerio.load(html);
-			const src = $('#local img').attr('src');
+			const src = $('#local img').attr('src')!;
 			assert.equal(src.startsWith('/blog'), true);
 			const img = await app.render(new Request(`https://example.com${src}`));
 			assert.equal(img.status, 200);
@@ -1012,25 +1006,25 @@ describe('astro:image', () => {
 		it('writes out images to dist folder', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			const src = $('#local img').attr('src');
+			const src = $('#local img').attr('src')!;
 			assert.equal(src.length > 0, true);
-			const data = await fixture.readFile(src, null);
+			const data = await fixture.readBuffer(src);
 			assert.equal(data instanceof Buffer, true);
 		});
 
 		it('writes out allowed remote images', async () => {
 			const html = await fixture.readFile('/remote/index.html');
 			const $ = cheerio.load(html);
-			const src = $('#remote img').attr('src');
+			const src = $('#remote img').attr('src')!;
 			assert.equal(src.length > 0, true);
-			const data = await fixture.readFile(src, null);
+			const data = await fixture.readBuffer(src);
 			assert.equal(data instanceof Buffer, true);
 		});
 
 		it('writes out images to dist folder with proper extension if no format was passed', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			const src = $('#local img').attr('src');
+			const src = $('#local img').attr('src')!;
 			assert.equal(src.endsWith('.webp'), true);
 		});
 
@@ -1044,8 +1038,8 @@ describe('astro:image', () => {
 			assert.equal($img.attr('alt'), 'a penguin');
 
 			// image itself
-			const src = $img.attr('src');
-			const data = await fixture.readFile(src, null);
+			const src = $img.attr('src')!;
+			const data = await fixture.readBuffer(src);
 			assert.equal(data instanceof Buffer, true);
 		});
 
@@ -1054,10 +1048,10 @@ describe('astro:image', () => {
 			const $ = cheerio.load(html);
 			const $img = $('img');
 			assert.equal($img.length, 1);
-			const src = $img.attr('src');
+			const src = $img.attr('src')!;
 			// The filename should be encoded and sanitized
 			assert.ok(src.startsWith('/_astro/c_23'));
-			const data = await fixture.readFile(src, null);
+			const data = await fixture.readBuffer(src);
 			assert.ok(data instanceof Buffer);
 		});
 
@@ -1070,10 +1064,10 @@ describe('astro:image', () => {
 			assert.equal($img.length, 1);
 			assert.equal($source.length, 2);
 
-			const srcset = parseSrcset($source.attr('srcset'));
+			const srcset = parseSrcset($source.attr('srcset')!);
 			let hasExistingSrc = await Promise.all(
 				srcset.map(async (src) => {
-					const data = await fixture.readFile(src.url, null);
+					const data = await fixture.readBuffer(src.url);
 					return data instanceof Buffer;
 				}),
 			);
@@ -1094,8 +1088,8 @@ describe('astro:image', () => {
 			assert.equal($img.attr('alt'), 'My article cover');
 
 			// image itself
-			const src = $img.attr('src');
-			const data = await fixture.readFile(src, null);
+			const src = $img.attr('src')!;
+			const data = await fixture.readBuffer(src);
 			assert.equal(data instanceof Buffer, true);
 		});
 
@@ -1110,8 +1104,8 @@ describe('astro:image', () => {
 			assert.equal($img.attr('alt'), 'A penguin!');
 
 			// image itself
-			const src = $img.attr('src');
-			const data = await fixture.readFile(src, null);
+			const src = $img.attr('src')!;
+			const data = await fixture.readBuffer(src);
 			assert.equal(data instanceof Buffer, true);
 		});
 
@@ -1126,8 +1120,8 @@ describe('astro:image', () => {
 			assert.equal($img.attr('alt'), 'A penguin');
 
 			// image itself
-			const src = $img.attr('src');
-			const data = await fixture.readFile(src, null);
+			const src = $img.attr('src')!;
+			const data = await fixture.readBuffer(src);
 			assert.equal(data instanceof Buffer, true);
 		});
 
@@ -1138,12 +1132,12 @@ describe('astro:image', () => {
 			let $img = $('img');
 			assert.equal($img.length, 2);
 
-			const srcdirect = $('#direct-image img').attr('src');
-			const datadirect = await fixture.readFile(srcdirect, null);
+			const srcdirect = $('#direct-image img').attr('src')!;
+			const datadirect = await fixture.readBuffer(srcdirect);
 			assert.equal(datadirect instanceof Buffer, true);
 
-			const srcnested = $('#nested-image img').attr('src');
-			const datanested = await fixture.readFile(srcnested, null);
+			const srcnested = $('#nested-image img').attr('src')!;
+			const datanested = await fixture.readBuffer(srcnested);
 			assert.equal(datanested instanceof Buffer, true);
 		});
 
@@ -1177,18 +1171,20 @@ describe('astro:image', () => {
 		});
 
 		it('uses cache entries', async () => {
-			const logs = [];
+			const logs: Array<AstroLogMessage> = [];
 
-			await fixture.build({
-				logger: new AstroLogger({
-					destination: {
-						write(chunk) {
-							logs.push(chunk);
-							return true;
-						},
+			const logger = new AstroLogger({
+				destination: {
+					write(chunk) {
+						logs.push(chunk);
+						return true;
 					},
-					level: 'info',
-				}),
+				},
+				level: 'info',
+			});
+			await fixture.build({
+				// @ts-expect-error: `logger` is an internal API
+				logger,
 			});
 			const generatingImageIndex = logs.findIndex((logLine) =>
 				logLine.message?.includes('generating optimized images'),
@@ -1208,8 +1204,8 @@ describe('astro:image', () => {
 			const html = await fixture.readFile('/remote/index.html');
 			const $ = cheerio.load(html);
 			const metaSrc =
-				'../node_modules/.astro/assets/' + basename($('#remote img').attr('src')) + '.json';
-			const data = await fixture.readFile(metaSrc, null);
+				'../node_modules/.astro/assets/' + basename($('#remote img').attr('src')!) + '.json';
+			const data = await fixture.readBuffer(metaSrc);
 			assert.equal(data instanceof Buffer, true);
 			const metadata = JSON.parse(data.toString());
 			assert.equal(typeof metadata.expires, 'number');
@@ -1222,19 +1218,19 @@ describe('astro:image', () => {
 
 			// Find image
 			const regex = /src:"([^"]*)/;
-			const imageSrc = regex.exec($script.html())[1];
-			const data = await fixture.readFile(imageSrc, null);
+			const imageSrc = regex.exec($script.html()!)![1];
+			const data = await fixture.readBuffer(imageSrc);
 			assert.equal(data instanceof Buffer, true);
 		});
 
 		it('client images srcset parsed correctly', async () => {
 			const html = await fixture.readFile('/srcset/index.html');
 			const $ = cheerio.load(html);
-			const srcset = $('#local-2-widths-with-spaces img').attr('srcset');
+			const srcset = $('#local-2-widths-with-spaces img').attr('srcset')!;
 
 			// Find image
 			const regex = /^(.+?) \d+[wx]$/m;
-			const imageSrcset = regex.exec(srcset)[1];
+			const imageSrcset = regex.exec(srcset)![1];
 			assert.notEqual(imageSrcset.includes(' '), true);
 		});
 
@@ -1242,7 +1238,7 @@ describe('astro:image', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 			const img = $('#encoded-chars img');
-			const src = img.attr('src');
+			const src = img.attr('src')!;
 			const data = await fixture.readFile(src);
 			assert.notEqual(data, undefined);
 		});
@@ -1277,8 +1273,7 @@ describe('astro:image', () => {
 	});
 
 	describe('dev ssr', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
+		let devServer: DevServer;
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/core-image-ssr/',
@@ -1341,7 +1336,7 @@ describe('astro:image', () => {
 				outDir: './dist/server-prod',
 				adapter: testAdapter(),
 				image: {
-					endpoint: { entrypoint: 'astro/assets/endpoint/node' },
+					endpoint: { route: '/_image', entrypoint: 'astro/assets/endpoint/node' },
 					service: testImageService(),
 				},
 			});
@@ -1355,7 +1350,7 @@ describe('astro:image', () => {
 			assert.equal(response.status, 200);
 			const html = await response.text();
 			const $ = cheerio.load(html);
-			const src = $('#local img').attr('src');
+			const src = $('#local img').attr('src')!;
 			request = new Request('http://example.com' + src);
 			response = await app.render(request);
 			assert.equal(response.status, 200);
@@ -1469,8 +1464,8 @@ describe('astro:image', () => {
 		it('prerendered routes images are built', async () => {
 			const html = await fixture.readFile('/client/prerender/index.html');
 			const $ = cheerio.load(html);
-			const src = $('img').attr('src');
-			const imgData = await fixture.readFile('/client' + src, null);
+			const src = $('img').attr('src')!;
+			const imgData = await fixture.readBuffer('/client' + src);
 			assert.equal(imgData instanceof Buffer, true);
 		});
 
@@ -1505,7 +1500,7 @@ describe('astro:image', () => {
 				outDir: './dist/server-prod-svg-validation',
 				adapter: testAdapter(),
 				image: {
-					endpoint: { entrypoint: 'astro/assets/endpoint/node' },
+					endpoint: { route: '/_image', entrypoint: 'astro/assets/endpoint/node' },
 					service: testImageService(),
 					remotePatterns: [{ protocol: 'data' }],
 				},
@@ -1551,8 +1546,7 @@ describe('astro:image', () => {
 	});
 
 	describe('trailing slash on the endpoint', () => {
-		/** @type {import('./test-utils').DevServer} */
-		let devServer;
+		let devServer: DevServer;
 
 		it('includes a trailing slash if trailing slash is set to always', async () => {
 			fixture = await loadFixture({
@@ -1568,7 +1562,7 @@ describe('astro:image', () => {
 			let html = await res.text();
 
 			const $ = cheerio.load(html);
-			const src = $('#local img').attr('src');
+			const src = $('#local img').attr('src')!;
 
 			assert.equal(src.startsWith('/_image/?'), true);
 		});
@@ -1587,7 +1581,7 @@ describe('astro:image', () => {
 			let html = await res.text();
 
 			const $ = cheerio.load(html);
-			const src = $('#local img').attr('src');
+			const src = $('#local img').attr('src')!;
 
 			assert.equal(src.startsWith('/_image?'), true);
 		});
@@ -1627,9 +1621,9 @@ describe('astro:image', () => {
 		it('uses short hash for data url filename', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			const src1 = $('#data-url img').attr('src');
+			const src1 = $('#data-url img').attr('src')!;
 			assert.equal(basename(src1).length < 32, true);
-			const src2 = $('#data-url-no-size img').attr('src');
+			const src2 = $('#data-url-no-size img').attr('src')!;
 			assert.equal(basename(src2).length < 32, true);
 			assert.equal(src1.split('_')[0], src2.split('_')[0]);
 		});
@@ -1637,16 +1631,16 @@ describe('astro:image', () => {
 		it('adds file extension for data url images', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			const src = $('#data-url img').attr('src');
+			const src = $('#data-url img').attr('src')!;
 			assert.equal(src.endsWith('.webp'), true);
 		});
 
 		it('writes data url images to dist', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			const src = $('#data-url img').attr('src');
+			const src = $('#data-url img').attr('src')!;
 			assert.equal(src.length > 0, true);
-			const data = await fixture.readFile(src, null);
+			const data = await fixture.readBuffer(src);
 			assert.equal(data instanceof Buffer, true);
 		});
 

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -42,6 +42,7 @@ process.env.ASTRO_TELEMETRY_DISABLED = true;
  * @property {(path: string) => Promise<boolean>} pathExists
  * @property {(url: string, opts?: Parameters<typeof fetch>[1]) => Promise<Response>} fetch
  * @property {(path: string) => Promise<string>} readFile
+ * @property {(path: string) => Promise<Buffer>} readBuffer
  * @property {(path: string, updater: (content: string) => string, waitForNextWrite = true) => Promise<() => void>} editFile
  * @property {(path: string) => Promise<string[]>} readdir
  * @property {(pattern: string) => Promise<string[]>} glob
@@ -252,6 +253,9 @@ export async function loadFixture(inlineConfig) {
 				new URL(filePath.replace(/^\//, ''), config.outDir),
 				encoding === undefined ? 'utf8' : encoding,
 			),
+		readBuffer: (filePath) => {
+			return fs.promises.readFile(new URL(filePath.replace(/^\//, ''), config.outDir));
+		},
 		readdir: (fp) => fs.promises.readdir(new URL(fp.replace(/^\//, ''), config.outDir)),
 		glob: (p) =>
 			glob(p, {


### PR DESCRIPTION
Part of https://github.com/withastro/astro/issues/16241 

Added a new method `content: Buffer = fixture.readBuffer(filePath)` to replace `content: Buffer = fixture.readFile(filePath, null)`. It's easier to add a TypeScript type to it (i.e., no function overloading), and it's also a bit shorter.