### PR TITLE
fix(cloudflare): preserve existing KV namespace bindings when injecting SESSION

### DIFF
--- a/packages/integrations/cloudflare/src/wrangler.ts
+++ b/packages/integrations/cloudflare/src/wrangler.ts
@@ -17,6 +17,17 @@ interface CloudflareConfigOptions {
 	imagesBindingName?: string | false | undefined;
 }
 
+type KVNamespace = NonNullable<WorkerConfig['kv_namespaces']>[number];
+
+function withSessionKVBinding(
+	existing: KVNamespace[] | undefined,
+	sessionBinding: string,
+): KVNamespace[] {
+	const namespaces: KVNamespace[] = existing ? [...existing] : [];
+	namespaces.push({ binding: sessionBinding });
+	return namespaces;
+}
+
 /**
  * Returns a config customizer that sets up the Astro Cloudflare defaults.
  * Sets the main entrypoint and adds bindings for auto-provisioning.
@@ -36,7 +47,7 @@ export function cloudflareConfigCustomizer(
 			nonInheritableConfig: WorkerConfig['previews'],
 		): WorkerConfig['previews'] => {
 			const hasSessionBinding = nonInheritableConfig?.kv_namespaces?.some(
-				(kv) => kv.binding === sessionKVBindingName,
+				(kv: KVNamespace) => kv.binding === sessionKVBindingName,
 			);
 			const hasImagesBinding = nonInheritableConfig?.images?.binding !== undefined;
 
@@ -44,11 +55,7 @@ export function cloudflareConfigCustomizer(
 				kv_namespaces:
 					!needsSessionKVBinding || hasSessionBinding
 						? undefined
-						: [
-								{
-									binding: sessionKVBindingName,
-								},
-							],
+						: withSessionKVBinding(nonInheritableConfig?.kv_namespaces, sessionKVBindingName),
 				images:
 					hasImagesBinding || !imagesBindingName
 						? undefined

--- a/packages/integrations/cloudflare/test/wrangler.test.ts
+++ b/packages/integrations/cloudflare/test/wrangler.test.ts
@@ -63,7 +63,10 @@ describe('cloudflareConfigCustomizer', () => {
 				kv_namespaces: [{ binding: 'OTHER_KV', id: 'other-id' }],
 			});
 
-			assert.deepEqual(result.kv_namespaces, [{ binding: DEFAULT_SESSION_KV_BINDING_NAME }]);
+			assert.deepEqual(result.kv_namespaces, [
+				{ binding: 'OTHER_KV', id: 'other-id' },
+				{ binding: DEFAULT_SESSION_KV_BINDING_NAME },
+			]);
 		});
 
 		it('does not add SESSION binding when session KV binding is disabled', () => {
@@ -155,6 +158,20 @@ describe('cloudflareConfigCustomizer', () => {
 			});
 
 			assert.equal(result.previews?.images, undefined);
+		});
+
+		it('preserves existing previews KV bindings when adding SESSION binding', () => {
+			const customizer = cloudflareConfigCustomizer();
+			const result = customizer({
+				previews: {
+					kv_namespaces: [{ binding: 'OTHER_KV', id: 'other-id' }],
+				},
+			});
+
+			assert.deepEqual(result.previews?.kv_namespaces, [
+				{ binding: 'OTHER_KV', id: 'other-id' },
+				{ binding: DEFAULT_SESSION_KV_BINDING_NAME },
+			]);
 		});
 
 		it('adds SESSION binding to previews even when top-level has it', () => {


### PR DESCRIPTION
## Changes

- Fixes a bug in `@astrojs/cloudflare` where custom KV namespace bindings (e.g. `MY_KV`, `CACHE`) were silently removed when Astro's session functionality was enabled.
- The root cause was in `packages/integrations/cloudflare/src/wrangler.ts`: when injecting the `SESSION` KV binding, the code returned a fresh single-item array instead of merging with the user's existing `kv_namespaces`.
- Extracted a `withSessionKVBinding` helper that copies existing namespaces and appends the SESSION binding, preserving all user-defined bindings.
- Fix applies to both the top-level config and the `previews` config (same code path).
- Updated the existing test that was asserting the broken behavior, and added a new test covering the `previews` case.

Closes #16554

## Testing

- Updated `packages/integrations/cloudflare/test/wrangler.test.ts`: fixed the assertion in _"adds SESSION binding when other KV bindings exist but not the session one"_ to verify `OTHER_KV` is preserved alongside `SESSION`.
- Added a new test _"preserves existing previews KV bindings when adding SESSION binding"_ covering the same scenario in the `previews` config.
- No integration test needed: the bug and fix are fully exercised by the unit test suite for `cloudflareConfigCustomizer`.

## Docs

No docs change needed. This is a bug fix restoring behavior that users already rely on — their existing `kv_namespaces` entries in `wrangler.toml` now survive when sessions are enabled.
