### PR TITLE
fix(cloudflare): alias `debug` to obug-backed shim in server environments

### DIFF
--- a/.changeset/cloudflare-debug-alias.md
+++ b/.changeset/cloudflare-debug-alias.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes `ReferenceError: module is not defined` on every request when running `astro dev` with the Cloudflare adapter. The error was triggered whenever a page's dependency graph pulled in the CJS `debug` package (transitively via `micromark`, `stylus`, and many other common npm packages). The adapter now aliases `debug` to an internal ESM shim backed by `obug` in the `ssr`, `astro`, and `prerender` Vite environments, so the workerd runner used by `@cloudflare/vite-plugin` no longer hits the missing `module` global.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -45,6 +45,7 @@
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/underscore-redirects": "workspace:*",
     "@cloudflare/vite-plugin": "^1.32.3",
+    "obug": "^2.1.1",
     "piccolore": "^0.1.3",
     "tinyglobby": "^0.2.15",
     "vite": "^7.3.2"

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -1,6 +1,7 @@
 import { createReadStream, existsSync, readFileSync } from 'node:fs';
 import { appendFile, rename, stat } from 'node:fs/promises';
 import { createInterface } from 'node:readline/promises';
+import { fileURLToPath } from 'node:url';
 import { removeLeadingForwardSlash } from '@astrojs/internal-helpers/path';
 import { createRedirectsFromAstroRoutes, printAsRedirects } from '@astrojs/underscore-redirects';
 import { cloudflare as cfVitePlugin, type PluginConfig } from '@cloudflare/vite-plugin';
@@ -206,12 +207,24 @@ export default function createIntegration({
 					globalThis.astroCloudflareOptions = cfPluginConfig;
 				}
 
+				// Replace the CJS `debug` package (pulled transitively by
+				// `micromark`, `stylus`, and many other npm packages) with an
+				// ESM-compatible shim backed by `obug`. The original `debug`
+				// references `module.exports` at the top level, which fails
+				// with `ReferenceError: module is not defined` when
+				// @cloudflare/vite-plugin loads it in the workerd runner used
+				// for `astro dev`, SSR and prerendering.
+				const debugShim = fileURLToPath(new URL('./shims/debug.js', import.meta.url));
+
 				updateConfig({
 					build: {
 						redirects: false,
 					},
 					session,
 					vite: {
+						resolve: {
+							alias: { debug: debugShim },
+						},
 						plugins: [
 							...(prerenderEnvironment === 'node' && command === 'dev'
 								? [createNodePrerenderPlugin()]

--- a/packages/integrations/cloudflare/src/shims/debug.ts
+++ b/packages/integrations/cloudflare/src/shims/debug.ts
@@ -1,0 +1,16 @@
+// Drop-in ESM replacement for the `debug` package, used via Vite's
+// `resolve.alias` in server environments that run under workerd
+// (astro dev + @cloudflare/vite-plugin).
+//
+// The original `debug` package references `module.exports` at the top
+// level of its CJS entrypoint, which throws `ReferenceError: module is
+// not defined` when @cloudflare/vite-plugin loads it in the Workers
+// runner. `obug` (https://www.npmjs.com/package/obug) is an ESM fork
+// with the same behavior but exposes only named exports; this shim
+// re-exposes a default export so consumers that do
+// `import debug from "debug"` or `const debug = require("debug")`
+// keep working after the alias is applied.
+import { createDebug, disable, enable, enabled, namespaces } from 'obug';
+
+export default createDebug;
+export { createDebug, disable, enable, enabled, namespaces };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,10 +126,10 @@ importers:
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: 5.2.0
-        version: 5.2.0(tinybench@2.9.0)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(tinybench@2.9.0)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)))
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
 
   benchmark/packages/adapter:
     dependencies:
@@ -236,7 +236,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       '@types/react':
         specifier: ^18.3.28
@@ -510,7 +510,7 @@ importers:
         version: link:../../packages/astro
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/astro:
     dependencies:
@@ -772,7 +772,7 @@ importers:
         version: 11.0.5
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       sharp:
         specifier: ^0.34.0
@@ -4294,7 +4294,7 @@ importers:
         version: link:../../..
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/astro/test/fixtures/vue-component:
     dependencies:
@@ -4608,6 +4608,9 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.32.3
         version: 1.32.3(@cloudflare/workers-types@4.20260228.0)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260415.1)
+      obug:
+        specifier: ^2.1.1
+        version: 2.1.1
       piccolore:
         specifier: ^0.1.3
         version: 0.1.3
@@ -15579,6 +15582,7 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^7.3.2
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -16693,12 +16697,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@codspeed/vitest-plugin@5.2.0(tinybench@2.9.0)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@codspeed/vitest-plugin@5.2.0(tinybench@2.9.0)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@codspeed/core': 5.2.0
       tinybench: 2.9.0
       vite: 7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - debug
 
@@ -25473,7 +25477,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -25499,17 +25503,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.2.3
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:


### PR DESCRIPTION
## Changes

`astro dev` with `@astrojs/cloudflare` currently responds with HTTP 500 on every page request:

```
[ERROR] [vite] Internal server error: module is not defined
    at runInRunnerObject (workers/runner-worker/index.js:106:3)
    at _NonRunnablePipeline.getComponentByRoute (.vite/deps_ssr/astro_app_entrypoint_dev.js:196:20)
    at matchRoute (.vite/deps_ssr/astro_app_entrypoint_dev.js:266:14)
    at DevApp.devMatch (.vite/deps_ssr/astro_app_entrypoint_dev.js:375:26)
    at Object.handle [as fetch] (.vite/deps_ssr/@astrojs_cloudflare_entrypoints_server.js:165:20)
    at maybeCaptureError (workers/runner-worker/index.js:50:10)
```

The cause is the CJS [`debug`](https://www.npmjs.com/package/debug) package. Its entrypoint (`node_modules/debug/src/index.js`) reads `module.exports` at the top level, and `module` is not a global in the workerd runner that `@cloudflare/vite-plugin` uses for `astro dev`, SSR and prerender environments, so evaluation throws `ReferenceError: module is not defined`.

#15565 already addressed this for astro core by replacing its own `debug` usage with [`obug`](https://www.npmjs.com/package/obug) (an ESM fork) and documented adding a Vite alias for the rehype/remark rabbit hole. In practice though, `debug` is pulled by a much broader set of transitive dependencies — e.g. `micromark` (via `@astrojs/markdown-remark` → `remark-parse` → `mdast-util-from-markdown`), `stylus` (via Vite's peer dep), and many others — so any Astro 6 project that uses markdown content or stylus transitively still crashes on every request.

This PR extends the fix to user dependency graphs by aliasing `debug` to an adapter-owned ESM shim in the Vite config the adapter installs. The shim forwards to `obug` and also re-exposes a default export, because consumers do `import debug from "debug"` or `require("debug")` and `obug` only ships named exports.

### What the shim looks like

```ts
// packages/integrations/cloudflare/src/shims/debug.ts
import { createDebug, disable, enable, enabled, namespaces } from 'obug';

export default createDebug;
export { createDebug, disable, enable, enabled, namespaces };
```

### Where the alias is applied

Top-level `vite.resolve.alias` inside the adapter's `astro:config:setup` hook, so it propagates to every Vite environment created by the adapter (`astro`, `ssr`, `prerender`):

```ts
const debugShim = fileURLToPath(new URL('./shims/debug.js', import.meta.url));

updateConfig({
  // ...
  vite: {
    resolve: {
      alias: { debug: debugShim },
    },
    plugins: [ /* ... */ ],
  },
});
```

`obug` is added as a direct dependency of `@astrojs/cloudflare` so the shim resolves inside the adapter's own package scope regardless of hoisting.

## Reproduction

Minimal reproduction — any Astro 6 project using `@astrojs/cloudflare@13` with Markdown content or `stylus` in its dep tree will hit this. Starting from `npm create astro@latest` with the Cloudflare adapter and one markdown page under `src/content/` is enough.

## Testing

- Manually verified against a real production blog (Astro 5 → 6 migration in progress, adapter `@astrojs/cloudflare@13.3.0`, Node 22.22.2). Before the patch: `/`, `/blog/`, `/posts/:slug/`, `/about/`, `/archive/`, `/projects/` all return HTTP 500 with the `module is not defined` trace above. With the built adapter dropped into `node_modules` and no other workaround: all the same routes return HTTP 200 with full content.
- Verified `pnpm --filter @astrojs/cloudflare build:ci` produces the expected `dist/shims/debug.js` alongside the patched `dist/index.js`.
- A dedicated unit test is tricky here because the failure only manifests when the workerd runner attempts to evaluate a module whose dep graph reaches `debug`; happy to add an integration test under `packages/integrations/cloudflare/test/fixtures/` modelled after `astro-dev-platform/code-test.astro` if maintainers want one — just point me at the preferred shape.

## Related

- #15284 — original "Astro v6 with cloudflare adapter does not work with `<Code>` components" issue (closed)
- #15565 — original logging overhaul that replaced astro core's `debug` with `obug`
- #15906 — same workerd-runner class of failure, Svelte path
- [expressive-code/expressive-code#439](https://github.com/expressive-code/expressive-code/issues/439) — same error reported against expressive-code; upstream cause is the same.

## Docs

N/A — internal adapter behavior change, transparent to users.