### PR TITLE
perf(astro): skip session storage lookup if no cookie is set

### DIFF
--- a/.changeset/skip-session-storage-no-cookie.md
+++ b/.changeset/skip-session-storage-no-cookie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Skips session storage reads when no session cookie is present. Previously, calling `session.get()` on a request without a session cookie would initialize the storage driver and make a read that was guaranteed to miss. On network-backed drivers this added latency and resource usage to every anonymous request.

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -343,11 +343,21 @@ export class AstroSession {
 	 */
 
 	async #ensureData() {
-		const storage = await this.#ensureStorage();
 		if (this.#data && !this.#partial) {
 			return this.#data;
 		}
 		this.#data ??= new Map();
+
+		// If no session ID has been set yet (no prior set() call) and there is no
+		// session cookie, there is nothing to load from storage. Returning early
+		// avoids initialising the storage driver and making a guaranteed-miss read
+		// on every anonymous request.
+		if (!this.#sessionID && !this.#cookies.get(this.#cookieName)?.value) {
+			this.#partial = false;
+			return this.#data;
+		}
+
+		const storage = await this.#ensureStorage();
 
 		// We stored this as a devalue string, but unstorage will have parsed it as JSON
 		const raw = await storage.get<any[]>(this.#ensureSessionID());

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -554,3 +554,76 @@ describe('AstroSession - Storage Errors', () => {
 });
 
 // #endregion Storage Errors
+
+// #region No-Cookie Short Circuit
+describe('AstroSession - No-Cookie Short Circuit', () => {
+	it('should not initialize the storage driver or read when no session cookie is present', async () => {
+		let driverInitCount = 0;
+		const countingDriverFactory: SessionDriverFactory = () => {
+			driverInitCount++;
+			return driverFactory();
+		};
+
+		const noCookieMock: MockCookies = {
+			set: () => {},
+			delete: () => {},
+			get: () => undefined,
+		};
+
+		// Use a unique driver name so the static #sharedStorage cache from
+		// earlier tests can't mask a regression.
+		const session = new AstroSession({
+			cookies: noCookieMock as any,
+			config: { ...defaultConfig, driver: 'no-cookie-test' },
+			runtimeMode: 'production',
+			driverFactory: countingDriverFactory,
+			mockStorage: null,
+		});
+
+		const value = await session.get('nonexistent');
+		assert.equal(value, undefined);
+		assert.equal(driverInitCount, 0, 'Driver factory should never have been called');
+	});
+
+	it('should read from storage when session cookie is present', async () => {
+		let storageReadCount = 0;
+		const mockStorage = {
+			get: async () => {
+				storageReadCount++;
+				return stringify(new Map([['user', { data: 'alice' }]]));
+			},
+			setItem: async () => {},
+		} as unknown as Storage;
+
+		const withCookieMock: MockCookies = {
+			set: () => {},
+			delete: () => {},
+			get: (name: string) => {
+				if (name === 'test-session') return { value: 'existing-session-id' };
+				return undefined;
+			},
+		};
+
+		const session = createSession(defaultConfig, withCookieMock, mockStorage);
+
+		const value = await session.get('user');
+		assert.equal(value, 'alice');
+		assert.equal(storageReadCount, 1, 'Storage should have been read once');
+	});
+
+	it('should allow set() then get() without a cookie (new session)', async () => {
+		const noCookieMock: MockCookies = {
+			set: () => {},
+			delete: () => {},
+			get: () => undefined,
+		};
+
+		const session = createSession(defaultConfig, noCookieMock);
+
+		session.set('key', 'expected' );
+		const value = await session.get('key');
+		assert.equal(value, 'expected');
+	});
+});
+
+// #endregion No-Cookie Short Circuit


### PR DESCRIPTION
## Changes

Short-circuits session storage reads, returning an empty session when no session cookie is present. Previously, calling `session.get()` on a request without a session cookie would initialize the storage driver with a new session ID, and make a read that was guaranteed to miss. On network-backed drivers this added latency and resource usage to every anonymous request.


## Testing

Tests added

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Perf optimisation only

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
