### PR TITLE
fix(compile): strip bogus scoped class from spread when styles are all global

### DIFF
--- a/packages/astro/src/core/compile/compile-rs.ts
+++ b/packages/astro/src/core/compile/compile-rs.ts
@@ -5,6 +5,10 @@ import type { AstroError } from '../errors/errors.js';
 import { AggregateError, CompilerError } from '../errors/errors.js';
 import { AstroErrorData } from '../errors/index.js';
 import { normalizePath, resolvePath } from '../viteUtils.js';
+import {
+	shouldStripSpreadScopeArg,
+	stripIncorrectSpreadScopeClass,
+} from './strip-incorrect-spread-scope.js';
 import { createStylePreprocessor, type PartialCompileCssResult } from './style.js';
 import type { CompileCssResult } from './types.js';
 
@@ -100,8 +104,13 @@ export async function compile({
 
 	handleCompileResultErrors(filename, transformResult, cssTransformErrors);
 
+	const code = shouldStripSpreadScopeArg(cssPartialCompileResults)
+		? stripIncorrectSpreadScopeClass(transformResult.code)
+		: transformResult.code;
+
 	return {
 		...transformResult,
+		code,
 		css: transformResult.css.map((cssCode: string, i: number) => ({
 			...cssPartialCompileResults[i],
 			code: cssCode,

--- a/packages/astro/src/core/compile/compile-rs.ts
+++ b/packages/astro/src/core/compile/compile-rs.ts
@@ -102,9 +102,9 @@ export async function compile({
 
 	return {
 		...transformResult,
-		css: transformResult.css.map((code: string, i: number) => ({
+		css: transformResult.css.map((cssCode: string, i: number) => ({
 			...cssPartialCompileResults[i],
-			code,
+			code: cssCode,
 		})),
 	};
 }

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -7,6 +7,10 @@ import type { AstroError } from '../errors/errors.js';
 import { AggregateError, CompilerError } from '../errors/errors.js';
 import { AstroErrorData } from '../errors/index.js';
 import { normalizePath, resolvePath } from '../viteUtils.js';
+import {
+	shouldStripSpreadScopeArg,
+	stripIncorrectSpreadScopeClass,
+} from './strip-incorrect-spread-scope.js';
 import { createStylePreprocessor, type PartialCompileCssResult } from './style.js';
 import type { CompileCssResult } from './types.js';
 
@@ -82,8 +86,13 @@ export async function compile({
 
 	handleCompileResultErrors(transformResult, cssTransformErrors);
 
+	const code = shouldStripSpreadScopeArg(cssPartialCompileResults)
+		? stripIncorrectSpreadScopeClass(transformResult.code)
+		: transformResult.code;
+
 	return {
 		...transformResult,
+		code,
 		css: transformResult.css.map((cssCode, i) => ({
 			...cssPartialCompileResults[i],
 			code: cssCode,

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -84,9 +84,9 @@ export async function compile({
 
 	return {
 		...transformResult,
-		css: transformResult.css.map((code, i) => ({
+		css: transformResult.css.map((cssCode, i) => ({
 			...cssPartialCompileResults[i],
-			code,
+			code: cssCode,
 		})),
 	};
 }

--- a/packages/astro/src/core/compile/strip-incorrect-spread-scope.ts
+++ b/packages/astro/src/core/compile/strip-incorrect-spread-scope.ts
@@ -1,0 +1,96 @@
+/**
+ * When every `<style>` in a component is `is:global`, there is no scoped stylesheet, but
+ * `@astrojs/compiler` may still inject `{ class: scope }` into `$$spreadAttributes(...)`.
+ *
+ * Prefer fixing this in `@astrojs/compiler`; keep this shim until WASM includes that fix so builds pass.
+ *
+ * @see https://github.com/withastro/astro/issues/16576
+ */
+export function shouldStripSpreadScopeArg(
+	cssPartialCompileResults: { isGlobal: boolean }[],
+): boolean {
+	return (
+		cssPartialCompileResults.length > 0 && cssPartialCompileResults.every((entry) => entry.isGlobal)
+	);
+}
+
+/** Removes synthetic `$$spreadAttributes(first, undefined, { "class": "<scope>" })` tail when needed. */
+export function stripIncorrectSpreadScopeClass(code: string): string {
+	const open = '$$spreadAttributes(';
+	let out = '';
+	let pos = 0;
+
+	while (pos < code.length) {
+		const start = code.indexOf(open, pos);
+		if (start === -1) {
+			out += code.slice(pos);
+			break;
+		}
+		out += code.slice(pos, start);
+		const openParen = start + open.length - 1;
+		const closeParen = findMatchingParen(code, openParen);
+		if (closeParen === -1) {
+			out += code.slice(start);
+			break;
+		}
+		const inner = code.slice(openParen + 1, closeParen);
+		const stripped = tryStripSpreadScopeSuffix(inner);
+		if (stripped !== null) {
+			out += `${open}${stripped})`;
+		} else {
+			out += code.slice(start, closeParen + 1);
+		}
+		pos = closeParen + 1;
+	}
+
+	return out;
+}
+
+/** Third argument from the compiler: `{ "class": "<scoped-hash>" }` */
+const spreadScopeSuffix = /^([\s\S]*),\s*undefined\s*,\s*\{\s*"class"\s*:\s*"[^"]+"\s*\}$/;
+
+function tryStripSpreadScopeSuffix(inner: string): string | null {
+	const match = spreadScopeSuffix.exec(inner);
+	return match?.[1] ?? null;
+}
+
+function findMatchingParen(code: string, openIdx: number): number {
+	if (code.charAt(openIdx) !== '(') {
+		return -1;
+	}
+	let depth = 0;
+	let inString: '"' | "'" | '`' | null = null;
+	let escaped = false;
+
+	for (let i = openIdx; i < code.length; i++) {
+		const ch = code[i];
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (ch === '\\' && inString !== '`') {
+				escaped = true;
+				continue;
+			}
+			if (ch === inString) {
+				inString = null;
+			}
+			continue;
+		}
+		if (ch === '"' || ch === "'" || ch === '`') {
+			inString = ch;
+			continue;
+		}
+		if (ch === '(') {
+			depth++;
+		} else if (ch === ')') {
+			depth--;
+			if (depth === 0) {
+				return i;
+			}
+		}
+	}
+
+	return -1;
+}

--- a/packages/astro/test/astro-basic.test.ts
+++ b/packages/astro/test/astro-basic.test.ts
@@ -36,6 +36,12 @@ describe('Astro basic build', () => {
 		assert.match($('#spread-class-list').attr('class')!, /astro-.*/);
 	});
 
+	it('Does not add scoped class to spread when only is:global styles exist', async () => {
+		const html = await fixture.readFile('/spread-scope-global/index.html');
+		const $ = cheerio.load(html);
+		assert.equal($('#spread-global-link').attr('class'), 'big');
+	});
+
 	it('supports special chars in filename', async () => {
 		// will have already erred by now, but add test anyway
 		assert.ok(await fixture.readFile('/special-“characters” -in-file/index.html'));

--- a/packages/astro/test/fixtures/astro-basic/src/pages/spread-scope-global.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/spread-scope-global.astro
@@ -1,0 +1,16 @@
+---
+const linkAttributes = { class: 'big', href: '#', rel: 'noopener' };
+---
+
+<html>
+	<head></head>
+	<body>
+		<a id="spread-global-link" {...linkAttributes}>Astro</a>
+		<style is:global>
+			.big {
+				font-size: 3rem;
+				font-weight: 700;
+			}
+		</style>
+	</body>
+</html>

--- a/packages/astro/test/units/compile/strip-incorrect-spread-scope.test.ts
+++ b/packages/astro/test/units/compile/strip-incorrect-spread-scope.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	shouldStripSpreadScopeArg,
+	stripIncorrectSpreadScopeClass,
+} from '../../../dist/core/compile/strip-incorrect-spread-scope.js';
+
+describe('stripIncorrectSpreadScopeClass', () => {
+	it('removes injected scope class argument from compiler-shaped spreadAttributes', () => {
+		const input = `$$spreadAttributes(props,undefined,{"class":"astro-abc12"})`;
+		assert.equal(stripIncorrectSpreadScopeClass(input), '$$spreadAttributes(props)');
+	});
+
+	it('supports member expression as first argument', () => {
+		const input = `$$spreadAttributes(foo.bar,undefined,{"class":"astro-abc12"})`;
+		assert.equal(stripIncorrectSpreadScopeClass(input), '$$spreadAttributes(foo.bar)');
+	});
+
+	it('leaves two-argument spreadAttributes unchanged', () => {
+		const input = '$$spreadAttributes(x)';
+		assert.equal(stripIncorrectSpreadScopeClass(input), input);
+	});
+
+	it('leaves spread with scope when pattern is not the synthetic undefined + class object', () => {
+		const input = `$$spreadAttributes(x, undefined, other)`;
+		assert.equal(stripIncorrectSpreadScopeClass(input), input);
+	});
+
+	it('shouldStripSpreadScopeArg', () => {
+		assert.equal(shouldStripSpreadScopeArg([]), false);
+		assert.equal(shouldStripSpreadScopeArg([{ isGlobal: true }]), true);
+		assert.equal(shouldStripSpreadScopeArg([{ isGlobal: false }]), false);
+		assert.equal(shouldStripSpreadScopeArg([{ isGlobal: true }, { isGlobal: false }]), false);
+	});
+});


### PR DESCRIPTION

## Changes

- Fixes a bug where spreading props that include `class` onto an element could still get an extra `astro-*` class when the component only used `<style is:global>`. The compiler treated “has any `<style>` tag” like “needs scoping” for spreads; Astro now strips the synthetic `$$spreadAttributes(..., undefined, { class })` third argument when every stylesheet in that file is global.

## Testing

- Adds `spread-scope-global.astro` in the `astro-basic` fixture and an assertion that the spread link’s `class` is exactly the spread value (no `astro-*` hash).
- Adds unit tests for `stripIncorrectSpreadScopeClass` / `shouldStripSpreadScopeArg` covering typical compiler-shaped output and the “don’t strip when pattern differs” case.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

- No docs update: behavior now matches what scoped vs global styles already implied for non-spread attributes.
Closes #16576
