### PR TITLE
docs(sessions): update outdated code snippet and add env vars info

### DIFF
--- a/.changeset/plain-swans-add.md
+++ b/.changeset/plain-swans-add.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an outdated code snippet in the documentation for session storage configuration.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1410,7 +1410,7 @@ export interface AstroUserConfig<
 	 * Some adapters may provide a default session driver, but you can override it with your own configuration:
 	 *
 	 * ```js title="astro.config.mjs"
-	 * import { defineConfig, sessionDrivers } from 'astro/config'
+	 * import { defineConfig, sessionDrivers } from 'astro/config';
 
 	 * export default defineConfig({
 	 *   session: {
@@ -1419,7 +1419,7 @@ export interface AstroUserConfig<
 	 *       url: process.env.REDIS_URL
 	 *     }),
 	 *   }
-	 * })
+	 * });
 	 * ```
 	 *
 	 * Session drivers are configured at build time. This means environment variables used in the driver configuration are inlined. You must create your own driver entrypoint to [override the configuration at runtime](https://docs.astro.build/en/guides/sessions/#overriding-the-configuration-at-runtime).

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1406,23 +1406,25 @@ export interface AstroUserConfig<
 	 * @description
 	 *
 	 * Configures session storage for your Astro project. This is used to store session data in a persistent way, so that it can be accessed across different requests.
-	 * Some adapters may provide a default session driver, but you can override it with your own configuration.
 	 *
-	 * See [the sessions guide](https://docs.astro.build/en/guides/sessions/) for more information.
+	 * Some adapters may provide a default session driver, but you can override it with your own configuration:
 	 *
 	 * ```js title="astro.config.mjs"
-	 *   {
-	 *     session: {
-	 *       // The name of the Unstorage driver
-	 *       driver: 'redis',
-	 *       // The required options depend on the driver
-	 *       options: {
-	 *         url: process.env.REDIS_URL,
-	 *       },
-	 *       ttl: 3600, // 1 hour
-	 *     }
+	 * import { defineConfig, sessionDrivers } from 'astro/config'
+
+	 * export default defineConfig({
+	 *   session: {
+	 *     driver: sessionDrivers.redis({
+	 *       // The options are driver-dependent and some may be required.
+	 *       url: process.env.REDIS_URL
+	 *     }),
 	 *   }
+	 * })
 	 * ```
+	 *
+	 * Session drivers are configured at build time. This means environment variables used in the driver configuration are inlined. You must create your own driver entrypoint to [override the configuration at runtime](https://docs.astro.build/en/guides/sessions/#overriding-the-configuration-at-runtime).
+	 *
+	 * See [the sessions guide](https://docs.astro.build/en/guides/sessions/) for more information.
 	 */
 	session?: SessionConfig<TDriver>;
 


### PR DESCRIPTION
## Changes

* Updates an outdated code snippet in the session config: `options` is deprecated so it shouldn't be used as example.
* Adds a paragraph about environment variables with a link to learn how to override the config at runtime.

Fixes https://github.com/withastro/docs/issues/13028

## Testing

N/A. Well, this can be previewed here: https://deploy-preview-13784--astro-docs-2.netlify.app/en/reference/configuration-reference/#session-options

## Docs

This is docs. Companion PR for https://github.com/withastro/docs/pull/13784
Changeset added only for the outdated code snippet.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
