### PR TITLE
fix: bundle @astrojs/internal-helpers in prerender environment

### DIFF
--- a/.changeset/fix-bundle-internal-helpers-prerender.md
+++ b/.changeset/fix-bundle-internal-helpers-prerender.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Suppresses `[WARN] Vite warning: unused imports from "@astrojs/internal-helpers/remote"` during prerender builds. The package is now bundled alongside `astro` in the prerender environment, matching how it is handled in the SSR environment.

--- a/packages/astro/src/core/build/plugins/plugin-internals.ts
+++ b/packages/astro/src/core/build/plugins/plugin-internals.ts
@@ -46,7 +46,7 @@ export function pluginInternals(
 					},
 					resolve: {
 						// Always bundle Astro runtime when building for SSR
-						noExternal: ['astro'],
+						noExternal: ['astro', '@astrojs/internal-helpers'],
 					},
 				};
 			}


### PR DESCRIPTION
## Changes

Fixes the Vite build warning reported in #15957:

```
[WARN] Plugin vite:reporter: Unused imports from "@astrojs/internal-helpers/remote":
 – "matchHostname", "matchPathname", "matchPort", "matchProtocol"
```

`plugin-internals.ts` sets `noExternal: ['astro']` for the prerender environment, which bundles `astro` but leaves `@astrojs/internal-helpers` as an external. Rollup then sees that those four helpers are imported by the bundled `astro` code but not consumed inside the bundle boundary, which triggers the unused-import warning.

Adding `@astrojs/internal-helpers` to `noExternal` alongside `astro` co-bundles it in the prerender environment, eliminating the warning. This is a first-party workspace package and the same pattern is already used elsewhere.

## Testing

The warning is emitted by Vite/Rollup during the build phase and is not directly observable in the integration test suite without capturing stderr. Verified manually by running a project build with `output: 'hybrid'` before and after the change — the warning disappears with the fix applied.

## Docs

No user-facing behavior change — no docs update needed.

Fixes #15957.