### PR TITLE
Suppress content config warning for projects without content collections

### DIFF
--- a/.changeset/fix-content-config-warning.md
+++ b/.changeset/fix-content-config-warning.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a spurious `[WARN] [content] Content config not loaded` warning during `astro dev` for projects that don't use content collections

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -128,7 +128,7 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 		});
 		contentLayer.watchContentConfig();
 		await contentLayer.sync();
-	} else {
+	} else if (config.status !== 'does-not-exist') {
 		logger.warn('content', 'Content config not loaded');
 	}
 


### PR DESCRIPTION
## Changes

- Projects without content collections no longer see `[WARN] [content] Content config not loaded` during `astro dev`. The observer status `'does-not-exist'` is now treated as a valid non-warning state, matching how the content layer itself already handles it silently.

## Testing

- Verified manually: `astro dev` on a project with no content config file no longer emits the warning.

## Docs

- No docs update needed — this removes incorrect noise from the dev server output.