### PR TITLE
Fetch CI logs in merge-fix orchestrator instead of gh CLI

### DIFF
--- a/.agents/skills/merge/fix-tests.md
+++ b/.agents/skills/merge/fix-tests.md
@@ -7,9 +7,10 @@ Fix test failures identified from CI logs on the merge PR. Do NOT re-run the ful
 ## Prerequisites
 
 - **`prNumber`** — The PR number for the merge PR.
+- **`ciLogs`** — The CI failure logs, pre-fetched by the orchestrator. Contains the failed job names and their log output.
 - The working directory is the repo root, checked out on the merge branch.
 - Merge conflicts should already be resolved before this skill runs.
-- CI has already run and failed — you need to look at those logs.
+- Dependencies are installed and packages are built on the host.
 
 ## Overview
 
@@ -27,23 +28,15 @@ pnpm build
 
 Fix any build errors first — these may be the cause of test failures downstream.
 
-### Step 2: Get CI failure logs
+### Step 2: Analyze CI failure logs
 
-Use the GitHub CLI to find the failed CI run and download its logs:
-
-```bash
-# List recent workflow runs on this branch
-gh run list --branch ci/merge-main-to-next --workflow ci.yml --limit 5 --json databaseId,status,conclusion
-
-# Get the most recent failed run
-gh run view <run-id> --log-failed
-```
-
-Parse the output to identify:
+The `ciLogs` argument contains the pre-fetched CI failure logs. Parse them to identify:
 
 - Which test files failed
 - The specific test names that failed
 - The error messages and assertion diffs
+
+**Note:** Do NOT use `gh` CLI commands — they don't work inside the sandbox. All CI log data is provided in the `ciLogs` argument.
 
 ### Step 3: Analyze failures
 

--- a/.flue/workflows/merge-fix/WORKFLOW.ts
+++ b/.flue/workflows/merge-fix/WORKFLOW.ts
@@ -1,6 +1,7 @@
 import type { FlueClient } from '@flue/client';
 import { anthropic, github, githubBody } from '@flue/client/proxies';
 import * as v from 'valibot';
+import { fetchCIFailureLogs, postPRComment } from './github.ts';
 
 export const proxies = {
 	anthropic: anthropic(),
@@ -26,7 +27,12 @@ export const args = v.object({
 export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOutput<typeof args>) {
 	const branch = 'ci/merge-main-to-next';
 
-	// Step 1: Verify conflict resolutions and resolve any remaining source code conflicts.
+	// Step 1: Fetch CI failure logs before entering the sandbox.
+	// The gh CLI doesn't work inside the Flue sandbox (auth goes through a proxy),
+	// so we fetch logs here in the orchestrator and pass them to the skill.
+	const ciLogs = await fetchCIFailureLogs(branch);
+
+	// Step 2: Verify conflict resolutions and resolve any remaining source code conflicts.
 	// JSON/YAML conflicts were pre-stripped by the GitHub Action (keeping next side).
 	// This skill checks that nothing important from main was lost, and resolves
 	// any remaining conflict markers in .ts/.js/.md/.astro files.
@@ -44,7 +50,7 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		}),
 	});
 
-	// Step 2: Remove stale changesets that were already released on main
+	// Step 3: Remove stale changesets that were already released on main
 	await flue.skill('merge/clean-changesets.md', {
 		args: { prNumber },
 		result: v.object({
@@ -55,9 +61,9 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		}),
 	});
 
-	// Step 3: Run tests and fix failures
+	// Step 4: Fix test failures using CI logs
 	const fixResult = await flue.skill('merge/fix-tests.md', {
-		args: { prNumber },
+		args: { prNumber, ciLogs },
 		result: v.object({
 			testsPass: v.pipe(v.boolean(), v.description('true if all tests pass after fixes')),
 			fixedFiles: v.pipe(
@@ -73,7 +79,7 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		}),
 	});
 
-	// Step 4: Commit and push all changes
+	// Step 5: Commit and push all changes
 	const status = await flue.shell('git status --porcelain');
 	if (status.stdout.trim()) {
 		await flue.shell('git add -A');
@@ -95,7 +101,7 @@ export default async function mergeFix(flue: FlueClient, { prNumber }: v.InferOu
 		}
 	}
 
-	// Step 5: Post a summary comment on the PR
+	// Step 6: Post a summary comment on the PR
 	const summaryParts = [];
 	if (verifyResult.correctedFiles.length > 0) {
 		summaryParts.push(`- Fixed conflict resolutions in: ${verifyResult.correctedFiles.join(', ')}`);
@@ -116,16 +122,7 @@ ${summaryParts.join('\n')}
 
 ${fixResult.testsPass ? 'All tests pass — this PR should be ready for review.' : 'Some tests still fail — manual intervention may be needed.'}`;
 
-		const token = process.env.FREDKBOT_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
-		await fetch(`https://api.github.com/repos/withastro/astro/issues/${prNumber}/comments`, {
-			method: 'POST',
-			headers: {
-				Authorization: `token ${token}`,
-				'Content-Type': 'application/json',
-				Accept: 'application/vnd.github+json',
-			},
-			body: JSON.stringify({ body: commentBody }),
-		});
+		await postPRComment(prNumber, commentBody);
 	}
 
 	return {

--- a/.flue/workflows/merge-fix/github.ts
+++ b/.flue/workflows/merge-fix/github.ts
@@ -1,0 +1,108 @@
+const REPO = 'withastro/astro';
+
+function headers(): Record<string, string> {
+	const token = process.env.FREDKBOT_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+	if (!token) throw new Error('token is not set');
+	return {
+		Authorization: `token ${token}`,
+		'Content-Type': 'application/json',
+		Accept: 'application/vnd.github+json',
+	};
+}
+
+interface WorkflowRun {
+	id: number;
+	status: string;
+	conclusion: string | null;
+	name: string;
+}
+
+/**
+ * Fetch the most recent failed CI run for a given branch.
+ */
+async function getFailedCIRun(branch: string): Promise<WorkflowRun | null> {
+	const res = await fetch(
+		`https://api.github.com/repos/${REPO}/actions/runs?branch=${encodeURIComponent(branch)}&status=failure&per_page=5`,
+		{ headers: headers() },
+	);
+	if (!res.ok) {
+		console.error(`Failed to fetch workflow runs (HTTP ${res.status}): ${await res.text()}`);
+		return null;
+	}
+	const data = (await res.json()) as { workflow_runs: WorkflowRun[] };
+	// Find the most recent CI run (not the Merge Fix run itself)
+	return data.workflow_runs.find((r) => r.name === 'CI') ?? null;
+}
+
+/**
+ * Fetch the failed job logs for a workflow run.
+ * Returns the log text truncated to a reasonable size for the AI.
+ */
+export async function fetchCIFailureLogs(branch: string): Promise<string> {
+	const run = await getFailedCIRun(branch);
+	if (!run) {
+		return 'No failed CI run found for this branch. Try running `pnpm build` and checking for build errors.';
+	}
+
+	// Get jobs for this run
+	const jobsRes = await fetch(
+		`https://api.github.com/repos/${REPO}/actions/runs/${run.id}/jobs?filter=failed`,
+		{ headers: headers() },
+	);
+	if (!jobsRes.ok) {
+		return `Failed to fetch jobs (HTTP ${jobsRes.status}). Run ID: ${run.id}`;
+	}
+	const jobsData = (await jobsRes.json()) as {
+		jobs: Array<{
+			id: number;
+			name: string;
+			conclusion: string;
+			steps: Array<{ name: string; conclusion: string }>;
+		}>;
+	};
+
+	const failedJobs = jobsData.jobs.filter((j) => j.conclusion === 'failure');
+	if (failedJobs.length === 0) {
+		return `CI run ${run.id} has no failed jobs.`;
+	}
+
+	// Fetch logs for each failed job
+	const logParts: string[] = [];
+	logParts.push(`CI Run: ${run.id}`);
+	logParts.push(`Failed jobs: ${failedJobs.map((j) => j.name).join(', ')}`);
+	logParts.push('');
+
+	for (const job of failedJobs) {
+		const logRes = await fetch(
+			`https://api.github.com/repos/${REPO}/actions/jobs/${job.id}/logs`,
+			{ headers: headers(), redirect: 'follow' },
+		);
+		if (!logRes.ok) {
+			logParts.push(`## ${job.name}\nFailed to fetch logs (HTTP ${logRes.status})`);
+			continue;
+		}
+		const logText = await logRes.text();
+		// Truncate to last 5000 chars per job — the failures are at the end
+		const truncated =
+			logText.length > 5000 ? '...(truncated)\n' + logText.slice(-5000) : logText;
+		logParts.push(`## ${job.name}\n${truncated}`);
+	}
+
+	// Cap total size to avoid blowing up the prompt
+	const combined = logParts.join('\n\n');
+	if (combined.length > 20000) {
+		return combined.slice(0, 20000) + '\n...(truncated)';
+	}
+	return combined;
+}
+
+export async function postPRComment(prNumber: number, body: string): Promise<void> {
+	const res = await fetch(`https://api.github.com/repos/${REPO}/issues/${prNumber}/comments`, {
+		method: 'POST',
+		headers: headers(),
+		body: JSON.stringify({ body }),
+	});
+	if (!res.ok) {
+		console.error(`Failed to post comment (HTTP ${res.status}): ${await res.text()}`);
+	}
+}


### PR DESCRIPTION
## Changes

- The gh CLI does not work inside the Flue sandbox (auth routes through a proxy placeholder). The fix-tests skill was failing to fetch CI logs, falling back to running pnpm build to discover errors.
- Adds github.ts helper (following the triage workflow pattern) that fetches CI failure logs via the GitHub API in the WORKFLOW.ts orchestrator, then passes them to the fix-tests skill as a ciLogs argument.
- Updates the fix-tests skill to use the provided logs instead of gh commands.

## Testing

Manual — re-run the merge-fix workflow on the existing merge PR.

## Docs

No docs needed — internal CI automation.