### PR TITLE
chore: remove Vite 8 warning

### DIFF
--- a/.changeset/goofy-tigers-like.md
+++ b/.changeset/goofy-tigers-like.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes the warning that Astro does not support vite v8, since Astro v7 does support vite v8

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -234,13 +234,6 @@ export async function add(names: string[], { flags }: AddOptions) {
 					logger,
 					scripts: { 'generate-types': 'wrangler types' },
 				});
-
-				await updatePackageJsonOverrides({
-					configURL,
-					flags,
-					logger,
-					overrides: { vite: '^7' },
-				});
 			}
 			if (integrations.find((integration) => integration.id === 'tailwind')) {
 				const dir = new URL('./styles/', new URL(userConfig.srcDir ?? './src/', root));
@@ -699,67 +692,6 @@ async function updateAstroConfig({
 	if (await askToContinue({ flags, logger })) {
 		await fs.writeFile(fileURLToPath(configURL), output, { encoding: 'utf-8' });
 		logger.debug('add', `Updated astro config`);
-		return 'updated';
-	} else {
-		return 'cancelled';
-	}
-}
-
-async function updatePackageJsonOverrides({
-	configURL,
-	flags,
-	logger,
-	overrides,
-}: {
-	configURL: URL;
-	flags: Flags;
-	logger: AstroLogger;
-	overrides: Record<string, string>;
-}): Promise<UpdateResult> {
-	const pkgURL = new URL('./package.json', configURL);
-	if (!existsSync(pkgURL)) {
-		logger.debug('add', 'No package.json found, skipping overrides update');
-		return 'none';
-	}
-
-	const pkgPath = fileURLToPath(pkgURL);
-	const input = await fs.readFile(pkgPath, { encoding: 'utf-8' });
-	const pkgJson = JSON.parse(input);
-
-	pkgJson.overrides ??= {};
-	let hasChanges = false;
-	for (const [name, range] of Object.entries(overrides)) {
-		if (!(name in pkgJson.overrides)) {
-			pkgJson.overrides[name] = range;
-			hasChanges = true;
-		}
-	}
-
-	if (!hasChanges) {
-		return 'none';
-	}
-
-	const output = JSON.stringify(pkgJson, null, 2);
-	const diff = getDiffContent(input, output);
-
-	if (!diff) {
-		return 'none';
-	}
-
-	logger.info(
-		'SKIP_FORMAT',
-		`\n  ${magenta('Astro will add the following overrides to your package.json:')}`,
-	);
-
-	clack.box(diff, 'package.json', {
-		rounded: true,
-		withGuide: false,
-		width: 'auto',
-	});
-
-	if (await askToContinue({ flags, logger })) {
-		await fs.writeFile(pkgPath, output, { encoding: 'utf-8' });
-		logger.debug('add', 'Updated package.json overrides');
 		return 'updated';
 	} else {
 		return 'cancelled';

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import type http from 'node:http';
-import { createRequire } from 'node:module';
 import type { AddressInfo } from 'node:net';
 import { performance } from 'node:perf_hooks';
 import colors from 'piccolore';
@@ -25,19 +24,6 @@ import {
 } from './update-check.js';
 import { BuildTimeAstroVersionProvider } from '../../cli/infra/build-time-astro-version-provider.js';
 import { piccoloreTextStyler } from '../../cli/infra/piccolore-text-styler.js';
-import type { AstroLogger } from '../logger/core.js';
-
-function warnIfVite8({ root, logger }: { root: URL | string; logger: AstroLogger }) {
-	try {
-		const require = createRequire(root);
-		const { version } = require('vite/package.json') as { version: string };
-		if (major(version) >= 8) {
-			logger.warn('SKIP_FORMAT', msg.vite8Warning({ viteVersion: version }));
-		}
-	} catch {
-		// If vite can't be resolved from the project root, skip the warning
-	}
-}
 
 export interface DevServer {
 	address: AddressInfo;
@@ -153,8 +139,6 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 	if (restart.container.viteServer.config.server?.fs?.strict === false) {
 		logger.warn('SKIP_FORMAT', msg.fsStrictWarning());
 	}
-
-	setImmediate(() => warnIfVite8({ root: restart.container.settings.config.root, logger }));
 
 	logger.info(null, colors.green('watching for file changes...'));
 

--- a/packages/astro/src/core/messages/runtime.ts
+++ b/packages/astro/src/core/messages/runtime.ts
@@ -179,12 +179,6 @@ export function fsStrictWarning() {
 	return `${title}\n${subtitle}\n`;
 }
 
-export function vite8Warning({ viteVersion }: { viteVersion: string }) {
-	const title = yellow('▶ ' + `Vite ${bold(viteVersion)} detected in your project.`);
-	const subtitle = `  Astro requires Vite 7. Add ${bold('"overrides": { "vite": "^7" }')} to your ${bold('package.json')} to avoid issues.`;
-	return `${title}\n${subtitle}\n`;
-}
-
 export function prerelease({ currentVersion }: { currentVersion: string }) {
 	const tag = currentVersion.split('-').slice(1).join('-').replace(/\..*$/, '') || 'unknown';
 	const badge = bgYellow(black(` ${tag} `));


### PR DESCRIPTION
removes the log warning that vite 8 is not supported and users should use override. This is not true for Astro v7 anymore.