### PR TITLE
Support Cloudflare Preview deployments

### DIFF
--- a/.changeset/sharp-pears-boil.md
+++ b/.changeset/sharp-pears-boil.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Add support for Preview deployments (currently in private beta)
+
+Non-inheritable bindings set internally by the Cloudflare adapter are now also set in the `previews` section of the config so that they are inherited by Preview deployments.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -44,14 +44,14 @@
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/underscore-redirects": "workspace:*",
-    "@cloudflare/vite-plugin": "^1.25.6",
+    "@cloudflare/vite-plugin": "^1.32.3",
     "piccolore": "^0.1.3",
     "tinyglobby": "^0.2.15",
     "vite": "^7.3.1"
   },
   "peerDependencies": {
     "astro": "^6.0.0",
-    "wrangler": "^4.61.1"
+    "wrangler": "^4.83.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260228.0",

--- a/packages/integrations/cloudflare/src/wrangler.ts
+++ b/packages/integrations/cloudflare/src/wrangler.ts
@@ -25,38 +25,43 @@ export function cloudflareConfigCustomizer(
 			: (options?.imagesBindingName ?? DEFAULT_IMAGES_BINDING_NAME);
 
 	const customizer = (config: Partial<WorkerConfig>): Partial<WorkerConfig> => {
-		const hasSessionBinding = config.kv_namespaces?.some(
-			(kv) => kv.binding === sessionKVBindingName,
-		);
-		const hasImagesBinding = config.images?.binding !== undefined;
+		const getNonInheritableBindings = (
+			nonInheritableConfig: WorkerConfig['previews'],
+		): WorkerConfig['previews'] => {
+			const hasSessionBinding = nonInheritableConfig?.kv_namespaces?.some(
+				(kv) => kv.binding === sessionKVBindingName,
+			);
+			const hasImagesBinding = nonInheritableConfig?.images?.binding !== undefined;
+
+			return {
+				kv_namespaces:
+					!needsSessionKVBinding || hasSessionBinding
+						? undefined
+						: [
+								{
+									binding: sessionKVBindingName,
+								},
+							],
+				images:
+					hasImagesBinding || !imagesBindingName
+						? undefined
+						: {
+								binding: imagesBindingName,
+							},
+			};
+		};
+
 		const hasAssetsBinding = config.assets?.binding !== undefined;
 
-		const nonInheritableBindings = {
-			kv_namespaces:
-				!needsSessionKVBinding || hasSessionBinding
-					? undefined
-					: [
-							{
-								binding: sessionKVBindingName,
-							},
-						],
-			images:
-				hasImagesBinding || !imagesBindingName
-					? undefined
-					: {
-							binding: imagesBindingName,
-						},
-		} satisfies WorkerConfig['previews'];
-
 		return {
-			...nonInheritableBindings,
+			...getNonInheritableBindings(config),
 			main: config.main ?? '@astrojs/cloudflare/entrypoints/server',
 			assets: hasAssetsBinding
 				? undefined
 				: {
 						binding: DEFAULT_ASSETS_BINDING_NAME,
 					},
-			previews: nonInheritableBindings,
+			previews: getNonInheritableBindings(config.previews),
 		};
 	};
 

--- a/packages/integrations/cloudflare/src/wrangler.ts
+++ b/packages/integrations/cloudflare/src/wrangler.ts
@@ -31,8 +31,7 @@ export function cloudflareConfigCustomizer(
 		const hasImagesBinding = config.images?.binding !== undefined;
 		const hasAssetsBinding = config.assets?.binding !== undefined;
 
-		return {
-			main: config.main ?? '@astrojs/cloudflare/entrypoints/server',
+		const nonInheritableBindings = {
 			kv_namespaces:
 				!needsSessionKVBinding || hasSessionBinding
 					? undefined
@@ -47,11 +46,17 @@ export function cloudflareConfigCustomizer(
 					: {
 							binding: imagesBindingName,
 						},
+		} satisfies WorkerConfig['previews'];
+
+		return {
+			...nonInheritableBindings,
+			main: config.main ?? '@astrojs/cloudflare/entrypoints/server',
 			assets: hasAssetsBinding
 				? undefined
 				: {
 						binding: DEFAULT_ASSETS_BINDING_NAME,
 					},
+			previews: nonInheritableBindings,
 		};
 	};
 

--- a/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/package.json
@@ -7,6 +7,6 @@
     "astro": "workspace:*"
   },
   "devDependencies": {
-    "wrangler": "^4.69.0"
+    "wrangler": "^4.83.0"
   }
 }

--- a/packages/integrations/cloudflare/test/fixtures/astro-env/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/astro-env/package.json
@@ -7,6 +7,6 @@
     "astro": "workspace:*"
   },
   "devDependencies": {
-    "wrangler": "^4.69.0"
+    "wrangler": "^4.83.0"
   }
 }

--- a/packages/integrations/cloudflare/test/fixtures/custom-entryfile/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/custom-entryfile/package.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "@astrojs/cloudflare": "workspace:*",
     "astro": "workspace:*",
-    "wrangler": "^4.69.0"
+    "wrangler": "^4.83.0"
   }
 }

--- a/packages/integrations/cloudflare/test/fixtures/routing-priority/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/routing-priority/package.json
@@ -7,6 +7,6 @@
     "@astrojs/cloudflare": "workspace:*"
   },
   "devDependencies": {
-    "wrangler": "^4.69.0"
+    "wrangler": "^4.83.0"
   }
 }

--- a/packages/integrations/cloudflare/test/fixtures/sessions/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/sessions/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "astro": "workspace:*",
-    "wrangler": "^4.69.0"
+    "wrangler": "^4.83.0"
   },
   "scripts": {
     "build": "astro build",

--- a/packages/integrations/cloudflare/test/wrangler.test.ts
+++ b/packages/integrations/cloudflare/test/wrangler.test.ts
@@ -124,6 +124,84 @@ describe('cloudflareConfigCustomizer', () => {
 		});
 	});
 
+	describe('previews', () => {
+		it('adds default bindings to previews when none exist', () => {
+			const customizer = cloudflareConfigCustomizer();
+			const result = customizer({});
+
+			assert.deepEqual(result.previews?.kv_namespaces, [
+				{ binding: DEFAULT_SESSION_KV_BINDING_NAME },
+			]);
+			assert.deepEqual(result.previews?.images, { binding: DEFAULT_IMAGES_BINDING_NAME });
+		});
+
+		it('does not add SESSION binding to previews when one exists in previews config', () => {
+			const customizer = cloudflareConfigCustomizer();
+			const result = customizer({
+				previews: {
+					kv_namespaces: [{ binding: DEFAULT_SESSION_KV_BINDING_NAME, id: 'preview-id' }],
+				},
+			});
+
+			assert.equal(result.previews?.kv_namespaces, undefined);
+		});
+
+		it('does not add IMAGES binding to previews when one exists in previews config', () => {
+			const customizer = cloudflareConfigCustomizer();
+			const result = customizer({
+				previews: {
+					images: { binding: 'PREVIEW_IMAGES' },
+				},
+			});
+
+			assert.equal(result.previews?.images, undefined);
+		});
+
+		it('adds SESSION binding to previews even when top-level has it', () => {
+			const customizer = cloudflareConfigCustomizer();
+			const result = customizer({
+				kv_namespaces: [{ binding: DEFAULT_SESSION_KV_BINDING_NAME, id: 'top-level-id' }],
+			});
+
+			// Top-level should not add (already exists)
+			assert.equal(result.kv_namespaces, undefined);
+			// Previews should add (not defined in previews config)
+			assert.deepEqual(result.previews?.kv_namespaces, [
+				{ binding: DEFAULT_SESSION_KV_BINDING_NAME },
+			]);
+		});
+
+		it('adds IMAGES binding to previews even when top-level has it', () => {
+			const customizer = cloudflareConfigCustomizer();
+			const result = customizer({
+				images: { binding: 'TOP_LEVEL_IMAGES' },
+			});
+
+			// Top-level should not add (already exists)
+			assert.equal(result.images, undefined);
+			// Previews should add (not defined in previews config)
+			assert.deepEqual(result.previews?.images, { binding: DEFAULT_IMAGES_BINDING_NAME });
+		});
+
+		it('checks previews config independently from top-level config', () => {
+			const customizer = cloudflareConfigCustomizer();
+			const result = customizer({
+				kv_namespaces: [{ binding: DEFAULT_SESSION_KV_BINDING_NAME, id: 'top-level-id' }],
+				images: { binding: 'TOP_LEVEL_IMAGES' },
+				previews: {
+					kv_namespaces: [{ binding: DEFAULT_SESSION_KV_BINDING_NAME, id: 'preview-id' }],
+					images: { binding: 'PREVIEW_IMAGES' },
+				},
+			});
+
+			// Neither top-level nor previews should add bindings
+			assert.equal(result.kv_namespaces, undefined);
+			assert.equal(result.images, undefined);
+			assert.equal(result.previews?.kv_namespaces, undefined);
+			assert.equal(result.previews?.images, undefined);
+		});
+	});
+
 	describe('default binding names', () => {
 		it('exports DEFAULT_SESSION_KV_BINDING_NAME as SESSION', () => {
 			assert.equal(DEFAULT_SESSION_KV_BINDING_NAME, 'SESSION');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4560,8 +4560,8 @@ importers:
         specifier: workspace:*
         version: link:../../underscore-redirects
       '@cloudflare/vite-plugin':
-        specifier: ^1.25.6
-        version: 1.25.6(@cloudflare/workers-types@4.20260228.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260305.0)
+        specifier: ^1.32.3
+        version: 1.32.3(@cloudflare/workers-types@4.20260228.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260415.1)
       piccolore:
         specifier: ^0.1.3
         version: 0.1.3
@@ -4601,8 +4601,8 @@ importers:
         version: link:../../../../../astro
     devDependencies:
       wrangler:
-        specifier: ^4.69.0
-        version: 4.69.0(@cloudflare/workers-types@4.20260228.0)
+        specifier: ^4.83.0
+        version: 4.83.0(@cloudflare/workers-types@4.20260228.0)
 
   packages/integrations/cloudflare/test/fixtures/astro-env:
     dependencies:
@@ -4614,8 +4614,8 @@ importers:
         version: link:../../../../../astro
     devDependencies:
       wrangler:
-        specifier: ^4.69.0
-        version: 4.69.0(@cloudflare/workers-types@4.20260228.0)
+        specifier: ^4.83.0
+        version: 4.83.0(@cloudflare/workers-types@4.20260228.0)
 
   packages/integrations/cloudflare/test/fixtures/binding-image-service:
     dependencies:
@@ -4653,8 +4653,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
       wrangler:
-        specifier: ^4.69.0
-        version: 4.69.0(@cloudflare/workers-types@4.20260228.0)
+        specifier: ^4.83.0
+        version: 4.83.0(@cloudflare/workers-types@4.20260228.0)
 
   packages/integrations/cloudflare/test/fixtures/dev-image-endpoint:
     dependencies:
@@ -4767,8 +4767,8 @@ importers:
         version: link:../../../../../astro
     devDependencies:
       wrangler:
-        specifier: ^4.69.0
-        version: 4.69.0(@cloudflare/workers-types@4.20260228.0)
+        specifier: ^4.83.0
+        version: 4.83.0(@cloudflare/workers-types@4.20260228.0)
 
   packages/integrations/cloudflare/test/fixtures/server-entry:
     dependencies:
@@ -4804,8 +4804,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
       wrangler:
-        specifier: ^4.69.0
-        version: 4.69.0(@cloudflare/workers-types@4.20260228.0)
+        specifier: ^4.83.0
+        version: 4.83.0(@cloudflare/workers-types@4.20260228.0)
 
   packages/integrations/cloudflare/test/fixtures/sql-import:
     dependencies:
@@ -7460,46 +7460,46 @@ packages:
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
 
-  '@cloudflare/unenv-preset@2.14.0':
-    resolution: {integrity: sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg==}
+  '@cloudflare/unenv-preset@2.16.0':
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
     peerDependencies:
       unenv: 2.0.0-rc.24
-      workerd: ^1.20260218.0
+      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
     peerDependenciesMeta:
       workerd:
         optional: true
 
-  '@cloudflare/vite-plugin@1.25.6':
-    resolution: {integrity: sha512-p00Wcifec/rpzLFhZnA86JcPYazDkQ54q/ieAwuJQ+YUjbNKWjq872SUwUuX3+nIvo0KIRQmL9VBLE8mWfTE7g==}
+  '@cloudflare/vite-plugin@1.32.3':
+    resolution: {integrity: sha512-a8ZkCA/SOiJ36jT3LlBLkUb7ZzGInhYJoTY4BMRBGdk+nsh44HavbNvtu/RdaqS5VJEMLM4+LqVIJ+V0ahGeFg==}
     peerDependencies:
-      vite: ^6.1.0 || ^7.0.0
+      vite: ^6.1.0 || ^7.0.0 || ^8.0.0
 
-  '@cloudflare/workerd-darwin-64@1.20260305.0':
-    resolution: {integrity: sha512-chhKOpymo0Eh9J3nymrauMqKGboCc4uz/j0gA1G4gioMnKsN2ZDKJ+qjRZDnCoVGy8u2C4pxlmyIfsXCAfIzhQ==}
+  '@cloudflare/workerd-darwin-64@1.20260415.1':
+    resolution: {integrity: sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260305.0':
-    resolution: {integrity: sha512-K9aG2OQk5bBfOP+fyGPqLcqZ9OR3ra6uwnxJ8f2mveq2A2LsCI7ZeGxQiAj75Ti80ytH/gJffZIx4Np2JtU3aQ==}
+  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
+    resolution: {integrity: sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260305.0':
-    resolution: {integrity: sha512-tt7XUoIw/cYFeGbkPkcZ6XX1aZm26Aju/4ih+DXxOosbBeGshFSrNJDBfAKKOvkjsAZymJ+WWVDBU+hmNaGfwA==}
+  '@cloudflare/workerd-linux-64@1.20260415.1':
+    resolution: {integrity: sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260305.0':
-    resolution: {integrity: sha512-72QTkY5EzylmvCZ8ZTrnJ9DctmQsfSof1OKyOWqu/pv/B2yACfuPMikq8RpPxvVu7hhS0ztGP6ZvXz72Htq4Zg==}
+  '@cloudflare/workerd-linux-arm64@1.20260415.1':
+    resolution: {integrity: sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260305.0':
-    resolution: {integrity: sha512-BA0uaQPOaI2F6mJtBDqplGnQQhpXCzwEMI33p/TnDxtSk9u8CGIfBFuI6uqo8mJ6ijIaPjeBLGOn2CiRMET4qg==}
+  '@cloudflare/workerd-windows-64@1.20260415.1':
+    resolution: {integrity: sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -13269,8 +13269,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  miniflare@4.20260305.0:
-    resolution: {integrity: sha512-jVhtKJtiwaZa3rI+WgoLvSJmEazDsoUmAPYRUmEe2VO6VSbvkhbnDRm+dsPbYRatgNIExwrpqG1rv96jHiSb0w==}
+  miniflare@4.20260415.0:
+    resolution: {integrity: sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -15106,12 +15106,12 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.18.2:
-    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.0:
     resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -15695,20 +15695,20 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20260305.0:
-    resolution: {integrity: sha512-JkhfCLU+w+KbQmZ9k49IcDYc78GBo7eG8Mir8E2+KVjR7otQAmpcLlsous09YLh8WQ3Bt3Mi6/WMStvMAPukeA==}
+  workerd@1.20260415.1:
+    resolution: {integrity: sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==}
     engines: {node: '>=16'}
     hasBin: true
 
   workerpool@9.3.4:
     resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
 
-  wrangler@4.69.0:
-    resolution: {integrity: sha512-EmVfIM65I5b4ITHe3Y9R7zQyf4NUBQ1leStakMlWiVR9n6VlDwuEltyQI2l3i0JciDnWyR3uqe+T6C08ivniTQ==}
-    engines: {node: '>=20.0.0'}
+  wrangler@4.83.0:
+    resolution: {integrity: sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==}
+    engines: {node: '>=20.3.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260305.0
+      '@cloudflare/workers-types': ^4.20260415.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -16571,19 +16571,19 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@cloudflare/unenv-preset@2.14.0(unenv@2.0.0-rc.24)(workerd@1.20260305.0)':
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260305.0
+      workerd: 1.20260415.1
 
-  '@cloudflare/vite-plugin@1.25.6(@cloudflare/workers-types@4.20260228.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260305.0)':
+  '@cloudflare/vite-plugin@1.32.3(@cloudflare/workers-types@4.20260228.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260415.1)':
     dependencies:
-      '@cloudflare/unenv-preset': 2.14.0(unenv@2.0.0-rc.24)(workerd@1.20260305.0)
-      miniflare: 4.20260305.0
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)
+      miniflare: 4.20260415.0
       unenv: 2.0.0-rc.24
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
-      wrangler: 4.69.0(@cloudflare/workers-types@4.20260228.0)
+      wrangler: 4.83.0(@cloudflare/workers-types@4.20260228.0)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -16591,19 +16591,19 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/workerd-darwin-64@1.20260305.0':
+  '@cloudflare/workerd-darwin-64@1.20260415.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260305.0':
+  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260305.0':
+  '@cloudflare/workerd-linux-64@1.20260415.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260305.0':
+  '@cloudflare/workerd-linux-arm64@1.20260415.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260305.0':
+  '@cloudflare/workerd-windows-64@1.20260415.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260228.0': {}
@@ -22862,12 +22862,12 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  miniflare@4.20260305.0:
+  miniflare@4.20260415.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.18.2
-      workerd: 1.20260305.0
+      undici: 7.24.8
+      workerd: 1.20260415.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -24997,9 +24997,9 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.18.2: {}
-
   undici@7.24.0: {}
+
+  undici@7.24.8: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -25617,26 +25617,26 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20260305.0:
+  workerd@1.20260415.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260305.0
-      '@cloudflare/workerd-darwin-arm64': 1.20260305.0
-      '@cloudflare/workerd-linux-64': 1.20260305.0
-      '@cloudflare/workerd-linux-arm64': 1.20260305.0
-      '@cloudflare/workerd-windows-64': 1.20260305.0
+      '@cloudflare/workerd-darwin-64': 1.20260415.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260415.1
+      '@cloudflare/workerd-linux-64': 1.20260415.1
+      '@cloudflare/workerd-linux-arm64': 1.20260415.1
+      '@cloudflare/workerd-windows-64': 1.20260415.1
 
   workerpool@9.3.4: {}
 
-  wrangler@4.69.0(@cloudflare/workers-types@4.20260228.0):
+  wrangler@4.83.0(@cloudflare/workers-types@4.20260228.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.14.0(unenv@2.0.0-rc.24)(workerd@1.20260305.0)
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260305.0
+      miniflare: 4.20260415.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260305.0
+      workerd: 1.20260415.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260228.0
       fsevents: 2.3.3


### PR DESCRIPTION
## Changes

Add support for Preview deployments (currently in private beta)

Non-inheritable bindings set internally by the Cloudflare adapter are now also set in the `previews` section of the config so that they are inherited by Preview deployments.

## Testing

Tests added.

## Docs

This feature is currently in private beta. The docs will be available on the Cloudflare docs site when it is released publicly.