### PR TITLE
Widen `typescript` peer dependency range to allow v6

### DIFF
--- a/.changeset/tricky-islands-lay.md
+++ b/.changeset/tricky-islands-lay.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/check': patch
+'@astrojs/svelte': patch
+---
+
+Adds support for TypeScript v6 to peer dependencies range

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "astro": "^6.0.0",
     "svelte": "^5.43.6",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3 || ^6.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/packages/language-tools/astro-check/package.json
+++ b/packages/language-tools/astro-check/package.json
@@ -44,6 +44,6 @@
     "tsx": "^4.21.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0 || ^6.0.0"
   }
 }


### PR DESCRIPTION
## Changes

- `@astrojs/check` and `@astrojs/svelte` use TypeScript as a peer dependency
- This PR widens the supported version range to allow TS v6

## Testing

Existing tests should pass

## Docs

n/a