### PR TITLE
fix: route mismatch using trail slash never

### DIFF
--- a/.changeset/great-eyes-behave.md
+++ b/.changeset/great-eyes-behave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the index route would return a 404 error when using a custom `base` path combined with `trailingSlash: 'never'`. This ensures that the home page and internal rewrites are correctly matched under these configurations.

--- a/packages/astro/src/core/routing/pattern.ts
+++ b/packages/astro/src/core/routing/pattern.ts
@@ -38,7 +38,7 @@ export function getPattern(
 	const trailing =
 		addTrailingSlash && segments.length ? getTrailingSlashPattern(addTrailingSlash) : '$';
 	let initial = '\\/';
-	if (addTrailingSlash === 'never' && base !== '/') {
+	if (addTrailingSlash === 'never' && base !== '/' && pathname !== '') {
 		initial = '';
 	}
 	// nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -227,10 +227,7 @@ export function normalizeRewritePathname(
 			urlPathname === base || urlPathname === removeTrailingForwardSlash(base);
 
 		if (isBasePathRequest) {
-			// For root path requests at the base URL
-			// When trailingSlash is 'never', we should match '' (empty string pathname)
-			// When trailingSlash is 'always', we should match '/' pathname
-			pathname = shouldAppendSlash ? '/' : '';
+			pathname = '/';
 		} else if (urlPathname.startsWith(base)) {
 			// For non-root paths under the base
 			pathname = shouldAppendSlash
@@ -245,10 +242,6 @@ export function normalizeRewritePathname(
 		pathname = prependForwardSlash(pathname);
 	}
 
-	// Convert '/' to '' for trailingSlash: 'never'
-	if (pathname === '/' && base !== '/' && !shouldAppendSlash) {
-		pathname = '';
-	}
 	// If config.build.format = 'file' then pathname includes .html, so we need to remove it
 	if (buildFormat === 'file') {
 		pathname = pathname.replace(/\.html$/, '');

--- a/packages/astro/src/vite-plugin-app/app.ts
+++ b/packages/astro/src/vite-plugin-app/app.ts
@@ -166,12 +166,6 @@ export class AstroServerApp extends BaseApp<RunnablePipeline> {
 			pathname = decodeURI(url.pathname);
 		}
 
-		// Normalize root path to empty string when trailingSlash is 'never' and there's a non-root base
-		// This ensures consistent route matching for the index route (e.g., /base?query -> '')
-		if (this.manifest.trailingSlash === 'never' && pathname === '/' && this.manifest.base !== '/') {
-			pathname = '';
-		}
-
 		// Add config.base back to url before passing it to SSR
 		url.pathname = removeTrailingForwardSlash(this.manifest.base) + url.pathname;
 		if (

--- a/packages/astro/test/units/routing/manifest.test.ts
+++ b/packages/astro/test/units/routing/manifest.test.ts
@@ -61,8 +61,8 @@ describe('routing - createRoutesList', () => {
 			defaultLogger,
 		);
 		const [{ pattern }] = manifest.routes;
-		assert.equal(pattern.test(''), true);
-		assert.equal(pattern.test('/'), false);
+		assert.equal(pattern.test('/'), true);
+		assert.equal(pattern.test(''), false);
 	});
 
 	it('endpoint routes are sorted before page routes', async () => {

--- a/packages/astro/test/units/routing/pattern.test.ts
+++ b/packages/astro/test/units/routing/pattern.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getPattern } from '../../../dist/core/routing/pattern.js';
+
+describe('getPattern', () => {
+	describe('root route (empty segments)', () => {
+		it('should produce a pattern matching "/" with trailingSlash: "never" and base: "/"', () => {
+			const pattern = getPattern([], '/', 'never');
+			assert.ok(pattern.test('/'), `pattern /${pattern.source}/ should match "/"`);
+			assert.ok(!pattern.test(''), `pattern /${pattern.source}/ should not match ""`);
+		});
+
+		// When trailingSlash === 'never' and base !== '/', getPattern() set initial = ''　
+		// Root route, pathname is already '', the regex became ^$ instead of ^\/$, causing a 404
+		it('should produce a pattern matching "/" with trailingSlash: "never" and base: "/mybase"', () => {
+			const pattern = getPattern([], '/mybase', 'never');
+			assert.ok(pattern.test('/'), `pattern /${pattern.source}/ should match "/"`);
+			assert.ok(!pattern.test(''), `pattern /${pattern.source}/ should not match ""`);
+		});
+	});
+
+	describe('non-root routes with trailingSlash: "never" and base path', () => {
+		it('should preserve pathname for non-root routes when base !== "/"', () => {
+			// Non-root routes have pathname = '/about' (not empty), so initial = ''
+			// doesn't cause problems. The regex becomes \/about$ which correctly
+			// matches '/about' after base-stripping in the router.
+			const pattern = getPattern([[{ content: 'about', dynamic: false, spread: false }]], '/mybase', 'never');
+			assert.ok(pattern.test('/about'), `pattern /${pattern.source}/ should match "/about"`);
+			assert.ok(!pattern.test('/about/'), `pattern /${pattern.source}/ should not match "/about/"`);
+		});
+	});
+});

--- a/packages/astro/test/units/routing/rewrite.test.ts
+++ b/packages/astro/test/units/routing/rewrite.test.ts
@@ -43,7 +43,7 @@ describe('normalizeRewritePathname', () => {
 
 		it('handles base path root with trailingSlash never', () => {
 			const result = normalizeRewritePathname('/docs', '/docs/', 'never', 'directory');
-			assert.equal(result.pathname, '');
+			assert.equal(result.pathname, '/');
 			assert.equal(result.resolvedUrlPathname, '/docs');
 		});
 
@@ -87,9 +87,9 @@ describe('normalizeRewritePathname', () => {
 			assert.equal(result.pathname, '/about');
 		});
 
-		it('converts root with base to empty string', () => {
+		it('converts root with base to root slash', () => {
 			const result = normalizeRewritePathname('/docs/', '/docs/', 'never', 'directory');
-			assert.equal(result.pathname, '');
+			assert.equal(result.pathname, '/');
 			assert.equal(result.resolvedUrlPathname, '/docs');
 		});
 	});


### PR DESCRIPTION
## Changes

Fixes #16247

#### Root Cause:
The `getPattern()` function in `packages/astro/src/core/routing/pattern.ts` was clearing the initial forward slash for **all routes** when a non-root base was configured, without considering whether the route is the root route or not:

## Testing

### Before Implementation

<img width="804" height="203" alt="スクリーンショット 2026-04-29 22 37 49" src="https://github.com/user-attachments/assets/4c97e733-8475-41bd-873d-ed3cb04a62e1" />

<img width="936" height="620" alt="スクリーンショット 2026-04-29 22 38 29" src="https://github.com/user-attachments/assets/6bbb542e-ce66-4ac9-b945-49c346be8db7" />

### After Implementation

<img width="807" height="209" alt="スクリーンショット 2026-04-29 22 45 43" src="https://github.com/user-attachments/assets/4b21e47d-faa6-432c-a303-c25643534531" />

<img width="752" height="160" alt="スクリーンショット 2026-04-29 22 48 26" src="https://github.com/user-attachments/assets/08b83c76-c750-404a-8ccd-9ef01f6348b7" />

## Docs