### PR TITLE
fix(astro): make `server` property correctly optional in config validation

### DIFF
--- a/.changeset/whole-walls-fail.md
+++ b/.changeset/whole-walls-fail.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an issue where a warning was displayed when the `server` property was missing during config validation, even though it is not required.

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -234,14 +234,14 @@ export const AstroConfigSchema = z.object({
 			concurrency: z.number().min(1).optional().default(ASTRO_CONFIG_DEFAULTS.build.concurrency),
 		})
 		.prefault({}),
-	server: z.preprocess(
-		// preprocess
-		// NOTE: Uses the "error" command here because this is overwritten by the
-		// individualized schema parser with the correct command.
-		(val) => (typeof val === 'function' ? val({ command: 'error' }) : val),
-		// validate
-		z
-			.object({
+	server: z
+		.preprocess(
+			// preprocess
+			// NOTE: Uses the "error" command here because this is overwritten by the
+			// individualized schema parser with the correct command.
+			(val) => (typeof val === 'function' ? val({ command: 'error' }) : val),
+			// validate
+			z.object({
 				open: z
 					.union([z.string(), z.boolean()])
 					.optional()
@@ -256,9 +256,9 @@ export const AstroConfigSchema = z.object({
 					.union([z.array(z.string()), z.literal(true)])
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.server.allowedHosts),
-			})
-			.prefault({}),
-	),
+			}),
+		)
+		.prefault({}),
 	redirects: z
 		.record(
 			z.string(),

--- a/packages/astro/src/core/config/schemas/relative.ts
+++ b/packages/astro/src/core/config/schemas/relative.ts
@@ -89,17 +89,17 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 			})
 			.optional()
 			.prefault({}),
-		server: z.preprocess(
-			// preprocess
-			(val) => {
-				if (typeof val === 'function') {
-					return val({ command: cmd === 'dev' ? 'dev' : 'preview' });
-				}
-				return val;
-			},
-			// validate
-			z
-				.object({
+		server: z
+			.preprocess(
+				// preprocess
+				(val) => {
+					if (typeof val === 'function') {
+						return val({ command: cmd === 'dev' ? 'dev' : 'preview' });
+					}
+					return val;
+				},
+				// validate
+				z.object({
 					open: z
 						.union([z.string(), z.boolean()])
 						.optional()
@@ -110,15 +110,13 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 						.default(ASTRO_CONFIG_DEFAULTS.server.host),
 					port: z.number().optional().default(ASTRO_CONFIG_DEFAULTS.server.port),
 					headers: z.custom<OutgoingHttpHeaders>().optional(),
-					streaming: z.boolean().optional().default(true),
 					allowedHosts: z
 						.union([z.array(z.string()), z.literal(true)])
 						.optional()
 						.default(ASTRO_CONFIG_DEFAULTS.server.allowedHosts),
-				})
-				.optional()
-				.prefault({}),
-		),
+				}),
+			)
+			.prefault({}),
 	}).transform((config) => {
 		// If the user changed `outDir`, we also need to update `build.client` and `build.server`
 		// the be based on the correct `outDir`

--- a/packages/astro/test/units/config/config-validate.test.ts
+++ b/packages/astro/test/units/config/config-validate.test.ts
@@ -14,7 +14,7 @@ async function validateConfig(userConfig: Record<string, unknown>) {
 
 describe('Config Validation', () => {
 	it('empty user config is valid', async () => {
-		assert.doesNotThrow(() => validateConfig({}).catch((err) => err));
+		await assert.doesNotReject(validateConfig({}));
 	});
 
 	it('Zod errors are returned when invalid config is used', async () => {


### PR DESCRIPTION
fixes: #16526

## Changes

Since zod v4.4.0, validating a config file would show a warning when the `server` property was missing, even though it is not required.

This pull request fixes this by moving `.prefault({})` to a different position, resolving the issue with minimal changes.

Additionally, while investigating, I found that an outdated `server.streaming` property definition was still present in `packages/astro/src/core/config/schemas/relative.ts`, so I removed that as well.

## Testing

There was already a test that checks no error is thrown when empty config data is passed, so no new tests were added in this pull request. However, the existing test had a mistake that caused it to not fail even when the issue was reproduced, so I fixed it to ensure the test runs correctly.

Steps to reproduce:
- Add zod to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`
- Run `pnpm i`
- Run the tests

## Docs
N/A, bug fix