### PR TITLE
Exclude astro-expressive-code from minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,7 @@ minimumReleaseAgeExclude:
   # Smoke test dependencies (docs site)
   - astro-og-canvas@0.11.0
   - astro-expressive-code
+  - rehype-expressive-code
   # @types/node@24.12.2 published <3 days ago
   - '@types/node@24.12.2'
   # Renovate security update: postcss@8.5.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,8 @@ minimumReleaseAgeExclude:
   - astro-og-canvas@0.11.0
   - astro-expressive-code
   - rehype-expressive-code
+  - expressive-code
+  - '@expressive-code/*'
   # @types/node@24.12.2 published <3 days ago
   - '@types/node@24.12.2'
   # Renovate security update: postcss@8.5.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,8 +48,9 @@ minimumReleaseAgeExclude:
   - smol-toml@1.6.1
   # Renovate security update: picomatch@4.0.4
   - picomatch@4.0.4
-  # Smoke test dependency (docs site)
+  # Smoke test dependencies (docs site)
   - astro-og-canvas@0.11.0
+  - astro-expressive-code
   # @types/node@24.12.2 published <3 days ago
   - '@types/node@24.12.2'
   # Renovate security update: postcss@8.5.10


### PR DESCRIPTION
Fixes the smoke test failure caused by `astro-expressive-code@0.42.0` being too recently published to pass the 3-day `minimumReleaseAge` gate. Since this is a Starlight dependency used by our docs smoke test, it should always be installable regardless of release age.