### PR TITLE
fix(language-server): remove circular dependency on svelte/vue integrations

### DIFF
--- a/packages/language-tools/language-server/src/importPackage.ts
+++ b/packages/language-tools/language-server/src/importPackage.ts
@@ -67,8 +67,8 @@ function importEditorIntegration<T>(packageName: string, fromPath: string): T | 
 	return undefined;
 }
 
-type SvelteIntegration = { toTSX: (code: string, className: string) => string };
-type VueIntegration = { toTSX: (code: string, className: string) => string };
+type SvelteIntegration = { toTSX(code: string, className: string): string };
+type VueIntegration = { toTSX(code: string, className: string): string };
 
 export function importSvelteIntegration(fromPath: string): SvelteIntegration | undefined {
 	return importEditorIntegration('@astrojs/svelte', fromPath);

--- a/packages/language-tools/language-server/src/importPackage.ts
+++ b/packages/language-tools/language-server/src/importPackage.ts
@@ -1,13 +1,6 @@
 import { dirname, resolve } from 'node:path';
 
-// Those three imports needs to always be `type` imports, as we always want to import them dynamically
-
-// TODO: Consider maybe somehow moving those integrations to a separate package to avoid circular dependencies?
-// @ts-ignore - Due to a circular dependency, we can't have those as dependencies
-import type * as svelte from '@astrojs/svelte/dist/editor.cjs';
-// @ts-ignore - Due to a circular dependency, we can't have those as dependencies
-import type * as vue from '@astrojs/vue/dist/editor.cjs';
-
+// The following import needs to always be `type` imports, as we always want to import it dynamically
 import type * as prettier from 'prettier';
 
 type PackageVersion = {
@@ -74,11 +67,14 @@ function importEditorIntegration<T>(packageName: string, fromPath: string): T | 
 	return undefined;
 }
 
-export function importSvelteIntegration(fromPath: string): typeof svelte | undefined {
+type SvelteIntegration = { toTSX: (code: string, className: string) => string };
+type VueIntegration = { toTSX: (code: string, className: string) => string };
+
+export function importSvelteIntegration(fromPath: string): SvelteIntegration | undefined {
 	return importEditorIntegration('@astrojs/svelte', fromPath);
 }
 
-export function importVueIntegration(fromPath: string): typeof vue | undefined {
+export function importVueIntegration(fromPath: string): VueIntegration | undefined {
 	return importEditorIntegration('@astrojs/vue', fromPath);
 }
 


### PR DESCRIPTION
## Changes

We were importing `@astrojs/svelte` in `@astrojs/language-server`, and this cause (type-level) circular dependency.

```
astro
  → @astrojs/check               (devDep)
    → @astrojs/language-server   (dep)
      → @astrojs/svelte           
        → astro                  (devDep)
```

This PR fixes the circular dependency by manually declaring the type of `@astrojs/svelte` in `@astrojs/language-server`, without actually importing `@astrojs/svelte`.

The type of `@astrojs/svelte` is simple enough and hasn't changed since it was first introduced [in 2022](https://github.com/withastro/astro/pull/3864), thus we don't need to worry about the type mismatching in the future. The type checking wasn't working anyway with `@ts-ignore`.

Avoiding circular dependency is required for my upcoming TypeScript project reference refactor.

Alternatively, we can add a new package like `@astrojs/svelte-internal` and move `dist/editor.cjs` into the new package, as shown in the original code comments, but I don't see enough benefit in this. My approach in this PR is much simpler.

## Testing

Green CI.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No runtime JS code change. No docs needed.


<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
