### PR TITLE
docs: fix typos in astro:i18n middleware JSDoc

### DIFF
--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -359,9 +359,9 @@ export type I18nMiddlewareOptions = {
 /**
  * @param {AstroConfig['i18n']['routing']} customOptions
  *
- * A function that allows to programmatically create the Astro i18n middleware.
+ * A function that allows you to programmatically create the Astro i18n middleware.
  *
- * This is use useful when you still want to use the default i18n logic, but add only few exceptions to your website.
+ * This is useful when you still want to use the default i18n logic, but add only a few exceptions to your website.
  *
  * ## Examples
  *


### PR DESCRIPTION
Fixes three small grammar typos in the JSDoc above `astro:i18n`'s exported `middleware` (`packages/astro/src/virtual-modules/i18n.ts`):

- "allows to programmatically create" -> "allows you to programmatically create"
- "is use useful" -> "is useful"
- "only few exceptions" -> "only a few exceptions"

The "allows you to" phrasing matches the convention used throughout the rest of the repo (CHANGELOGs use it 20+ times). Comment-only change, no behavior impact.
