### PR TITLE
feat(astro): add `observeDynamicLinks` option for prefetch settings

### DIFF
--- a/.changeset/bright-beans-take.md
+++ b/.changeset/bright-beans-take.md
@@ -1,0 +1,18 @@
+---
+'astro': minor
+---
+
+Adds a new `observeDynamicLinks` option to prefetch settings
+
+This option uses a `MutationObserver` to watch for links added to the DOM after the initial page load, ensuring they are captured for prefetching.
+
+This is useful when links are dynamically added to the DOM, for example, inside a component using `server:defer` with top-level await.
+
+```js
+// astro.config.js
+export default defineConfig({
+  prefetch: {
+    observeDynamicLinks: true,
+  },
+})
+```

--- a/packages/astro/e2e/fixtures/prefetch/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/prefetch/astro.config.mjs
@@ -1,7 +1,11 @@
+import node from '@astrojs/node'
+import react from '@astrojs/react';
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
+	adapter: node({ mode: 'standalone' }),
+	integrations: [react()],
 	devToolbar: {
 		enabled: false,
 	},

--- a/packages/astro/e2e/fixtures/prefetch/package.json
+++ b/packages/astro/e2e/fixtures/prefetch/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "astro": "workspace:*"
+		"@astrojs/node": "workspace:*",
+		"@astrojs/react": "workspace:*",
+		"astro": "workspace:*",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
   }
 }

--- a/packages/astro/e2e/fixtures/prefetch/src/components/Deferred.astro
+++ b/packages/astro/e2e/fixtures/prefetch/src/components/Deferred.astro
@@ -1,0 +1,11 @@
+---
+type Props = {
+	id: string,
+	href: string,
+}
+
+const { id, href } = Astro.props;
+
+await new Promise ((resolve) => setTimeout(resolve, 100));
+---
+<a id={id} href={href} data-astro-prefetch="load">load</a>

--- a/packages/astro/e2e/fixtures/prefetch/src/components/ToggleButton.jsx
+++ b/packages/astro/e2e/fixtures/prefetch/src/components/ToggleButton.jsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export default function ToggleButton({ id, children }) {
+	const [ showChild, setShowChild ] = useState(false);
+	const handleClick = () => setShowChild(state => !state);
+	
+	return (
+		<div className="toggle-button-group">
+			<button id={`toggle-button-${id}`} className="toggle-button" onClick={handleClick}>Toggle Link</button>
+			<div className="child-wrapper">
+				{showChild && children}
+			</div>
+		</div>
+	)
+}

--- a/packages/astro/e2e/fixtures/prefetch/src/pages/mutation-observer.astro
+++ b/packages/astro/e2e/fixtures/prefetch/src/pages/mutation-observer.astro
@@ -1,0 +1,33 @@
+---
+import ToggleButton from '../components/ToggleButton'
+---
+
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+</head>
+<body>
+<h1>Prefetch (with Mutation Observer)</h1>
+<!--The tap strategy is not affected by mutation observers.-->
+<!--This is provided to verify that the tap strategy functions correctly even when mutation observers are enabled.-->
+<ToggleButton id="tap" client:load>
+	<a id="prefetch-tap" href="/prefetch-tap" data-astro-prefetch="tap">tap</a>
+</ToggleButton>
+<br>
+<ToggleButton id="hover" client:load>
+	<a id="prefetch-hover" href="/prefetch-hover" data-astro-prefetch="hover">hover</a>
+</ToggleButton>
+<br>
+<span>Scroll down to trigger viewport prefetch</span>
+<!-- Large empty space to test viewport -->
+<div style="height: 1000px;"></div>
+<ToggleButton id="load" client:load>
+	<a id="prefetch-load" href="/prefetch-load" data-astro-prefetch="load">load</a>
+</ToggleButton>
+<br>
+<ToggleButton id="viewport" client:load>
+	<a id="prefetch-viewport" href="/prefetch-viewport" data-astro-prefetch="viewport">viewport</a>
+</ToggleButton>
+</body>
+</html>

--- a/packages/astro/e2e/fixtures/prefetch/src/pages/server-defer.astro
+++ b/packages/astro/e2e/fixtures/prefetch/src/pages/server-defer.astro
@@ -1,0 +1,14 @@
+---
+import Deferred from '../components/Deferred.astro';
+---
+
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+</head>
+<body>
+<h1>Prefetch with `server:defer`</h1>
+<Deferred id="prefetch-defer" href="/prefetch-load" server:defer />
+</body>
+</html>

--- a/packages/astro/e2e/prefetch.test.ts
+++ b/packages/astro/e2e/prefetch.test.ts
@@ -347,6 +347,77 @@ test.describe("Prefetch (prefetchAll: true, defaultStrategy: 'load')", () => {
 	});
 });
 
+test.describe('Prefetch (observeDynamicLinks: true)', () => {
+	let devServer: DevServer;
+
+	test.beforeAll(async ({ astro }) => {
+		devServer = await astro.startDevServer({
+			prefetch: {
+				observeDynamicLinks: true,
+			},
+		});
+	});
+
+	test.afterAll(async () => {
+		await devServer.stop();
+	});
+
+	test.describe('with server:defer', () => {
+		test('data-astro-prefetch="load" should prefetch', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/server-defer'));
+			await expectUrlPrefetched('/prefetch-load', page);
+		});
+	});
+
+	test.describe('with dynamically added links', () => {
+		// The tap strategy is not affected by mutation observers.
+		// This is provided to verify that the tap strategy functions correctly even when mutation observers are enabled.
+		test('data-astro-prefetch="tap" should prefetch on tap', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/mutation-observer'));
+			await expectUrlNotPrefetched('/prefetch-tap', page);
+			await Promise.all([
+				page.waitForEvent('request'), // wait prefetch request
+				page.locator('#prefetch-tap').click(),
+				page.locator('#toggle-button-tap').click(),
+			]);
+			await expectUrlPrefetched('/prefetch-tap', page);
+		});
+
+		test('data-astro-prefetch="hover" should prefetch on hover', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/mutation-observer'));
+			await expectUrlNotPrefetched('/prefetch-hover', page);
+
+			await page.locator('#toggle-button-hover').click();
+
+			await Promise.all([
+				page.waitForEvent('request'), // wait prefetch request
+				page.locator('#prefetch-hover').hover(),
+			]);
+			await expectUrlPrefetched('/prefetch-hover', page);
+		});
+
+		test('data-astro-prefetch="viewport" should prefetch on viewport', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/mutation-observer'));
+			await expectUrlNotPrefetched('/prefetch-viewport', page);
+			// Scroll down to show the element
+			await Promise.all([
+				page.waitForEvent('request'), // wait prefetch request
+				page.locator('#prefetch-viewport').scrollIntoViewIfNeeded(),
+				page.locator('#toggle-button-viewport').click(),
+			]);
+			await expectUrlPrefetched('/prefetch-viewport', page);
+		});
+
+		test('data-astro-prefetch="load" should prefetch', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/mutation-observer'));
+
+			await page.locator('#toggle-button-load').click();
+
+			await expectUrlPrefetched('/prefetch-load', page);
+		});
+	});
+});
+
 // Playwrights `request` event does not appear to fire when using the speculation rules API
 // Instead of checking for the added url, each test checks to see if `document.head`
 // contains a `script[type=speculationrules]` that has the `url` in it.

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -285,6 +285,7 @@ export const AstroConfigSchema = z.object({
 			z.object({
 				prefetchAll: z.boolean().optional(),
 				defaultStrategy: z.enum(['tap', 'hover', 'viewport', 'load']).optional(),
+				observeDynamicLinks: z.boolean().optional(),
 			}),
 		])
 		.optional(),

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -18,6 +18,8 @@ let prefetchAll: boolean = __PREFETCH_PREFETCH_ALL__;
 // @ts-expect-error injected global
 let defaultStrategy: string = __PREFETCH_DEFAULT_STRATEGY__;
 // @ts-expect-error injected global
+let observeDynamicLinks: boolean = __PREFETCH_OBSERVE_DYNAMIC_LINKS__;
+// @ts-expect-error injected global
 let clientPrerender: boolean = __EXPERIMENTAL_CLIENT_PRERENDER__;
 
 interface InitOptions {
@@ -106,6 +108,23 @@ function initHoverStrategy() {
 		}
 	});
 
+	if (observeDynamicLinks) {
+		onLinkAdded((anchor) => {
+			// Skip if already listening
+			if (listenedAnchors.has(anchor)) return;
+			// Add listeners for anchors matching the strategy
+			if (elMatchesStrategy(anchor, 'hover')) {
+				listenedAnchors.add(anchor);
+				anchor.addEventListener(
+					'mouseenter',
+					(e) => handleHoverIn((e.currentTarget as HTMLAnchorElement).href),
+					{ passive: true },
+				);
+				anchor.addEventListener('mouseleave', handleHoverOut, { passive: true });
+			}
+		});
+	}
+
 	function handleHoverIn(href: string) {
 		// Debounce hover prefetches by 80ms
 		if (timeout) {
@@ -143,6 +162,19 @@ function initViewportStrategy() {
 			}
 		}
 	});
+
+	if (observeDynamicLinks) {
+		onLinkAdded((anchor) => {
+			// Skip if already listening
+			if (listenedAnchors.has(anchor)) return;
+			// Observe for anchors matching the strategy
+			if (elMatchesStrategy(anchor, 'viewport')) {
+				listenedAnchors.add(anchor);
+				observer ??= createViewportIntersectionObserver();
+				observer.observe(anchor);
+			}
+		});
+	}
 }
 
 function createViewportIntersectionObserver() {
@@ -189,6 +221,15 @@ function initLoadStrategy() {
 			}
 		}
 	});
+
+	if (observeDynamicLinks) {
+		onLinkAdded((anchor) => {
+			if (elMatchesStrategy(anchor, 'load')) {
+				// Prefetch every link in this page
+				prefetch(anchor.href);
+			}
+		});
+	}
 }
 
 export interface PrefetchOptions {
@@ -320,6 +361,29 @@ function onPageLoad(cb: () => void) {
 		}
 		cb();
 	});
+}
+
+function onLinkAdded(cb: (anchor: HTMLAnchorElement) => void) {
+	const mutationObserver = new MutationObserver((records) => {
+		for (const record of records) {
+			// When a mutation is detected, `addedNode` represents the top-level element
+			// that was added to the DOM — not its descendants.
+			// For example, if `div > p > a` is added, `addedNode` will be the `div`.
+			// Therefore, we need to check both whether `addedNode` itself is an anchor,
+			// and whether any of its descendants are anchors.
+			for (const addedNode of record.addedNodes) {
+				if (addedNode instanceof HTMLAnchorElement) {
+					cb(addedNode);
+				}
+				if (addedNode instanceof HTMLElement) {
+					const childAnchors = Array.from(addedNode.getElementsByTagName('a'));
+					childAnchors.forEach(cb);
+				}
+			}
+		}
+	});
+
+	mutationObserver.observe(document.body, { childList: true, subtree: true });
 }
 
 /**

--- a/packages/astro/src/prefetch/vite-plugin-prefetch.ts
+++ b/packages/astro/src/prefetch/vite-plugin-prefetch.ts
@@ -69,6 +69,10 @@ export default function astroPrefetch({ settings }: { settings: AstroSettings })
 						`${JSON.stringify(prefetch?.defaultStrategy)}`.padEnd(29),
 					)
 					.replace(
+						'__PREFETCH_OBSERVE_DYNAMIC_LINKS__', // length: 34
+						`${JSON.stringify(prefetch?.observeDynamicLinks)}`.padEnd(34),
+					)
+					.replace(
 						'__EXPERIMENTAL_CLIENT_PRERENDER__', // length: 33
 						`${JSON.stringify(settings.config.experimental.clientPrerender)}`.padEnd(33),
 					);

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1647,6 +1647,23 @@ export interface AstroUserConfig<
 				 * ```
 				 */
 				defaultStrategy?: 'tap' | 'hover' | 'viewport' | 'load';
+
+				/**
+				 * @docs
+				 * @name prefetch.observeDynamicLinks
+				 * @type {boolean}
+				 * @description
+				 * Enable prefetching for links that are dynamically added to the DOM after the initial page load.
+				 *
+				 * This is useful when links are rendered dynamically, for example, inside a component using `server:defer` with top-level await.
+				 *
+				 * ```js
+				 * prefetch: {
+				 * 	observeDynamicLinks: true
+				 * }
+				 * ```
+				 */
+				observeDynamicLinks?: boolean;
 		  };
 
 	/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1561,9 +1561,21 @@ importers:
 
   packages/astro/e2e/fixtures/prefetch:
     dependencies:
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../../../../integrations/node
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../../../integrations/react
       astro:
         specifier: workspace:*
         version: link:../../..
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
 
   packages/astro/e2e/fixtures/react-component:
     dependencies:


### PR DESCRIPTION
fixes #13297

## Changes

In the current implementation, enabling prefetch settings causes links to be collected via `document.getElementsByTagName('a')` on the initial page load.
While this approach works for most cases, it fails to cover certain scenarios, such as the one reported in issue #13297.

The root cause of issue #13297 is that when a component with the `server:defer` attribute uses top-level await, its links are rendered after the Promise resolves, meaning they are not captured by the initial `document.getElementsByTagName('a')` call.
More broadly, the same issue occurs whenever links are dynamically added to the DOM after the initial page load.

To address this, this pull request adds the `observeDynamicLinks` option, which uses a `MutationObserver` to watch for dynamically added link elements.
This ensures that links added after the initial render are properly captured.

This feature is opt-in.

### Why MutationObserver?

<details>
<summary>Investigation process</summary>

- First, I checked the code around `server:defer` to see if it used any event notifications.
- It did not, but I found that the prefetch code [uses the `astro:page-load` event].
https://github.com/withastro/astro/blob/7711e471ab8950d00f38ae1dd1acba451705dd51/packages/astro/src/prefetch/index.ts#L316
- When I looked into whether `astro:page-load` could be used here, I found that the constant defining this event name is marked as `@deprecated`, so I decided to look for a different approach.
https://github.com/withastro/astro/blob/7711e471ab8950d00f38ae1dd1acba451705dd51/packages/astro/src/transitions/events.ts#L12-L13
- I also considered that the root cause of issue #13297 is not specific to `server:defer`, the same problem can occur in other situations where links are added to the DOM dynamically. For this reason, I wanted an approach that resolves the issue within the prefetch code itself, rather than adding prefetch-dependent logic to the `server:defer` side.
- As a result, I concluded that `MutationObserver` is the best approach, as it is well-suited for observing DOM changes and allows the fix to be fully self-contained within the prefetch implementation.

</details>

## Testing

Added tests to verify that the `observeDynamicLinks` option works correctly in the following scenarios:

- Links dynamically added via `server:defer`, as reported in issue #13297
- Links dynamically added by a toggle component (`ToggleButton.jsx`)

## Docs

/cc @withastro/maintainers-docs for feedback!
