### PR TITLE
fix(sync): skip adapter configureServer hooks during type generation

### DIFF
--- a/.changeset/fast-sync-temp-server.md
+++ b/.changeset/fast-sync-temp-server.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Skips adapter `configureServer` hooks and per-environment dependency pre-bundling during the temporary Vite server used by `astro build` for type generation. The temp server only resolves virtual modules — it never serves HTTP requests — so starting adapter runtimes (e.g. miniflare/workerd via `@astrojs/cloudflare`) and pre-bundling adapter `optimizeDeps.include` lists were both unnecessary. On a representative project this reduces the “Types Generated” phase from ~3.6 s to ~125 ms.

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -234,6 +234,12 @@ async function createTempViteServer(
 		{ dev: true },
 	);
 
+	// Disable dependency optimization for all environments. The temp server only needs
+	// to resolve virtual modules for type generation, not pre-bundle dependencies.
+	// Setting this per-environment ensures adapter plugins (e.g. Cloudflare) see the
+	// flag and skip injecting their own optimizeDeps.include lists.
+	const noOptimize = { optimizeDeps: { noDiscovery: true, include: [] } };
+
 	const tempViteServer = await createServer(
 		await createVite(
 			{
@@ -241,6 +247,32 @@ async function createTempViteServer(
 				optimizeDeps: { noDiscovery: true },
 				ssr: { external: [] },
 				logLevel: 'silent',
+				environments: {
+					client: noOptimize,
+					ssr: noOptimize,
+					astro: noOptimize,
+					prerender: noOptimize,
+				},
+				plugins: [
+					// Strip `configureServer` hooks from non-Astro plugins. The temp
+					// server is only used to resolve modules for type generation — it
+					// never serves HTTP requests. Removing these hooks prevents adapter
+					// plugins from starting heavy runtimes (e.g. miniflare/workerd for
+					// Cloudflare). Astro's own plugins (prefixed with `astro:`) are
+					// preserved because some rely on configureServer to set up state
+					// needed by their other hooks.
+					{
+						name: 'astro:sync:strip-server-hooks',
+						enforce: 'pre',
+						configResolved(config) {
+							for (const plugin of config.plugins) {
+								if (plugin.configureServer && !plugin.name.startsWith('astro:')) {
+									delete plugin.configureServer;
+								}
+							}
+						},
+					},
+				],
 			},
 			{
 				routesList,


### PR DESCRIPTION
## Changes

- During `astro build`, `createTempViteServer` (in `packages/astro/src/core/sync/index.ts`) creates a Vite dev server purely to resolve virtual modules for type generation. The server never handles HTTP requests, but every plugin's `configureServer` hook still fires — including adapter plugins that start heavy runtimes (notably `@astrojs/cloudflare` → `@cloudflare/vite-plugin` → miniflare/workerd, ~1–3.5 s of overhead).
- Additionally, top-level `optimizeDeps: { noDiscovery: true }` only applies to the `client` environment under Vite 7's Environment API, so adapters' `configEnvironment` hooks re-injected their `optimizeDeps.include` lists into `ssr` / `astro` / `prerender` and forced unnecessary pre-bundling.
- Two changes in `createTempViteServer`:
  - Per-environment `optimizeDeps: { noDiscovery: true, include: [] }` for all four environments.
  - Inline `astro:sync:strip-server-hooks` plugin that removes `configureServer` from non-`astro:` plugins in `configResolved`.
- Net effect on a representative project: `Types Generated` drops from ~3.6 s to ~125 ms; total build from ~13 s to ~9.2 s.
- Closes #16332.
- Changeset added (`patch` for `astro`).

This is the fix [astrobot-houston suggested](https://github.com/withastro/astro/compare/flue/fix-16332?expand=1) on the issue, applied verbatim.

## Testing

- `pnpm exec astro-scripts test test/astro-sync.test.ts --strip-types` — all 9 existing sync tests pass.
- Verified end-to-end against the MRE from #16332 (https://github.com/adamchal/astro-sync-perf): with `@astrojs/cloudflare` on the adapter, `Types Generated` drops from ~2.3 s to ~100 ms and miniflare no longer starts during sync.
- I have been running this same patch (applied as a `postinstall` monkey-patch) on a production Astro/Cloudflare site for the past few weeks with no regressions in dev or build.

## Docs

No user-facing API changes — this is a build-time perf fix. Adapter authors who relied on `configureServer` firing during sync would notice, but that path was unintentional and has no documented contract.
