### PR TITLE
Prebundle dev toolbar entrypoint in client environment

### DIFF
--- a/.changeset/toolbar-client-optimize-deps.md
+++ b/.changeset/toolbar-client-optimize-deps.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds the dev toolbar entrypoint to the client `optimizeDeps.include` to prevent a full page reload on first navigation during dev

--- a/.changeset/toolbar-client-optimize-deps.md
+++ b/.changeset/toolbar-client-optimize-deps.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds the dev toolbar entrypoint to the client `optimizeDeps.include` to prevent a full page reload on first navigation during dev
+Fixes an unnecessary full page reload on first navigation during dev

--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -18,6 +18,8 @@ test.afterAll(async () => {
 test.describe('Dev Toolbar - Audits', () => {
 	test('can warn about perf issues', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/audits-perf'));
+		// Reload so images are served from cache and are complete when the audit runs
+		await page.reload({ waitUntil: 'load' });
 
 		const toolbar = page.locator('astro-dev-toolbar');
 		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
@@ -49,6 +51,8 @@ test.describe('Dev Toolbar - Audits', () => {
 		astro,
 	}) => {
 		await page.goto(astro.resolveUrl('/audits-perf-body-unscrollable'));
+		// Reload so images are served from cache and are complete when the audit runs
+		await page.reload({ waitUntil: 'load' });
 
 		const toolbar = page.locator('astro-dev-toolbar');
 		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
@@ -91,6 +95,8 @@ test.describe('Dev Toolbar - Audits', () => {
 		astro,
 	}) => {
 		await page.goto(astro.resolveUrl('/audits-perf-absolute'));
+		// Reload so images are served from cache and are complete when the audit runs
+		await page.reload({ waitUntil: 'load' });
 
 		const toolbar = page.locator('astro-dev-toolbar');
 		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');

--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -18,8 +18,6 @@ test.afterAll(async () => {
 test.describe('Dev Toolbar - Audits', () => {
 	test('can warn about perf issues', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/audits-perf'));
-		// Reload so images are served from cache and are complete when the audit runs
-		await page.reload({ waitUntil: 'load' });
 
 		const toolbar = page.locator('astro-dev-toolbar');
 		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
@@ -51,8 +49,6 @@ test.describe('Dev Toolbar - Audits', () => {
 		astro,
 	}) => {
 		await page.goto(astro.resolveUrl('/audits-perf-body-unscrollable'));
-		// Reload so images are served from cache and are complete when the audit runs
-		await page.reload({ waitUntil: 'load' });
 
 		const toolbar = page.locator('astro-dev-toolbar');
 		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
@@ -95,8 +91,6 @@ test.describe('Dev Toolbar - Audits', () => {
 		astro,
 	}) => {
 		await page.goto(astro.resolveUrl('/audits-perf-absolute'));
-		// Reload so images are served from cache and are complete when the audit runs
-		await page.reload({ waitUntil: 'load' });
 
 		const toolbar = page.locator('astro-dev-toolbar');
 		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
@@ -194,10 +194,13 @@ export default {
 				return;
 			}
 
-			// If the element is an image but not yet loaded, ignore it
-			// TODO: We shouldn't ignore this, because it is valid for an image to not be loaded at start (e.g. lazy loading)
+			// If the element is an image that hasn't loaded yet, wait for it so that
+			// position-based checks (e.g. above/below the fold) have accurate layout data.
 			if (originalElement.nodeName === 'IMG' && !(originalElement as HTMLImageElement).complete) {
-				return;
+				await new Promise<void>((resolve) => {
+					originalElement.addEventListener('load', () => resolve(), { once: true });
+					originalElement.addEventListener('error', () => resolve(), { once: true });
+				});
 			}
 
 			audits.push({

--- a/packages/astro/src/vite-plugin-environment/index.ts
+++ b/packages/astro/src/vite-plugin-environment/index.ts
@@ -89,6 +89,7 @@ export function vitePluginEnvironment({
 					include: [
 						// For the dev toolbar
 						'astro > html-escaper',
+						'astro/runtime/client/dev-toolbar/entrypoint.js',
 					],
 					exclude: ['astro:*', 'virtual:astro:*', 'astro/virtual-modules/prefetch.js'],
 					// Astro files can't be rendered on the client


### PR DESCRIPTION
## Changes

- Adds `astro/runtime/client/dev-toolbar/entrypoint.js` to the client environment's `optimizeDeps.include`. That's all

## Testing

- Reproduced on a vanilla Astro project (no adapter): delete `node_modules/.vite`, start `astro dev`, navigate to `/`. Before: `new dependencies optimized: astro/runtime/client/dev-toolbar/entrypoint.js` + reload.

## Docs

- N/A, bug fix