### PR TITLE
fix(astro): validate dynamic redirect params

### DIFF
--- a/.changeset/tender-camels-divide.md
+++ b/.changeset/tender-camels-divide.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improve the error shown when prerendering dynamic redirects whose destinations omit source route parameters.

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1058,19 +1058,32 @@ export const UnsupportedExternalRedirect = {
 
 /**
  * @docs
+ * @message
+ * **Example error messages:**<br/>
+ * InvalidRedirectDestination: The redirect from "FROM" to "TO" is invalid. The destination "TO" does not match any existing route in your project.
+ * InvalidRedirectDestination: The redirect from "FROM" to "TO" is invalid. The destination "TO" is missing the dynamic parameter [PARAM] required by the source route "FROM".
  * @see
  * - [Configured redirects](https://docs.astro.build/en/guides/routing/#configured-redirects)
  * @description
- * A dynamic redirect destination must match an existing route pattern.
+ * A dynamic redirect destination must match an existing route pattern and include
+ * the source route's dynamic parameters.
  * This error occurs when a redirect with dynamic parameters points to a destination
- * that doesn't correspond to any page in your project.
+ * that doesn't correspond to any page in your project, or omits parameters from
+ * the source route.
  */
 export const InvalidRedirectDestination = {
 	name: 'InvalidRedirectDestination',
 	title: 'Invalid redirect destination.',
-	message: (from: string, to: string) =>
-		`The redirect from "${from}" to "${to}" is invalid. The destination "${to}" does not match any existing route in your project.`,
-	hint: 'If you are redirecting to a specific page of a dynamic route (e.g., "/posts/[slug]/1"), this is not supported. The destination must be either a static path or a route pattern that matches an existing page (e.g., "/posts/[slug]/[page]").',
+	message(from: string, to: string, missingParams?: string[]) {
+		if (missingParams?.length) {
+			const params = missingParams.map((param) => `[${param}]`).join(', ');
+			const paramsLabel = missingParams.length === 1 ? 'parameter' : 'parameters';
+			return `The redirect from "${from}" to "${to}" is invalid. The destination "${to}" is missing the dynamic ${paramsLabel} ${params} required by the source route "${from}".`;
+		}
+
+		return `The redirect from "${from}" to "${to}" is invalid. The destination "${to}" does not match any existing route in your project.`;
+	},
+	hint: 'If you are redirecting to a specific page of a dynamic route (e.g., "/posts/[slug]/1"), this is not supported. The destination must be either a static path or a route pattern that matches an existing page and includes the dynamic parameters from the source route (e.g., "/posts/[slug]/[page]").',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -70,6 +70,10 @@ function getParts(part: string, file: string) {
 
 	return result;
 }
+
+function getParamName(param: string) {
+	return param.startsWith('...') ? param.slice(3) : param;
+}
 /**
  * Checks whether two route segments are semantically equivalent.
  *
@@ -557,6 +561,18 @@ function createRedirectRoutes(
 				...InvalidRedirectDestination,
 				message: InvalidRedirectDestination.message(from, destination),
 			});
+		}
+
+		if (params.length > 0 && redirectRoute && getPrerenderDefault(config)) {
+			const destinationParams = new Set(redirectRoute.params.map(getParamName));
+			const missingParams = params.filter((param) => !destinationParams.has(getParamName(param)));
+
+			if (missingParams.length > 0) {
+				throw new AstroError({
+					...InvalidRedirectDestination,
+					message: InvalidRedirectDestination.message(from, destination, missingParams),
+				});
+			}
 		}
 
 		routes.push({

--- a/packages/astro/test/units/redirects/static-build.test.ts
+++ b/packages/astro/test/units/redirects/static-build.test.ts
@@ -307,6 +307,54 @@ describe('static redirects — invalid redirect destination throws', () => {
 			},
 		);
 	});
+
+	it('throws InvalidRedirectDestination when a dynamic redirect points to a static route', async () => {
+		// Regression test for https://github.com/withastro/astro/issues/16482
+		// where /project/[slug] -> / matched index.astro, then failed later with
+		// GetStaticPathsRequired against the static destination page.
+		await assert.rejects(
+			() =>
+				createStaticBuildOptions({
+					pages: {
+						'src/pages/index.astro': TARGET_PAGE,
+					},
+					inlineConfig: {
+						redirects: {
+							'/project/[slug]': '/',
+						},
+					},
+				}),
+			(err: Error & { name: string }) => {
+				assert.ok(!err.message.includes('getStaticPaths()'));
+				assert.ok(err.message.includes('missing the dynamic parameter [slug]'));
+				assert.equal(err.name, 'InvalidRedirectDestination');
+				return true;
+			},
+		);
+	});
+
+	it('throws InvalidRedirectDestination when destination route is missing source params', async () => {
+		await assert.rejects(
+			() =>
+				createStaticBuildOptions({
+					pages: {
+						'src/pages/posts/[id].astro':
+							'---\nexport function getStaticPaths() { return []; }\n---\n<p>post</p>',
+					},
+					inlineConfig: {
+						redirects: {
+							'/old/[id]/[page]': '/posts/[id]',
+						},
+					},
+				}),
+			(err: Error & { name: string }) => {
+				assert.ok(!err.message.includes('getStaticPaths()'));
+				assert.ok(err.message.includes('missing the dynamic parameter [page]'));
+				assert.equal(err.name, 'InvalidRedirectDestination');
+				return true;
+			},
+		);
+	});
 });
 
 describe('Astro.redirect() in a page component — build.redirects = false', () => {


### PR DESCRIPTION
## Changes

- Validates prerendered dynamic configured redirects whose destination route omits source params.
- Reuses `InvalidRedirectDestination` with a redirect-specific message instead of allowing a later misleading `GetStaticPathsRequired` error.
- Adds regression coverage for dynamic-to-static and fewer-param redirect destinations.
- Adds a changeset for `astro`.

Fixes #16482.

## Testing

- `pnpm -C packages/astro build`
- `pnpm -C packages/astro exec astro-scripts test "test/units/redirects/static-build.test.ts" --strip-types`
- `pnpm -C packages/astro typecheck:tests`
- `pnpm exec biome check --formatter-enabled=false packages/astro/src/core/routing/create-manifest.ts packages/astro/src/core/errors/errors-data.ts packages/astro/test/units/redirects/static-build.test.ts`

## Docs

No docs changes. This improves an existing error path and includes a changeset.
