### PR TITLE
fix(i18n): honor first-match-wins in computePreferredLocale codes branch

### DIFF
--- a/.changeset/fix-i18n-compute-preferred-locale-codes-break.md
+++ b/.changeset/fix-i18n-compute-preferred-locale-codes-break.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes `computePreferredLocale` violating its "first match wins" semantics when the `i18n.locales` config contains object-form entries (`{ path, codes }`). The inner `break` only exited the codes-array loop, so a later normalize-equivalent code could overwrite the earlier match. The function now correctly returns the first matching code across both string and object entries.
+Fixes `Astro.preferredLocale` returning the wrong value when `i18n.locales` mixes object-form entries (`{ path, codes }`) with string entries that normalize to the same locale. The first matching code in the configured `locales` order is now selected, matching the documented behavior.

--- a/.changeset/fix-i18n-compute-preferred-locale-codes-break.md
+++ b/.changeset/fix-i18n-compute-preferred-locale-codes-break.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `computePreferredLocale` violating its "first match wins" semantics when the `i18n.locales` config contains object-form entries (`{ path, codes }`). The inner `break` only exited the codes-array loop, so a later normalize-equivalent code could overwrite the earlier match. The function now correctly returns the first matching code across both string and object entries.

--- a/packages/astro/src/i18n/utils.ts
+++ b/packages/astro/src/i18n/utils.ts
@@ -83,35 +83,33 @@ function sortAndFilterLocales(browserLocaleList: BrowserLocale[], locales: Local
  * If multiple locales are present in the header, they are sorted by their quality value and the highest is selected as current locale.
  *
  */
-function findFirstMatchingLocale(locales: Locales, target: string): string | undefined {
-	const normalizedTarget = normalizeTheLocale(target);
-	for (const candidate of locales) {
-		if (typeof candidate === 'string') {
-			if (normalizeTheLocale(candidate) === normalizedTarget) {
-				return candidate;
-			}
-			continue;
-		}
-		for (const code of candidate.codes) {
-			if (normalizeTheLocale(code) === normalizedTarget) {
-				return code;
-			}
-		}
-	}
-	return undefined;
-}
-
 export function computePreferredLocale(request: Request, locales: Locales): string | undefined {
 	const acceptHeader = request.headers.get('Accept-Language');
-	if (!acceptHeader) {
-		return undefined;
+	let result: string | undefined = undefined;
+	if (acceptHeader) {
+		const browserLocaleList = sortAndFilterLocales(parseLocale(acceptHeader), locales);
+
+		const firstResult = browserLocaleList.at(0);
+		if (firstResult && firstResult.locale !== '*') {
+			outer: for (const currentLocale of locales) {
+				if (typeof currentLocale === 'string') {
+					if (normalizeTheLocale(currentLocale) === normalizeTheLocale(firstResult.locale)) {
+						result = currentLocale;
+						break;
+					}
+				} else {
+					for (const currentCode of currentLocale.codes) {
+						if (normalizeTheLocale(currentCode) === normalizeTheLocale(firstResult.locale)) {
+							result = currentCode;
+							break outer;
+						}
+					}
+				}
+			}
+		}
 	}
-	const browserLocaleList = sortAndFilterLocales(parseLocale(acceptHeader), locales);
-	const firstResult = browserLocaleList.at(0);
-	if (!firstResult || firstResult.locale === '*') {
-		return undefined;
-	}
-	return findFirstMatchingLocale(locales, firstResult.locale);
+
+	return result;
 }
 
 export function computePreferredLocaleList(request: Request, locales: Locales): string[] {

--- a/packages/astro/src/i18n/utils.ts
+++ b/packages/astro/src/i18n/utils.ts
@@ -83,33 +83,35 @@ function sortAndFilterLocales(browserLocaleList: BrowserLocale[], locales: Local
  * If multiple locales are present in the header, they are sorted by their quality value and the highest is selected as current locale.
  *
  */
-export function computePreferredLocale(request: Request, locales: Locales): string | undefined {
-	const acceptHeader = request.headers.get('Accept-Language');
-	let result: string | undefined = undefined;
-	if (acceptHeader) {
-		const browserLocaleList = sortAndFilterLocales(parseLocale(acceptHeader), locales);
-
-		const firstResult = browserLocaleList.at(0);
-		if (firstResult && firstResult.locale !== '*') {
-			for (const currentLocale of locales) {
-				if (typeof currentLocale === 'string') {
-					if (normalizeTheLocale(currentLocale) === normalizeTheLocale(firstResult.locale)) {
-						result = currentLocale;
-						break;
-					}
-				} else {
-					for (const currentCode of currentLocale.codes) {
-						if (normalizeTheLocale(currentCode) === normalizeTheLocale(firstResult.locale)) {
-							result = currentCode;
-							break;
-						}
-					}
-				}
+function findFirstMatchingLocale(locales: Locales, target: string): string | undefined {
+	const normalizedTarget = normalizeTheLocale(target);
+	for (const candidate of locales) {
+		if (typeof candidate === 'string') {
+			if (normalizeTheLocale(candidate) === normalizedTarget) {
+				return candidate;
+			}
+			continue;
+		}
+		for (const code of candidate.codes) {
+			if (normalizeTheLocale(code) === normalizedTarget) {
+				return code;
 			}
 		}
 	}
+	return undefined;
+}
 
-	return result;
+export function computePreferredLocale(request: Request, locales: Locales): string | undefined {
+	const acceptHeader = request.headers.get('Accept-Language');
+	if (!acceptHeader) {
+		return undefined;
+	}
+	const browserLocaleList = sortAndFilterLocales(parseLocale(acceptHeader), locales);
+	const firstResult = browserLocaleList.at(0);
+	if (!firstResult || firstResult.locale === '*') {
+		return undefined;
+	}
+	return findFirstMatchingLocale(locales, firstResult.locale);
 }
 
 export function computePreferredLocaleList(request: Request, locales: Locales): string[] {

--- a/packages/astro/test/units/i18n/i18n-utils.test.ts
+++ b/packages/astro/test/units/i18n/i18n-utils.test.ts
@@ -99,7 +99,7 @@ describe('computePreferredLocale', () => {
 	});
 
 	it('returns the matched code from a multi-code entry, not the path', () => {
-		const localesMulti: Locales = [{ path: 'us', codes: ['xx', 'EN-US', 'yy'] }, 'en-us'];
+		const localesMulti: Locales = [{ path: 'us', codes: ['en-gb', 'EN-US'] }, 'en-us'];
 		const req = new Request('http://example.com/', {
 			headers: { 'Accept-Language': 'en-us' },
 		});

--- a/packages/astro/test/units/i18n/i18n-utils.test.ts
+++ b/packages/astro/test/units/i18n/i18n-utils.test.ts
@@ -79,61 +79,31 @@ describe('computePreferredLocale', () => {
 		assert.equal(computePreferredLocale(req, locales), undefined);
 	});
 
-	describe('regression: issue #16598 (first-match wins on object-form locales)', () => {
-		interface FirstMatchCase {
-			readonly name: string;
-			readonly locales: ReadonlyArray<string | { path: string; codes: string[] }>;
-			readonly accept: string;
-			readonly expected: string;
-		}
-
-		const buildRequest = (acceptLanguage: string): Request => {
-			return new Request('http://example.com/', {
-				headers: { 'Accept-Language': acceptLanguage },
-			});
-		};
-
-		const runCase = (testCase: FirstMatchCase): void => {
-			const request = buildRequest(testCase.accept);
-			const actual = computePreferredLocale(request, testCase.locales as Locales);
-			assert.equal(actual, testCase.expected, testCase.name);
-		};
-
-		const cases: FirstMatchCase[] = [
-			{
-				name: 'object-then-string: object code wins over later string',
-				locales: [{ path: 'us', codes: ['EN-US'] }, 'en-us'],
-				accept: 'en-us',
-				expected: 'EN-US',
-			},
-			{
-				name: 'object-then-object: first codes entry wins over normalize-equivalent later one',
-				locales: [
-					{ path: 'us', codes: ['EN'] },
-					{ path: 'gb', codes: ['en'] },
-				],
-				accept: 'en',
-				expected: 'EN',
-			},
-			{
-				name: 'object-with-multi-codes still resolves to the matched code (not the path)',
-				locales: [{ path: 'us', codes: ['xx', 'EN-US', 'yy'] }, 'en-us'],
-				accept: 'en-us',
-				expected: 'EN-US',
-			},
-		];
-
-		for (const testCase of cases) {
-			it(testCase.name, () => {
-				runCase(testCase);
-			});
-		}
-
-		it('falls through to undefined when no entry matches (sanity guard for early return)', () => {
-			const onlyObject: Locales = [{ path: 'us', codes: ['EN'] }];
-			const request = buildRequest('de');
-			assert.equal(computePreferredLocale(request, onlyObject), undefined);
+	it('returns the first matching code when an object-form entry precedes a string entry', () => {
+		const localesMixed: Locales = [{ path: 'us', codes: ['EN-US'] }, 'en-us'];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'en-us' },
 		});
+		assert.equal(computePreferredLocale(req, localesMixed), 'EN-US');
+	});
+
+	it('returns the first matching code when two object-form entries normalize-equivalently', () => {
+		const localesObjects: Locales = [
+			{ path: 'us', codes: ['EN'] },
+			{ path: 'gb', codes: ['en'] },
+		];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'en' },
+		});
+		assert.equal(computePreferredLocale(req, localesObjects), 'EN');
+	});
+
+	it('returns the matched code from a multi-code entry, not the path', () => {
+		const localesMulti: Locales = [{ path: 'us', codes: ['xx', 'EN-US', 'yy'] }, 'en-us'];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'en-us' },
+		});
+		assert.equal(computePreferredLocale(req, localesMulti), 'EN-US');
 	});
 });
 

--- a/packages/astro/test/units/i18n/i18n-utils.test.ts
+++ b/packages/astro/test/units/i18n/i18n-utils.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import type { Locales } from '../../../dist/types/public/config.js';
 import {
 	computeCurrentLocale,
 	computePreferredLocale,
@@ -76,6 +77,63 @@ describe('computePreferredLocale', () => {
 	it('returns undefined when no Accept-Language header', () => {
 		const req = new Request('http://example.com/');
 		assert.equal(computePreferredLocale(req, locales), undefined);
+	});
+
+	describe('regression: issue #16598 (first-match wins on object-form locales)', () => {
+		interface FirstMatchCase {
+			readonly name: string;
+			readonly locales: ReadonlyArray<string | { path: string; codes: string[] }>;
+			readonly accept: string;
+			readonly expected: string;
+		}
+
+		const buildRequest = (acceptLanguage: string): Request => {
+			return new Request('http://example.com/', {
+				headers: { 'Accept-Language': acceptLanguage },
+			});
+		};
+
+		const runCase = (testCase: FirstMatchCase): void => {
+			const request = buildRequest(testCase.accept);
+			const actual = computePreferredLocale(request, testCase.locales as Locales);
+			assert.equal(actual, testCase.expected, testCase.name);
+		};
+
+		const cases: FirstMatchCase[] = [
+			{
+				name: 'object-then-string: object code wins over later string',
+				locales: [{ path: 'us', codes: ['EN-US'] }, 'en-us'],
+				accept: 'en-us',
+				expected: 'EN-US',
+			},
+			{
+				name: 'object-then-object: first codes entry wins over normalize-equivalent later one',
+				locales: [
+					{ path: 'us', codes: ['EN'] },
+					{ path: 'gb', codes: ['en'] },
+				],
+				accept: 'en',
+				expected: 'EN',
+			},
+			{
+				name: 'object-with-multi-codes still resolves to the matched code (not the path)',
+				locales: [{ path: 'us', codes: ['xx', 'EN-US', 'yy'] }, 'en-us'],
+				accept: 'en-us',
+				expected: 'EN-US',
+			},
+		];
+
+		for (const testCase of cases) {
+			it(testCase.name, () => {
+				runCase(testCase);
+			});
+		}
+
+		it('falls through to undefined when no entry matches (sanity guard for early return)', () => {
+			const onlyObject: Locales = [{ path: 'us', codes: ['EN'] }];
+			const request = buildRequest('de');
+			assert.equal(computePreferredLocale(request, onlyObject), undefined);
+		});
 	});
 });
 


### PR DESCRIPTION
## Changes

- Fix `computePreferredLocale` violating its "first match wins" semantics when a `Locales` config contains object-form entries (`{ path, codes }`).
- Root cause: the inner `break` in the codes-array branch only exits the inner loop, so a later normalize-equivalent code can overwrite an earlier (correct) match. The string-entry branch correctly breaks the outer loop.
- Refactored to extract a `findFirstMatchingLocale(locales, target)` helper that uses `return` instead of `break`. Early return naturally exits *both* enclosing loops, making the bug type-impossible. Also normalizes the target once instead of per-iteration.
- Closes #16598.

**Before:**
- `[{ path: 'us', codes: ['EN-US'] }, 'en-us']` + `Accept-Language: en-us` → `'en-us'` (wrong)
- `[{ path: 'us', codes: ['EN'] }, { path: 'gb', codes: ['en'] }]` + `Accept-Language: en` → `'en'` (wrong)

**After:** Both return the first matching code: `'EN-US'` and `'EN'` respectively.

> Don't forget a changeset! Run `pnpm changeset`.

## Testing
