### PR TITLE
fix(node): serve prerendered .html files when build.format is 'file'

### DIFF
--- a/.changeset/fix-node-file-format-static.md
+++ b/.changeset/fix-node-file-format-static.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/node": patch
+---
+
+Fixes prerendered pages returning 404 when `build.format` is set to `'file'` in standalone mode. Pages are emitted as `page.html` with this format, and the static file handler now correctly resolves clean URL requests (e.g. `/about`) to the matching `.html` file on disk.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -124,6 +124,11 @@ export function createStaticHandler(
 			const stream = send(req, normalizedPathname, {
 				root: client,
 				dotfiles: normalizedPathname.startsWith('/.well-known/') ? 'allow' : 'deny',
+				// When build.format is 'file', pages are emitted as `page.html` rather
+				// than `page/index.html`. Pass the extension hint so that clean-URL
+				// requests like `/about` resolve to `about.html` on disk instead of
+				// falling through to the SSR handler and returning 404.
+				extensions: app.manifest.buildFormat === 'file' ? (['html'] as string[]) : [],
 			});
 
 			let forwardError = false;

--- a/packages/integrations/node/test/prerender.test.ts
+++ b/packages/integrations/node/test/prerender.test.ts
@@ -449,4 +449,44 @@ describe('Hybrid rendering', () => {
 			assert.equal($('h1').text(), 'shared');
 		});
 	});
+
+	describe("build.format: 'file'", () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/prerender/',
+				output: 'server',
+				outDir: './dist/file-format',
+				build: { format: 'file' },
+				adapter: nodejs({ mode: 'standalone' }),
+			});
+			await fixture.build();
+			const { startServer } = await fixture.loadAdapterEntryModule();
+			const res = startServer();
+			server = res.server;
+			await waitServerListen(server.server);
+		});
+
+		after(async () => {
+			await server.stop();
+			await fixture.clean();
+		});
+
+		it('serves a prerendered page via its clean URL', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/two`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'Two');
+		});
+
+		it('still serves the SSR route', async () => {
+			const res = await fetch(`http://${server.host}:${server.port}/one`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'One');
+		});
+	});
 });


### PR DESCRIPTION
## Changes

Fixes prerendered pages returning 404 when `build.format: 'file'` is set in the Node standalone adapter.

When `build.format` is `'file'`, pages are emitted as flat `.html` files (`about.html`) instead of `about/index.html`. The `send` library's `extensions` option tells it to try appending `.html` before giving up, so a request to `/about` resolves correctly on disk instead of falling through to the SSR handler as a 404.

One-line change in `serve-static.ts` — `app.manifest.buildFormat` is already available in scope (same as `app.manifest.trailingSlash` used just above).

## Testing

Added two cases to the existing `prerender.test.ts` under a new `"build.format: 'file'"` describe block:
- prerendered page is served correctly via its clean URL
- SSR route still works alongside it

## Docs

No user-facing behavior change beyond bug fix — no docs update needed.

Fixes #16570.