### PR TITLE
Moves tinyglobby from dependencies to devDependencies

### DIFF
--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -46,7 +46,6 @@
     "@astrojs/underscore-redirects": "workspace:*",
     "@cloudflare/vite-plugin": "^1.32.3",
     "piccolore": "^0.1.3",
-    "tinyglobby": "^0.2.15",
     "vite": "^7.3.2"
   },
   "peerDependencies": {
@@ -59,7 +58,8 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "cheerio": "1.2.0",
-    "devalue": "^5.6.3"
+    "devalue": "^5.6.3",
+    "tinyglobby": "^0.2.15"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -47,7 +47,6 @@
     "@astrojs/underscore-redirects": "workspace:*",
     "@cloudflare/vite-plugin": "^1.39.0",
     "piccolore": "^0.1.3",
-    "tinyglobby": "^0.2.15",
     "vite": "^8.0.13"
   },
   "peerDependencies": {
@@ -62,7 +61,8 @@
     "astro-scripts": "workspace:*",
     "cheerio": "1.2.0",
     "devalue": "^5.8.1",
-    "prismjs": "^1.30.0"
+    "prismjs": "^1.30.0",
+    "tinyglobby": "^0.2.15"
   },
   "publishConfig": {
     "provenance": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4581,9 +4581,6 @@ importers:
       piccolore:
         specifier: ^0.1.3
         version: 0.1.3
-      tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.16
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -4606,6 +4603,9 @@ importers:
       devalue:
         specifier: ^5.6.3
         version: 5.6.4
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.16
 
   packages/integrations/cloudflare/test/fixtures/allowed-hosts:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4221,9 +4221,6 @@ importers:
       piccolore:
         specifier: ^0.1.3
         version: 0.1.3
-      tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.16
       vite:
         specifier: ^8.0.13
         version: 8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
@@ -4252,6 +4249,9 @@ importers:
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.16
 
   packages/integrations/cloudflare/test/fixtures/allowed-hosts:
     dependencies:


### PR DESCRIPTION
## Changes

- Moves `tinyglobby` from `dependencies` to `devDependencies`

## Testing

<!-- How was this change tested? -->


```bash
# Builds cloudflare after moving tinyglobby to devDependencies.
$ pnpm -C packages/integrations/cloudflare build

# Checks whether the built runtime output still imports tinyglobby. This is expected to return no matches.
$ rg "tinyglobby" packages/integrations/cloudflare/dist

# Creates the publish tarball
$ pnpm -C packages/integrations/cloudflare pack --out /tmp/cloudflare-check.tgz

Inspects the packaged package.json to confirm tinyglobby is listed under devDependencies, not dependencies.
$ tar -xOf /tmp/cloudflare-check.tgz package/package.json | rg "tinyglobby|dependencies|devDependencies"
$ rg "tinyglobby" packages/integrations/cloudflare
  ```

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->