### PR TITLE
refactor(astro): migrate 2 tests to typescript

### DIFF
--- a/packages/astro/test/vue-component.test.ts
+++ b/packages/astro/test/vue-component.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { isWindows, loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, isWindows, loadFixture } from './test-utils.js';
 
 describe.skip('Vue component build', { todo: 'This test currently times out, investigate' }, () => {
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -44,8 +44,8 @@ describe.skip('Vue component build', { todo: 'This test currently times out, inv
 
 if (!isWindows) {
 	describe.skip('Vue component dev', { todo: 'This test currently times out, investigate' }, () => {
-		let devServer;
-		let fixture;
+		let devServer: DevServer;
+		let fixture: Fixture;
 
 		before(async () => {
 			fixture = await loadFixture({

--- a/packages/astro/test/vue-with-multi-renderer.test.ts
+++ b/packages/astro/test/vue-with-multi-renderer.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { type Fixture, loadFixture } from './test-utils.js';
 
 describe('Vue with multi-renderer', () => {
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({


### PR DESCRIPTION
Part of https://github.com/withastro/astro/issues/16241 

Migrates `packages/astro/test/vue-*.test.js` to TypeScript.