### PR TITLE
Tighten image endpoint path handling

### DIFF
--- a/.changeset/image-endpoint-cleanup.md
+++ b/.changeset/image-endpoint-cleanup.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/internal-helpers': patch
+---
+
+Tightens `isRemotePath()` to reject control characters after a leading slash and fixes the dev image endpoint origin check

--- a/packages/astro/src/assets/endpoint/dev.ts
+++ b/packages/astro/src/assets/endpoint/dev.ts
@@ -55,7 +55,7 @@ async function loadLocalImage(src: string, url: URL) {
 		const sourceUrl = new URL(src, url.origin);
 		// This is only allowed if this is the same origin
 		if (sourceUrl.origin !== url.origin) {
-			returnValue = undefined;
+			return undefined;
 		}
 		return loadRemoteImage(sourceUrl);
 	}

--- a/packages/internal-helpers/src/path.ts
+++ b/packages/internal-helpers/src/path.ts
@@ -150,7 +150,7 @@ export function isRemotePath(src: string) {
 
 	// Check for Unix absolute path (starts with / followed by a normal path character)
 	// This needs to be before the backslash check
-	if (decoded[0] === '/' && /^\/[a-zA-Z0-9._@-]/.test(decoded)) {
+	if (decoded[0] === '/' && /^\/[\w.@-]/.test(decoded)) {
 		return false;
 	}
 

--- a/packages/internal-helpers/src/path.ts
+++ b/packages/internal-helpers/src/path.ts
@@ -148,9 +148,9 @@ export function isRemotePath(src: string) {
 		return false;
 	}
 
-	// Check for Unix absolute path (starts with / but not // or /\)
+	// Check for Unix absolute path (starts with / followed by a normal path character)
 	// This needs to be before the backslash check
-	if (decoded[0] === '/' && decoded[1] !== '/' && decoded[1] !== '\\') {
+	if (decoded[0] === '/' && /^\/[a-zA-Z0-9._@-]/.test(decoded)) {
 		return false;
 	}
 

--- a/packages/internal-helpers/test/path.test.ts
+++ b/packages/internal-helpers/test/path.test.ts
@@ -78,6 +78,17 @@ describe('isRemotePath', () => {
 		'\\%0Aexample.com/test',
 		'\\%0Dexample.com/test',
 
+		// CRLF injection in path (control chars after leading slash cause URL parser
+		// to treat the remainder as a protocol-relative URL)
+		'/%0d%0a/example.com',
+		'/%0d%0a/example.com:8080/path',
+		'/%0a/example.com',
+		'/%0d/example.com',
+		'/\r\n/example.com',
+		'/\n/example.com',
+		'/\r/example.com',
+		'/\t/example.com',
+
 		// IP addresses
 		'http://192.168.1.1/test',
 		'//192.168.1.1/test',


### PR DESCRIPTION
## Changes

- `isRemotePath()` now uses a positive allowlist (`/^\/[a-zA-Z0-9._@-]/`) for the Unix absolute path early-return instead of a negative check against `/` and `\`. Control characters like CR, LF, and tab after a leading slash no longer short-circuit as "local".
- The dev image endpoint origin check in `loadLocalImage` now `return undefined` instead of setting a variable and falling through to `loadRemoteImage`.

## Testing

- Added 8 cases to the `remotePaths` array in `packages/internal-helpers/test/path.test.ts` covering URL-encoded and literal CRLF/LF/CR/tab injection after a leading slash.

## Docs

- No docs changes needed — internal behavior only.