### PR TITLE
Fix merge-fix workflow to handle conflict markers before install

### DIFF
--- a/.agents/skills/merge/fix-tests.md
+++ b/.agents/skills/merge/fix-tests.md
@@ -17,7 +17,17 @@ This skill follows a "fix and push" approach. After pushing, CI will re-run auto
 
 ## Steps
 
-### Step 1: Get CI failure logs
+### Step 1: Build all packages
+
+Before analyzing test failures, ensure all packages are built:
+
+```bash
+pnpm build
+```
+
+Fix any build errors first — these may be the cause of test failures downstream.
+
+### Step 2: Get CI failure logs
 
 Use the GitHub CLI to find the failed CI run and download its logs:
 
@@ -35,7 +45,7 @@ Parse the output to identify:
 - The specific test names that failed
 - The error messages and assertion diffs
 
-### Step 2: Analyze failures
+### Step 3: Analyze failures
 
 For each failure, determine the cause:
 
@@ -47,7 +57,7 @@ For each failure, determine the cause:
 
 4. **Configuration mismatches** — Test fixtures using config options that changed on `next`. Fix by updating the fixture config.
 
-### Step 3: Fix the failures
+### Step 4: Fix the failures
 
 For each failure:
 
@@ -68,7 +78,7 @@ For each failure:
 - Smoke tests — these are allowed to fail
 - `astro check` failures — these are permitted to fail
 
-### Step 4: Verify fixes locally (targeted only)
+### Step 5: Verify fixes locally (targeted only)
 
 Only run the specific tests you fixed, not the full suite:
 
@@ -78,7 +88,7 @@ pnpm -C <package-directory> exec astro-scripts test "test/<specific-test>.test.j
 
 This is a quick sanity check, not a replacement for CI. CI will do the full validation after you push.
 
-### Step 5: Rebuild if source files were modified
+### Step 6: Rebuild if source files were modified
 
 If you modified any source files in `packages/` (not just test files), rebuild the affected package:
 
@@ -88,7 +98,7 @@ pnpm -C packages/<affected-package> build
 
 Then re-run the specific affected tests to confirm.
 
-### Step 6: Ensure dependencies are up to date
+### Step 7: Ensure dependencies are up to date
 
 If the merge introduced new dependencies or changed versions, run:
 

--- a/.agents/skills/merge/resolve-conflicts.md
+++ b/.agents/skills/merge/resolve-conflicts.md
@@ -50,7 +50,11 @@ When resolving conflicts, follow these rules based on file type:
 2. For each conflicted file, read the file and resolve the conflict following the strategy above.
 3. After resolving each file, run `git add <file>` to mark it as resolved.
 4. After all files are resolved, verify no conflict markers remain: `grep -r "<<<<<<< " --include="*.ts" --include="*.js" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.md" .`
-5. Do NOT commit — the orchestrator will handle committing.
+5. After conflicts are resolved, regenerate the lockfile and install dependencies:
+   ```bash
+   pnpm install --no-frozen-lockfile
+   ```
+6. Do NOT commit — the orchestrator will handle committing.
 
 ## Output
 

--- a/.flue/workflows/merge-fix/WORKFLOW.ts
+++ b/.flue/workflows/merge-fix/WORKFLOW.ts
@@ -49,7 +49,14 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		});
 	}
 
-	// Step 3: Remove stale changesets that were already released on main
+	// Step 3: Ensure dependencies are installed
+	// If conflicts were resolved, the resolve-conflicts skill already ran pnpm install.
+	// If not, we still need to install deps before proceeding.
+	if (!hasConflicts) {
+		await flue.shell('pnpm install --no-frozen-lockfile');
+	}
+
+	// Step 4: Remove stale changesets that were already released on main
 	await flue.skill('merge/clean-changesets.md', {
 		args: { prNumber },
 		result: v.object({
@@ -60,7 +67,7 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		}),
 	});
 
-	// Step 4: Run tests and fix failures
+	// Step 5: Run tests and fix failures
 	const fixResult = await flue.skill('merge/fix-tests.md', {
 		args: { prNumber },
 		result: v.object({
@@ -78,7 +85,7 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		}),
 	});
 
-	// Step 5: Commit and push all changes
+	// Step 6: Commit and push all changes
 	const status = await flue.shell('git status --porcelain');
 	if (status.stdout.trim()) {
 		await flue.shell('git add -A');
@@ -100,7 +107,7 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		}
 	}
 
-	// Step 6: Post a summary comment on the PR
+	// Step 7: Post a summary comment on the PR
 	const summaryParts = [];
 	if (hasConflicts) summaryParts.push('- Resolved merge conflicts');
 	if (fixResult.fixedFiles.length > 0) {

--- a/.github/workflows/merge-fix.yml
+++ b/.github/workflows/merge-fix.yml
@@ -102,15 +102,14 @@ jobs:
           node-version: 24.15.0
           cache: pnpm
 
-      - name: Install deps
+      - name: Install root deps only
         if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
-        # Use --no-frozen-lockfile because the merge may have introduced
-        # lockfile conflicts or new dependencies that need resolving
-        run: pnpm install --no-frozen-lockfile
-
-      - name: Build
-        if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'
-        run: pnpm build
+        # Only install root workspace deps (where @flue/cli lives).
+        # Cannot install the full monorepo here because merge conflicts
+        # in package.json files would break pnpm install.
+        # Full install and build happen inside the Flue sandbox after
+        # conflicts are resolved.
+        run: pnpm install --no-frozen-lockfile --filter .
 
       - name: Log in to GHCR
         if: steps.pr.outputs.number != '' && steps.attempts.outputs.skip != 'true'


### PR DESCRIPTION
## Changes

- Moves `pnpm install` and `pnpm build` out of the merge-fix GitHub Action and into the Flue sandbox skills. The previous version failed because merge conflict markers in `package.json` files made `pnpm install` crash before Flue could resolve them.
- The GitHub Action now only installs root deps (`pnpm install --filter .`) to get `@flue/cli` available, then hands off to Flue immediately.
- Conflict resolution skill now runs `pnpm install` after fixing conflicts. Test fix skill now runs `pnpm build` as its first step.

## Testing

Manual — re-run the merge-fix workflow on the existing merge PR.

## Docs

No docs needed — internal CI automation.