### PR TITLE
Fix stale HMR by notifying SSR module runner of invalidations

### DIFF
--- a/.changeset/fix-stale-getstaticpaths-props.md
+++ b/.changeset/fix-stale-getstaticpaths-props.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes HMR for components passed as props via `getStaticPaths()` in dev mode

--- a/packages/astro/src/core/app/entrypoints/virtual/dev.ts
+++ b/packages/astro/src/core/app/entrypoints/virtual/dev.ts
@@ -34,6 +34,14 @@ export const createApp: CreateApp = ({ streaming } = {}) => {
 			currentDevApp.pipeline.routeCache.clearAll();
 		});
 
+		// Listen for SSR module changes via HMR.
+		// Clear the route cache so getStaticPaths() is re-evaluated with fresh modules.
+		// This ensures components passed as props via getStaticPaths are not stale.
+		import.meta.hot.on('astro:ssr-changed', () => {
+			if (!currentDevApp) return;
+			currentDevApp.pipeline.routeCache.clearAll();
+		});
+
 		// Listen for middleware file changes via HMR.
 		// Clear the cached middleware so it is re-resolved on the next request.
 		import.meta.hot.on('astro:middleware-updated', () => {

--- a/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
+++ b/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
@@ -75,6 +75,14 @@ export default async function createAstroServerApp(
 			actualLogger.debug('router', 'Route cache cleared due to content change');
 		});
 
+		// Listen for SSR module changes via HMR.
+		// Clear the route cache so getStaticPaths() is re-evaluated with fresh modules.
+		// This ensures components passed as props via getStaticPaths are not stale.
+		import.meta.hot.on('astro:ssr-changed', () => {
+			app.clearRouteCache();
+			actualLogger.debug('router', 'Route cache cleared due to SSR module change');
+		});
+
 		// Listen for middleware file changes via HMR.
 		// Clear the cached middleware so it is re-resolved on the next request.
 		import.meta.hot.on('astro:middleware-updated', () => {

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -61,6 +61,10 @@ export default function hmrReload(): Plugin {
 
 				if (hasSsrOnlyModules) {
 					server.ws.send({ type: 'full-reload' });
+					// Clear the route cache so getStaticPaths() is re-evaluated with fresh modules.
+					// Without this, components passed as props via getStaticPaths remain stale
+					// because the cached result holds references to the old module exports.
+					this.environment.hot.send('astro:ssr-changed', {});
 					return [];
 				}
 


### PR DESCRIPTION
## Changes

- Sends a `full-reload` through the environment's hot channel (`this.environment.hot.send`) when SSR-only modules change. Previously, the `astro:hmr-reload` plugin only sent `full-reload` to the browser via `server.ws.send`, but never notified the SSR module runner. This left the runner's `evaluatedModules` cache stale — subsequent requests returned old module exports even though the server-side module graph was correctly invalidated.
- Also sends a new `astro:ssr-changed` event to clear the `RouteCache`, so `getStaticPaths()` is re-evaluated with fresh module references. Previously the route cache was only cleared on `astro:content-changed`.

Together these fix all reported stale-HMR patterns: static imports, dynamic `import()`, and components passed as props via `getStaticPaths`.

Closes #16522
Closes #16000
Closes #16342

## Testing

- No new tests. This is an HMR behavior that requires a running dev server and file edits to verify. Manually confirmed all patterns from the issue reflect changes on refresh.

## Docs

- No docs changes needed. This restores existing expected behavior.