### PR TITLE
fix(remark): preserve empty alt attribute on markdown images

### DIFF
--- a/.changeset/preserve-empty-alt-on-markdown-images.md
+++ b/.changeset/preserve-empty-alt-on-markdown-images.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdown-remark": patch
+---
+
+Preserves an empty `alt` attribute on markdown images written without alt text (e.g. `![](./img.png)`). Previously the resulting `<img>` had no `alt` attribute at all, which is invalid for accessibility. Decorative markdown images now correctly emit `alt`.

--- a/packages/markdown/remark/src/rehype-images.ts
+++ b/packages/markdown/remark/src/rehype-images.ts
@@ -44,6 +44,12 @@ export function rehypeImages() {
 				return;
 			}
 
+			// mdast-util-to-hast omits alt when the markdown image has empty alt
+			// text (`![](url)`); restore it so the rendered <img> includes alt.
+			if (typeof imageProperties.alt !== 'string') {
+				imageProperties.alt = '';
+			}
+
 			// Separate HAST-only properties from image processing properties
 			const hastProperties: Properties = {};
 			for (const key of HAST_PRESERVED_PROPERTIES) {

--- a/packages/markdown/remark/test/remark-collect-images.test.ts
+++ b/packages/markdown/remark/test/remark-collect-images.test.ts
@@ -46,6 +46,24 @@ describe('collect images', async () => {
 		assert.deepEqual(remoteImagePaths, []);
 	});
 
+	it('should preserve empty alt for inline image without alt text', async () => {
+		const markdown = `Hello ![](./img.png)`;
+		const fileURL = new URL('file.md', import.meta.url);
+
+		const {
+			code,
+			metadata: { localImagePaths, remoteImagePaths },
+		} = await processor.render(markdown, { fileURL });
+
+		assert.equal(
+			code,
+			'<p>Hello <img __ASTRO_IMAGE_="{&#x22;src&#x22;:&#x22;./img.png&#x22;,&#x22;alt&#x22;:&#x22;&#x22;,&#x22;index&#x22;:0}"></p>',
+		);
+
+		assert.deepEqual(localImagePaths, ['./img.png']);
+		assert.deepEqual(remoteImagePaths, []);
+	});
+
 	it('should collect allowed remote image paths', async () => {
 		const markdown = `Hello ![inline remote image url](https://example.com/example.png)`;
 		const fileURL = new URL('file.md', import.meta.url);


### PR DESCRIPTION
## Summary

Fixes [#16621](https://github.com/withastro/astro/issues/16621).

When a markdown image is written without alt text (`![](./img.png)`), the resulting `<img>` was rendered without any `alt` attribute at all. `mdast-util-to-hast` strips the `alt` property when alt text is empty, so by the time the image reaches `rehypeImages`, `node.properties.alt` is `undefined` and never makes it into the `__ASTRO_IMAGE_` JSON marker. The downstream `<img>` therefore omits `alt` entirely, which is invalid for accessibility.

This restores `alt` as an empty string in `rehypeImages` so decorative markdown images include the attribute (HTML5 `<img alt>` is equivalent to `alt=""`).

The existing test fixture only covered non-empty alt cases, so the regression slipped past CI. A regression test was added.

## Changes

- `packages/markdown/remark/src/rehype-images.ts` — default `alt` to `''` when missing
- `packages/markdown/remark/test/remark-collect-images.test.ts` — regression test for `![](./img.png)`
- `.changeset/preserve-empty-alt-on-markdown-images.md` — patch bump for `@astrojs/markdown-remark`

## Test plan

- [x] `pnpm --filter @astrojs/markdown-remark test` — all 44 tests pass, including the new regression test
- [ ] CI checks pass

Closes #16621
