### PR TITLE
WIP(astro): migrate 4 tests to typescript

### DIFF
--- a/packages/astro/test/before-hydration.test.ts
+++ b/packages/astro/test/before-hydration.test.ts
@@ -3,13 +3,12 @@ import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { preact } from './fixtures/before-hydration/deps.mjs';
 import testAdapter from './test-adapter.js';
-import { loadFixture } from './test-utils.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.js';
 
 describe('Astro Scripts before-hydration', () => {
 	describe('SSG', () => {
 		describe('Is used by an integration', () => {
-			/** @type {import('./test-utils').Fixture} */
-			let fixture;
+			let fixture: Fixture;
 
 			before(async () => {
 				fixture = await loadFixture({
@@ -30,8 +29,7 @@ describe('Astro Scripts before-hydration', () => {
 			});
 
 			describe('Development', () => {
-				/** @type {import('./test-utils').DevServer} */
-				let devServer;
+				let devServer: DevServer;
 
 				before(async () => {
 					devServer = await fixture.startDevServer();
@@ -63,7 +61,7 @@ describe('Astro Scripts before-hydration', () => {
 				it('Emits the before-hydration chunk to the client output', async () => {
 					let html = await fixture.readFile('/index.html');
 					let $ = cheerio.load(html);
-					let url = $('astro-island').attr('before-hydration-url');
+					let url = $('astro-island').attr('before-hydration-url')!;
 					assert.ok(url, 'before-hydration-url attribute should have a value');
 					// The URL should point to a file that exists in the build output
 					let content = await fixture.readFile(url);
@@ -73,8 +71,7 @@ describe('Astro Scripts before-hydration', () => {
 		});
 
 		describe('Is not used by an integration', () => {
-			/** @type {import('./test-utils').Fixture} */
-			let fixture;
+			let fixture: Fixture;
 
 			before(async () => {
 				fixture = await loadFixture({
@@ -84,8 +81,7 @@ describe('Astro Scripts before-hydration', () => {
 			});
 
 			describe('Development', () => {
-				/** @type {import('./test-utils').DevServer} */
-				let devServer;
+				let devServer: DevServer;
 
 				before(async () => {
 					devServer = await fixture.startDevServer();
@@ -119,8 +115,7 @@ describe('Astro Scripts before-hydration', () => {
 
 	describe('SSR', () => {
 		describe('Is used by an integration', () => {
-			/** @type {import('./test-utils').Fixture} */
-			let fixture;
+			let fixture: Fixture;
 
 			before(async () => {
 				fixture = await loadFixture({
@@ -159,8 +154,7 @@ describe('Astro Scripts before-hydration', () => {
 		});
 
 		describe('Is not used by an integration', () => {
-			/** @type {import('./test-utils').Fixture} */
-			let fixture;
+			let fixture: Fixture;
 
 			before(async () => {
 				fixture = await loadFixture({

--- a/packages/astro/test/build-assets.test.ts
+++ b/packages/astro/test/build-assets.test.ts
@@ -3,12 +3,11 @@ import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { preact } from './fixtures/before-hydration/deps.mjs';
 import testAdapter from './test-adapter.js';
-import { loadFixture } from './test-utils.js';
+import { type Fixture, loadFixture } from './test-utils.js';
 
 describe('build assets (static)', () => {
 	describe('with default configuration', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let fixture;
+		let fixture: Fixture;
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -36,7 +35,7 @@ describe('build assets (static)', () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
 
-			assert.match($('link[href$=".css"]').attr('href'), /^\/_astro\//);
+			assert.match($('link[href$=".css"]').attr('href')!, /^\/_astro\//);
 		});
 
 		it('emits JS assets to /_astro', async () => {
@@ -45,14 +44,13 @@ describe('build assets (static)', () => {
 
 			const island = $('astro-island');
 			assert.equal(island.length, 1);
-			assert.match(island.attr('component-url'), /^\/_astro\//);
-			assert.match(island.attr('renderer-url'), /^\/_astro\//);
+			assert.match(island.attr('component-url')!, /^\/_astro\//);
+			assert.match(island.attr('renderer-url')!, /^\/_astro\//);
 		});
 	});
 
 	describe('with custom configuration', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let fixture;
+		let fixture: Fixture;
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -75,7 +73,7 @@ describe('build assets (static)', () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
 
-			assert.match($('link[href$=".css"]').attr('href'), /^\/custom-assets\//);
+			assert.match($('link[href$=".css"]').attr('href')!, /^\/custom-assets\//);
 		});
 
 		it('emits JS assets to /custom-assets', async () => {
@@ -84,16 +82,15 @@ describe('build assets (static)', () => {
 
 			const island = $('astro-island');
 			assert.equal(island.length, 1);
-			assert.match(island.attr('component-url'), /^\/custom-assets\//);
-			assert.match(island.attr('renderer-url'), /^\/custom-assets\//);
+			assert.match(island.attr('component-url')!, /^\/custom-assets\//);
+			assert.match(island.attr('renderer-url')!, /^\/custom-assets\//);
 		});
 	});
 });
 
 describe('build assets (server)', () => {
 	describe('with default configuration', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let fixture;
+		let fixture: Fixture;
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -122,7 +119,7 @@ describe('build assets (server)', () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
 
-			assert.match($('link[href$=".css"]').attr('href'), /^\/_astro\//);
+			assert.match($('link[href$=".css"]').attr('href')!, /^\/_astro\//);
 		});
 
 		it('emits JS assets to /_astro', async () => {
@@ -131,14 +128,13 @@ describe('build assets (server)', () => {
 
 			const island = $('astro-island');
 			assert.equal(island.length, 1);
-			assert.match(island.attr('component-url'), /^\/_astro\//);
-			assert.match(island.attr('renderer-url'), /^\/_astro\//);
+			assert.match(island.attr('component-url')!, /^\/_astro\//);
+			assert.match(island.attr('renderer-url')!, /^\/_astro\//);
 		});
 	});
 
 	describe('with custom configuration', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let fixture;
+		let fixture: Fixture;
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -168,7 +164,7 @@ describe('build assets (server)', () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
 
-			assert.match($('link[href$=".css"]').attr('href'), /^\/custom-assets\//);
+			assert.match($('link[href$=".css"]').attr('href')!, /^\/custom-assets\//);
 		});
 
 		it('emits JS assets to /custom-assets', async () => {
@@ -177,8 +173,8 @@ describe('build assets (server)', () => {
 
 			const island = $('astro-island');
 			assert.equal(island.length, 1);
-			assert.match(island.attr('component-url'), /^\/custom-assets\//);
-			assert.match(island.attr('renderer-url'), /^\/custom-assets\//);
+			assert.match(island.attr('component-url')!, /^\/custom-assets\//);
+			assert.match(island.attr('renderer-url')!, /^\/custom-assets\//);
 		});
 	});
 });

--- a/packages/astro/test/build-concurrency.test.ts
+++ b/packages/astro/test/build-concurrency.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { type Fixture, loadFixture } from './test-utils.js';
 
 describe('Building with concurrency > 1', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -21,7 +20,7 @@ describe('Building with concurrency > 1', () => {
 			await fixture.build();
 			built = true;
 		} catch (err) {
-			assert.match(err.message, /This is a test/);
+			assert.match((err as Error).message, /This is a test/);
 		}
 
 		assert.equal(built, false, 'Build should not complete');

--- a/packages/astro/test/build-readonly-file.test.ts
+++ b/packages/astro/test/build-readonly-file.test.ts
@@ -1,11 +1,12 @@
+import fs from 'node:fs';
 import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import testAdapter from './test-adapter.js';
-import { loadFixture } from './test-utils.js';
+import { type Fixture, loadFixture } from './test-utils.js';
 
 describe('When a read-only file exists in /public (static)', () => {
-	let fixture;
-	let testFilePath;
+	let fixture: Fixture;
+	let testFilePath: string;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -27,8 +28,8 @@ describe('When a read-only file exists in /public (static)', () => {
 });
 
 describe('When a read-only file exists in /public (server)', () => {
-	let fixture;
-	let testFilePath;
+	let fixture: Fixture;
+	let testFilePath: string;
 
 	before(async () => {
 		fixture = await loadFixture({

--- a/packages/astro/tsconfig.test.json
+++ b/packages/astro/tsconfig.test.json
@@ -12,6 +12,7 @@
     "test/test-utils.js",
     "package.json"
   ],
+  "files": ["test/fixtures/before-hydration/deps.mjs"],
   "exclude": ["test/units/_temp-fixtures/**", "test/fixtures/**", "e2e/fixtures/**"],
   "compilerOptions": {
     "types": ["vite/client", "node"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,10 +122,10 @@ importers:
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: 5.2.0
-        version: 5.2.0(tinybench@2.9.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 5.2.0(tinybench@2.9.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
 
   benchmark/packages/adapter:
     dependencies:
@@ -232,7 +232,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
     devDependencies:
       '@types/react':
         specifier: ^18.3.28
@@ -506,7 +506,7 @@ importers:
         version: link:../../packages/astro
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/astro:
     dependencies:
@@ -765,7 +765,7 @@ importers:
         version: 11.0.5
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       sharp:
         specifier: ^0.34.0
@@ -4248,7 +4248,7 @@ importers:
         version: link:../../..
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/astro/test/fixtures/vue-component:
     dependencies:
@@ -15503,7 +15503,6 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -16618,12 +16617,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@codspeed/vitest-plugin@5.2.0(tinybench@2.9.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@codspeed/vitest-plugin@5.2.0(tinybench@2.9.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@codspeed/core': 5.2.0
       tinybench: 2.9.0
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - debug
 
@@ -25397,7 +25396,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -25423,7 +25422,17 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.2.3
     transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:


### PR DESCRIPTION
## Summary

- Migrates 4 test files in `packages/astro/test/` matching `b*.test.js` to TypeScript: `before-hydration`, `build-assets`, `build-concurrency`, `build-readonly-file`.
- Adds `test/fixtures/before-hydration/deps.mjs` to `tsconfig.test.json#files` so the typechecker can follow the fixture import used by `before-hydration` and `build-assets`.
- Adds the missing `node:fs` import to `build-readonly-file.test.ts` (was previously relying on an undeclared global).

## Test plan

- [x] `pnpm -C packages/astro run typecheck:tests`
- [x] `pnpm -C packages/astro run test:integration:ts` (all 499 passing tests pass, 0 failures)