### PR TITLE
Automate merging main into next after releases

### DIFF
--- a/.agents/skills/merge/clean-changesets.md
+++ b/.agents/skills/merge/clean-changesets.md
@@ -1,0 +1,49 @@
+# Clean Changesets
+
+Remove changeset files that were already released on `main` and should not be included in the `next` branch's pre-release versioning.
+
+**SCOPE: Do not spawn tasks/sub-agents.**
+
+## Prerequisites
+
+- **`prNumber`** — The PR number for the merge PR.
+- The working directory is the repo root, checked out on the merge branch.
+
+## Background
+
+When `main` is merged into `next`, changeset files (`.changeset/*.md`) that were consumed by a release on `main` may still appear as new files on `next` if the `next` branch diverged before that release. These stale changesets cause pre-release versions on `next` to include version bumps that were already released as stable versions, leading to version conflicts like `@astrojs/sitemap@3.6.1-beta.3` being published after `@astrojs/sitemap@3.7.0`.
+
+## Steps
+
+1. **Identify stale changesets.** Compare the changeset files on this branch against what exists on `origin/next`:
+   ```bash
+   # List changeset .md files that are new (not in next already)
+   git diff --name-only --diff-filter=A origin/next -- .changeset/
+   ```
+
+2. **Check each new changeset.** For each file found:
+   - Read the file contents to see which packages it bumps
+   - Check if those bumps have already been released on `main` by looking at the current versions in `package.json` files on `origin/main`
+   - A changeset is stale if the version bump it describes has already been released
+
+3. **Also check `pre.json`.** Read `.changeset/pre.json` if it exists. This file tracks the pre-release state. Ensure it does not reference any changesets that should be removed.
+
+4. **Remove stale changesets.** Delete the identified files:
+   ```bash
+   git rm .changeset/<stale-file>.md
+   ```
+
+5. **Verify.** Run `pnpm changeset status` to confirm the remaining changesets are valid and there are no errors.
+
+6. Do NOT commit — the orchestrator will handle committing.
+
+## Important Notes
+
+- Do NOT remove changesets that are specific to `next` (ones that describe major version changes or new features being developed on `next`).
+- Do NOT remove the `.changeset/config.json` file.
+- Do NOT remove `.changeset/pre.json` — it's needed for pre-release mode.
+- If unsure whether a changeset is stale, err on the side of keeping it. A human reviewer can remove it later.
+
+## Output
+
+Return the list of changeset files that were removed.

--- a/.agents/skills/merge/fix-tests.md
+++ b/.agents/skills/merge/fix-tests.md
@@ -1,0 +1,101 @@
+# Fix Test Failures
+
+Fix test failures identified from CI logs on the merge PR. Do NOT re-run the full test suite — CI has already done that. Instead, analyze the CI failure logs and fix the specific failures.
+
+**SCOPE: Do not spawn tasks/sub-agents.**
+
+## Prerequisites
+
+- **`prNumber`** — The PR number for the merge PR.
+- The working directory is the repo root, checked out on the merge branch.
+- Merge conflicts should already be resolved before this skill runs.
+- CI has already run and failed — you need to look at those logs.
+
+## Overview
+
+This skill follows a "fix and push" approach. After pushing, CI will re-run automatically. If there are still failures, this workflow will be triggered again (up to 3 total attempts). So you don't need to fix everything in one pass — focus on the failures visible in the current CI logs.
+
+## Steps
+
+### Step 1: Get CI failure logs
+
+Use the GitHub CLI to find the failed CI run and download its logs:
+
+```bash
+# List recent workflow runs on this branch
+gh run list --branch ci/merge-main-to-next --workflow ci.yml --limit 5 --json databaseId,status,conclusion
+
+# Get the most recent failed run
+gh run view <run-id> --log-failed
+```
+
+Parse the output to identify:
+- Which test files failed
+- The specific test names that failed
+- The error messages and assertion diffs
+
+### Step 2: Analyze failures
+
+For each failure, determine the cause:
+
+1. **Snapshot/output mismatch** — Test expects specific HTML/output but got something different. This is common when the `next` branch uses a newer compiler or has API changes. Fix by updating the expected output to match the new behavior.
+
+2. **Import/module errors** — Code from `main` references modules or exports that changed on `next`. Fix by updating imports or adapting the code.
+
+3. **Type errors** — TypeScript compilation failures from API changes between branches. Fix by updating types.
+
+4. **Configuration mismatches** — Test fixtures using config options that changed on `next`. Fix by updating the fixture config.
+
+### Step 3: Fix the failures
+
+For each failure:
+
+1. **Read the failing test file** to understand what it's testing
+2. **Read the source code** it's testing if needed
+3. **Make the minimal fix** — only change what's needed to make the test pass
+
+**Fix principles:**
+- Keep changes minimal — only fix what CI reported as failing
+- Don't refactor unrelated code
+- Don't change test intent — only adapt expectations to the current branch state
+- If a test expectation needs updating (e.g., expected HTML output changed), update it to match the new correct output
+
+**What NOT to fix:**
+- Tests that were already failing on `next` before the merge — check with `git log origin/next -- <test-file>` if unsure
+- Smoke tests — these are allowed to fail
+- `astro check` failures — these are permitted to fail
+
+### Step 4: Verify fixes locally (targeted only)
+
+Only run the specific tests you fixed, not the full suite:
+
+```bash
+pnpm -C <package-directory> exec astro-scripts test "test/<specific-test>.test.js"
+```
+
+This is a quick sanity check, not a replacement for CI. CI will do the full validation after you push.
+
+### Step 5: Rebuild if source files were modified
+
+If you modified any source files in `packages/` (not just test files), rebuild the affected package:
+
+```bash
+pnpm -C packages/<affected-package> build
+```
+
+Then re-run the specific affected tests to confirm.
+
+### Step 6: Ensure dependencies are up to date
+
+If the merge introduced new dependencies or changed versions, run:
+
+```bash
+pnpm install --no-frozen-lockfile
+```
+
+## Output
+
+Return:
+- Whether all identified test failures were fixed
+- List of files that were modified
+- List of any remaining failures that could not be fixed automatically (e.g., require deeper architectural understanding)

--- a/.agents/skills/merge/resolve-conflicts.md
+++ b/.agents/skills/merge/resolve-conflicts.md
@@ -1,0 +1,57 @@
+# Resolve Merge Conflicts
+
+Resolve merge conflicts from merging `main` into the `next` branch.
+
+**SCOPE: Do not spawn tasks/sub-agents.**
+
+## Prerequisites
+
+- **`prNumber`** — The PR number for the merge PR.
+- **`branch`** — The branch name (e.g., `ci/merge-main-to-next`).
+- The working directory is the repo root, checked out on the merge branch with conflict markers present.
+
+## Strategy
+
+When resolving conflicts, follow these rules based on file type:
+
+### Changeset files (`.changeset/*.md`)
+
+- If a changeset file exists on `main` but not on `next`, it was likely already released. **Delete it.** The clean-changesets skill will handle this more thoroughly, but removing obvious ones here unblocks the merge.
+- If both branches modified the same changeset, prefer the `next` version since it's the one targeting the upcoming major.
+
+### `package.json` and version files
+
+- **Prefer `next` branch versions.** The `next` branch has the pre-release versions (alpha/beta) which should not be overwritten by `main`'s stable versions.
+- For dependency version updates from `main`, accept those — they are typically patches/minors that should be forward-ported.
+
+### `pnpm-lock.yaml`
+
+- Do not try to manually resolve lockfile conflicts. Instead:
+  1. Accept the `next` version: `git checkout --theirs pnpm-lock.yaml`
+  2. The lockfile will be regenerated after `pnpm install` later.
+
+### Source code (`packages/**/*.ts`, `packages/**/*.js`)
+
+- **Prefer `main` for bug fixes.** If `main` fixed a bug, that fix should carry over to `next`.
+- **Prefer `next` for API changes.** If `next` changed an API (new major version features), keep the `next` version and adapt the `main` fix to work with it if needed.
+- When in doubt, prefer `next` — it's the forward-looking branch.
+
+### Test files
+
+- If tests conflict, prefer `next` and adapt. Tests on `next` may test new major-version behavior.
+
+### Configuration files (`.changeset/config.json`, `tsconfig.json`, etc.)
+
+- Prefer `next` unless `main` has a clear fix that should be forward-ported.
+
+## Steps
+
+1. Run `git diff --name-only --diff-filter=U` to list all conflicted files.
+2. For each conflicted file, read the file and resolve the conflict following the strategy above.
+3. After resolving each file, run `git add <file>` to mark it as resolved.
+4. After all files are resolved, verify no conflict markers remain: `grep -r "<<<<<<< " --include="*.ts" --include="*.js" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.md" .`
+5. Do NOT commit — the orchestrator will handle committing.
+
+## Output
+
+Return the list of files that were resolved and whether all conflicts were successfully handled.

--- a/.flue/workflows/merge-fix/WORKFLOW.ts
+++ b/.flue/workflows/merge-fix/WORKFLOW.ts
@@ -1,0 +1,149 @@
+import type { FlueClient } from '@flue/client';
+import { anthropic, github, githubBody } from '@flue/client/proxies';
+import * as v from 'valibot';
+
+export const proxies = {
+	anthropic: anthropic(),
+	github: github({
+		policy: {
+			base: 'allow-read',
+			allow: [
+				// Allow GraphQL
+				{ method: 'POST', path: '/graphql', body: githubBody.graphql() },
+				// Allow git clone, fetch, and push over smart HTTP transport
+				{ method: 'GET', path: '/*/*/info/refs' },
+				{ method: 'POST', path: '/*/*/git-upload-pack' },
+				{ method: 'POST', path: '/*/*/git-receive-pack' },
+			],
+		},
+	}),
+};
+
+export const args = v.object({
+	prNumber: v.number(),
+});
+
+export default async function mergeFix(
+	flue: FlueClient,
+	{ prNumber }: v.InferOutput<typeof args>,
+) {
+	const branch = 'ci/merge-main-to-next';
+
+	// Step 1: Check for merge conflicts (unresolved conflict markers in files)
+	const conflictCheck = await flue.shell(
+		'git diff --check HEAD 2>&1 || grep -r "<<<<<<< " --include="*.ts" --include="*.js" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.md" --include="*.mjs" --include="*.cjs" . 2>/dev/null | head -20',
+	);
+	const hasConflicts = conflictCheck.stdout.includes('<<<<<<<');
+
+	// Step 2: Resolve conflicts if any
+	if (hasConflicts) {
+		await flue.skill('merge/resolve-conflicts.md', {
+			args: { prNumber, branch },
+			result: v.object({
+				resolved: v.pipe(
+					v.boolean(),
+					v.description('true if all merge conflicts were resolved successfully'),
+				),
+				filesResolved: v.pipe(
+					v.array(v.string()),
+					v.description('List of files where conflicts were resolved'),
+				),
+			}),
+		});
+	}
+
+	// Step 3: Remove stale changesets that were already released on main
+	await flue.skill('merge/clean-changesets.md', {
+		args: { prNumber },
+		result: v.object({
+			removedChangesets: v.pipe(
+				v.array(v.string()),
+				v.description('List of changeset files that were removed'),
+			),
+		}),
+	});
+
+	// Step 4: Run tests and fix failures
+	const fixResult = await flue.skill('merge/fix-tests.md', {
+		args: { prNumber },
+		result: v.object({
+			testsPass: v.pipe(
+				v.boolean(),
+				v.description('true if all tests pass after fixes'),
+			),
+			fixedFiles: v.pipe(
+				v.array(v.string()),
+				v.description('List of test files or source files that were modified to fix failures'),
+			),
+			remainingFailures: v.pipe(
+				v.array(v.string()),
+				v.description(
+					'Test names or files that still fail and could not be resolved automatically',
+				),
+			),
+		}),
+	});
+
+	// Step 5: Commit and push all changes
+	const status = await flue.shell('git status --porcelain');
+	if (status.stdout.trim()) {
+		await flue.shell('git add -A');
+
+		const commitParts = [];
+		if (hasConflicts) commitParts.push('resolve merge conflicts');
+		if (fixResult.fixedFiles.length > 0) commitParts.push('fix test failures');
+		const commitMsg =
+			commitParts.length > 0
+				? `chore: ${commitParts.join(' and ')} for main-to-next merge`
+				: 'chore: update main-to-next merge';
+
+		await flue.shell(`git commit -m ${JSON.stringify(commitMsg)}`);
+		const pushResult = await flue.shell(`git push origin ${branch}`);
+		console.info('push result:', pushResult);
+
+		if (pushResult.exitCode !== 0) {
+			return { pushed: false, testsPass: fixResult.testsPass };
+		}
+	}
+
+	// Step 6: Post a summary comment on the PR
+	const summaryParts = [];
+	if (hasConflicts) summaryParts.push('- Resolved merge conflicts');
+	if (fixResult.fixedFiles.length > 0) {
+		summaryParts.push(`- Fixed test failures in: ${fixResult.fixedFiles.join(', ')}`);
+	}
+	if (fixResult.remainingFailures.length > 0) {
+		summaryParts.push(
+			`- ⚠️ Remaining failures that need manual attention: ${fixResult.remainingFailures.join(', ')}`,
+		);
+	}
+
+	if (summaryParts.length > 0) {
+		const commentBody = `## Automated Merge Fix
+
+${summaryParts.join('\n')}
+
+${fixResult.testsPass ? 'All tests pass — this PR should be ready for review.' : 'Some tests still fail — manual intervention may be needed.'}`;
+
+		const token = process.env.FREDKBOT_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+		await fetch(
+			`https://api.github.com/repos/withastro/astro/issues/${prNumber}/comments`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: `token ${token}`,
+					'Content-Type': 'application/json',
+					Accept: 'application/vnd.github+json',
+				},
+				body: JSON.stringify({ body: commentBody }),
+			},
+		);
+	}
+
+	return {
+		pushed: true,
+		testsPass: fixResult.testsPass,
+		hasConflicts,
+		remainingFailures: fixResult.remainingFailures,
+	};
+}

--- a/.github/workflows/merge-fix.yml
+++ b/.github/workflows/merge-fix.yml
@@ -1,0 +1,158 @@
+name: Merge Fix
+
+on:
+  # Auto-trigger when CI fails on the merge branch
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [ci/merge-main-to-next]
+  # Manual trigger with PR number
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to fix (defaults to the open merge PR)"
+        required: false
+        type: string
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/flue-sandbox
+  PNPM_STORE_DIR: .pnpm-store
+
+concurrency:
+  group: merge-fix
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    name: Fix merge PR
+    # Only run when CI failed (or manual dispatch), and only in the withastro org
+    if: >-
+      github.repository_owner == 'withastro' &&
+      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: read
+    steps:
+      - name: Lowercase image name
+        run: echo "IMAGE=${IMAGE,,}" >> "$GITHUB_ENV"
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          INPUT_PR: ${{ inputs.pr_number }}
+        run: |
+          if [ -n "$INPUT_PR" ]; then
+            echo "number=$INPUT_PR" >> "$GITHUB_OUTPUT"
+          else
+            PR_NUMBER=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --head "ci/merge-main-to-next" \
+              --base "next" \
+              --json number \
+              --jq '.[0].number' 2>/dev/null || echo "")
+            if [ -z "$PR_NUMBER" ]; then
+              echo "No open merge PR found — nothing to fix."
+              echo "number=" >> "$GITHUB_OUTPUT"
+            else
+              echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Checkout
+        if: steps.pr.outputs.number != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ci/merge-main-to-next
+          fetch-depth: 0
+          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+
+      - name: Configure Git identity
+        if: steps.pr.outputs.number != ''
+        run: |
+          git config user.name "astrobot-houston"
+          git config user.email "fred+astrobot@astro.build"
+
+      - name: Check fix attempt count
+        if: steps.pr.outputs.number != ''
+        id: attempts
+        run: |
+          # Count prior fix commits by the bot on this branch (since it diverged from next)
+          COUNT=$(git log --oneline origin/next..HEAD --author="astrobot-houston" --grep="chore:.*main-to-next merge" | wc -l | tr -d ' ')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -ge 3 ]; then
+            echo "::warning::Merge fix has already been attempted $COUNT times. Skipping to avoid infinite recursion."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Attempt $((COUNT + 1)) of 3"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup PNPM
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install deps
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        # Use --no-frozen-lockfile because the merge may have introduced
+        # lockfile conflicts or new dependencies that need resolving
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        run: pnpm build
+
+      - name: Log in to GHCR
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull sandbox image
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        run: docker pull $IMAGE:latest
+
+      - name: Start Cloudflare Tunnel
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+          cloudflared tunnel --url http://localhost:48765 --no-autoupdate 2>&1 | tee /tmp/cloudflared.log &
+          for i in $(seq 1 30); do
+            if grep -qo 'https://[^ ]*\.trycloudflare\.com' /tmp/cloudflared.log; then
+              break
+            fi
+            sleep 1
+          done
+          echo "=========================================="
+          echo "TUNNEL URL:"
+          grep -o 'https://[^ ]*\.trycloudflare\.com' /tmp/cloudflared.log || echo "WARNING: tunnel URL not found"
+          echo "=========================================="
+          echo ""
+          echo "To attach from your machine:"
+          echo "  OPENCODE_API_URL=\$(grep -o 'https://[^ ]*\\.trycloudflare\\.com' /tmp/cloudflared.log) opencode attach"
+
+      - name: Run merge fix workflow
+        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FREDKBOT_GITHUB_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          pnpm flue run .flue/workflows/merge-fix/WORKFLOW.ts \
+            --sandbox $IMAGE:latest \
+            --args "{\"prNumber\": $PR_NUMBER}" \
+            --model anthropic/claude-opus-4-6

--- a/.github/workflows/merge-main-to-next.yml
+++ b/.github/workflows/merge-main-to-next.yml
@@ -20,7 +20,26 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check if this was an actual release
+        id: check-release
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            # Check if the head commit on main is a release commit
+            COMMIT_MSG=$(gh api repos/${{ github.repository }}/commits/main --jq '.commit.message' 2>/dev/null || echo "")
+            if echo "$COMMIT_MSG" | grep -q "^\[ci\] release"; then
+              echo "released=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "released=false" >> "$GITHUB_OUTPUT"
+              echo "Not a release commit — nothing to do."
+            fi
+          fi
+
       - name: Check if next branch exists
+        if: steps.check-release.outputs.released == 'true'
         id: check-next
         env:
           GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
@@ -33,20 +52,20 @@ jobs:
           fi
 
       - name: Checkout repo
-        if: steps.check-next.outputs.exists == 'true'
+        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
 
       - name: Configure Git identity
-        if: steps.check-next.outputs.exists == 'true'
+        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
         run: |
           git config user.name "astrobot-houston"
           git config user.email "fred+astrobot@astro.build"
 
       - name: Attempt merge
-        if: steps.check-next.outputs.exists == 'true'
+        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
         id: merge
         run: |
           BRANCH="ci/merge-main-to-next"
@@ -69,7 +88,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Open or update PR
-        if: steps.check-next.outputs.exists == 'true'
+        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           CONFLICT: ${{ steps.merge.outputs.conflict }}

--- a/.github/workflows/merge-main-to-next.yml
+++ b/.github/workflows/merge-main-to-next.yml
@@ -1,0 +1,106 @@
+name: Merge main into next
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  merge:
+    name: Merge main into next
+    # Only run when the Release workflow succeeded (or manual dispatch)
+    # and only in the withastro org (not forks)
+    if: >-
+      github.repository_owner == 'withastro' &&
+      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check if next branch exists
+        id: check-next
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+        run: |
+          if gh api repos/${{ github.repository }}/branches/next --silent 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No 'next' branch found — nothing to do."
+          fi
+
+      - name: Checkout repo
+        if: steps.check-next.outputs.exists == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+
+      - name: Configure Git identity
+        if: steps.check-next.outputs.exists == 'true'
+        run: |
+          git config user.name "astrobot-houston"
+          git config user.email "fred+astrobot@astro.build"
+
+      - name: Attempt merge
+        if: steps.check-next.outputs.exists == 'true'
+        id: merge
+        run: |
+          BRANCH="ci/merge-main-to-next"
+
+          # Start from the next branch
+          git checkout origin/next
+          git checkout -B "$BRANCH"
+
+          # Attempt the merge
+          if git merge origin/main --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            # Stage the conflicted state so we can push it
+            git add -A
+            git commit --no-edit -m "chore: merge main into next (conflicts)" || true
+          fi
+
+          git push -f origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update PR
+        if: steps.check-next.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          CONFLICT: ${{ steps.merge.outputs.conflict }}
+          BRANCH: ${{ steps.merge.outputs.branch }}
+        run: |
+          if [ "$CONFLICT" = "true" ]; then
+            BODY="## Merge main into next
+
+          This PR merges \`main\` into \`next\` after a release.
+
+          > **⚠️ This merge has conflicts that need to be resolved.**
+
+          If CI fails, the merge-fix workflow will attempt to resolve conflicts and fix test failures automatically."
+          else
+            BODY="## Merge main into next
+
+          This PR merges \`main\` into \`next\` after a release.
+
+          The merge was clean — review CI results and merge when ready."
+          fi
+
+          # Check if a PR already exists for this branch
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --base next --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --body "$BODY"
+            echo "Updated existing PR #$EXISTING_PR"
+          else
+            gh pr create \
+              --head "$BRANCH" \
+              --base next \
+              --title "chore: merge main into next" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/merge-main-to-next.yml
+++ b/.github/workflows/merge-main-to-next.yml
@@ -1,45 +1,20 @@
 name: Merge main into next
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
-    branches: [main]
+  repository_dispatch:
+    types: [release-published]
   workflow_dispatch:
 
 jobs:
   merge:
     name: Merge main into next
-    # Only run when the Release workflow succeeded (or manual dispatch)
-    # and only in the withastro org (not forks)
-    if: >-
-      github.repository_owner == 'withastro' &&
-      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    if: github.repository_owner == 'withastro'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Check if this was an actual release
-        id: check-release
-        env:
-          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-          else
-            # Check if the head commit on main is a release commit
-            COMMIT_MSG=$(gh api repos/${{ github.repository }}/commits/main --jq '.commit.message' 2>/dev/null || echo "")
-            if echo "$COMMIT_MSG" | grep -q "^\[ci\] release"; then
-              echo "released=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "released=false" >> "$GITHUB_OUTPUT"
-              echo "Not a release commit — nothing to do."
-            fi
-          fi
-
       - name: Check if next branch exists
-        if: steps.check-release.outputs.released == 'true'
         id: check-next
         env:
           GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
@@ -52,20 +27,20 @@ jobs:
           fi
 
       - name: Checkout repo
-        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
+        if: steps.check-next.outputs.exists == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
 
       - name: Configure Git identity
-        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
+        if: steps.check-next.outputs.exists == 'true'
         run: |
           git config user.name "astrobot-houston"
           git config user.email "fred+astrobot@astro.build"
 
       - name: Attempt merge
-        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
+        if: steps.check-next.outputs.exists == 'true'
         id: merge
         run: |
           BRANCH="ci/merge-main-to-next"
@@ -88,7 +63,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Open or update PR
-        if: steps.check-release.outputs.released == 'true' && steps.check-next.outputs.exists == 'true'
+        if: steps.check-next.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           CONFLICT: ${{ steps.merge.outputs.conflict }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,10 @@ jobs:
         uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # 0.4.0
         with:
           args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"
+
+      - name: Dispatch post-release event
+        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          event-type: release-published


### PR DESCRIPTION
## Changes

- Adds two new GitHub Actions workflows that automate the process of merging `main` into `next` after a release, preventing stale changesets from causing version conflicts (e.g., `@astrojs/sitemap@3.6.1-beta.3` published after `3.7.0` stable).
- **Workflow 1** (`merge-main-to-next.yml`): Triggers after the Release workflow succeeds on `main`. Merges `main` into a `ci/merge-main-to-next` branch and opens a PR targeting `next`.
- **Workflow 2** (`merge-fix.yml`): Triggers when CI fails on the merge PR. Uses Flue to resolve merge conflicts, clean stale changesets, and fix test failures by analyzing CI logs. Retries up to 3 times recursively (push fix → CI re-runs → bot retries if still failing).

## Testing

No automated tests — these are CI workflow files. Manual validation needed by triggering the workflows.

## Docs

No docs needed — internal CI automation.