### PR TITLE
feat(astro-env): Allow setting descriptions on env schema config

### DIFF
--- a/.changeset/shy-dingos-tease.md
+++ b/.changeset/shy-dingos-tease.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow setting descriptions on env schema config

--- a/packages/astro/src/env/schema.ts
+++ b/packages/astro/src/env/schema.ts
@@ -11,6 +11,7 @@ const StringSchema = z.object({
 	includes: z.string().optional(),
 	startsWith: z.string().optional(),
 	endsWith: z.string().optional(),
+	description: z.string().optional(),
 });
 export type StringSchema = z.infer<typeof StringSchema>;
 const NumberSchema = z.object({
@@ -22,12 +23,14 @@ const NumberSchema = z.object({
 	lt: z.number().optional(),
 	max: z.number().optional(),
 	int: z.boolean().optional(),
+	description: z.string().optional(),
 });
 export type NumberSchema = z.infer<typeof NumberSchema>;
 const BooleanSchema = z.object({
 	type: z.literal('boolean'),
 	optional: z.boolean().optional(),
 	default: z.boolean().optional(),
+	description: z.string().optional(),
 });
 const EnumSchema = z.object({
 	type: z.literal('enum'),
@@ -39,6 +42,7 @@ const EnumSchema = z.object({
 	),
 	optional: z.boolean().optional(),
 	default: z.string().optional(),
+	description: z.string().optional(),
 });
 export type EnumSchema = z.infer<typeof EnumSchema>;
 

--- a/packages/astro/src/env/sync.ts
+++ b/packages/astro/src/env/sync.ts
@@ -7,7 +7,11 @@ export function syncAstroEnv(settings: AstroSettings): void {
 	let server = '';
 
 	for (const [key, options] of Object.entries(settings.config.env.schema)) {
-		const str = `	export const ${key}: ${getEnvFieldType(options)};	\n`;
+		let str = '';
+		if(options.description) {
+			str += `	/** ${options.description} */`;
+		}
+		str += `	export const ${key}: ${getEnvFieldType(options)};\n`;
 		if (options.context === 'client') {
 			client += str;
 		} else {
@@ -21,6 +25,9 @@ export function syncAstroEnv(settings: AstroSettings): void {
 ${client}}`;
 	}
 	if (server !== '') {
+		if(content !== '') {
+			content += '\n';
+		}
 		content += `declare module 'astro:env/server' {
 ${server}}`;
 	}

--- a/packages/astro/src/env/sync.ts
+++ b/packages/astro/src/env/sync.ts
@@ -8,8 +8,8 @@ export function syncAstroEnv(settings: AstroSettings): void {
 
 	for (const [key, options] of Object.entries(settings.config.env.schema)) {
 		let str = '';
-		if(options.description) {
-			str += `	/** ${options.description} */`;
+		if (options.description) {
+			str += `	/** ${options.description} */\n`;
 		}
 		str += `	export const ${key}: ${getEnvFieldType(options)};\n`;
 		if (options.context === 'client') {
@@ -25,7 +25,7 @@ export function syncAstroEnv(settings: AstroSettings): void {
 ${client}}`;
 	}
 	if (server !== '') {
-		if(content !== '') {
+		if (content !== '') {
 			content += '\n';
 		}
 		content += `declare module 'astro:env/server' {

--- a/packages/astro/test/fixtures/astro-env/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-env/astro.config.mjs
@@ -4,9 +4,9 @@ import { defineConfig, envField } from 'astro/config';
 export default defineConfig({
 	env: {
 		schema: {
-			FOO: envField.string({ context: "client", access: "public", optional: true, default: "ABC" }),
+			FOO: envField.string({ context: "client", access: "public", optional: true, default: "ABC", description: "The FOO variable", }),
 			BAR: envField.string({ context: "client", access: "public", optional: true, default: "DEF" }),
-			BAZ: envField.string({ context: "server", access: "public", optional: true, default: "GHI" }),
+			BAZ: envField.string({ context: "server", access: "public", optional: true, default: "GHI", description: "The BAZ variable" }),
 		}
 	}
 });


### PR DESCRIPTION
## Changes

- Allows setting descriptions on env schema config
- Useful for describing where variables come from, how to generate them, etc.
- Description will be emitted in generated typescript definition file, for intellisense &c.

## Testing

Additional config was added to a test fixture, and generated typescript definition was manually verified.

## Docs

Probably could add a note in https://docs.astro.build/en/guides/environment-variables/#type-safe-environment-variables
