### PR TITLE
fix(actions): correctly parse false string in z.array(z.boolean()) fo…

### DIFF
--- a/.changeset/fix-actions-array-boolean-false.md
+++ b/.changeset/fix-actions-array-boolean-false.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `z.array(z.boolean())` in form actions incorrectly coercing the string `"false"` to `true`. Boolean array elements now use the same `'true'`/`'false'` string comparison as single `z.boolean()` fields, so submitting `["false", "true", "false"]` correctly parses as `[false, true, false]`.

--- a/packages/astro/src/actions/runtime/server.ts
+++ b/packages/astro/src/actions/runtime/server.ts
@@ -408,7 +408,7 @@ function handleFormDataGetAll(key: string, formData: FormData, validator: z.$Zod
 	if (elementValidator instanceof z.$ZodNumber) {
 		return entries.map(Number);
 	} else if (elementValidator instanceof z.$ZodBoolean) {
-		return entries.map(Boolean);
+		return entries.map((v) => (v === 'true' ? true : v === 'false' ? false : Boolean(v)));
 	}
 	return entries;
 }

--- a/packages/astro/test/units/actions/form-data-to-object.test.ts
+++ b/packages/astro/test/units/actions/form-data-to-object.test.ts
@@ -176,6 +176,51 @@ describe('formDataToObject', () => {
 		assert.deepEqual(res.age.sort(), [25, 30, 35]);
 	});
 
+	describe('boolean arrays', () => {
+		it('should preserve "false" string values in boolean arrays', () => {
+			const formData = new FormData();
+			formData.append('flags', 'false');
+			formData.append('flags', 'true');
+			formData.append('flags', 'false');
+
+			const input = z.object({
+				flags: z.array(z.boolean()),
+			});
+
+			const res = formDataToObject(formData, input);
+
+			assert.ok(Array.isArray(res.flags), 'flags is not an array');
+			assert.deepEqual(res.flags, [false, true, false]);
+		});
+
+		it('should coerce mixed boolean array values correctly', () => {
+			const cases: Array<{ input: string[]; expected: boolean[] }> = [
+				{ input: ['true', 'true'], expected: [true, true] },
+				{ input: ['false', 'false'], expected: [false, false] },
+				{ input: ['true', 'false', 'true'], expected: [true, false, true] },
+			];
+
+			for (const { input: values, expected } of cases) {
+				const formData = new FormData();
+				for (const value of values) {
+					formData.append('flags', value);
+				}
+
+				const schema = z.object({
+					flags: z.array(z.boolean()),
+				});
+
+				const res = formDataToObject(formData, schema);
+
+				assert.ok(Array.isArray(res.flags), 'flags is not an array');
+				assert.equal(res.flags.length, expected.length);
+				for (let i = 0; i < expected.length; i++) {
+					assert.equal(res.flags[i], expected[i]);
+				}
+			}
+		});
+	});
+
 	it('should handle an array of File objects', () => {
 		const formData = new FormData();
 		const file1 = new File([''], 'test1.txt');


### PR DESCRIPTION
## Changes

- Fix `z.array(z.boolean())` in form actions incorrectly coercing the string `"false"` to `true`.
- `handleFormDataGetAll` was using `entries.map(Boolean)`, but `FormData` values are always strings and `Boolean("false") === true`. Replaced with the same `'true'` / `'false'` comparison already used for single `z.boolean()` fields in `handleFormDataGet`.
- Closes #16584.

**Before:** `["false", "true", "false"]` → `[true, true, true]`
**After:** `["false", "true", "false"]` → `[false, true, false]`


## Testing

- Added a new `boolean arrays` suite in `packages/astro/test/units/actions/form-data-to-object.test.ts`:
  - `should preserve "false" string values in boolean arrays` — direct regression test for the reported case.
  - `should coerce mixed boolean array values correctly` — table-driven coverage across all-true / all-false / mixed inputs.
- All 25 tests in `formDataToObject` pass locally (`node --test test/units/actions/form-data-to-object.test.ts`).

## Docs

No docs change required — this is a behavior fix bringing array-element parsing in line with the already-documented single-boolean coercion behavior.
