### PR TITLE
refactor: update tsconfig to use TypeScript project references

### DIFF
--- a/.github/scripts/tsconfig.json
+++ b/.github/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../configs/tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
     "allowJs": true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Lint publish code
         run: pnpm run publint
 
-      - name: Type-check test files
-        run: pnpm run typecheck:tests
+      - name: Type-check files
+        run: pnpm run typecheck
 
   test:
     name: 'Test (${{ matrix.TEST_SUITE.name }}): ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})'

--- a/benchmark/packages/adapter/tsconfig.json
+++ b/benchmark/packages/adapter/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../configs/tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
     "rootDir": "./src",

--- a/benchmark/packages/timer/tsconfig.json
+++ b/benchmark/packages/timer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../configs/tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
     "rootDir": "./src",

--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -1,9 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "composite": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "strict": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "nodenext",
     "target": "esnext",
     "module": "nodenext",
@@ -14,7 +17,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "outDir": "${configDir}/node_modules/.cache/tsconfig/out",
+    // Emit declaration and cache files to a directory that wouldn't be ignored by tools like Git and ESLint.  
+    "outDir": "${configDir}/node_modules/.cache/ts_base/out",
     "types": ["node"]
   }
 }

--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -17,7 +17,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    // Emit declaration and cache files to a directory that wouldn't be ignored by tools like Git and ESLint.  
+    // Emit declaration and cache files to a directory that would be ignored by tools like Git and ESLint.  
     "outDir": "${configDir}/node_modules/.cache/ts_base/out",
     "types": ["node"]
   }

--- a/configs/tsconfig.build.json
+++ b/configs/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "${configDir}/src",
+    "outDir": "${configDir}/dist",
+    // `._cache/` is ignored when publishing to NPM registry, so it's a safe place to put build artifacts that we don't want to publish.
+    // See https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files
+    "tsBuildInfoFile": "${configDir}/dist/._cache/ts_build/build.tsbuildinfo"
+  },
+  "include": ["${configDir}/src"]
+}

--- a/configs/tsconfig.language-tools.json
+++ b/configs/tsconfig.language-tools.json
@@ -1,15 +1,13 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["WebWorker", "ES2021"],
     "module": "commonjs",
     // TODO: when upgrading to TS 6, will need to be set to "bundler"
     "moduleResolution": "node",
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "verbatimModuleSyntax": false,
+    "erasableSyntaxOnly": false
   }
 }

--- a/configs/tsconfig.test.json
+++ b/configs/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "${configDir}",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "allowImportingTsExtensions": true,
+    "outDir": "${configDir}/node_modules/.cache/ts_test/out"
+  },
+  "include": ["${configDir}/test/**/*"],
+  "exclude": ["${configDir}/test/fixtures/**/*"]
+}

--- a/knip.js
+++ b/knip.js
@@ -1,4 +1,6 @@
 // @ts-check
+const srcEntry = 'src/**/*.{js,ts,cts}';
+const dtsEntry = '*.d.ts';
 const testEntry = 'test/**/*.test.{js,ts}';
 
 /** @type {import('knip').KnipConfig} */
@@ -24,12 +26,14 @@ export default {
 			entry: ['.flue/agents/*.ts', '.flue/workflows/*/WORKFLOW.ts'],
 		},
 		'packages/*': {
-			entry: [testEntry],
+			entry: [srcEntry, dtsEntry, testEntry],
 		},
 		'packages/astro': {
 			entry: [
 				// Can't be detected automatically since it's only in package.json#files
 				'templates/**/*',
+				srcEntry,
+				dtsEntry,
 				testEntry,
 				'test/types/**/*',
 				'e2e/**/*.test.{js,ts}',
@@ -53,37 +57,30 @@ export default {
 				'rehype-toc',
 				'remark-code-titles',
 				'@types/http-cache-semantics',
-				// Dynamically imported by astro add cloudflare
-				'@astrojs/cloudflare',
 			],
 		},
 		'packages/db': {
-			entry: [testEntry, 'test/types/**/*'],
+			entry: [srcEntry, dtsEntry, testEntry, 'test/types/**/*'],
 		},
 		'packages/integrations/*': {
-			entry: [testEntry],
+			entry: [srcEntry, dtsEntry, testEntry],
 		},
 		'packages/integrations/cloudflare': {
-			entry: [testEntry],
+			entry: [srcEntry, dtsEntry, testEntry],
 			// False positive because of cloudflare:workers
 			ignoreDependencies: ['cloudflare'],
 		},
-		'packages/integrations/mdx': {
-			entry: [testEntry],
-			// Required but not imported directly
-			ignoreDependencies: ['@types/*'],
-		},
 		'packages/integrations/netlify': {
-			entry: [testEntry],
+			entry: [srcEntry, dtsEntry, testEntry],
 			ignore: ['test/hosted/**'],
 		},
 		'packages/integrations/solid': {
-			entry: [testEntry],
+			entry: [srcEntry, dtsEntry, testEntry],
 			// It's an optional peer dep (triggers a warning) but it's fine in this case
 			ignoreDependencies: ['solid-devtools'],
 		},
 		'packages/markdown/remark': {
-			entry: [testEntry],
+			entry: [srcEntry, dtsEntry, testEntry],
 			// package.json#imports are not resolved at the moment
 			ignore: ['src/import-plugin-browser.ts', 'src/shiki-engine-workerd.ts'],
 		},

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:e2e": "cd packages/astro && pnpm playwright install firefox && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install firefox && pnpm run test:e2e:match",
     "test:e2e:hosts": "turbo run test:hosted",
-    "typecheck:tests": "pnpm -r run --sequential typecheck:tests",
+    "typecheck": "tsc -b",
     "benchmark": "astro-benchmark",
     "lint": "biome lint && knip && eslint . --report-unused-disable-directives-severity=warn --concurrency=auto",
     "lint:ci": "knip && pnpm run eslint:ci",

--- a/packages/astro-prism/package.json
+++ b/packages/astro-prism/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://docs.astro.build/en/reference/api-reference/#prism-",
   "main": "dist/index.js",
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc -p ./tsconfig.json",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },

--- a/packages/astro-prism/tsconfig.build.json
+++ b/packages/astro-prism/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../configs/tsconfig.build.json"
+}

--- a/packages/astro-prism/tsconfig.json
+++ b/packages/astro-prism/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/astro-rss/package.json
+++ b/packages/astro-rss/package.json
@@ -21,11 +21,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "devDependencies": {
     "@types/xml2js": "^0.4.14",

--- a/packages/astro-rss/tsconfig.build.json
+++ b/packages/astro-rss/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../configs/tsconfig.build.json"
+}

--- a/packages/astro-rss/tsconfig.json
+++ b/packages/astro-rss/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/astro-rss/tsconfig.test.json
+++ b/packages/astro-rss/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../astro/tsconfig.test.json" }]
+  "extends": "../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/astro/components/tsconfig.json
+++ b/packages/astro/components/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../configs/tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
     "emitDeclarationOnly": false,
-    "noEmit": true,
     "jsx": "preserve"
-  }
+  },
+  "references": [{ "path": "../tsconfig.build.json" }]
 }

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -112,7 +112,7 @@
   ],
   "scripts": {
     "prebuild": "astro-scripts prebuild --to-string \"src/runtime/server/astro-island.ts\" \"src/runtime/client/{idle,load,media,only,visible}.ts\"",
-    "build": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm && tsc && astro-check -- -- --root ./components",
+    "build": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm && tsc -b && astro-check -- -- --root ./components",
     "build:ci": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm",
     "dev": "astro-scripts dev --copy-wasm --prebuild \"src/runtime/server/astro-island.ts\" --prebuild \"src/runtime/client/{idle,load,media,only,visible}.ts\" \"src/**/*.{ts,js}\"",
     "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:types",
@@ -123,7 +123,6 @@
     "test:e2e:chrome": "playwright test",
     "test:e2e:firefox": "playwright test --config playwright.firefox.config.js",
     "test:types": "tsc --build test/types/tsconfig.json",
-    "typecheck:tests": "tsc --build tsconfig.test.json",
     "test:unit": "astro-scripts test \"test/units/**/*.test.ts\" --strip-types --teardown ./test/units/teardown.ts",
     "test:integration": "pnpm run test:integration:js && pnpm run test:integration:ts",
     "test:integration:js": "astro-scripts test \"test/*.test.js\"",

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -3,7 +3,7 @@ import { ensureProcessNodeEnv } from '../../core/util.js';
 import { createLoggerFromFlags, type Flags, flagsToAstroInlineConfig } from '../flags.js';
 import { getPackage } from '../install-package.js';
 
-export async function check(flags: Flags) {
+export async function check(flags: Flags): Promise<boolean | void> {
 	ensureProcessNodeEnv('production');
 	const logger = createLoggerFromFlags(flags);
 	const getPackageOpts = {

--- a/packages/astro/test/cli.test.ts
+++ b/packages/astro/test/cli.test.ts
@@ -29,7 +29,7 @@ describe('astro cli', () => {
 		});
 		const logs: LogEntry[] = [];
 
-		const checkServer = await fixture.check({
+		const checkServer: boolean | void = await fixture.check({
 			_: [],
 			flags: { watch: true },
 			logging: {

--- a/packages/astro/test/types/tsconfig.json
+++ b/packages/astro/test/types/tsconfig.json
@@ -1,8 +1,6 @@
 {
-  "extends": "../../../../tsconfig.base.json",
+  "extends": "../../../../configs/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "allowJs": true,
     "emitDeclarationOnly": false
   }
 }

--- a/packages/astro/tsconfig.build.json
+++ b/packages/astro/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../configs/tsconfig.build.json",
+  "compilerOptions": {
+    "jsx": "preserve"
+  },
+  "include": ["./src", "./dev-only.d.ts"],
+  "references": [
+    { "path": "../internal-helpers/tsconfig.json" },
+    { "path": "../telemetry/tsconfig.json" },
+    { "path": "../markdown/remark/tsconfig.json" }
+  ]
+}

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -1,15 +1,9 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src", "dev-only.d.ts"],
-  "exclude": ["dist"],
-  "compilerOptions": {
-    "composite": true,
-    "rootDir": "./src",
-    "allowJs": true,
-    "declarationDir": "./dist",
-    "outDir": "./dist",
-    "jsx": "preserve",
-    "tsBuildInfoFile": "${configDir}/dist/._cache/tsconfig/tsbuildinfo.json",
-    "erasableSyntaxOnly": true
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+    { "path": "./components/tsconfig.json" }
+  ]
 }

--- a/packages/astro/tsconfig.test.json
+++ b/packages/astro/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../configs/tsconfig.test.json",
   "include": ["test/units/**/*.ts", "test/*.ts", "e2e/*.ts", "package.json"],
   "exclude": ["test/units/_temp-fixtures/**", "test/fixtures/**", "e2e/fixtures/**"],
   "files": [
@@ -9,19 +9,7 @@
     "./test/fixtures/before-hydration/deps.mjs"
   ],
   "compilerOptions": {
-    "types": ["vite/client", "node"],
-    "composite": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
+    "types": ["vite/client", "node"]
   },
-  "references": [
-    {
-      "path": "./tsconfig.json"
-    },
-    {
-      "path": "../../scripts/tsconfig.json"
-    }
-  ]
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "../../scripts/tsconfig.json" }]
 }

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -19,11 +19,10 @@
     "create-astro": "./create-astro.mjs"
   },
   "scripts": {
-    "build": "astro-scripts build \"src/index.ts\" --bundle && tsc",
+    "build": "astro-scripts build \"src/index.ts\" --bundle && tsc -b",
     "build:ci": "astro-scripts build \"src/index.ts\" --bundle",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "files": [
     "dist",

--- a/packages/create-astro/tsconfig.build.json
+++ b/packages/create-astro/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../configs/tsconfig.build.json",
+  "references": [{ "path": "../internal-helpers/tsconfig.json" }]
+}

--- a/packages/create-astro/tsconfig.json
+++ b/packages/create-astro/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/create-astro/tsconfig.test.json
+++ b/packages/create-astro/tsconfig.test.json
@@ -1,16 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -63,13 +63,11 @@
     "astro-integration"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "pnpm run test:integration && pnpm run test:types",
-    "test:integration": "astro-scripts test \"test/**/*.test.ts\"",
-    "test:types": "tsc --project test/types/tsconfig.json",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "pnpm run test:integration",
+    "test:integration": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@clack/prompts": "^1.0.1",

--- a/packages/db/test/types/tsconfig.json
+++ b/packages/db/test/types/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "allowJs": true,
-    "emitDeclarationOnly": false,
-    "noEmit": true
-  }
-}

--- a/packages/db/tsconfig.build.json
+++ b/packages/db/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../configs/tsconfig.build.json",
+  "references": [{ "path": "../astro/tsconfig.json" }]
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/db/tsconfig.test.json
+++ b/packages/db/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../astro/tsconfig.test.json" }]
+  "extends": "../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -28,11 +28,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test:e2e": "playwright test",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test:e2e": "playwright test"
   },
   "peerDependencies": {
     "@types/alpinejs": "^3.0.0",

--- a/packages/integrations/alpinejs/tsconfig.build.json
+++ b/packages/integrations/alpinejs/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "references": [{ "path": "../../astro/tsconfig.json" }]
+}

--- a/packages/integrations/alpinejs/tsconfig.json
+++ b/packages/integrations/alpinejs/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/alpinejs/tsconfig.test.json
+++ b/packages/integrations/alpinejs/tsconfig.test.json
@@ -1,17 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -36,10 +36,9 @@
   ],
   "scripts": {
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "build": "astro-scripts build \"src/**/*.ts\" --clean-dts && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" --clean-dts && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
-    "test": "astro-scripts test --force-exit \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test --force-exit \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/integrations/cloudflare/tsconfig.build.json
+++ b/packages/integrations/cloudflare/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "include": ["./src", "./virtual.d.ts"],
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../internal-helpers/tsconfig.json" },
+    { "path": "../../underscore-redirects/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/cloudflare/tsconfig.json
+++ b/packages/integrations/cloudflare/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src", "virtual.d.ts", "types.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/cloudflare/tsconfig.test.json
+++ b/packages/integrations/cloudflare/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../../astro/tsconfig.test.json" }]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -56,11 +56,10 @@
     "template"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test --timeout 100000 \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test --timeout 100000 \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/integrations/markdoc/tsconfig.build.json
+++ b/packages/integrations/markdoc/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../internal-helpers/tsconfig.json" },
+    { "path": "../../markdown/remark/tsconfig.json" },
+    { "path": "../../astro-prism/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/markdoc/tsconfig.json
+++ b/packages/integrations/markdoc/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/markdoc/tsconfig.test.json
+++ b/packages/integrations/markdoc/tsconfig.test.json
@@ -1,17 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -28,11 +28,10 @@
     "template"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test --timeout 70000 \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test --timeout 70000 \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/markdown-remark": "workspace:*",

--- a/packages/integrations/mdx/tsconfig.build.json
+++ b/packages/integrations/mdx/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../markdown/remark/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/mdx/tsconfig.json
+++ b/packages/integrations/mdx/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/mdx/tsconfig.test.json
+++ b/packages/integrations/mdx/tsconfig.test.json
@@ -1,13 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true,
-    "rootDir": "."
-  },
-  "references": [{ "path": "../../astro/tsconfig.test.json" }]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -30,14 +30,13 @@
   ],
   "scripts": {
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "pnpm run test-fn && pnpm run test-static && pnpm run test:dev",
     "test-fn": "astro-scripts test \"test/functions/*.test.ts\"",
     "test:dev": "astro-scripts test \"test/development/*.test.ts\"",
     "test-static": "astro-scripts test \"test/static/*.test.ts\"",
-    "test:hosted": "astro-scripts test \"test/hosted/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test:hosted": "astro-scripts test \"test/hosted/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/integrations/netlify/tsconfig.build.json
+++ b/packages/integrations/netlify/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "include": ["./src", "./virtual.d.ts"],
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../internal-helpers/tsconfig.json" },
+    { "path": "../../underscore-redirects/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/netlify/tsconfig.json
+++ b/packages/integrations/netlify/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src", "virtual.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/netlify/tsconfig.test.json
+++ b/packages/integrations/netlify/tsconfig.test.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/**/fixtures/**", "test/hosted/hosted-astro-project/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true,
-    "rootDir": "."
-  },
-  "references": [{ "path": "../../astro/tsconfig.test.json" }]
+  "extends": "../../../configs/tsconfig.test.json",
+  "exclude": ["./test/**/fixtures/**", "./test/hosted/hosted-astro-project/**"],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -28,10 +28,9 @@
   ],
   "scripts": {
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/integrations/node/tsconfig.build.json
+++ b/packages/integrations/node/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "include": ["./src", "./virtual.d.ts"],
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../internal-helpers/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/node/tsconfig.json
+++ b/packages/integrations/node/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src", "virtual.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/node/tsconfig.test.json
+++ b/packages/integrations/node/tsconfig.test.json
@@ -1,17 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },

--- a/packages/integrations/partytown/tsconfig.build.json
+++ b/packages/integrations/partytown/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "references": [{ "path": "../../astro/tsconfig.json" }]
+}

--- a/packages/integrations/partytown/tsconfig.json
+++ b/packages/integrations/partytown/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },

--- a/packages/integrations/preact/tsconfig.build.json
+++ b/packages/integrations/preact/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "include": ["./src", "./env.d.ts"],
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../internal-helpers/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/preact/tsconfig.json
+++ b/packages/integrations/preact/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src", "env.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -33,11 +33,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/integrations/react/tsconfig.build.json
+++ b/packages/integrations/react/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "include": ["./src", "./env.d.ts"],
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../internal-helpers/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/react/tsconfig.json
+++ b/packages/integrations/react/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src", "env.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/react/tsconfig.test.json
+++ b/packages/integrations/react/tsconfig.test.json
@@ -1,17 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -27,11 +27,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "sitemap": "^9.0.0",

--- a/packages/integrations/sitemap/tsconfig.build.json
+++ b/packages/integrations/sitemap/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "references": [{ "path": "../../astro/tsconfig.json" }]
+}

--- a/packages/integrations/sitemap/tsconfig.json
+++ b/packages/integrations/sitemap/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/sitemap/tsconfig.test.json
+++ b/packages/integrations/sitemap/tsconfig.test.json
@@ -1,17 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../../configs/tsconfig.test.json",
+  "files": ["./test/fixtures/static/deps.mjs"],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },

--- a/packages/integrations/solid/tsconfig.build.json
+++ b/packages/integrations/solid/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "references": [{ "path": "../../astro/tsconfig.json" }]
+}

--- a/packages/integrations/solid/tsconfig.json
+++ b/packages/integrations/solid/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -32,11 +32,10 @@
     "svelte-shims.d.ts"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && astro-scripts build \"src/editor.cts\" --force-cjs --no-clean-dist && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && astro-scripts build \"src/editor.cts\" --force-cjs --no-clean-dist && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\" && astro-scripts build \"src/editor.cts\" --force-cjs --no-clean-dist",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.4",

--- a/packages/integrations/svelte/tsconfig.build.json
+++ b/packages/integrations/svelte/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "compilerOptions": {
+    // `"verbatimModuleSyntax": false` is required to support import/export statements in `src/editor.cts` file.
+    "verbatimModuleSyntax": false
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.cts"],
+  "references": [{ "path": "../../astro/tsconfig.json" }]
+}

--- a/packages/integrations/svelte/tsconfig.json
+++ b/packages/integrations/svelte/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "verbatimModuleSyntax": false
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/svelte/tsconfig.test.json
+++ b/packages/integrations/svelte/tsconfig.test.json
@@ -1,17 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -40,11 +40,10 @@
   ],
   "scripts": {
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "test": "astro-scripts test --timeout 60000 \"test/**/!(hosted).test.ts\"",
-    "test:hosted": "astro-scripts test --timeout 30000 \"test/hosted/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test:hosted": "astro-scripts test --timeout 30000 \"test/hosted/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/integrations/vercel/tsconfig.build.json
+++ b/packages/integrations/vercel/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "include": ["./src", "./virtual.d.ts"],
+  "references": [
+    { "path": "../../astro/tsconfig.json" },
+    { "path": "../../internal-helpers/tsconfig.json" }
+  ]
+}

--- a/packages/integrations/vercel/tsconfig.json
+++ b/packages/integrations/vercel/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src", "virtual.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/vercel/tsconfig.test.json
+++ b/packages/integrations/vercel/tsconfig.test.json
@@ -1,13 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true,
-    "rootDir": "."
-  },
-  "references": [{ "path": "../../astro/tsconfig.test.json" }]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -32,11 +32,10 @@
     "vue-shims.d.ts"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && astro-scripts build \"src/editor.cts\" --force-cjs --no-clean-dist && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && astro-scripts build \"src/editor.cts\" --force-cjs --no-clean-dist && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\" && astro-scripts build \"src/editor.cts\" --force-cjs --no-clean-dist",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@vitejs/plugin-vue": "^6.0.5",

--- a/packages/integrations/vue/tsconfig.build.json
+++ b/packages/integrations/vue/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "compilerOptions": {
+    // `"verbatimModuleSyntax": false` is required to support import/export statements in `src/editor.cts` file.
+    "verbatimModuleSyntax": false
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.cts", "./env.d.ts"],
+  "references": [{ "path": "../../astro/tsconfig.json" }]
+}

--- a/packages/integrations/vue/tsconfig.json
+++ b/packages/integrations/vue/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src", "env.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "verbatimModuleSyntax": false
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/integrations/vue/tsconfig.test.json
+++ b/packages/integrations/vue/tsconfig.test.json
@@ -1,17 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [
-    {
-      "path": "../../astro/tsconfig.test.json"
-    }
-  ]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/internal-helpers/package.json
+++ b/packages/internal-helpers/package.json
@@ -47,11 +47,10 @@
   ],
   "scripts": {
     "prepublish": "pnpm build",
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc -p tsconfig.json",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "picomatch": "^4.0.4"

--- a/packages/internal-helpers/tsconfig.build.json
+++ b/packages/internal-helpers/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../configs/tsconfig.build.json"
+}

--- a/packages/internal-helpers/tsconfig.json
+++ b/packages/internal-helpers/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/internal-helpers/tsconfig.test.json
+++ b/packages/internal-helpers/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../astro/tsconfig.test.json" }]
+  "extends": "../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/language-tools/astro-check/package.json
+++ b/packages/language-tools/astro-check/package.json
@@ -26,8 +26,8 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc -b",
+    "dev": "tsc -b --watch",
     "test": "astro-scripts test \"**/*.test.ts\"  --tsx true"
   },
   "dependencies": {

--- a/packages/language-tools/astro-check/test/bin.test.ts
+++ b/packages/language-tools/astro-check/test/bin.test.ts
@@ -2,11 +2,16 @@ import assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 
 describe('astro-check - binary', async () => {
 	it('Can run the binary', async () => {
-		const childProcess = spawnSync('node', ['../bin/astro-check.js', '--root', './fixture'], {
-			cwd: fileURLToPath(new URL('./', import.meta.url)),
+		const pkgPath = fileURLToPath(new URL('..', import.meta.url));
+		const binPath = path.join(pkgPath, 'bin', 'astro-check.js');
+		const fixturePath = path.join(pkgPath, 'test', 'fixture');
+		const childProcess = spawnSync('node', [binPath], {
+			// Set the working directory to the fixture directory so that `astro check` can use the tsconfig in the fixture directory.
+			cwd: fixturePath,
 		});
 
 		assert.strictEqual(childProcess.status, 1);

--- a/packages/language-tools/astro-check/test/fixture/index.ts
+++ b/packages/language-tools/astro-check/test/fixture/index.ts
@@ -1,0 +1,2 @@
+// An empty ts file to satisfy the `tsconfig.json` to make sure it contains at least one standard ts file when running `tsc`. This file is not needed when running `astro-check`.
+export {}

--- a/packages/language-tools/astro-check/test/fixture/tsconfig.json
+++ b/packages/language-tools/astro-check/test/fixture/tsconfig.json
@@ -1,4 +1,10 @@
 {
   // A `tsconfig.json` isn't needed for astro check to work, however if we don't have this file,
   // TypeScript will pick up the root `tsconfig.json` from the monorepo, which does not include the `.astro` files in this folder
+  "compilerOptions": {
+    "composite": true,
+    "verbatimModuleSyntax": true,
+    "outDir": "./node_modules/.cache/ts_fixture/out",
+  },
+  "include": ["./*", "./*.astro"]
 }

--- a/packages/language-tools/astro-check/test/tsconfig.json
+++ b/packages/language-tools/astro-check/test/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "emitDeclarationOnly": false,
-    "noEmit": true,
-    "module": "ESNext",
-    "allowImportingTsExtensions": true
-  }
-}

--- a/packages/language-tools/astro-check/tsconfig.build.json
+++ b/packages/language-tools/astro-check/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../configs/tsconfig.language-tools.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "emitDeclarationOnly": false,
+    "sourceMap": true
+  },
+  "references": [{ "path": "../language-server/tsconfig.json" }]
+}

--- a/packages/language-tools/astro-check/tsconfig.json
+++ b/packages/language-tools/astro-check/tsconfig.json
@@ -1,12 +1,5 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "emitDeclarationOnly": false,
-    "sourceMap": true,
-    "module": "ES2022",
-    "target": "ES2022"
-  },
-  "include": ["src"]
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/language-tools/astro-check/tsconfig.test.json
+++ b/packages/language-tools/astro-check/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./test/fixture/tsconfig.json" }]
+}

--- a/packages/language-tools/language-server/package.json
+++ b/packages/language-tools/language-server/package.json
@@ -20,11 +20,10 @@
     "astro-ls": "./bin/nodeServer.js"
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc -b",
+    "dev": "tsc -b --watch",
     "test": "astro-scripts test \"**/*.test.ts\" --teardown-test ./test/misc/teardown.ts --tsx true --setup ./test/setup.ts",
-    "test:match": "pnpm run test --match",
-    "typecheck:tests": "tsc --build test/tsconfig.json"
+    "test:match": "pnpm run test --match"
   },
   "dependencies": {
     "@astrojs/compiler": "^2.13.1",

--- a/packages/language-tools/language-server/test/tsconfig.json
+++ b/packages/language-tools/language-server/test/tsconfig.json
@@ -1,12 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "allowJs": true,
-    "composite": true,
-    "emitDeclarationOnly": false,
-    "noEmit": true,
-    "allowImportingTsExtensions": true
-  },
+  "extends": "../../../../configs/tsconfig.test.json",
   "include": ["."],
   "exclude": ["node_modules/", "fixture/", "check/fixture/"],
   "references": [{ "path": "../../../astro/tsconfig.test.json" }]

--- a/packages/language-tools/language-server/tsconfig.build.json
+++ b/packages/language-tools/language-server/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../configs/tsconfig.language-tools.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "sourceMap": true
+  },
+  "references": [{ "path": "../yaml2ts/tsconfig.json" }]
+}

--- a/packages/language-tools/language-server/tsconfig.json
+++ b/packages/language-tools/language-server/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "emitDeclarationOnly": false,
-    "sourceMap": true
-  },
-  "include": ["src"]
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/language-tools/ts-plugin/package.json
+++ b/packages/language-tools/ts-plugin/package.json
@@ -20,10 +20,9 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "vscode-test",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "build": "tsc -b",
+    "dev": "tsc -b --watch",
+    "test": "vscode-test"
   },
   "author": "withastro",
   "license": "MIT",

--- a/packages/language-tools/ts-plugin/tsconfig.build.json
+++ b/packages/language-tools/ts-plugin/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../configs/tsconfig.language-tools.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false
+  },
+  "references": [{ "path": "../yaml2ts/tsconfig.json" }]
+}

--- a/packages/language-tools/ts-plugin/tsconfig.json
+++ b/packages/language-tools/ts-plugin/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "emitDeclarationOnly": false
-  },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/language-tools/ts-plugin/tsconfig.test.json
+++ b/packages/language-tools/ts-plugin/tsconfig.test.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../configs/tsconfig.test.json",
   "include": ["test/**/*.mts", "test/**/*.ts", ".vscode-test.*"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "types": ["node"],
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../../astro/tsconfig.test.json" }]
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/language-tools/vscode/package.json
+++ b/packages/language-tools/vscode/package.json
@@ -236,15 +236,14 @@
   },
   "scripts": {
     "prebuild": "cd ../ts-plugin && pnpm build",
-    "build": "tsc && pnpm prebuild && node scripts/build.mjs -- --minify",
+    "build": "tsc -b && pnpm prebuild && node scripts/build.mjs -- --minify",
     "dev": "node scripts/build.mjs -- --watch",
     "build:grammar": "node scripts/build-grammar.mjs",
     "dev:grammar": "node scripts/build-grammar.mjs -- --watch",
     "test": "pnpm test:vscode && pnpm test:grammar",
     "test:vscode": "vscode-test",
     "test:grammar": "pnpm build:grammar && node ./test/grammar/test.mjs",
-    "update-grammar-snapshots": "node ./test/grammar/test.mjs --updateSnapshot",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "update-grammar-snapshots": "node ./test/grammar/test.mjs --updateSnapshot"
   },
   "devDependencies": {
     "@astrojs/language-server": "^2.16.6",

--- a/packages/language-tools/vscode/tsconfig.build.json
+++ b/packages/language-tools/vscode/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../configs/tsconfig.language-tools.json",
+  "references": [
+    { "path": "../language-server/tsconfig.json" },
+    { "path": "../ts-plugin/tsconfig.json" }
+  ]
+}

--- a/packages/language-tools/vscode/tsconfig.json
+++ b/packages/language-tools/vscode/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "emitDeclarationOnly": true,
-    "checkJs": true
-  },
-  "include": ["src"]
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/language-tools/vscode/tsconfig.test.json
+++ b/packages/language-tools/vscode/tsconfig.test.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.mts", "test/**/*.ts", ".vscode-test.*"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "types": ["node"],
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../../astro/tsconfig.test.json" }]
+  "extends": "../../../configs/tsconfig.test.json",
+  "include": ["test/**/*.mts", "test/**/*.mjs", "test/**/*.ts", ".vscode-test.*"],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/language-tools/yaml2ts/package.json
+++ b/packages/language-tools/yaml2ts/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.3",
   "description": "Package to convert a YAML string to a Volar VirtualCode, to be used by the Astro language server to provide intellisense",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch"
+    "build": "tsc -b",
+    "dev": "tsc -b --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/language-tools/yaml2ts/tsconfig.build.json
+++ b/packages/language-tools/yaml2ts/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../configs/tsconfig.language-tools.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "sourceMap": true
+  }
+}

--- a/packages/language-tools/yaml2ts/tsconfig.json
+++ b/packages/language-tools/yaml2ts/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "emitDeclarationOnly": false,
-    "sourceMap": true
-  },
-  "include": ["src"]
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -31,11 +31,10 @@
   ],
   "scripts": {
     "prepublish": "pnpm build",
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc -p tsconfig.json",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/markdown/remark/tsconfig.build.json
+++ b/packages/markdown/remark/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "references": [
+    { "path": "../../internal-helpers/tsconfig.json" },
+    { "path": "../../astro-prism/tsconfig.json" }
+  ]
+}

--- a/packages/markdown/remark/tsconfig.json
+++ b/packages/markdown/remark/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
-  }
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/markdown/remark/tsconfig.test.json
+++ b/packages/markdown/remark/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../../astro/tsconfig.test.json" }]
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -20,11 +20,10 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "files": [
     "dist"

--- a/packages/telemetry/tsconfig.build.json
+++ b/packages/telemetry/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../configs/tsconfig.build.json"
+}

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/telemetry/tsconfig.test.json
+++ b/packages/telemetry/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../astro/tsconfig.test.json" }]
+  "extends": "../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/underscore-redirects/package.json
+++ b/packages/underscore-redirects/package.json
@@ -21,11 +21,10 @@
   ],
   "scripts": {
     "prepublish": "pnpm build",
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc -p tsconfig.json",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/underscore-redirects/tsconfig.build.json
+++ b/packages/underscore-redirects/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../configs/tsconfig.build.json",
+  "references": [{ "path": "../astro/tsconfig.json" }]
+}

--- a/packages/underscore-redirects/tsconfig.json
+++ b/packages/underscore-redirects/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/underscore-redirects/tsconfig.test.json
+++ b/packages/underscore-redirects/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../astro/tsconfig.test.json" }]
+  "extends": "../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -17,11 +17,10 @@
   "main": "./upgrade.mjs",
   "bin": "./upgrade.mjs",
   "scripts": {
-    "build": "astro-scripts build \"src/index.ts\" --bundle && tsc",
+    "build": "astro-scripts build \"src/index.ts\" --bundle && tsc -b",
     "build:ci": "astro-scripts build \"src/index.ts\" --bundle",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.ts\"",
-    "typecheck:tests": "tsc --build tsconfig.test.json"
+    "test": "astro-scripts test \"test/**/*.test.ts\""
   },
   "files": [
     "dist/**/*.js",

--- a/packages/upgrade/tsconfig.build.json
+++ b/packages/upgrade/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../configs/tsconfig.build.json"
+}

--- a/packages/upgrade/tsconfig.json
+++ b/packages/upgrade/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["src", "index.d.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "allowJs": true,
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "outDir": "./dist",
-    "declarationDir": "./dist"
-  }
+  "extends": "../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/upgrade/tsconfig.test.json
+++ b/packages/upgrade/tsconfig.test.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": ["test/**/*.ts"],
-  "exclude": ["test/fixtures/**"],
-  "compilerOptions": {
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "rewriteRelativeImportExtensions": true
-  },
-  "references": [{ "path": "../astro/tsconfig.test.json" }]
+  "extends": "../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -123,6 +123,7 @@ export default async function build(...args) {
 async function clean(outdir, cleanDts) {
 	const files = await glob('**', {
 		cwd: outdir,
+		dot: true,
 		filesOnly: true,
 		ignore: cleanDts ? undefined : ['**/*.d.ts'],
 		absolute: true,

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../configs/tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
     "allowJs": true

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,5 +2,5 @@
   "compilerOptions": {
     "allowJs": true
   },
-  "extends": "./tsconfig.base.json"
+  "extends": "./configs/tsconfig.base.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,38 @@
-// Yes this file is intentionally empty!
-// ---
-// Having a blank `tsconfig.json` file prevents TypeScript from crawling up your directory tree
-// and possibly picking up a parent `tsconfig.json` (which, unsurprisingly, is very hard to debug)
-{}
+// This file is the workspace solution: it references each package's
+// tsconfig.json so a single `tsc -b` covers the whole monorepo.
+{
+  "extends": "./configs/tsconfig.base.json",
+  "files": ["./prettier.config.mjs"],
+  "references": [
+    { "path": "./packages/internal-helpers/tsconfig.json" },
+    { "path": "./packages/telemetry/tsconfig.json" },
+    { "path": "./packages/astro-prism/tsconfig.json" },
+    { "path": "./packages/astro-rss/tsconfig.json" },
+    { "path": "./packages/markdown/remark/tsconfig.json" },
+    { "path": "./packages/astro/tsconfig.json" },
+    { "path": "./packages/underscore-redirects/tsconfig.json" },
+    { "path": "./packages/integrations/alpinejs/tsconfig.json" },
+    { "path": "./packages/integrations/cloudflare/tsconfig.json" },
+    { "path": "./packages/integrations/markdoc/tsconfig.json" },
+    { "path": "./packages/integrations/mdx/tsconfig.json" },
+    { "path": "./packages/integrations/netlify/tsconfig.json" },
+    { "path": "./packages/integrations/node/tsconfig.json" },
+    { "path": "./packages/integrations/partytown/tsconfig.json" },
+    { "path": "./packages/integrations/preact/tsconfig.json" },
+    { "path": "./packages/integrations/react/tsconfig.json" },
+    { "path": "./packages/integrations/sitemap/tsconfig.json" },
+    { "path": "./packages/integrations/solid/tsconfig.json" },
+    { "path": "./packages/integrations/svelte/tsconfig.json" },
+    { "path": "./packages/integrations/vercel/tsconfig.json" },
+    { "path": "./packages/integrations/vue/tsconfig.json" },
+    { "path": "./packages/create-astro/tsconfig.json" },
+    { "path": "./packages/db/tsconfig.json" },
+    { "path": "./packages/upgrade/tsconfig.json" },
+    { "path": "./packages/language-tools/astro-check/tsconfig.json" },
+    { "path": "./packages/language-tools/language-server/tsconfig.json" },
+    { "path": "./packages/language-tools/language-server/test/tsconfig.json" },
+    { "path": "./packages/language-tools/ts-plugin/tsconfig.json" },
+    { "path": "./packages/language-tools/vscode/tsconfig.json" },
+    { "path": "./packages/language-tools/yaml2ts/tsconfig.json" }
+  ]
+}


### PR DESCRIPTION

## WHAT is TypeScript project reference?

[TypeScript project reference](https://www.typescriptlang.org/docs/handbook/project-references.html) is a TypeScript feature that lets you split a TypeScript codebase into smaller, independently buildable projects. The mental model is similar to a PNPM monorepo: each project declares its dependencies on other projects, and the compiler builds them in the correct order. PNPM monorepo use `package.json` and `dependencies`/`devDependencies` fields to declare dependency graph, which TypeScript uses `tsconfig.json` and `references` field to declare the graph.

To use TypeScript project references, the following changes are needed:

-  Use `tsc --build` or `tsc -b` instead of `tsc` or `tsc --project`
-  Add `composite: true` to tsconfig
-  Add `noEmit: false` since you need to emit and cache declaration files
-  Use the `references` field in tsconfig to declare the dependency graph


## WHY is it better?

1. **Faster builds.** With project references, TypeScript only rebuilds the projects that have actually changed (and their dependents), instead of re-typechecking the entire codebase from scratch on every run. This significantly reduces build times in a large monorepo like this one.

   ```bash
   $ pnpm -w typecheck --clean # clean all emitted files and cache before typechecking
   > tsc -b --clean
   
   $ time pnpm -w typecheck # build the whole repo from scratch
   > tsc -b
   15.044 total
   
   $ time pnpm -w typecheck # build again. Nothing changed so it should be very fast
   > tsc -b
   0.510 total

   $ vim packages/integrations/cloudflare/src/index.ts # make a small change 
   $ time pnpm -w typecheck # build again. Only cloudflare package and its dependents should be rebuilt.
   > tsc -b
   1.886 total
   ```

2. **Better editor support.** "Go to Definition" can jump straight to the original `.ts` source across project boundaries, even before `pnpm build`, and across different pnpm packages. See the demo below: it's a fresh clone of the repo with no `dist/`, and I can still jump from `cloudflare/test/sessions.test.ts` to `cloudflare/src/index.ts` (a source file in the same pnpm package) and on to `packages/astro/src/types/public/config.ts` (a source file in a different pnpm package).

   https://github.com/user-attachments/assets/b73b4a6a-9f92-4682-8c91-688f9dc150dc

<!--
git clone --depth 1 https://github.com/ocavue-forks/astro.git --branch ocavue-test-cleanup8 \
  && cd ./astro \
  && pnpm i \
  && code . \
  && sleep 4 \
  && code ./packages/integrations/cloudflare/test/sessions.test.ts
-->

## HOW are tsconfigs organized in this repo?

Shared configs live under `configs/` at the repo root:

- `configs/tsconfig.base.json`:            The base tsconfig that every other tsconfig extends from.
- `configs/tsconfig.build.json`:           The tsconfig used to build packages. It includes `src/` and writes declaration files to `dist/`.
- `configs/tsconfig.test.json`:            The tsconfig used to typecheck tests. It includes `test/` and excludes `test/fixtures/`.
- `configs/tsconfig.language-tools.json`:  The tsconfig used to build packages under `packages/language-tools/`. The main difference from `tsconfig.build.json` is that it targets commonjs.

A classic package at `packages/xx/` then has three tsconfig files:

```jsonc
// packages/xx/tsconfig.build.json
{
  "extends": "../../configs/tsconfig.build.json",
  // Use `references` to declare workspace dependencies. Every referenced package
  // is built before this one. This list should mirror the workspace dependencies
  // declared in package.json. We maintain it manually for now since the
  // dependency graph rarely changes.
  "references": [{ "path": "../dep1/tsconfig.json" }, { "path": "../dep2/tsconfig.json" }]
}
```

```jsonc
// packages/xx/tsconfig.test.json
{
  "extends": "../../configs/tsconfig.test.json",
  // Reference the package's own tsconfig.build.json so dist/ is built before
  // tests are typechecked.
  "references": [{ "path": "./tsconfig.build.json" }]
}
```

```jsonc
// packages/xx/tsconfig.json
{
  "extends": "../../configs/tsconfig.base.json",
  // `"files": []` makes this a pure solution file: it doesn't include any source
  // files itself. Its only purpose is to act as an entry point that points to
  // tsconfig.build.json and tsconfig.test.json.
  "files": [],
  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
}
```

The repo-root `tsconfig.json` is the top-level solution file that references every package:

```jsonc
// tsconfig.json
{
  "extends": "./configs/tsconfig.base.json",
  // A few loose files that don't belong to any package (e.g. config files) can
  // be listed here directly.
  "files": ["./prettier.config.mjs"],
  "references": [
    { "path": "./packages/pkg1/tsconfig.json" },
    { "path": "./packages/pkg2/tsconfig.json" },
    // ...
  ]
}
```

## Testing

This PR touches a large number of tsconfig files, which are part of the build pipeline, so it's important to verify that the build artifacts are unchanged after the refactor.

I wrote a script that compares the packed output of this branch against the target branch. The two things it checks are:

1. The `dist/` directory contains the exact same `.js` and `.d.ts` files in both branches.
2. The `.tsbuildinfo` cache files do not leak into the packed output.

The script and its output are available here: https://gist.github.com/ocavue/065faf832d2c45137c93dc2d0f1c72e5

## Docs

Not included in this PR yet, but the plan is to add a section to `CONTRIBUTING.md` based on a refined version of this PR description.
