### PR TITLE
fix(build): exclude prerendered route styles from SSR manifest

### DIFF
--- a/.changeset/strip-prerender-styles-ssr-manifest.md
+++ b/.changeset/strip-prerender-styles-ssr-manifest.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes inline CSS for prerendered routes from the SSR manifest. The static HTML on disk already inlines those styles, and the SSR worker never renders prerendered routes, so the data was dead weight. Builds with many prerendered routes and `build.inlineStylesheets: "always"` (or `"auto"` with small stylesheets) will see a smaller SSR entry chunk, which reduces cold-start parse time on platforms like Cloudflare Workers.

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -95,7 +95,12 @@ export async function manifestBuildPostHook(
 				? internals.middlewareEntryPoint
 				: undefined,
 		});
-		const code = injectManifest(manifest, ssrManifestChunk.code);
+		// Prerendered routes' styles are dead weight in the SSR manifest: the static
+		// HTML on disk already has them inlined, and the SSR worker never renders
+		// these routes. Stripping keeps the entry chunk small on platforms like
+		// Cloudflare Workers that re-parse it on every cold isolate start.
+		const ssrManifest = stripPrerenderedRouteStyles(manifest);
+		const code = injectManifest(ssrManifest, ssrManifestChunk.code);
 		mutate(ssrManifestChunk.fileName, code, false);
 	}
 
@@ -148,6 +153,22 @@ function injectManifest(manifest: SerializedSSRManifest, code: string) {
 	return code.replace(replaceExp, () => {
 		return JSON.stringify(manifest);
 	});
+}
+
+/**
+ * Returns a copy of the manifest with `styles` cleared on every prerendered
+ * route. Inline CSS for prerendered routes is dead weight in the SSR manifest:
+ * the prerendered HTML on disk already contains the `<style>` tags, and the
+ * SSR worker never renders these routes.
+ */
+function stripPrerenderedRouteStyles(manifest: SerializedSSRManifest): SerializedSSRManifest {
+	let stripped = false;
+	const routes = manifest.routes.map((route) => {
+		if (!route.routeData.prerender || route.styles.length === 0) return route;
+		stripped = true;
+		return { ...route, styles: [] };
+	});
+	return stripped ? { ...manifest, routes } : manifest;
 }
 
 async function buildManifest(

--- a/packages/astro/test/ssr-prerender.test.ts
+++ b/packages/astro/test/ssr-prerender.test.ts
@@ -106,6 +106,67 @@ describe('SSR: prerender', () => {
 	});
 });
 
+describe('SSR manifest does not include inline CSS for prerendered routes', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-prerender/',
+			output: 'server',
+			outDir: './dist/inline-stylesheets',
+			adapter: testAdapter(),
+			build: {
+				inlineStylesheets: 'always',
+			},
+		});
+		await fixture.build();
+	});
+
+	it('prerendered routes have empty styles in the SSR manifest', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const prerenderedRoutes = app.manifest.routes.filter((r) => r.routeData.prerender);
+		assert.ok(prerenderedRoutes.length > 0, 'fixture must have prerendered routes');
+		for (const route of prerenderedRoutes) {
+			assert.deepEqual(
+				route.styles,
+				[],
+				`route ${route.routeData.route} should have no styles in the SSR manifest`,
+			);
+		}
+	});
+
+	it('SSR routes still have inline styles in the SSR manifest', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const ssrRoute = app.manifest.routes.find((r) => r.routeData.route === '/not-prerendered');
+		assert.ok(ssrRoute, 'expected /not-prerendered route');
+		const hasInline = ssrRoute.styles.some(
+			(s) => s.type === 'inline' && s.content.includes('ssr-only'),
+		);
+		assert.ok(hasInline, 'SSR route should retain its inline CSS in the manifest');
+	});
+
+	it('prerendered HTML on disk still contains inline <style> tags', async () => {
+		const html = await fixture.readFile('/client/static/index.html');
+		const $ = cheerio.load(html);
+		const inlineStyles = $('style')
+			.map((_, el) => $(el).text() ?? '')
+			.toArray()
+			.join('');
+		assert.ok(
+			inlineStyles.includes('prerender-only'),
+			'prerendered HTML should still inline the route CSS',
+		);
+	});
+
+	it('SSR entry chunk does not contain the prerender-only CSS string', async () => {
+		const entry = (await fixture.readFile('/server/entry.mjs')).toString();
+		assert.ok(
+			!entry.includes('prerender-only'),
+			'SSR entry should not carry inline CSS for prerendered routes',
+		);
+	});
+});
+
 // NOTE: This test doesn't make sense as it relies on the fact that on the client build,
 // you can change the prerender state of pages from the SSR build, however, the client build
 // is not always guaranteed to run. If we want to support this feature, we may want to only allow


### PR DESCRIPTION
## Changes

- Strip `styles` from prerendered routes in the SSR manifest only. The prerender chunk and prerendered HTML output are unchanged.
- Adds `stripPrerenderedRouteStyles` helper in `plugin-manifest.ts` that returns the original manifest object when no stripping is needed.
- Adds 4 regression tests under `ssr-prerender.test.ts` covering the SSR manifest, the SSR-only route, the prerendered HTML on disk, and the SSR entry chunk text.

Discussion: https://github.com/withastro/roadmap/discussions/1351

## Background

In hybrid builds (`output: "server"` with prerendered routes, or `output: "static"` with SSR endpoints) using `build.inlineStylesheets: "always"` (or `"auto"` with small stylesheets), the SSR worker's serialized manifest contained the full inlined CSS of every prerendered route. That data was never consumed at runtime — the prerendered HTML on disk already inlines those styles, and the SSR worker never renders prerendered routes — but it was parsed and held in memory on every cold isolate start on platforms like Cloudflare Workers. On a real Astro 6 site with ~280 prerendered routes, this inflated `dist/server/index.mjs` from ~325 KB to ~2.1 MB.

## Test plan

- [x] New tests in `packages/astro/test/ssr-prerender.test.ts` (4 cases)
- [x] Existing `ssr-prerender.test.ts` passes (9 cases)
- [x] `css-inline-stylesheets.test.ts` passes (18 cases)
- [x] `serializeManifest.test.ts`, `css-deduplication`, `css-order`, `astro-css-bundling`, `server-islands` all pass
- [x] `pnpm build:ci` succeeds across the workspace
