### PR TITLE
Clear route cache on SSR module changes

### DIFF
--- a/.changeset/hmr-module-runner-invalidation.md
+++ b/.changeset/hmr-module-runner-invalidation.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes HMR for components passed as props via `getStaticPaths()` in dev mode

--- a/packages/astro/src/core/app/entrypoints/virtual/dev.ts
+++ b/packages/astro/src/core/app/entrypoints/virtual/dev.ts
@@ -34,6 +34,13 @@ export const createApp: CreateApp = ({ streaming } = {}) => {
 			currentDevApp.pipeline.routeCache.clearAll();
 		});
 
+		// Listen for SSR module changes via HMR.
+		// Clear the route cache so getStaticPaths() is re-evaluated with fresh modules.
+		import.meta.hot.on('astro:ssr-changed', () => {
+			if (!currentDevApp) return;
+			currentDevApp.pipeline.routeCache.clearAll();
+		});
+
 		// Listen for middleware file changes via HMR.
 		// Clear the cached middleware so it is re-resolved on the next request.
 		import.meta.hot.on('astro:middleware-updated', () => {

--- a/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
+++ b/packages/astro/src/vite-plugin-app/createAstroServerApp.ts
@@ -75,6 +75,13 @@ export default async function createAstroServerApp(
 			actualLogger.debug('router', 'Route cache cleared due to content change');
 		});
 
+		// Listen for SSR module changes via HMR.
+		// Clear the route cache so getStaticPaths() is re-evaluated with fresh modules.
+		import.meta.hot.on('astro:ssr-changed', () => {
+			app.clearRouteCache();
+			actualLogger.debug('router', 'Route cache cleared due to SSR module change');
+		});
+
 		// Listen for middleware file changes via HMR.
 		// Clear the cached middleware so it is re-resolved on the next request.
 		import.meta.hot.on('astro:middleware-updated', () => {

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -61,6 +61,11 @@ export default function hmrReload(): Plugin {
 
 				if (hasSsrOnlyModules) {
 					server.ws.send({ type: 'full-reload' });
+					// Clear the route cache so getStaticPaths() is re-evaluated with
+					// fresh modules on the next request. Without this, components passed
+					// as props via getStaticPaths remain stale because the cached result
+					// holds references to the old module exports.
+					this.environment.hot.send('astro:ssr-changed', {});
 					return [];
 				}
 


### PR DESCRIPTION
## Changes

- Sends a new `astro:ssr-changed` HMR event when the `astro:hmr-reload` plugin detects SSR-only module changes. Listeners in `createAstroServerApp.ts` and `dev.ts` clear the `RouteCache` in response. Previously the route cache was only cleared on `astro:content-changed` events, so `getStaticPaths()` results holding component references (passed as props) remained stale after file edits.

Closes #16522

## Testing

- No new tests. Manually confirmed that editing a component passed as a prop via `getStaticPaths` now reflects on refresh.

## Docs

- No docs changes needed. This restores expected dev server behavior.