### PR TITLE
Fix deleted content collection entries persisting in dev

### DIFF
--- a/.changeset/fix-content-collection-stale-entry-on-delete.md
+++ b/.changeset/fix-content-collection-stale-entry-on-delete.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes deleted content collection entries persisting in `getCollection()` results during dev

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -1,7 +1,7 @@
 import nodeFs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dataToEsm } from '@rollup/pluginutils';
-import { normalizePath, type Plugin, type ViteDevServer } from 'vite';
+import { isRunnableDevEnvironment, normalizePath, type Plugin, type ViteDevServer } from 'vite';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { rootRelativePath } from '../core/viteUtils.js';
@@ -38,6 +38,19 @@ function invalidateDataStore(viteServer: ViteDevServer) {
 		const timestamp = Date.now();
 		// Pass `true` to mark this as HMR invalidation so Vite drops cached SSR results.
 		environment.moduleGraph.invalidateModule(module, undefined, timestamp, true);
+	}
+	// Also invalidate the module in the SSR module runner's evaluation cache.
+	// Server-side invalidation only clears `transformResult`, but the runner
+	// may still hold a stale evaluated result. When the runner's `fetchModule`
+	// call triggers a fresh server transform, the transform re-populates
+	// `transformResult` before the runner checks it, causing a false cache hit.
+	if (isRunnableDevEnvironment(environment)) {
+		const runnerModule = environment.runner.evaluatedModules.getModuleById(
+			RESOLVED_DATA_STORE_VIRTUAL_ID,
+		);
+		if (runnerModule) {
+			environment.runner.evaluatedModules.invalidateModule(runnerModule);
+		}
 	}
 	// Signal the SSR runner to clear its route cache so that getStaticPaths()
 	// is re-evaluated with the updated content collection data.


### PR DESCRIPTION
## Changes

- Invalidates the `astro:data-layer-content` virtual module in the SSR module runner's `evaluatedModules` cache when the data store changes, not just in the server-side module graph. The existing `invalidateModule` call only clears the server's `transformResult`, but a subsequent `transformRequest` (triggered during module resolution) re-populates it before the runner's `fetchModule` check, causing a false cache hit that returns stale data.

Closes #16561

## Testing

- No new tests added. Manually verified with a content collection setup: deleting entries correctly updates `getCollection()` results on the next page load in dev.

## Docs

- No docs update needed; this is a bug fix with no API change.
