### PR TITLE
fix: add empty integrations array to Astro config

### DIFF
--- a/examples/basics/astro.config.mjs
+++ b/examples/basics/astro.config.mjs
@@ -2,4 +2,6 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+	integrations: [],
+});


### PR DESCRIPTION
## Changes

- Adds an explicit empty `integrations` array to the `examples/basics` Astro config.
- Keeps the basic example aligned with config shape that includes `integrations`.

No changeset added because this only updates an example config and does not affect package behavior.

## Testing

Not run. This is a config-only example update with no runtime behavior change.

## Docs

No docs update needed. This only changes an example config.

fixes #16526