### PR TITLE
fix(upgrade): use bundled JS output

### DIFF
--- a/packages/upgrade/tsconfig.json
+++ b/packages/upgrade/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "allowJs": true,
-    "emitDeclarationOnly": false,
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
## Changes


`upgrade/package.json` has `"build": "astro-scripts build \"src/index.ts\" --bundle && tsc"`. The output `dist/index.js` should be emitted by `astro-scripts`, while `tsc` should only emit `.d.ts` files.

In https://github.com/withastro/astro/pull/16493, `tsc` emits both `.js` and `.d.ts` files, which overrides the bundled ``dist/index.js`` file that was just emitted by `astro-scripts`.

This PR updates `upgrade/tsconfig.json` to ensure that `tsc` won't emit any `.js` files.
 
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Before this PR:

```bash
$ pnpm -w build
$ tree ./packages/upgrade/dist/
./packages/upgrade/dist/
├── actions
│   ├── context.d.ts
│   ├── context.js
│   ├── help.d.ts
│   ├── help.js
│   ├── install.d.ts
│   ├── install.js
│   ├── verify.d.ts
│   └── verify.js
├── index.d.ts
├── index.js
├── messages.d.ts
├── messages.js
├── shell.d.ts
└── shell.js

2 directories, 14 files
```

After this PR:

```bash
$ pnpm -w build
$ tree ./packages/upgrade/dist/
./packages/upgrade/dist/
├── actions
│   ├── context.d.ts
│   ├── help.d.ts
│   ├── install.d.ts
│   └── verify.d.ts
├── index.d.ts
├── index.js
├── messages.d.ts
└── shell.d.ts

2 directories, 8 files
```

After this PR, only one bundled `dist/index.js` file is emitted in `dist/`.

## Docs


The previous and afterward outputs can both work, so there is no behavior change. No docs are needed.



<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
