### PR TITLE
fix formatting in JSDoc

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1411,7 +1411,7 @@ export interface AstroUserConfig<
 	 *
 	 * ```js title="astro.config.mjs"
 	 * import { defineConfig, sessionDrivers } from 'astro/config';
-
+	 *
 	 * export default defineConfig({
 	 *   session: {
 	 *     driver: sessionDrivers.redis({


### PR DESCRIPTION

## Changes

This PR adds the missing `*` line from a code sample in JSDoc, which basically removed the whitespace between the imports and the code.

This doesn't need a changeset, AFAIK

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

That's all it is.
