### PR TITLE
chore: clean up some stale imports

### DIFF
--- a/packages/astro/e2e/custom-client-directives.test.ts
+++ b/packages/astro/e2e/custom-client-directives.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import testAdapter from '../test/test-adapter.js';
+import testAdapter from '../test/test-adapter.ts';
 import { type PreviewServer, type DevServer, testFactory, waitForHydrate } from './test-utils.ts';
 
 const test = testFactory(import.meta.url, {

--- a/packages/astro/e2e/test-utils.ts
+++ b/packages/astro/e2e/test-utils.ts
@@ -9,7 +9,7 @@ import {
 	type Fixture,
 	type PreviewServer,
 	loadFixture as baseLoadFixture,
-} from '../test/test-utils.js';
+} from '../test/test-utils.ts';
 
 export type { AstroInlineConfig, DevServer, Fixture, PreviewServer };
 

--- a/packages/astro/performance/content-benchmark.mjs
+++ b/packages/astro/performance/content-benchmark.mjs
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import colors from 'picocolors';
-import { loadFixture } from '../test/test-utils.js';
+import { loadFixture } from '../test/test-utils.ts';
 import { generatePosts } from './scripts/generate-posts.mjs';
 
 // Skip nonessential remark / rehype plugins for a fair comparison.

--- a/packages/astro/test/fixtures/server-islands/ssr/astro.config.mjs
+++ b/packages/astro/test/fixtures/server-islands/ssr/astro.config.mjs
@@ -1,6 +1,6 @@
 import svelte from '@astrojs/svelte';
 import { defineConfig } from 'astro/config';
-import testAdapter from '../../../test-adapter.js';
+import testAdapter from '../../../test-adapter.ts';
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({
@@ -11,4 +11,3 @@ export default defineConfig({
     mdx()
   ],
 });
-

--- a/packages/astro/tsconfig.test.json
+++ b/packages/astro/tsconfig.test.json
@@ -1,13 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": [
-    "test/units/**/*.ts",
-    "test/*.ts",
-    "e2e/*.ts",
-    "test/test-adapter.js",
-    "test/test-utils.js",
-    "package.json"
-  ],
+  "include": ["test/units/**/*.ts", "test/*.ts", "e2e/*.ts", "package.json"],
   "exclude": ["test/units/_temp-fixtures/**", "test/fixtures/**", "e2e/fixtures/**"],
   "files": [
     // Extra files that aren't included in the "include" glob patterns, but are still needed for tests.


### PR DESCRIPTION
## Changes

1. Remove the unused file in `packages/astro/tsconfig.test.json`  
2. Fix some imports to use the real file path `xx.ts` instead of the outdated `xx.js`

## Testing

Green CI
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
