### PR TITLE
fix(config): update validation for omitted `integrations` fields with newer Zod versions

### DIFF
--- a/.changeset/soft-ducks-validate.md
+++ b/.changeset/soft-ducks-validate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes config validation for omitted `integrations` fields with newer Zod versions.

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -1,21 +1,21 @@
-import type { OutgoingHttpHeaders } from 'node:http';
 import type {
 	RehypePlugin as _RehypePlugin,
 	RemarkPlugin as _RemarkPlugin,
 	RemarkRehype as _RemarkRehype,
-	ShikiConfig,
 	Smartypants as _Smartypants,
+	ShikiConfig,
 } from '@astrojs/markdown-remark';
 import { markdownConfigDefaults, syntaxHighlightDefaults } from '@astrojs/markdown-remark';
+import type { OutgoingHttpHeaders } from 'node:http';
 import { type BuiltinTheme, bundledThemes } from 'shiki';
 import * as z from 'zod/v4';
 import { FontFamilySchema } from '../../../assets/fonts/config.js';
+import { SvgOptimizerSchema } from '../../../assets/svg/config.js';
 import { EnvSchema } from '../../../env/schema.js';
 import type { AstroUserConfig, ViteUserConfig } from '../../../types/public/config.js';
-import { allowedDirectivesSchema, cspAlgorithmSchema, cspHashSchema } from '../../csp/config.js';
 import { CacheSchema, RouteRulesSchema } from '../../cache/config.js';
+import { allowedDirectivesSchema, cspAlgorithmSchema, cspHashSchema } from '../../csp/config.js';
 import { SessionSchema } from '../../session/config.js';
-import { SvgOptimizerSchema } from '../../../assets/svg/config.js';
 
 // The below types are required boilerplate to work around a Zod issue since v3.21.2. Since that version,
 // Zod's compiled TypeScript would "simplify" certain values to their base representation, causing references
@@ -193,15 +193,16 @@ export const AstroConfigSchema = z.object({
 		.union([z.literal('where'), z.literal('class'), z.literal('attribute')])
 		.optional()
 		.default('attribute'),
-	adapter: z.object({ name: z.string(), hooks: z.object({}).passthrough().default({}) }).optional(),
-	integrations: z.preprocess(
-		// preprocess
-		(val) => (Array.isArray(val) ? val.flat(Number.POSITIVE_INFINITY).filter(Boolean) : val),
-		// validate
-		z
-			.array(z.object({ name: z.string(), hooks: z.object({}).passthrough().default({}) }))
-			.default(ASTRO_CONFIG_DEFAULTS.integrations),
-	),
+	adapter: z.object({ name: z.string(), hooks: z.object({}).loose().default({}) }).optional(),
+	integrations: z
+		.preprocess(
+			// preprocess
+			(val) => (Array.isArray(val) ? val.flat(Number.POSITIVE_INFINITY).filter(Boolean) : val),
+			// validate
+			z.array(z.object({ name: z.string(), hooks: z.object({}).loose().default({}) })),
+		)
+		.optional()
+		.default(ASTRO_CONFIG_DEFAULTS.integrations),
 	build: z
 		.object({
 			format: z


### PR DESCRIPTION
## Changes

- Fixes config validation when `integrations` is omitted from `astro.config.*`.
- Prevents fresh projects using `defineConfig({})` from failing with `integrations: Required` when newer Zod versions are installed.
- Keeps existing integration normalization behavior, including flattening nested arrays and filtering falsy entries.
- Adds a patch changeset.

## Testing

- Ran `pnpm -C packages/astro build`.
- Ran `pnpm -C packages/astro exec astro-scripts test "test/units/config/config-validate.test.ts"`.
- Manually verified `validateConfig({})` works with `zod@4.4.1`.

## Docs

No docs changes needed. This restores the documented/default behavior for empty Astro configs.

related to #16526
related to #16528
