### PR TITLE
fix: svelte testing library type

### DIFF
--- a/.changeset/nine-dots-cross.md
+++ b/.changeset/nine-dots-cross.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Adjusted the generated Svelte editor wrapper to avoid intersecting with the original `$$Component` type and instead use an explicit wrapper type with distinct Astro prop and Svelte internals call signatures. The change preserves generic inference by using `GenericPropsWithClientDirectives` for generic components, restores invalid prop errors in astro check, and maintains compatibility with `@testing-library/svelte`.

--- a/.changeset/nine-dots-cross.md
+++ b/.changeset/nine-dots-cross.md
@@ -2,4 +2,4 @@
 '@astrojs/svelte': patch
 ---
 
-Adjusted the generated Svelte editor wrapper to avoid intersecting with the original `$$Component` type and instead use an explicit wrapper type with distinct Astro prop and Svelte internals call signatures. The change preserves generic inference by using `GenericPropsWithClientDirectives` for generic components, restores invalid prop errors in astro check, and maintains compatibility with `@testing-library/svelte`.
+Fixes a type mismatch issue where Svelte 5 components were incorrectly flagged as incompatible with testing libraries (e.g. `@testing-library/svelte`) during astro check. This fix ensures that Svelte 5 components pass validation in unit tests while preserving support for Astro's `client:* directives` in `.astro` files.

--- a/.changeset/nine-dots-cross.md
+++ b/.changeset/nine-dots-cross.md
@@ -2,4 +2,4 @@
 '@astrojs/svelte': patch
 ---
 
-Fixes a type mismatch issue where Svelte 5 components were incorrectly flagged as incompatible with testing libraries (e.g. `@testing-library/svelte`) during astro check. This fix ensures that Svelte 5 components pass validation in unit tests while preserving support for Astro's `client:* directives` in `.astro` files.
+Fixed an issue where type errors occurred during testing library type checks because Astro overrides Svelte 5 component types.

--- a/knip.js
+++ b/knip.js
@@ -82,6 +82,11 @@ export default {
 			// It's an optional peer dep (triggers a warning) but it's fine in this case
 			ignoreDependencies: ['solid-devtools'],
 		},
+		'packages/integrations/svelte': {
+			entry: [testEntry],
+			// Used in testing-library compatibility tests but not directly imported
+			ignoreDependencies: ['@testing-library/svelte'],
+		},
 		'packages/markdown/remark': {
 			entry: [testEntry],
 			// package.json#imports are not resolved at the moment

--- a/knip.js
+++ b/knip.js
@@ -82,6 +82,11 @@ export default {
 			// It's an optional peer dep (triggers a warning) but it's fine in this case
 			ignoreDependencies: ['solid-devtools'],
 		},
+		'packages/integrations/svelte': {
+			entry: [testEntry],
+			// Used in testing-library compatibility tests but not directly imported
+			ignoreDependencies: ['@testing-library/svelte'],
+		},
 		'packages/markdown/remark': {
 			entry: [srcEntry, dtsEntry, testEntry],
 		},

--- a/knip.js
+++ b/knip.js
@@ -83,7 +83,7 @@ export default {
 			ignoreDependencies: ['solid-devtools'],
 		},
 		'packages/integrations/svelte': {
-			entry: [testEntry],
+			entry: [srcEntry, dtsEntry, testEntry],
 			// Used in testing-library compatibility tests but not directly imported
 			ignoreDependencies: ['@testing-library/svelte'],
 		},

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -45,6 +45,7 @@
     "vitefu": "^1.1.2"
   },
   "devDependencies": {
+    "@testing-library/svelte": "^5.3.1",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.2.0",

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -44,6 +44,7 @@
     "vitefu": "^1.1.2"
   },
   "devDependencies": {
+    "@testing-library/svelte": "^5.3.1",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.2.0",

--- a/packages/integrations/svelte/src/editor.cts
+++ b/packages/integrations/svelte/src/editor.cts
@@ -15,22 +15,26 @@ export function toTSX(code: string, className: string): string {
 		// New svelte2tsx output (Svelte 5)
 		if (tsx.includes('export default $$Component;')) {
 			const generics = extractGenerics(tsx);
-			const genericSuffix = generics ? `<${generics.params}>` : '';
 			const innerType = generics
 				? `ReturnType<__sveltets_Render<${generics.names}>['props']>`
 				: `import('svelte').ComponentProps<typeof $$$$Component>`;
-			// Generic components use a simpler type wrapper that preserves generic
-			// inference. Non-generic components use the full snippet handling.
-			const propsType = generics ? 'GenericPropsWithClientDirectives' : 'PropsWithClientDirectives';
+			const propsOnlySignature = generics
+				? `<${generics.params}>(props: import('@astrojs/svelte/svelte-shims.d.ts').GenericPropsWithClientDirectives<${innerType}>): any;`
+				: `(props: import('@astrojs/svelte/svelte-shims.d.ts').PropsWithClientDirectives<${innerType}>): any;`;
+			const internalsSignature = generics
+				? `<${generics.params}>(this: void, _internals: import('svelte').ComponentInternals, _props: ${innerType}): Record<string, any>;`
+				: `(this: void, _internals: import('svelte').ComponentInternals, _props: ${innerType}): Record<string, any>;`;
 			result = tsx.replace(
 				'export default $$Component;',
-				`export default function ${className}__AstroComponent_${genericSuffix}(_props: import('@astrojs/svelte/svelte-shims.d.ts').${propsType}<${innerType}>): any {}`,
+				`const ${className}__AstroComponent_ = $$Component as unknown as { ${propsOnlySignature} ${internalsSignature} };\nexport default ${className}__AstroComponent_;`,
 			);
 		} else {
 			// Old svelte2tsx output
 			result = tsx.replace(
 				'export default class extends __sveltets_2_createSvelte2TsxComponent(',
-				`export default function ${className}__AstroComponent_(_props: import('@astrojs/svelte/svelte-shims.d.ts').PropsWithClientDirectives<typeof Component.props>): any {}\nlet Component = `,
+				`function ${className}__AstroComponent_Inner(_props: import('@astrojs/svelte/svelte-shims.d.ts').PropsWithClientDirectives<typeof Component.props>): any { return {}; }\n` +
+				`const ${className}__AstroComponent_ = ${className}__AstroComponent_Inner as unknown as typeof ${className}__AstroComponent_Inner & { (this: void, _internals: import('svelte').ComponentInternals, _props: typeof Component.props): Record<string, any>; };\n` +
+				`export default ${className}__AstroComponent_;\nlet Component = `,
 			);
 		}
 	} catch {

--- a/packages/integrations/svelte/svelte-shims.d.ts
+++ b/packages/integrations/svelte/svelte-shims.d.ts
@@ -121,3 +121,18 @@ export type GenericPropsWithClientDirectives<T> = StripNeverIndexSignatures<
 	WidenChildrenIfSnippet<NormalizeNeverChildren<T>>
 > &
 	AstroClientDirectives;
+
+/**
+ * Wraps a Svelte component type for Astro usage.
+ *
+ * Creates a type that:
+ * 1. Has a call signature `(_props: PropsWithClientDirectives<Props>) => any`
+ *    for JSX prop resolution in `.astro` templates (used by astro check)
+ * 2. Has an additional 2-parameter call signature matching Svelte's `Component`
+ *    interface `(internals, props)` so the export remains assignable to
+ *    `svelte.Component` for use with tools like `@testing-library/svelte`
+ */
+export interface AstroSvelteComponent<Props> {
+	(_props: PropsWithClientDirectives<Props>): any;
+	(this: void, _internals: import('svelte').ComponentInternals, _props: Props): Record<string, any>;
+}

--- a/packages/integrations/svelte/svelte-shims.d.ts
+++ b/packages/integrations/svelte/svelte-shims.d.ts
@@ -121,18 +121,3 @@ export type GenericPropsWithClientDirectives<T> = StripNeverIndexSignatures<
 	WidenChildrenIfSnippet<NormalizeNeverChildren<T>>
 > &
 	AstroClientDirectives;
-
-/**
- * Wraps a Svelte component type for Astro usage.
- *
- * Creates a type that:
- * 1. Has a call signature `(_props: PropsWithClientDirectives<Props>) => any`
- *    for JSX prop resolution in `.astro` templates (used by astro check)
- * 2. Has an additional 2-parameter call signature matching Svelte's `Component`
- *    interface `(internals, props)` so the export remains assignable to
- *    `svelte.Component` for use with tools like `@testing-library/svelte`
- */
-export interface AstroSvelteComponent<Props> {
-	(_props: PropsWithClientDirectives<Props>): any;
-	(this: void, _internals: import('svelte').ComponentInternals, _props: Props): Record<string, any>;
-}

--- a/packages/integrations/svelte/test/check.test.ts
+++ b/packages/integrations/svelte/test/check.test.ts
@@ -183,4 +183,19 @@ describe('Svelte Check', () => {
 
 		assert.equal(exitCode, 1, 'Expected check to fail (exit code 1)');
 	});
+
+	it('should pass check for @testing-library/svelte compatibility', async () => {
+    const root = fileURLToPath(new URL('./fixtures/prop-types/types/testing-library', import.meta.url));
+    const tsConfigPath = fileURLToPath(
+      new URL('./fixtures/prop-types/tsconfig.testing-library.json', import.meta.url),
+    );
+
+    const { getResult } = cli('check', '--tsconfig', tsConfigPath, '--root', root);
+    const { exitCode, stdout, stderr } = await getResult();
+
+    // Failure message including stdout for easier debugging in CI
+    const failureMessage = `Expected check to pass for testing-library compatibility.\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`;
+    
+    assert.strictEqual(exitCode, 0, failureMessage);
+  });
 });

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.testing-library.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.testing-library.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "rootDir": "../../../../",
+    "types": ["@testing-library/svelte"]
+  },
+  "include": [
+    "./types/testing-library/Component.ts",
+    "./types/testing-library/Component.svelte",
+    "../../../../packages/integrations/svelte/svelte-shims.d.ts"
+  ]
+}

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.testing-library.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.testing-library.json
@@ -1,14 +1,6 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "Bundler",
-    "skipLibCheck": true,
-    "rootDir": "../../../../",
-    "types": ["@testing-library/svelte"]
-  },
-  "include": [
-    "./types/testing-library/Component.ts",
-    "./types/testing-library/Component.svelte",
-    "../../../../packages/integrations/svelte/svelte-shims.d.ts"
-  ]
+  // Separate tsconfig needed: verifies the Astro-wrapped Svelte component type
+  // is assignable to svelte.Component, as required by @testing-library/svelte render().
+  "extends": "./tsconfig.json",
+  "include": ["types/testing-library"]
 }

--- a/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.testing-library.json
+++ b/packages/integrations/svelte/test/fixtures/prop-types/tsconfig.testing-library.json
@@ -1,6 +1,6 @@
+// Separate tsconfig needed: verifies the Astro-wrapped Svelte component type
+// is assignable to svelte.Component, as required by @testing-library/svelte render().
 {
-  // Separate tsconfig needed: verifies the Astro-wrapped Svelte component type
-  // is assignable to svelte.Component, as required by @testing-library/svelte render().
   "extends": "./tsconfig.json",
   "include": ["types/testing-library"]
 }

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/testing-library/Component.svelte
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/testing-library/Component.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { name = "world" } = $props();
+</script>
+
+<h1>Hello {name}!</h1>

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/testing-library/Component.ts
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/testing-library/Component.ts
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/svelte';
+import type { Component as SvelteComponent } from 'svelte';
+import Component from './Component.svelte';
+
+/**
+ * Passing the component to Testing Library's render function.
+ * Reproduces the original issue where Astro's wrapped component type
+ * is incompatible with the expected Svelte component type.
+ */
+render(Component);
+
+/**
+ * Direct assignment to Svelte 5's standard Component type.
+ * Ensures the component can be treated as a standard Svelte component.
+ */
+const testAssign: SvelteComponent<any, any, any> = Component;
+
+/**
+ * Reference the variable to satisfy the compiler and ensure type checking
+ */
+export function useVariables() {
+	console.log(testAssign);
+}

--- a/packages/integrations/svelte/test/fixtures/prop-types/types/testing-library/Component.ts
+++ b/packages/integrations/svelte/test/fixtures/prop-types/types/testing-library/Component.ts
@@ -1,23 +1,4 @@
 import { render } from '@testing-library/svelte';
-import type { Component as SvelteComponent } from 'svelte';
 import Component from './Component.svelte';
 
-/**
- * Passing the component to Testing Library's render function.
- * Reproduces the original issue where Astro's wrapped component type
- * is incompatible with the expected Svelte component type.
- */
 render(Component);
-
-/**
- * Direct assignment to Svelte 5's standard Component type.
- * Ensures the component can be treated as a standard Svelte component.
- */
-const testAssign: SvelteComponent<any, any, any> = Component;
-
-/**
- * Reference the variable to satisfy the compiler and ensure type checking
- */
-export function useVariables() {
-	console.log(testAssign);
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6138,6 +6138,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
       astro:
         specifier: workspace:*
         version: link:../../astro
@@ -6192,6 +6195,9 @@ importers:
       '@astrojs/svelte':
         specifier: workspace:*
         version: link:../../..
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
       astro:
         specifier: workspace:*
         version: link:../../../../../astro
@@ -9897,6 +9903,29 @@ packages:
   '@test/server-entry-fake-adapter@file:packages/astro/test/fixtures/server-entry/fake-adapter':
     resolution: {directory: packages/astro/test/fixtures/server-entry/fake-adapter, type: directory}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: ^7.3.2
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
   '@textlint/ast-node-types@15.5.1':
     resolution: {integrity: sha512-2ABQSaQoM9u9fycXLJKcCv4XQulJWTUSwjo6F0i/ujjqOH8/AZ2A0RDKKbAddqxDhuabVB20lYoEsZZgzehccg==}
 
@@ -10630,6 +10659,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -10658,6 +10691,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -11470,6 +11506,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -13007,6 +13046,10 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -14096,6 +14139,10 @@ packages:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -14196,6 +14243,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -18803,6 +18853,30 @@ snapshots:
     dependencies:
       astro: link:packages/astro
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.55.3)':
+    dependencies:
+      svelte: 5.55.3
+
+  '@testing-library/svelte@5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.55.3)
+      svelte: 5.55.3
+    optionalDependencies:
+      vite: 7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+
   '@textlint/ast-node-types@15.5.1': {}
 
   '@textlint/linter-formatter@15.5.1':
@@ -19781,6 +19855,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
@@ -19820,6 +19896,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.1: {}
 
@@ -20588,6 +20668,8 @@ snapshots:
   direction@2.0.1: {}
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -22321,6 +22403,8 @@ snapshots:
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -23791,6 +23875,12 @@ snapshots:
 
   pretty-bytes@7.1.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -23888,6 +23978,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.18.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6195,9 +6195,6 @@ importers:
       '@astrojs/svelte':
         specifier: workspace:*
         version: link:../../..
-      '@testing-library/svelte':
-        specifier: ^5.3.1
-        version: 5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
       astro:
         specifier: workspace:*
         version: link:../../../../../astro

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6120,9 +6120,6 @@ importers:
       '@astrojs/svelte':
         specifier: workspace:*
         version: link:../../..
-      '@testing-library/svelte':
-        specifier: ^5.3.1
-        version: 5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
       astro:
         specifier: workspace:*
         version: link:../../../../../astro

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6063,6 +6063,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(vite@7.3.2)
     devDependencies:
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
       astro:
         specifier: workspace:*
         version: link:../../astro
@@ -6117,6 +6120,9 @@ importers:
       '@astrojs/svelte':
         specifier: workspace:*
         version: link:../../..
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
       astro:
         specifier: workspace:*
         version: link:../../../../../astro
@@ -10235,6 +10241,29 @@ packages:
   '@test/server-entry-fake-adapter@file:packages/astro/test/fixtures/server-entry/fake-adapter':
     resolution: {directory: packages/astro/test/fixtures/server-entry/fake-adapter, type: directory}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: ^7.3.2
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
   '@textlint/ast-node-types@15.5.1':
     resolution: {integrity: sha512-2ABQSaQoM9u9fycXLJKcCv4XQulJWTUSwjo6F0i/ujjqOH8/AZ2A0RDKKbAddqxDhuabVB20lYoEsZZgzehccg==}
 
@@ -10945,6 +10974,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -10973,6 +11006,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -11821,6 +11857,12 @@ packages:
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -13434,6 +13476,10 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -14579,6 +14625,14 @@ packages:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -14693,6 +14747,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -20116,6 +20173,30 @@ snapshots:
     dependencies:
       astro: link:packages/astro
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.55.3)':
+    dependencies:
+      svelte: 5.55.3
+
+  '@testing-library/svelte@5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.55.3)
+      svelte: 5.55.3
+    optionalDependencies:
+      vite: 7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+
   '@textlint/ast-node-types@15.5.1': {}
 
   '@textlint/linter-formatter@15.5.1':
@@ -21083,6 +21164,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
@@ -21122,6 +21205,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.1: {}
 
@@ -21923,6 +22010,10 @@ snapshots:
       path-type: 4.0.0
 
   direction@2.0.1: {}
+
+  dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -23752,6 +23843,8 @@ snapshots:
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -25255,6 +25348,16 @@ snapshots:
 
   pretty-bytes@7.1.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   prismjs@1.30.0: {}
 
   process-nextick-args@2.0.1: {}
@@ -25390,6 +25493,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.18.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6940,15 +6940,6 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
-<<<<<<< HEAD
-  triage/gh-16482:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../packages/astro
-
-=======
->>>>>>> db0eb522a (refator: testing code)
 packages:
 
   '@anthropic-ai/sdk@0.91.1':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6065,7 +6065,7 @@ importers:
     devDependencies:
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.3.1(svelte@5.55.3)(vite@7.3.2)(vitest@4.1.0)
       astro:
         specifier: workspace:*
         version: link:../../astro
@@ -6940,12 +6940,15 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+<<<<<<< HEAD
   triage/gh-16482:
     dependencies:
       astro:
         specifier: workspace:*
         version: link:../../packages/astro
 
+=======
+>>>>>>> db0eb522a (refator: testing code)
 packages:
 
   '@anthropic-ai/sdk@0.91.1':
@@ -10253,7 +10256,7 @@ packages:
     engines: {node: '>= 10'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
-      vite: ^7.3.2
+      vite: '*'
       vitest: '*'
     peerDependenciesMeta:
       vite:
@@ -11854,9 +11857,6 @@ packages:
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -14625,10 +14625,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  pretty-ms@9.3.0:
-    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
-    engines: {node: '>=18'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -20185,14 +20181,14 @@ snapshots:
     dependencies:
       svelte: 5.55.3
 
-  '@testing-library/svelte@5.3.1(svelte@5.55.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@testing-library/svelte@5.3.1(svelte@5.55.3)(vite@7.3.2)(vitest@4.1.0)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.55.3)
       svelte: 5.55.3
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@textlint/ast-node-types@15.5.1': {}
 
@@ -22007,8 +22003,6 @@ snapshots:
       path-type: 4.0.0
 
   direction@2.0.1: {}
-
-  dlv@1.1.3: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -25350,10 +25344,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  pretty-ms@9.3.0:
-    dependencies:
-      parse-ms: 4.0.0
 
   prismjs@1.30.0: {}
 


### PR DESCRIPTION
## Changes

Close #15689

Adjusted the generated Svelte editor wrapper to avoid intersecting with the original `$$Component` type and instead use an explicit wrapper type with distinct Astro prop and Svelte internals call signatures. The change preserves generic inference by using `GenericPropsWithClientDirectives` for generic components, restores invalid prop errors in astro check, and maintains compatibility with `@testing-library/svelte`.

## Testing Before Implementation

<img width="1329" height="355" alt="スクリーンショット 2026-05-23 14 04 51" src="https://github.com/user-attachments/assets/d1a6d526-e9e4-4198-bcdf-3a504deb25d5" />


## Testing After Implementation

<img width="710" height="257" alt="スクリーンショット 2026-05-23 14 20 11" src="https://github.com/user-attachments/assets/0c947871-bf35-48cb-a914-f1965ad26bf0" />


