### PR TITLE
Default Cloudflare compatibility_date to avoid workerd future date rejection

### DIFF
--- a/.changeset/fix-cloudflare-compat-date-default.md
+++ b/.changeset/fix-cloudflare-compat-date-default.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes Cloudflare dev and build failures caused by `@cloudflare/vite-plugin` defaulting `compatibility_date` to today's date, which can exceed the maximum date supported by the bundled `workerd` binary

--- a/packages/integrations/cloudflare/src/wrangler.ts
+++ b/packages/integrations/cloudflare/src/wrangler.ts
@@ -9,7 +9,7 @@ export const DEFAULT_ASSETS_BINDING_NAME = 'ASSETS';
 // date supported by the bundled workerd binary (which has a ~7 day buffer from its build date),
 // causing ERR_RUNTIME_FAILURE. A hard-coded date avoids this issue.
 // This should be updated when upgrading wrangler/workerd dependencies.
-export const DEFAULT_COMPATIBILITY_DATE = '2026-04-15';
+const DEFAULT_COMPATIBILITY_DATE = '2026-04-15';
 
 interface CloudflareConfigOptions {
 	sessionKVBindingName?: string | undefined;

--- a/packages/integrations/cloudflare/src/wrangler.ts
+++ b/packages/integrations/cloudflare/src/wrangler.ts
@@ -4,6 +4,13 @@ export const DEFAULT_SESSION_KV_BINDING_NAME = 'SESSION';
 export const DEFAULT_IMAGES_BINDING_NAME = 'IMAGES';
 export const DEFAULT_ASSETS_BINDING_NAME = 'ASSETS';
 
+// Default compatibility date used when the user doesn't set one in their wrangler config.
+// The @cloudflare/vite-plugin falls back to today's date, but that can exceed the maximum
+// date supported by the bundled workerd binary (which has a ~7 day buffer from its build date),
+// causing ERR_RUNTIME_FAILURE. A hard-coded date avoids this issue.
+// This should be updated when upgrading wrangler/workerd dependencies.
+export const DEFAULT_COMPATIBILITY_DATE = '2026-04-15';
+
 interface CloudflareConfigOptions {
 	sessionKVBindingName?: string | undefined;
 	needsSessionKVBinding?: boolean;
@@ -55,6 +62,7 @@ export function cloudflareConfigCustomizer(
 
 		return {
 			...getNonInheritableBindings(config),
+			compatibility_date: config.compatibility_date ?? DEFAULT_COMPATIBILITY_DATE,
 			main: config.main ?? '@astrojs/cloudflare/entrypoints/server',
 			assets: hasAssetsBinding
 				? undefined


### PR DESCRIPTION
## Changes

- When no wrangler.jsonc exists, the Cloudflare vite plugin defaults compatibility_date to today via getTodaysCompatDate(). However, the bundled workerd binary rejects dates past its compiled-in maximum (~7 days after its build date), causing ERR_RUNTIME_FAILURE. This affects both dev and build.
- The Astro Cloudflare integration now sets a hard-coded default compatibility_date in the config customizer, so the vite plugin broken fallback is never reached. Users who set compatibility_date in their own wrangler.jsonc are unaffected -- their value takes precedence.
- Upstream issue: the vite plugin getTodaysCompatDate() should clamp to the workerd binary max supported date rather than using today unchecked. Reported to the Cloudflare team. Reproduction: https://github.com/matthewp/cf-compat-repro-1

## Testing

- Verified binding-image-service and other test fixtures that lack a wrangler.jsonc now pass (these were the ones failing in CI).
- Confirmed the fix does not affect fixtures that already have an explicit compatibility_date in their wrangler config.

## Docs

- No docs update needed -- this is an internal default that prevents a crash; no user-facing API change.