### PR TITLE
Fix frontmatter scan plugin to prevent errant error messages

### DIFF
--- a/.changeset/fix-cloudflare-frontmatter-default-export.md
+++ b/.changeset/fix-cloudflare-frontmatter-default-export.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes the dependency scan failing with "No matching export for import 'default'" when a `.ts` file default-imports an `.astro` component
+
+The esbuild scan plugin now includes `export default {}` in its output for `.astro` files, preventing the scan from failing and ensuring all dependencies are discovered ahead of time.

--- a/packages/integrations/cloudflare/src/esbuild-plugin-astro-frontmatter.ts
+++ b/packages/integrations/cloudflare/src/esbuild-plugin-astro-frontmatter.ts
@@ -34,8 +34,13 @@ export function astroFrontmatterScanPlugin(): ESBuildPlugin {
 							.replace(/\breturn\s*;/g, 'throw 0;')
 							.replace(/\breturn\b/g, 'throw ');
 
+						// Append `export default {}` so that default imports of .astro files
+						// (e.g. `import MyComponent from './MyComponent.astro'`) resolve correctly
+						// during the dep scan. Without this, .astro files loaded in the `html`
+						// namespace (when imported from .ts files) would have no default export,
+						// causing esbuild to fail with "No matching export for import 'default'".
 						return {
-							contents,
+							contents: contents + '\nexport default {}',
 							loader: 'ts',
 						};
 					}
@@ -43,9 +48,9 @@ export function astroFrontmatterScanPlugin(): ESBuildPlugin {
 					// Ignore read errors
 				}
 
-				// No frontmatter or read error, return empty
+				// No frontmatter or read error, return empty with a default export
 				return {
-					contents: '',
+					contents: 'export default {}',
 					loader: 'ts',
 				};
 			});

--- a/packages/integrations/cloudflare/test/fixtures/ssr-deps/src/components/Duration.astro
+++ b/packages/integrations/cloudflare/test/fixtures/ssr-deps/src/components/Duration.astro
@@ -1,0 +1,6 @@
+---
+import ms from 'ms';
+
+const duration = ms('1 hour');
+---
+<span class="duration">{duration}</span>

--- a/packages/integrations/cloudflare/test/fixtures/ssr-deps/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/ssr-deps/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
-import ms from 'ms';
+import { getRenderers } from '../utils/get-renderers';
 
-const duration = ms('2 days');
+const { Duration } = getRenderers();
 ---
 <html>
 <head>
@@ -9,6 +9,6 @@ const duration = ms('2 days');
 </head>
 <body>
 	<h1>SSR Dependencies</h1>
-	<p>Two days in milliseconds: {duration}</p>
+	<p>One hour in milliseconds: <Duration /></p>
 </body>
 </html>

--- a/packages/integrations/cloudflare/test/fixtures/ssr-deps/src/utils/get-renderers.ts
+++ b/packages/integrations/cloudflare/test/fixtures/ssr-deps/src/utils/get-renderers.ts
@@ -1,0 +1,5 @@
+import Duration from '../components/Duration.astro';
+
+export function getRenderers() {
+	return { Duration };
+}

--- a/packages/integrations/cloudflare/test/ssr-deps.test.ts
+++ b/packages/integrations/cloudflare/test/ssr-deps.test.ts
@@ -1,62 +1,65 @@
 import * as assert from 'node:assert/strict';
 import { rmSync } from 'node:fs';
-import { Writable } from 'node:stream';
 import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { AstroLogger } from 'astro/_internal/logger';
+import { createLogger } from 'vite';
 import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
 
 describe('SSR dependencies', () => {
 	let fixture: Fixture;
 	let devServer: DevServer;
-	const logs: Array<{ message?: string }> = [];
+	const viteMessages: string[] = [];
 
 	before(async () => {
+		const logger = createLogger('info', { allowClearScreen: false });
+		const origInfo = logger.info.bind(logger);
+		const origWarn = logger.warn.bind(logger);
+		const origError = logger.error.bind(logger);
+		logger.info = (msg, opts) => { viteMessages.push(msg); origInfo(msg, opts); };
+		logger.warn = (msg, opts) => { viteMessages.push(msg); origWarn(msg, opts); };
+		logger.error = (msg, opts) => { viteMessages.push(msg); origError(msg, opts); };
+
 		fixture = await loadFixture({
 			root: './fixtures/ssr-deps/',
+			vite: {
+				customLogger: logger,
+			},
 		});
 
 		// Clear Vite cache to ensure dependencies are discovered fresh
 		const viteCacheDir = new URL('./node_modules/.vite/', fixture.config.root);
 		rmSync(fileURLToPath(viteCacheDir), { recursive: true, force: true });
 
-		const logger = new AstroLogger({
-			level: 'info',
-			destination: new Writable({
-				objectMode: true,
-				write(event, _, callback) {
-					logs.push(event);
-					callback();
-				},
-			}),
-		});
-		devServer = await fixture.startDevServer({
-			// @ts-expect-error: logger is internal API
-			logger,
-		});
+		devServer = await fixture.startDevServer();
 	});
 
 	after(async () => {
 		await devServer?.stop();
 	});
 
-	it('should discover server-side dependencies ahead of time', async () => {
-		// Make a request to trigger SSR rendering which uses the `ms` dependency
-		const res = await fixture.fetch('/');
-		const html = await res.text();
-
-		// Verify the page rendered correctly with the dependency
-		assert.ok(html.includes('172800000'), 'Expected ms() to compute 2 days in milliseconds');
-
-		// Check that we didn't get the "new dependencies optimized" warning
-		// This message indicates dependencies weren't discovered ahead of time
-		const optimizedLog = logs.find(
-			(log) => log.message && log.message.includes('new dependencies optimized'),
+	it('should not fail the dep scan when .ts files import .astro components', async () => {
+		// When a .ts file imports a .astro component with a default import
+		// (e.g. `import Duration from './Duration.astro'`), the esbuild scan plugin
+		// must provide a default export so the scan doesn't fail with
+		// "No matching export for import 'default'".
+		const scanFailedLog = viteMessages.find((msg) =>
+			msg.includes('Failed to scan for dependencies'),
 		);
 
 		assert.ok(
-			!optimizedLog,
-			`Should not see "new dependencies optimized" message, but got: ${optimizedLog?.message}`,
+			!scanFailedLog,
+			`Dependency scan should not have failed, but got: ${scanFailedLog}`,
 		);
+	});
+
+	it('should discover dependencies in nested .astro component imports ahead of time', async () => {
+		// The `ms` dependency is only imported from Duration.astro (a nested component),
+		// which is imported via a .ts utility file.
+		// The scanner must follow: index.astro → get-renderers.ts → Duration.astro → ms
+		const res = await fixture.fetch('/');
+		const html = await res.text();
+
+		// Verify the page rendered correctly with the dependency from the nested component
+		assert.ok(html.includes('3600000'), 'Expected ms("1 hour") to compute 3600000');
 	});
 });


### PR DESCRIPTION
## Changes

- Append `export default {}` to the `astroFrontmatterScanPlugin` onLoad output so `.astro` files are valid default-import targets during Vite's dep scan
- When a `.ts` file default-imports an `.astro` component (e.g. `import Foo from './Foo.astro'`), the scan plugin returns extracted frontmatter without a default export, causing esbuild to fail with "No matching export for import 'default'" — this breaks the entire dep scan

Prevents the error message like:

```
 ✘ [ERROR] No matching export in "html:/Users/matthewphillips/src/astro/cloudflare-frontmatter-scan-plugin-namespace/packages/integrations/cloudflare/test/fixtures/ssr-deps/src/components/Duration.astro" for import "default"
 ```
 
 We've seen this reported on discord.

## Testing

- Updated `ssr-deps` test fixture to reproduce the bug.