### PR TITLE
docs: improve readability of remotePattern section

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1848,14 +1848,15 @@ export interface AstroUserConfig<
 		 * }
 		 * ```
 		 *
-		 * You can use wildcards to define the permitted `hostname` and `pathname` values as described below. Otherwise, only the exact values provided will be configured:
-		 * `hostname`:
-		 *   - Start with '**.' to allow all subdomains ('endsWith').
-		 *   - Start with '*.' to allow only one level of subdomain.
+		 * You can use wildcards to define the permitted `hostname` and `pathname` values as described below. Otherwise, only the exact values provided will be configured.
 		 *
-		 * `pathname`:
-		 *   - End with '/**' to allow all sub-routes ('startsWith').
-		 *   - End with '/*' to allow only one level of sub-route.
+		 * `hostname` patterns:
+		 *   - Start with `**.` to allow all subdomains (like `endsWith`).
+		 *   - Start with `*.` to allow only one level of subdomain.
+		 *
+		 * `pathname` patterns:
+		 *   - End with `/**` to allow all sub-routes (like `startsWith`).
+		 *   - End with `/*` to allow only one level of sub-route.
 
 		 */
 		remotePatterns?: Partial<RemotePattern>[];


### PR DESCRIPTION
## Changes

Refine some colons to simple dots, quotes to inline code and add new line to make it more clear that these are the wildcard patterns. Also added `"patterns"` to the "headings" of the list.

Is a changeset necessary for such a docs only change? If so, I could take a look at the whole file and do a greater refinement PR, I just noticed the little inconvenience while reading the section and thought I would send a quick PR.

## Testing

This doesn't need testing.

## Docs

This does not need a docs PR.
