### PR TITLE
Use consistent error response in generic image endpoint

### DIFF
--- a/.changeset/fix-image-endpoint-error-leak.md
+++ b/.changeset/fix-image-endpoint-error-leak.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the generic image endpoint returning raw error details in the HTTP response body, matching the existing behavior in the Node endpoint

--- a/.changeset/fix-image-endpoint-error-leak.md
+++ b/.changeset/fix-image-endpoint-error-leak.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes the generic image endpoint returning raw error details in the HTTP response body, matching the existing behavior in the Node endpoint
+Uses a consistent generic error message in the image endpoint across all adapters

--- a/packages/astro/src/assets/endpoint/generic.ts
+++ b/packages/astro/src/assets/endpoint/generic.ts
@@ -85,6 +85,6 @@ export const GET: APIRoute = async ({ request }) => {
 		});
 	} catch (err: unknown) {
 		console.error('Could not process image request:', err);
-		return new Response(`Server Error: ${err}`, { status: 500 });
+		return new Response('Internal Server Error', { status: 500 });
 	}
 };


### PR DESCRIPTION
## Changes

- The Node image endpoint (`node.ts`) returns a generic `'Internal Server Error'` string on failure, but the generic adapter endpoint (`generic.ts`) was interpolating the error object into the response. This aligns `generic.ts` with `node.ts` so all adapters use the same consistent error response.

## Testing

- No new tests. Single-line string replacement in an error path — existing image endpoint tests cover the surrounding behavior.

## Docs

- No docs update needed.