### PR TITLE
Revert TypeScript 6 support in Svelte integration

### DIFF
--- a/.changeset/tricky-islands-lay.md
+++ b/.changeset/tricky-islands-lay.md
@@ -1,6 +1,5 @@
 ---
 '@astrojs/check': patch
-'@astrojs/svelte': patch
 ---
 
 Adds support for TypeScript v6 to peer dependencies range

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "astro": "^6.0.0",
     "svelte": "^5.43.6",
-    "typescript": "^5.3.3 || ^6.0.0"
+    "typescript": "^5.3.3"
   },
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION


## Changes

- This partially reverts #16471 based on information from @ocavue
- The Svelte integration has a dep that doesn’t support TS6 in its peer deps yet, so holding off updating it for now.

## Testing

Existing tests should pass

## Docs

n/a