### PR TITLE
chore: revamp renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     "schedule:weekly",
-    "group:allNonMajor",
     ":disablePeerDependencies",
     "regexManagers:biomeVersions",
     "helpers:pinGitHubActionDigestsToSemver"
@@ -16,6 +15,7 @@
   },
   "ignorePaths": ["**/node_modules/**"],
   "packageRules": [
+    //#region Infra groups
     {
       "groupName": "lockfile maintenance",
       "matchUpdateTypes": ["lockFileMaintenance"]
@@ -29,41 +29,154 @@
       "matchDepTypes": ["engines"],
       "enabled": false
     },
+    //#endregion
+
+    //#region Per-package groups (non-major only)
     {
-      "groupName": "astro dependencies",
+      "groupName": "astro",
       "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/astro/**"]
+    },
+    {
+      "groupName": "markdown",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
       "matchFileNames": [
-        "packages/astro/**",
-        "packages/integrations/mdx/**",
-        "packages/integrations/remark/**"
+        "packages/markdown/remark/**",
+        "packages/integrations/mdx/**"
       ]
     },
     {
-      "groupName": "astro adapters",
+      "groupName": "language-tools",
       "matchManagers": ["npm"],
-      "matchFileNames": [
-        "packages/integrations/node/**",
-        "packages/integrations/netlify/**",
-        "packages/integrations/cloudflare/**",
-        "packages/integrations/vercel/**"
-      ]
-    },
-    {
-      "groupName": "astro client runtimes",
-      "matchManagers": ["npm"],
-      "matchFileNames": [
-        "packages/integrations/react/**",
-        "packages/integrations/solid/**",
-        "packages/integrations/preact/**",
-        "packages/integrations/svelte/**",
-        "packages/integrations/vue/**"
-      ]
-    },
-    {
-      "groupName": "language tools",
-      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
       "matchFileNames": ["packages/language-tools/**"]
+    },
+    //#endregion
+
+    //#region Adapters
+    {
+      "groupName": "@astrojs/cloudflare",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/cloudflare/**"]
+    },
+    {
+      "groupName": "@astrojs/netlify",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/netlify/**"]
+    },
+    {
+      "groupName": "@astrojs/node",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/node/**"]
+    },
+    {
+      "groupName": "@astrojs/vercel",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/vercel/**"]
+    },
+    //#endregion
+
+    //#region Client runtimes
+    {
+      "groupName": "@astrojs/react",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/react/**"]
+    },
+    {
+      "groupName": "@astrojs/preact",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/preact/**"]
+    },
+    {
+      "groupName": "@astrojs/solid-js",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/solid/**"]
+    },
+    {
+      "groupName": "@astrojs/svelte",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/svelte/**"]
+    },
+    {
+      "groupName": "@astrojs/vue",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/vue/**"]
+    },
+    //#endregion
+
+    //#region Other integrations
+    {
+      "groupName": "@astrojs/alpinejs",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/alpinejs/**"]
+    },
+    {
+      "groupName": "@astrojs/markdoc",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/markdoc/**"]
+    },
+    {
+      "groupName": "@astrojs/partytown",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/partytown/**"]
+    },
+    {
+      "groupName": "@astrojs/sitemap",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/sitemap/**"]
+    },
+    //#endregion
+
+    //#region Standalone packages
+    {
+      "groupName": "@astrojs/db",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/db/**"]
+    },
+    {
+      "groupName": "create-astro",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/create-astro/**"]
+    },
+    {
+      "groupName": "@astrojs/upgrade",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/upgrade/**"]
+    },
+    //#endregion
+
+    //#region Minor packages (few external deps, rarely trigger updates)
+    {
+      "groupName": "minor packages",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": [
+        "packages/astro-prism/**",
+        "packages/astro-rss/**",
+        "packages/internal-helpers/**",
+        "packages/telemetry/**",
+        "packages/underscore-redirects/**"
+      ]
     }
+    //#endregion
   ],
   "ignoreDeps": [
     // manually bumping deps


### PR DESCRIPTION
## Changes

This PR revamps renovate to break down groups for each internal package. The reason why I decided to do this is because I realised that we rarely *can* merge renovate PRs because there's always something that breaks for a pacakge, which prevents us from updating valid updates for other packages.

This PR creates a group for each relevant package of the monorepo. The ones that rarely trigger an update are grouped together.

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
