### PR TITLE
fix(app): write responseSentSymbol to Request in production

### DIFF
--- a/.changeset/fix-app-response-sent-symbol-on-request.md
+++ b/.changeset/fix-app-response-sent-symbol-on-request.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.cookies.set` and similar response-mutating APIs silently dropping their effects in production when called after the response has been sent (for example, from an unawaited async function continuing past the render phase). A `ResponseSentError` is now thrown in production in these cases, matching the existing development-mode behavior.

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -441,7 +441,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 					},
 				},
 			);
-			this.#prepareResponse(response, { addCookieHeader });
+			this.#prepareResponse(request, response, { addCookieHeader });
 			return response;
 		}
 
@@ -600,11 +600,15 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 			});
 		}
 
-		this.#prepareResponse(response, { addCookieHeader });
+		this.#prepareResponse(request, response, { addCookieHeader });
 		return response;
 	}
 
-	#prepareResponse(response: Response, { addCookieHeader }: { addCookieHeader: boolean }): void {
+	#prepareResponse(
+		request: Request,
+		response: Response,
+		{ addCookieHeader }: { addCookieHeader: boolean },
+	): void {
 		// We remove internally-used header before we send the response to the user agent.
 		for (const headerName of [
 			REROUTE_DIRECTIVE_HEADER,
@@ -624,7 +628,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		}
 
 		this.logger.flush();
-		Reflect.set(response, responseSentSymbol, true);
+		Reflect.set(request, responseSentSymbol, true);
 	}
 
 	setCookieHeaders(response: Response) {
@@ -686,7 +690,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 					const override = { status, removeContentEncodingHeaders: true };
 
 					const newResponse = this.mergeResponses(response, originalResponse, override);
-					this.#prepareResponse(newResponse, resolvedRenderOptions);
+					this.#prepareResponse(request, newResponse, resolvedRenderOptions);
 					return newResponse;
 				}
 			}
@@ -707,7 +711,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 				session = renderContext.session;
 				const response = await renderContext.render(mod);
 				const newResponse = this.mergeResponses(response, originalResponse);
-				this.#prepareResponse(newResponse, resolvedRenderOptions);
+				this.#prepareResponse(request, newResponse, resolvedRenderOptions);
 				return newResponse;
 			} catch {
 				// Middleware may be the cause of the error, so we try rendering 404/500.astro without it.
@@ -725,7 +729,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		}
 
 		const response = this.mergeResponses(new Response(null, { status }), originalResponse);
-		this.#prepareResponse(response, resolvedRenderOptions);
+		this.#prepareResponse(request, response, resolvedRenderOptions);
 		return response;
 	}
 

--- a/packages/astro/test/units/app/astro-response.test.ts
+++ b/packages/astro/test/units/app/astro-response.test.ts
@@ -94,4 +94,12 @@ describe('Returning responses', () => {
 		assert.equal(response.status, 404);
 		assert.equal(html.includes('Custom 404'), true);
 	});
+
+	it('Sets responseSentSymbol on the Request after render (regression #16608)', async () => {
+		const request = new Request('http://example.com/not-found');
+		const response = await app.render(request);
+		const responseSentSymbol = Symbol.for('astro.responseSent');
+		assert.equal((request as any)[responseSentSymbol], true);
+		assert.equal((response as any)[responseSentSymbol], undefined);
+	});
 });


### PR DESCRIPTION
## Changes

- Fixes `Astro.cookies.set` and similar response-mutating APIs silently dropping their effects in production when called after the response has been sent — for example, from an unawaited async function continuing past the render phase. A `ResponseSentError` is now thrown in production in these cases, matching the existing development-mode behavior.
- The `responseSentSymbol` is now written to the Request object in production (matching the dev path in `vite-plugin-astro-server/response.ts`), so the readers in `core/cookies/cookies.ts` and `core/render-context.ts` — which both check the Request — actually fire.
- Closes #16608.

**Before (production only):**

```js
async function deferred() {
  await slow();
  Astro.cookies.set('processed', 'true'); // silently dropped
}
deferred();
