### PR TITLE
Strip sourcemap reference from dev toolbar entrypoint

### DIFF
--- a/.changeset/strip-toolbar-sourcemap.md
+++ b/.changeset/strip-toolbar-sourcemap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a spurious 404 request for a dev toolbar sourcemap during `astro dev` caused by the browser mis-resolving a relative `sourceMappingURL` from the `/@id/` URL prefix

--- a/packages/astro/src/toolbar/vite-plugin-dev-toolbar.ts
+++ b/packages/astro/src/toolbar/vite-plugin-dev-toolbar.ts
@@ -1,3 +1,4 @@
+import { readFileSync, writeFileSync } from 'node:fs';
 import type * as vite from 'vite';
 import { telemetry } from '../events/index.js';
 import { eventAppToggled } from '../events/toolbar.js';
@@ -21,6 +22,33 @@ export default function astroDevToolbar({ settings, logger }: AstroPluginOptions
 						'astro > axobject-query',
 						...(settings.devToolbarApps.length > 0 ? ['astro/toolbar'] : []),
 					],
+					esbuildOptions: {
+						plugins: [
+							{
+								name: 'astro:strip-toolbar-sourcemap',
+								setup(build) {
+									// The dev toolbar entrypoint is served via /@id/ which causes
+									// the browser to mis-resolve the relative sourceMappingURL that
+									// esbuild adds, producing a bogus 404 request. Strip it after
+									// esbuild writes the optimized deps to disk.
+									build.onEnd((result) => {
+										if (!result.metafile) return;
+										for (const outputPath of Object.keys(result.metafile.outputs)) {
+											if (!outputPath.includes('entrypoint') || !outputPath.endsWith('.js')) continue;
+											const code = readFileSync(outputPath, 'utf-8');
+											const stripped = code.replace(
+												/\/\/# sourceMappingURL=.*$/m,
+												'',
+											);
+											if (stripped !== code) {
+												writeFileSync(outputPath, stripped);
+											}
+										}
+									});
+								},
+							},
+						],
+					},
 				},
 			};
 		},


### PR DESCRIPTION
## Changes

- This removes the frequent 404 caused by the browser loading a sourcemap that doesn't exist.
- esbuild creates the sourcemap link, we remove it from the file when its optimized.

## Testing

- Verified manually: the spurious `.js.map` request no longer appears in dev server logs after opening a page in the browser.

## Docs

- No docs update needed.