### PR TITLE
fix(vercel): preserve duplex for forwarded request bodies

### DIFF
--- a/.changeset/tall-ravens-tap.md
+++ b/.changeset/tall-ravens-tap.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fix forwarded serverless requests with streamed bodies by preserving the required `duplex: 'half'` option when rewriting middleware paths.

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -29,7 +29,7 @@ export default {
 			request = new Request(url.toString(), {
 				method: request.method,
 				headers: request.headers,
-				body: request.body,
+				...(request.body ? { body: request.body, duplex: 'half' } : {}),
 			});
 		}
 


### PR DESCRIPTION
## Summary
- Preserve `duplex: 'half'` when the Vercel serverless entrypoint rewrites forwarded middleware requests that include a streamed body.
- Avoid passing an empty `body` option for bodyless requests while keeping method and headers intact.

## Test plan
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm -C packages/integrations/vercel run build:ci`
- `git diff --check`

Refs #16485
