### PR TITLE
fix: Astro is unable to properly handle Svelte 5 snippet props

### DIFF
--- a/.changeset/eager-crews-kick.md
+++ b/.changeset/eager-crews-kick.md
@@ -1,0 +1,12 @@
+---
+'@astrojs/svelte': minor
+---
+
+This change updates the Svelte integration's type shims to treat non-children
+snippet props and `any`-typed props as optional. Previously, these were
+incorrectly marked as required in Astro files, causing false-positive type
+errors when using Svelte 5 components.
+
+- Adds `HandleSnippetProps` to make Snippets optional in Astro.
+- Distinguishes between generic and non-generic components to preserve inference.
+- Updates TSX generation to apply the appropriate directive wrapper.

--- a/packages/integrations/svelte/src/editor.cts
+++ b/packages/integrations/svelte/src/editor.cts
@@ -19,9 +19,12 @@ export function toTSX(code: string, className: string): string {
 			const innerType = generics
 				? `ReturnType<__sveltets_Render<${generics.names}>['props']>`
 				: `import('svelte').ComponentProps<typeof $$$$Component>`;
+			// Generic components use a simpler type wrapper that preserves generic
+			// inference. Non-generic components use the full snippet handling.
+			const propsType = generics ? 'GenericPropsWithClientDirectives' : 'PropsWithClientDirectives';
 			result = tsx.replace(
 				'export default $$Component;',
-				`export default function ${className}__AstroComponent_${genericSuffix}(_props: import('@astrojs/svelte/svelte-shims.d.ts').PropsWithClientDirectives<${innerType}>): any {}`,
+				`export default function ${className}__AstroComponent_${genericSuffix}(_props: import('@astrojs/svelte/svelte-shims.d.ts').${propsType}<${innerType}>): any {}`,
 			);
 		} else {
 			// Old svelte2tsx output

--- a/packages/integrations/svelte/svelte-shims.d.ts
+++ b/packages/integrations/svelte/svelte-shims.d.ts
@@ -53,13 +53,71 @@ type WidenChildrenIfSnippet<T> = {
 };
 
 /**
+ * Detect `any` without triggering on generic type parameters.
+ * `0 extends 1 & T` is `true` only when `T` is `any`.
+ */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
+ * Check whether a prop type is `Snippet`-like or `any` (which subsumes `Snippet`).
+ * Returns `true` for `any`, `Snippet`, `Snippet<[...]>`, `Snippet | null`, etc.
+ * Returns `false` for concrete non-snippet types and deferred generic parameters.
+ */
+type IsSnippetOrAny<T> =
+	IsAny<T> extends true ? true : Extract<NonNullable<T>, Snippet> extends never ? false : true;
+
+/**
+ * Handle Snippet-typed and `any`-typed props for Astro compatibility:
+ * - `children` that includes `Snippet`: widen to `any` (Astro slot/content)
+ * - Other props whose type is `any` or includes `Snippet`: make optional.
+ *   `svelte2tsx` types renamed/destructured snippet props and event handlers
+ *   as `any` without marking them optional, even when they have defaults.
+ *   Astro cannot pass Svelte snippets, so these are safe to omit.
+ *
+ * NOTE: This type uses an intersection of two mapped types, which breaks
+ * TypeScript's generic type parameter inference. Use `GenericPropsWithClientDirectives`
+ * for generic Svelte components instead.
+ */
+type HandleSnippetProps<T> = {
+	[K in keyof T as K extends 'children'
+		? K
+		: IsSnippetOrAny<T[K]> extends true
+			? never
+			: K]: K extends 'children'
+		? Extract<NonNullable<T[K]>, Snippet> extends never
+			? T[K]
+			: any
+		: T[K];
+} & {
+	[K in keyof T as K extends 'children'
+		? never
+		: IsSnippetOrAny<T[K]> extends true
+			? K
+			: never]?: T[K];
+};
+
+/**
  * `T` (Svelte props) made safe for Astro:
+ * - Normalize `children` (avoid `never`/missing cases)
+ * - Widen snippet-based `children` to `any` (Astro slot/content compatibility)
+ * - Make snippet/any-typed non-children props optional
+ * - Strip useless `never` index signatures (allow extra keys like `client:*`)
+ * - Add Astro client directives
+ */
+export type PropsWithClientDirectives<T> = StripNeverIndexSignatures<
+	HandleSnippetProps<NormalizeNeverChildren<T>>
+> &
+	AstroClientDirectives;
+
+/**
+ * `T` (Svelte props) made safe for Astro (generic components):
+ * Uses a simpler homomorphic mapped type that preserves generic inference.
  * - Normalize `children` (avoid `never`/missing cases)
  * - Widen snippet-based `children` to `any` (Astro slot/content compatibility)
  * - Strip useless `never` index signatures (allow extra keys like `client:*`)
  * - Add Astro client directives
  */
-export type PropsWithClientDirectives<T> = StripNeverIndexSignatures<
+export type GenericPropsWithClientDirectives<T> = StripNeverIndexSignatures<
 	WidenChildrenIfSnippet<NormalizeNeverChildren<T>>
 > &
 	AstroClientDirectives;

--- a/packages/integrations/svelte/test/check.test.ts
+++ b/packages/integrations/svelte/test/check.test.ts
@@ -146,6 +146,33 @@ describe('Svelte Check', () => {
 		assert.equal(exitCode, 1, 'Expected check to fail (exit code 1)');
 	});
 
+	it('should pass check when snippet props are omitted', async () => {
+		const root = fileURLToPath(new URL('./fixtures/prop-types/types/snippets', import.meta.url));
+		const tsConfigPath = fileURLToPath(
+			new URL('./fixtures/prop-types/tsconfig.snippets-pass.json', import.meta.url),
+		);
+		const { getResult } = cli('check', '--tsconfig', tsConfigPath, '--root', root);
+		const { exitCode, stdout, stderr } = await getResult();
+
+		if (exitCode !== 0) {
+			console.error(stdout);
+			console.error(stderr);
+		}
+		assert.equal(exitCode, 0, 'Expected check to pass (exit code 0)');
+	});
+
+	it('should fail check when non-snippet required props are missing', async () => {
+		const root = fileURLToPath(new URL('./fixtures/prop-types/types/snippets', import.meta.url));
+		const tsConfigPath = fileURLToPath(
+			new URL('./fixtures/prop-types/tsconfig.snippets-fail.json', import.meta.url),
+		);
+		const { getResult } = cli('check', '--tsconfig', tsConfigPath, '--root', root);
+		const { exitCode, stdout } = await getResult();
+
+		assert.equal(exitCode, 1, 'Expected check to fail (exit code 1)');
+		assert.ok(stdout.includes(`'title'`), 'Expected title to be reported as missing');
+	});
+
 	it('should fail check on invalid element children', { skip: true }, async () => {
 		const root = fileURLToPath(new URL('./fixtures/prop-types/types/children', import.meta.url));
 		const tsConfigPath = fileURLToPath(

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.snippets-fail.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.snippets-fail.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["types/snippets/Fail.astro"]
+}

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.snippets-pass.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.snippets-pass.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["types/snippets/Pass.astro"]
+}

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/snippets/Fail.astro
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/snippets/Fail.astro
@@ -1,0 +1,6 @@
+---
+import SnippetProps from './SnippetProps.svelte';
+---
+
+<!-- title is required and should fail when missing -->
+<SnippetProps />

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/snippets/Pass.astro
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/snippets/Pass.astro
@@ -1,0 +1,7 @@
+---
+import SnippetProps from './SnippetProps.svelte';
+---
+
+<!-- Snippet props should be optional - only title (non-snippet) is required -->
+<SnippetProps title="Hello" />
+<SnippetProps title="Hello">Some children</SnippetProps>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/snippets/SnippetProps.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/snippets/SnippetProps.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  interface Props {
+    title: string;
+    loadingIcon: Snippet;
+    successIcon: Snippet;
+    errorIcon: Snippet;
+    children?: Snippet;
+  }
+  const { title, loadingIcon, successIcon, errorIcon, children }: Props = $props();
+</script>
+
+<h1>{title}</h1>
+{@render loadingIcon()}
+{@render successIcon()}
+{@render errorIcon()}
+{#if children}
+  {@render children()}
+{/if}


### PR DESCRIPTION
## Changes

issue : #16217

This change updates the Svelte integration's type shims to treat non-children
snippet props and `any`-typed props as optional. Previously, these were
incorrectly marked as required in Astro files, causing false-positive type
errors when using Svelte 5 components.

- Adds `HandleSnippetProps` to make Snippets optional in Astro.
- Distinguishes between generic and non-generic components to preserve inference.
- Updates TSX generation to apply the appropriate directive wrapper.

## Testing

### Before implementation

<img width="962" height="530" alt="スクリーンショット 2026-04-24 0 38 17" src="https://github.com/user-attachments/assets/4cb72af0-ba50-4411-8506-f20a477901e5" />

### After implementation

<img width="681" height="268" alt="スクリーンショット 2026-04-24 0 55 15" src="https://github.com/user-attachments/assets/19cf43b2-1ee9-4c5d-9060-5fe2a96ccc0f" />


## Docs