### PR TITLE
fix(upgrade): fix test types

### DIFF
--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -24,8 +24,9 @@
     "typecheck:tests": "tsc --build tsconfig.test.json"
   },
   "files": [
-    "dist",
-    "upgrade.js"
+    "dist/**/*.js",
+    "dist/**/*.mjs",
+    "upgrade.mjs"
   ],
   "//a": "MOST PACKAGES SHOULD GO IN DEV_DEPENDENCIES! THEY WILL BE BUNDLED.",
   "//b": "DEPENDENCIES IS FOR UNBUNDLED PACKAGES",

--- a/packages/upgrade/test/install.test.ts
+++ b/packages/upgrade/test/install.test.ts
@@ -7,17 +7,25 @@ import { setup, type ShellFunction } from './test-utils.ts';
 
 const tmpUrl = pathToFileURL(tmpdir());
 
+type Context = Parameters<typeof install>[0];
+
 describe('install', () => {
 	const fixture = setup();
-	const ctx = {
-		cwd: '',
+	const ctx: Context = {
+		cwd: tmpUrl,
 		version: 'latest',
-		packageManager: 'npm',
+		packageManager: { name: 'npm', agent: 'npm' },
 		dryRun: true,
+		// @ts-expect-error: fake `prompt` callback for testing
+		prompt: async () => ({ proceed: true }),
+		exit: (): never => {
+			return undefined as never;
+		},
+		packages: [],
 	};
 
 	it('up to date', async () => {
-		const context = {
+		const context: Context = {
 			...ctx,
 			packages: [
 				{
@@ -32,7 +40,7 @@ describe('install', () => {
 	});
 
 	it('patch', async () => {
-		const context = {
+		const context: Context = {
 			...ctx,
 			packages: [
 				{
@@ -47,7 +55,7 @@ describe('install', () => {
 	});
 
 	it('minor', async () => {
-		const context = {
+		const context: Context = {
 			...ctx,
 			packages: [
 				{
@@ -63,15 +71,17 @@ describe('install', () => {
 
 	it('major (reject)', async () => {
 		let prompted = false;
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
-			prompt: () => {
+			// @ts-expect-error: fake `prompt` callback for testing
+			prompt: async () => {
 				prompted = true;
 				return { proceed: false };
 			},
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{
@@ -93,15 +103,17 @@ describe('install', () => {
 
 	it('major (accept)', async () => {
 		let prompted = false;
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
-			prompt: () => {
+			// @ts-expect-error: fake `prompt` callback for testing
+			prompt: async () => {
 				prompted = true;
 				return { proceed: true };
 			},
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{
@@ -123,15 +135,17 @@ describe('install', () => {
 
 	it('multiple major', async () => {
 		let prompted = false;
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
-			prompt: () => {
+			// @ts-expect-error: fake `prompt` callback for testing
+			prompt: async () => {
 				prompted = true;
 				return { proceed: true };
 			},
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{
@@ -165,15 +179,17 @@ describe('install', () => {
 
 	it('current patch minor major', async () => {
 		let prompted = false;
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
-			prompt: () => {
+			// @ts-expect-error: fake `prompt` callback for testing
+			prompt: async () => {
 				prompted = true;
 				return { proceed: true };
 			},
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{
@@ -224,14 +240,15 @@ describe('install', () => {
 			return { stdout: '', stderr: '', exitCode: 0 };
 		});
 
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
 			dryRun: false,
 			cwd: tmpUrl,
 			packageManager: { name: 'npm', agent: 'npm' },
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{
@@ -263,14 +280,15 @@ describe('install', () => {
 			throw new Error('npm ERR! some other error');
 		});
 
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
 			dryRun: false,
 			cwd: tmpUrl,
 			packageManager: { name: 'npm', agent: 'npm' },
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{
@@ -295,14 +313,15 @@ describe('install', () => {
 			throw new Error('npm ERR! peer dependencies conflict');
 		});
 
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
 			dryRun: false,
 			cwd: tmpUrl,
 			packageManager: { name: 'npm', agent: 'npm' },
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{
@@ -335,14 +354,15 @@ describe('install', () => {
 			throw new Error('pnpm ERR! peer dependencies conflict');
 		});
 
-		let exitCode;
-		const context = {
+		let exitCode: number | undefined;
+		const context: Context = {
 			...ctx,
 			dryRun: false,
 			cwd: tmpUrl,
 			packageManager: { name: 'pnpm', agent: 'pnpm' },
-			exit: (code: number) => {
+			exit: (code: number): never => {
 				exitCode = code;
+				return undefined as never;
 			},
 			packages: [
 				{

--- a/packages/upgrade/tsconfig.json
+++ b/packages/upgrade/tsconfig.json
@@ -9,6 +9,6 @@
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "outDir": "./dist",
-    "declarationDir": "./dist",
+    "declarationDir": "./dist"
   }
 }

--- a/packages/upgrade/tsconfig.json
+++ b/packages/upgrade/tsconfig.json
@@ -5,11 +5,10 @@
     "rootDir": "./src",
     "allowJs": true,
     "emitDeclarationOnly": false,
-    "noEmit": true,
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "outDir": "./dist",
-    "declarationDir": "./dist/types"
+    "declarationDir": "./dist",
   }
 }


### PR DESCRIPTION
## Changes

1. Removed `noEmit: true` from `packages/upgrade/tsconfig.json`. This actually reveals the following error in CI. This is an old bug but since we didn't emit `.d.ts` files we didn't find it out. 

```
@astrojs/upgrade@0.7.2 : typecheck:tests packages/upgrade
  
  > @astrojs/upgrade@0.7.2 typecheck:tests /home/runner/work/astro/astro/packages/upgrade
  > tsc --build tsconfig.test.json
  
  Error: test/install.test.ts(30,17): error TS2345: Argument of type '{ packages: { name: string; currentVersion: string; targetVersion: string; }[]; cwd: string; version: string; packageManager: string; dryRun: boolean; }' is not assignable to parameter of type 'Pick<Context, "version" | "packages" | "packageManager" | "prompt" | "dryRun" | "exit" | "cwd">'.
    Type '{ packages: { name: string; currentVersion: string; targetVersion: string; }[]; cwd: string; version: string; packageManager: string; dryRun: boolean; }' is missing the following properties from type 'Pick<Context, "version" | "packages" | "packageManager" | "prompt" | "dryRun" | "exit" | "cwd">': prompt, exit
```
   
2. Actually fix the TS typing so that this error is gone. 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
