### PR TITLE
Harden nested object path lookups

### DIFF
--- a/.changeset/harden-object-path-lookups.md
+++ b/.changeset/harden-object-path-lookups.md
@@ -1,5 +1,6 @@
 ---
 'astro': patch
+'@astrojs/internal-helpers': patch
 '@astrojs/markdown-remark': patch
 'create-astro': patch
 ---

--- a/.changeset/harden-object-path-lookups.md
+++ b/.changeset/harden-object-path-lookups.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+'@astrojs/markdown-remark': patch
+'create-astro': patch
+---
+
+Hardens nested object and package metadata lookups to ignore prototype keys in content handling and project scaffolding

--- a/.changeset/harden-object-path-lookups.md
+++ b/.changeset/harden-object-path-lookups.md
@@ -1,6 +1,6 @@
 ---
 'astro': patch
-'@astrojs/internal-helpers': patch
+'@astrojs/internal-helpers': minor
 '@astrojs/markdown-remark': patch
 'create-astro': patch
 ---

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -29,6 +29,8 @@ import type { SessionDriverFactory } from './session/types.js';
 import { NodePool } from '../runtime/server/render/queue/pool.js';
 import { HTMLStringCache } from '../runtime/server/html-string-cache.js';
 
+const FORBIDDEN_ACTION_PATH_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * The `Pipeline` represents the static parts of rendering that do not change between requests.
  * These are mostly known when the server first starts up and do not change.
@@ -287,6 +289,12 @@ export abstract class Pipeline {
 		}
 
 		for (const key of pathKeys) {
+			if (FORBIDDEN_ACTION_PATH_KEYS.has(key)) {
+				throw new AstroError({
+					...ActionNotFoundError,
+					message: ActionNotFoundError.message(pathKeys.join('.')),
+				});
+			}
 			if (!Object.hasOwn(server, key)) {
 				throw new AstroError({
 					...ActionNotFoundError,

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -28,8 +28,7 @@ import type { CompiledCacheRoute } from './cache/runtime/route-matching.js';
 import type { SessionDriverFactory } from './session/types.js';
 import { NodePool } from '../runtime/server/render/queue/pool.js';
 import { HTMLStringCache } from '../runtime/server/html-string-cache.js';
-
-const FORBIDDEN_ACTION_PATH_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+import { FORBIDDEN_PATH_KEYS } from '@astrojs/internal-helpers/object';
 
 /**
  * The `Pipeline` represents the static parts of rendering that do not change between requests.
@@ -289,7 +288,7 @@ export abstract class Pipeline {
 		}
 
 		for (const key of pathKeys) {
-			if (FORBIDDEN_ACTION_PATH_KEYS.has(key)) {
+			if (FORBIDDEN_PATH_KEYS.has(key)) {
 				throw new AstroError({
 					...ActionNotFoundError,
 					message: ActionNotFoundError.message(pathKeys.join('.')),

--- a/packages/astro/src/core/cache/memory-provider.ts
+++ b/packages/astro/src/core/cache/memory-provider.ts
@@ -236,7 +236,7 @@ function parseVaryHeader(response: Response): string[] | undefined {
  * Extract the values of Vary'd headers from a request.
  */
 function getVaryValues(request: Request, varyHeaders: string[]): Record<string, string> {
-	const values: Record<string, string> = {};
+	const values = Object.create(null) as Record<string, string>;
 	for (const header of varyHeaders) {
 		values[header] = request.headers.get(header) ?? '';
 	}

--- a/packages/astro/src/preferences/dlv.ts
+++ b/packages/astro/src/preferences/dlv.ts
@@ -1,4 +1,4 @@
-const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+import { FORBIDDEN_PATH_KEYS } from '@astrojs/internal-helpers/object';
 
 export default function dlv(obj: Record<string, unknown>, key: string): any {
 	for (const k of key.split('.')) {

--- a/packages/astro/src/preferences/dlv.ts
+++ b/packages/astro/src/preferences/dlv.ts
@@ -1,7 +1,12 @@
+const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export default function dlv(obj: Record<string, unknown>, key: string): any {
 	for (const k of key.split('.')) {
+		if (FORBIDDEN_PATH_KEYS.has(k) || !obj || typeof obj !== 'object' || !Object.hasOwn(obj, k)) {
+			return undefined;
+		}
 		// @ts-expect-error: Type 'unknown' is not assignable to type 'Record<string, unknown>'.
-		obj = obj?.[k];
+		obj = obj[k];
 	}
 	return obj;
 }

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -98,15 +98,10 @@ const FILES_TO_UPDATE = {
 		fs.promises.readFile(file, 'utf-8').then((value) => {
 			// Match first indent in the file or fall back to `\t`
 			const indent = /(^\s+)/m.exec(value)?.[1] ?? '\t';
-			return fs.promises.writeFile(
-				file,
-				JSON.stringify(
-					Object.assign(JSON.parse(value), Object.assign(overrides, { private: undefined })),
-					null,
-					indent,
-				),
-				'utf-8',
-			);
+			const packageJson = JSON.parse(value);
+			packageJson.name = overrides.name;
+			delete packageJson.private;
+			return fs.promises.writeFile(file, JSON.stringify(packageJson, null, indent), 'utf-8');
 		}),
 };
 

--- a/packages/internal-helpers/package.json
+++ b/packages/internal-helpers/package.json
@@ -17,7 +17,8 @@
     "./fs": "./dist/fs.js",
     "./cli": "./dist/cli.js",
     "./create-filter": "./dist/create-filter.js",
-    "./request": "./dist/request.js"
+    "./request": "./dist/request.js",
+    "./object": "./dist/object.js"
   },
   "typesVersions": {
     "*": {
@@ -35,6 +36,9 @@
       ],
       "create-filter": [
         "./dist/create-filter.d.ts"
+      ],
+      "object": [
+        "./dist/object.d.ts"
       ]
     }
   },

--- a/packages/internal-helpers/src/object.ts
+++ b/packages/internal-helpers/src/object.ts
@@ -1,0 +1,5 @@
+/**
+ * Keys that must be rejected when traversing object paths (e.g. dot-separated
+ * property lookups) to prevent prototype-pollution attacks.
+ */
+export const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'constructor', 'prototype']);

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -6,9 +6,10 @@ import { visit } from 'unist-util-visit';
 import type { VFile } from 'vfile';
 import type { MarkdownHeading, RehypePlugin } from './types.js';
 
+import { FORBIDDEN_PATH_KEYS } from '@astrojs/internal-helpers/object';
+
 const rawNodeTypes = new Set(['text', 'raw', 'mdxTextExpression']);
 const codeTagNames = new Set(['code', 'pre']);
-const FORBIDDEN_FRONTMATTER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 /**
  * Rehype plugin that adds `id` attributes to headings based on their text content.
@@ -119,7 +120,7 @@ function getMdxFrontmatterVariableValue(frontmatter: Record<string, any>, path: 
 
 	for (const key of path) {
 		if (
-			FORBIDDEN_FRONTMATTER_KEYS.has(key) ||
+			FORBIDDEN_PATH_KEYS.has(key) ||
 			!value ||
 			typeof value !== 'object' ||
 			!Object.hasOwn(value, key)

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -8,6 +8,7 @@ import type { MarkdownHeading, RehypePlugin } from './types.js';
 
 const rawNodeTypes = new Set(['text', 'raw', 'mdxTextExpression']);
 const codeTagNames = new Set(['code', 'pre']);
+const FORBIDDEN_FRONTMATTER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 /**
  * Rehype plugin that adds `id` attributes to headings based on their text content.
@@ -117,7 +118,14 @@ function getMdxFrontmatterVariableValue(frontmatter: Record<string, any>, path: 
 	let value = frontmatter;
 
 	for (const key of path) {
-		if (!value[key]) return undefined;
+		if (
+			FORBIDDEN_FRONTMATTER_KEYS.has(key) ||
+			!value ||
+			typeof value !== 'object' ||
+			!Object.hasOwn(value, key)
+		) {
+			return undefined;
+		}
 
 		value = value[key];
 	}


### PR DESCRIPTION
## Changes

- Blocks prototype-like keys when traversing action handlers, user preferences, and MDX frontmatter so nested lookups stop at unsafe property names.
- Switches vary-header storage to a null-prototype map and updates `create-astro` package JSON rewriting to avoid broad object merging.

## Testing

- Installed dependencies in a fresh worktree to validate the split branch in isolation.
- Ran Biome against the touched source files and changeset to confirm the branch stays formatted and lint-clean.

## Docs

- No docs update needed, because this is internal hardening for existing code paths.