### PR TITLE
Fix broken test-utils imports in .test.js files

### DIFF
--- a/packages/astro/test/alias-path-alias-style.test.js
+++ b/packages/astro/test/alias-path-alias-style.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture } from './test-utils.ts';
 
 // Regression test for https://github.com/withastro/astro/issues/15963
 // <style> tags in components imported via tsconfig path aliases should compile correctly.

--- a/packages/astro/test/head-propagation-prerender-env.test.js
+++ b/packages/astro/test/head-propagation-prerender-env.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { loadFixture } from './test-utils.ts';
 
 // Regression test for https://github.com/withastro/astro/issues/16291
 //

--- a/packages/astro/test/partials-css-boundary.test.js
+++ b/packages/astro/test/partials-css-boundary.test.js
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture } from './test-utils.ts';
 
 describe('Partials CSS propagation', () => {
-	/** @type {import('./test-utils.js').Fixture} */
+	/** @type {import('./test-utils.ts').Fixture} */
 	let fixture;
 
 	before(async () => {


### PR DESCRIPTION
## Changes

- Updates `./test-utils.js` imports to `./test-utils.ts` in three `.test.js` files that were missed when #16492 renamed `test-utils.js` → `test-utils.ts`.

## Testing

- No new tests. This fixes the existing `test:integration:js` suite which fails immediately with `ERR_MODULE_NOT_FOUND`.

## Docs

- No docs needed — test-only change.