### PR TITLE
Escape interpolated values in redirect HTML template

### DIFF
--- a/.changeset/escape-redirect-template.md
+++ b/.changeset/escape-redirect-template.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Escapes interpolated values in the redirect HTML template, consistent with how the 404 template already handles them
+Escapes interpolated values in the dev server redirect HTML template, consistent with how the 404 template already handles them

--- a/.changeset/escape-redirect-template.md
+++ b/.changeset/escape-redirect-template.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Escapes interpolated values in the redirect HTML template, consistent with how the 404 template already handles them

--- a/packages/astro/src/core/routing/3xx.ts
+++ b/packages/astro/src/core/routing/3xx.ts
@@ -1,3 +1,5 @@
+import { escape } from 'html-escaper';
+
 type RedirectTemplate = {
 	from?: string;
 	absoluteLocation: string | URL;
@@ -17,12 +19,15 @@ export function redirectTemplate({
 	// A short delay causes Google to interpret the redirect as temporary.
 	// https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh
 	const delay = status === 302 ? 2 : 0;
+	const rel = escape(String(relativeLocation));
+	const abs = escape(String(absoluteLocation));
+	const fromHtml = from ? `from <code>${escape(from)}</code> ` : '';
 	return `<!doctype html>
-<title>Redirecting to: ${relativeLocation}</title>
-<meta http-equiv="refresh" content="${delay};url=${relativeLocation}">
+<title>Redirecting to: ${rel}</title>
+<meta http-equiv="refresh" content="${delay};url=${rel}">
 <meta name="robots" content="noindex">
-<link rel="canonical" href="${absoluteLocation}">
+<link rel="canonical" href="${abs}">
 <body>
-	<a href="${relativeLocation}">Redirecting ${from ? `from <code>${from}</code> ` : ''}to <code>${relativeLocation}</code></a>
+	<a href="${rel}">Redirecting ${fromHtml}to <code>${rel}</code></a>
 </body>`;
 }


### PR DESCRIPTION
## Changes

- The redirect template in `3xx.ts` interpolated URL values directly into HTML without escaping. The sibling `4xx.ts` template already escapes its values using `html-escaper`. This applies the same pattern to the redirect template for consistency.

## Testing

- No new tests. The change adds `escape()` calls around existing interpolations — the same approach `4xx.ts` already uses.

## Docs

- No docs update needed.