### PR TITLE
fix: emit fallback rewrite pages

### DIFF
--- a/.changeset/loose-groups-design.md
+++ b/.changeset/loose-groups-design.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where `i18n.fallback` pages with `fallbackType: 'rewrite'` were emitted with empty bodies during `astro build`.

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -102,7 +102,7 @@ export function createI18nMiddleware(
 		if (i18n.fallback && i18n.fallbackType) {
 			const fallbackDecision = computeFallbackRoute({
 				pathname: context.url.pathname,
-				responseStatus: response.status,
+				responseStatus: typeHeader === 'fallback' ? 404 : response.status,
 				currentLocale: context.currentLocale,
 				fallback: i18n.fallback,
 				fallbackType: i18n.fallbackType,

--- a/packages/astro/test/units/i18n/i18n-middleware.test.ts
+++ b/packages/astro/test/units/i18n/i18n-middleware.test.ts
@@ -22,6 +22,13 @@ function makePageResponse(
 	});
 }
 
+function makeFallbackSentinelResponse(): Response {
+	return new Response(null, {
+		status: 500,
+		headers: { 'X-Astro-Route-Type': 'fallback' },
+	});
+}
+
 interface I18nManifestOverrides {
 	defaultLocale?: string;
 	locales?: Locales;
@@ -187,6 +194,30 @@ describe('createI18nMiddleware', () => {
 
 			assert.equal(result.status, 200);
 			assert.equal(await result.text(), 'rewritten to /en/start');
+		});
+
+		it('rewrites for the fallback-type sentinel response (regression #16113)', async () => {
+			const handler = createI18nMiddleware(
+				makeI18nManifest({
+					strategy: 'pathname-prefix-other-locales',
+					fallbackType: 'rewrite',
+					fallback: { it: 'en' },
+				}),
+				'/',
+				'ignore',
+				'directory',
+			);
+			const ctx = createMockAPIContext({
+				url: 'http://localhost/it/about',
+				rewrite: async (_path: string) =>
+					new Response(`<h1>about page</h1>`, { status: 200 }),
+			} as any);
+			const next = async () => makeFallbackSentinelResponse();
+
+			const result = await callHandler(handler, ctx, next);
+
+			assert.equal(result.status, 200);
+			assert.match(await result.text(), /about page/);
 		});
 	});
 


### PR DESCRIPTION
Close #16113

## Summary

When i18n.fallback is combined with `fallbackType: 'rewrite'`, every fallback locale page is built as an empty HTML file. 

Default-locale pages render fine, but folders like `/es/` and `/fr/` end up with (file not created, response body was empty) and no files on disk.


## Changes

### Before

The render pipeline emits an internal sentinel response for fallback routes.

- `status: 500`
- `X-Astro-Route-Type: fallback`

The i18n middleware passes this to `computeFallbackRoute()`, which only fires on status `404`. The sentinel arrives with `500`, so the rewrite never runs and the empty body flows through to the build, which skips the file.

### After

Inside the i18n middleware, treat any response that carries `X-Astro-Route-Type: fallback` as if its status were `404`, regardless of the actual code. The header is the real signal that the response is an internal fallback sentinel.

```diff
- responseStatus: response.status,
+ responseStatus: typeHeader === 'fallback' ? 404 : response.status,
```

`computeFallbackRoute()` now triggers on the sentinel, the rewrite to the default locale runs, and the locale folder gets the expected HTML.

## Tests

A unit test that feeds the middleware a fallback sentinel and asserts `context.rewrite()` is called.