### PR TITLE
test(csp): add regression tests for pushDirective duplication (#16594)

### DIFF
--- a/.changeset/fix-csp-push-directive-duplicate.md
+++ b/.changeset/fix-csp-push-directive-duplicate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `pushDirective` in the CSP runtime duplicating the new directive once per existing non-matching directive. Calling `insertDirective()` (or otherwise pushing a directive whose name is not yet in the list) now appends it exactly once, and a directive that merges with a later existing entry no longer leaves an unmerged copy behind.

--- a/packages/astro/src/core/csp/runtime.ts
+++ b/packages/astro/src/core/csp/runtime.ts
@@ -34,24 +34,26 @@ export function pushDirective(
 	directives: SSRManifestCSP['directives'],
 	newDirective: CspDirective,
 ): SSRManifestCSP['directives'] {
-	let deduplicated = false;
 	if (directives.length === 0) {
 		return [newDirective];
 	}
 	const finalDirectives: SSRManifestCSP['directives'] = [];
+	let matched = false;
 	for (const directive of directives) {
-		if (deduplicated) {
+		if (matched) {
 			finalDirectives.push(directive);
 			continue;
 		}
 		const result = deduplicateDirectiveValues(directive, newDirective);
 		if (result) {
 			finalDirectives.push(result);
-			deduplicated = true;
+			matched = true;
 		} else {
 			finalDirectives.push(directive);
-			finalDirectives.push(newDirective);
 		}
+	}
+	if (!matched) {
+		finalDirectives.push(newDirective);
 	}
 	return finalDirectives;
 }

--- a/packages/astro/test/units/csp/runtime.test.ts
+++ b/packages/astro/test/units/csp/runtime.test.ts
@@ -47,4 +47,131 @@ describe('pushDirective', () => {
 
 		assert.deepStrictEqual(result, ["img-src 'self' https://example.com", "default-src 'self'"]);
 	});
+
+	describe('regression: issue #16594', () => {
+		const directiveNameOf = (directive) => {
+			const head = directive.split(/\s+/).filter(Boolean)[0];
+			return head ?? '';
+		};
+
+		const countOccurrences = (list, target) => {
+			let count = 0;
+			for (const entry of list) {
+				if (entry === target) {
+					count += 1;
+				}
+			}
+			return count;
+		};
+
+		const assertExactlyOnce = (list, target) => {
+			const occurrences = countOccurrences(list, target);
+			assert.equal(occurrences, 1, `expected ${target} to appear once, got ${occurrences}`);
+		};
+
+		it('appends a non-matching new directive exactly once (Mode 1)', () => {
+			const existing = ["img-src 'self'", "style-src 'self'"];
+			const incoming = "script-src 'self'";
+
+			const result = pushDirective(existing, incoming);
+
+			assert.deepStrictEqual(result, [...existing, incoming]);
+			assertExactlyOnce(result, incoming);
+		});
+
+		it('returns a single-element array when the input list is empty', () => {
+			const incoming = "script-src 'self'";
+
+			const result = pushDirective([], incoming);
+
+			assert.equal(result.length, 1);
+			assert.deepStrictEqual(result, [incoming]);
+		});
+
+		it('merges with a later match without leaving an unmerged copy (Mode 2)', () => {
+			const existing = ["img-src 'self'", "script-src 'self'"];
+			const incoming = "script-src 'unsafe-inline'";
+
+			const result = pushDirective(existing, incoming);
+
+			assert.deepStrictEqual(result, [
+				"img-src 'self'",
+				"script-src 'self' 'unsafe-inline'",
+			]);
+
+			for (const entry of result) {
+				if (directiveNameOf(entry) === 'script-src') {
+					assert.ok(entry.includes("'self'"));
+					assert.ok(entry.includes("'unsafe-inline'"));
+				}
+			}
+		});
+
+		it('does not duplicate the new directive across many non-matches', () => {
+			const existing = [
+				"img-src 'self'",
+				"style-src 'self'",
+				"font-src 'self'",
+				"connect-src 'self'",
+			];
+			const incoming = "script-src 'self'";
+
+			const result = pushDirective(existing, incoming);
+
+			assert.equal(result.length, existing.length + 1);
+			assertExactlyOnce(result, incoming);
+
+			const nameCounts = new Map();
+			for (const entry of result) {
+				const name = directiveNameOf(entry);
+				nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+			}
+			for (const [name, count] of nameCounts) {
+				assert.equal(count, 1, `directive name "${name}" should be unique, got ${count}`);
+			}
+		});
+
+		it('table-driven: every shape produces a unique-name list with the new directive once', () => {
+			const cases = [
+				{
+					name: 'two non-matches before insert',
+					existing: ["img-src 'self'", "style-src 'self'"],
+					incoming: "script-src 'self'",
+					expectMatched: false,
+				},
+				{
+					name: 'match in the middle',
+					existing: ["img-src 'self'", "script-src 'self'", "style-src 'self'"],
+					incoming: "script-src 'unsafe-inline'",
+					expectMatched: true,
+				},
+				{
+					name: 'match at the end',
+					existing: ["img-src 'self'", "style-src 'self'", "script-src 'self'"],
+					incoming: "script-src 'unsafe-inline'",
+					expectMatched: true,
+				},
+			];
+
+			for (const testCase of cases) {
+				const result = pushDirective(testCase.existing, testCase.incoming);
+
+				if (testCase.expectMatched) {
+					assert.equal(result.length, testCase.existing.length, testCase.name);
+					const occurrencesOfIncoming = countOccurrences(result, testCase.incoming);
+					assert.equal(occurrencesOfIncoming, 0, `${testCase.name}: incoming should be merged, not raw`);
+				} else {
+					assert.equal(result.length, testCase.existing.length + 1, testCase.name);
+					assertExactlyOnce(result, testCase.incoming);
+				}
+
+				const seenNames = new Set();
+				for (const entry of result) {
+					const name = directiveNameOf(entry);
+					assert.equal(seenNames.has(name), false, `${testCase.name}: duplicate ${name}`);
+					seenNames.add(name);
+				}
+			}
+		});
+	});
 });

--- a/packages/astro/test/units/csp/runtime.test.ts
+++ b/packages/astro/test/units/csp/runtime.test.ts
@@ -1,6 +1,7 @@
 // @ts-check
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import type { CspDirective } from '../../../dist/core/csp/config.js';
 import { deduplicateDirectiveValues, pushDirective } from '../../../dist/core/csp/runtime.js';
 
 describe('deduplicateDirectiveValues', () => {
@@ -49,12 +50,12 @@ describe('pushDirective', () => {
 	});
 
 	describe('regression: issue #16594', () => {
-		const directiveNameOf = (directive) => {
+		const directiveNameOf = (directive: CspDirective): string => {
 			const head = directive.split(/\s+/).filter(Boolean)[0];
 			return head ?? '';
 		};
 
-		const countOccurrences = (list, target) => {
+		const countOccurrences = (list: readonly CspDirective[], target: CspDirective): number => {
 			let count = 0;
 			for (const entry of list) {
 				if (entry === target) {
@@ -64,14 +65,14 @@ describe('pushDirective', () => {
 			return count;
 		};
 
-		const assertExactlyOnce = (list, target) => {
+		const assertExactlyOnce = (list: readonly CspDirective[], target: CspDirective): void => {
 			const occurrences = countOccurrences(list, target);
 			assert.equal(occurrences, 1, `expected ${target} to appear once, got ${occurrences}`);
 		};
 
 		it('appends a non-matching new directive exactly once (Mode 1)', () => {
-			const existing = ["img-src 'self'", "style-src 'self'"];
-			const incoming = "script-src 'self'";
+			const existing: CspDirective[] = ["img-src 'self'", "font-src 'self'"];
+			const incoming: CspDirective = "connect-src 'self'";
 
 			const result = pushDirective(existing, incoming);
 
@@ -80,27 +81,28 @@ describe('pushDirective', () => {
 		});
 
 		it('returns a single-element array when the input list is empty', () => {
-			const incoming = "script-src 'self'";
+			const incoming: CspDirective = "connect-src 'self'";
+			const empty: CspDirective[] = [];
 
-			const result = pushDirective([], incoming);
+			const result = pushDirective(empty, incoming);
 
 			assert.equal(result.length, 1);
 			assert.deepStrictEqual(result, [incoming]);
 		});
 
 		it('merges with a later match without leaving an unmerged copy (Mode 2)', () => {
-			const existing = ["img-src 'self'", "script-src 'self'"];
-			const incoming = "script-src 'unsafe-inline'";
+			const existing: CspDirective[] = ["img-src 'self'", "connect-src 'self'"];
+			const incoming: CspDirective = "connect-src 'unsafe-inline'";
 
 			const result = pushDirective(existing, incoming);
 
 			assert.deepStrictEqual(result, [
 				"img-src 'self'",
-				"script-src 'self' 'unsafe-inline'",
+				"connect-src 'self' 'unsafe-inline'",
 			]);
 
 			for (const entry of result) {
-				if (directiveNameOf(entry) === 'script-src') {
+				if (directiveNameOf(entry) === 'connect-src') {
 					assert.ok(entry.includes("'self'"));
 					assert.ok(entry.includes("'unsafe-inline'"));
 				}
@@ -108,20 +110,20 @@ describe('pushDirective', () => {
 		});
 
 		it('does not duplicate the new directive across many non-matches', () => {
-			const existing = [
+			const existing: CspDirective[] = [
 				"img-src 'self'",
-				"style-src 'self'",
 				"font-src 'self'",
-				"connect-src 'self'",
+				"media-src 'self'",
+				"frame-src 'self'",
 			];
-			const incoming = "script-src 'self'";
+			const incoming: CspDirective = "connect-src 'self'";
 
 			const result = pushDirective(existing, incoming);
 
 			assert.equal(result.length, existing.length + 1);
 			assertExactlyOnce(result, incoming);
 
-			const nameCounts = new Map();
+			const nameCounts = new Map<string, number>();
 			for (const entry of result) {
 				const name = directiveNameOf(entry);
 				nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
@@ -132,23 +134,30 @@ describe('pushDirective', () => {
 		});
 
 		it('table-driven: every shape produces a unique-name list with the new directive once', () => {
-			const cases = [
+			interface PushDirectiveCase {
+				name: string;
+				existing: CspDirective[];
+				incoming: CspDirective;
+				expectMatched: boolean;
+			}
+
+			const cases: PushDirectiveCase[] = [
 				{
 					name: 'two non-matches before insert',
-					existing: ["img-src 'self'", "style-src 'self'"],
-					incoming: "script-src 'self'",
+					existing: ["img-src 'self'", "font-src 'self'"],
+					incoming: "connect-src 'self'",
 					expectMatched: false,
 				},
 				{
 					name: 'match in the middle',
-					existing: ["img-src 'self'", "script-src 'self'", "style-src 'self'"],
-					incoming: "script-src 'unsafe-inline'",
+					existing: ["img-src 'self'", "connect-src 'self'", "font-src 'self'"],
+					incoming: "connect-src 'unsafe-inline'",
 					expectMatched: true,
 				},
 				{
 					name: 'match at the end',
-					existing: ["img-src 'self'", "style-src 'self'", "script-src 'self'"],
-					incoming: "script-src 'unsafe-inline'",
+					existing: ["img-src 'self'", "font-src 'self'", "connect-src 'self'"],
+					incoming: "connect-src 'unsafe-inline'",
 					expectMatched: true,
 				},
 			];
@@ -159,13 +168,17 @@ describe('pushDirective', () => {
 				if (testCase.expectMatched) {
 					assert.equal(result.length, testCase.existing.length, testCase.name);
 					const occurrencesOfIncoming = countOccurrences(result, testCase.incoming);
-					assert.equal(occurrencesOfIncoming, 0, `${testCase.name}: incoming should be merged, not raw`);
+					assert.equal(
+						occurrencesOfIncoming,
+						0,
+						`${testCase.name}: incoming should be merged, not raw`,
+					);
 				} else {
 					assert.equal(result.length, testCase.existing.length + 1, testCase.name);
 					assertExactlyOnce(result, testCase.incoming);
 				}
 
-				const seenNames = new Set();
+				const seenNames = new Set<string>();
 				for (const entry of result) {
 					const name = directiveNameOf(entry);
 					assert.equal(seenNames.has(name), false, `${testCase.name}: duplicate ${name}`);

--- a/packages/astro/test/units/csp/runtime.test.ts
+++ b/packages/astro/test/units/csp/runtime.test.ts
@@ -51,7 +51,7 @@ describe('pushDirective', () => {
 
 	describe('regression: issue #16594', () => {
 		const directiveNameOf = (directive: CspDirective): string => {
-			const head = directive.split(/\s+/).filter(Boolean)[0];
+			const head = directive.split(/\s+/).find(Boolean);
 			return head ?? '';
 		};
 


### PR DESCRIPTION
## Changes

- Fix `pushDirective` in the CSP runtime duplicating the new directive once per existing non-matching directive.
- Root cause: the `else` branch inside the loop pushed `newDirective` on every non-match instead of once after the loop. Replaced the `deduplicated` flag with a `matched` flag and moved the `newDirective` push outside the loop, guarded by `!matched`.
- Closes #16594.

**Before:** `pushDirective(["img-src 'self'", "style-src 'self'"], "script-src 'self'")` → `["img-src 'self'", "script-src 'self'", "style-src 'self'", "script-src 'self'"]` (duplicated + interleaved)
**After:** → `["img-src 'self'", "style-src 'self'", "script-src 'self'"]`

Also fixes Mode 2: a directive that merges with a later existing entry no longer leaves an unmerged copy in front of the merged result.

> Don't forget a changeset! Run `pnpm changeset`. — Added: `.changeset/fix-csp-push-directive-duplicate.md`

## Testing

- Added a `regression: issue #16594` suite in `packages/astro/test/units/csp/runtime.test.ts` covering:
  - **Mode 1** — non-matching new directive appended exactly once.
  - **Mode 2** — merge with a later match, no unmerged copy left behind.
  - Empty input list edge case.
  - Many non-matches: directive-name uniqueness asserted via a `Map` count.
  - Table-driven sweep across "non-match", "match in middle", "match at end" shapes, asserting both length and `Set`-based name uniqueness.
- All 11 tests in `csp/runtime.test.ts` pass locally (`node --test test/units/csp/runtime.test.ts`).

## Docs

No docs change required — `pushDirective` is internal CSP runtime; public `insertDirective()` semantics are unchanged (this restores them to the documented behavior).
