### PR TITLE
fix(slots): unwrap conditional slot callbacks

### DIFF
--- a/.changeset/tender-slots-unwrap.md
+++ b/.changeset/tender-slots-unwrap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix conditional named slot callbacks receiving arguments from `Astro.slots.render()`.

--- a/packages/astro/src/core/render/slots.ts
+++ b/packages/astro/src/core/render/slots.ts
@@ -1,5 +1,6 @@
 import { type ComponentSlots, renderSlotToString } from '../../runtime/server/index.js';
 import { renderJSX } from '../../runtime/server/jsx.js';
+import { isRenderTemplateResult } from '../../runtime/server/render/astro/index.js';
 import { chunkToString } from '../../runtime/server/render/index.js';
 import { isRenderInstruction } from '../../runtime/server/render/instruction.js';
 import type { SSRResult } from '../../types/public/internal.js';
@@ -8,9 +9,15 @@ import type { AstroLogger } from '../logger/core.js';
 
 function getFunctionExpression(slot: any) {
 	if (!slot) return;
-	const expressions = slot?.expressions?.filter((e: unknown) => isRenderInstruction(e) === false);
+	const expressions = slot?.expressions?.filter(
+		(e: unknown) => isRenderInstruction(e) === false || isRenderTemplateResult(e),
+	);
 	if (expressions?.length !== 1) return;
-	return expressions[0] as (...args: any[]) => any;
+	const expression = expressions[0];
+	if (isRenderTemplateResult(expression)) {
+		return getFunctionExpression(expression);
+	}
+	return expression as (...args: any[]) => any;
 }
 
 export class Slots {

--- a/packages/astro/test/astro-slots.test.ts
+++ b/packages/astro/test/astro-slots.test.ts
@@ -182,6 +182,13 @@ describe('Slots', () => {
 		assert.deepEqual(afterDiv.text(), 'Test Content AFTER');
 	});
 
+	it('Arguments can be passed to conditional named slots with Astro.slots.render()', async () => {
+		const html = await fixture.readFile('/conditional-slotted-callback/index.html');
+		const $ = cheerio.load(html);
+
+		assert.equal($('#conditional-block').text(), 'Block: block');
+	});
+
 	it('Unused slot builds without error', async () => {
 		const html = await fixture.readFile('/unused-slot/index.html');
 		const $ = cheerio.load(html);

--- a/packages/astro/test/fixtures/astro-slots/src/components/ConditionalSlottedCallback.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/ConditionalSlottedCallback.astro
@@ -1,0 +1,8 @@
+---
+let html = '';
+if (Astro.slots.has('block')) {
+	html = await Astro.slots.render('block', [{ test: 'block' }]);
+}
+---
+
+<Fragment set:html={html} />

--- a/packages/astro/test/fixtures/astro-slots/src/pages/conditional-slotted-callback.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/conditional-slotted-callback.astro
@@ -1,0 +1,13 @@
+---
+import ConditionalSlottedCallback from '../components/ConditionalSlottedCallback.astro';
+---
+
+<ConditionalSlottedCallback>
+	{
+		true && (
+			<fragment slot="block">
+				{({ test }) => <div id="conditional-block">Block: {test}</div>}
+			</fragment>
+		)
+	}
+</ConditionalSlottedCallback>


### PR DESCRIPTION
## Changes

- Recursively unwrap nested `RenderTemplateResult` values when locating callback expressions for slotted content.
- Adds a regression fixture for a conditional `<fragment slot="block">` callback receiving `Astro.slots.render('block', [{ test: 'block' }])` arguments.
- Adds a patch changeset for `astro`.

Closes #16463

## Testing

- `pnpm -r --workspace-concurrency=1 --filter @astrojs/internal-helpers --filter @astrojs/prism --filter @astrojs/markdown-remark --filter @astrojs/telemetry run build`
- `pnpm -r --workspace-concurrency=1 --filter @astrojs/yaml2ts --filter @astrojs/language-server --filter @astrojs/check run build`
- `pnpm -C packages/astro run build`
- `pnpm -C packages/astro exec astro-scripts test "test/astro-slots.test.ts" --strip-types`
- `pnpm exec biome check packages/astro/src/core/render/slots.ts packages/astro/test/astro-slots.test.ts`
- `pnpm exec prettier --check packages/astro/test/fixtures/astro-slots/src/components/ConditionalSlottedCallback.astro packages/astro/test/fixtures/astro-slots/src/pages/conditional-slotted-callback.astro .changeset/tender-slots-unwrap.md`
- `git diff HEAD^ --check`

## Docs

No docs changes. This restores expected callback argument behavior for an existing slots API pattern.