### PR TITLE
fix(live-collections): add missing utility type ExtractDataType

### DIFF
--- a/.changeset/short-singers-pay.md
+++ b/.changeset/short-singers-pay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `entry.data` type inference when a live collection is configured without a schema.

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -134,6 +134,7 @@ declare module 'astro:content' {
 	type ExtractEntryFilterType<T> = ExtractLoaderTypes<T>['entryFilter'];
 	type ExtractCollectionFilterType<T> = ExtractLoaderTypes<T>['collectionFilter'];
 	type ExtractErrorType<T> = ExtractLoaderTypes<T>['error'];
+	type ExtractDataType<T> = ExtractLoaderTypes<T>['data'];
 
 	type LiveLoaderDataType<C extends keyof LiveContentConfig['collections']> =
 		LiveContentConfig['collections'][C]['schema'] extends undefined


### PR DESCRIPTION
## Changes

Right now, types for `entry.data` field returned by `getLiveEntry()` are not working.

```astro
---
import { getLiveEntry } from "astro:content";

const { entry } = await getLiveEntry("example", "hello-world");
const data = entry?.data; // type `any` instead of defined type from loader.
---
```

The cause is that the utility type `ExtractDataType` [used here](https://github.com/withastro/astro/blob/12a03f2492c2f32f0bd39dd85b8bc8bf1fbbc138/packages/astro/templates/content/types.d.ts#L140) is missing, so `entry.data` is always of type `any`.

This pr adds the missing utility type to the file.

## Testing

Tested by manually adding the missing utility type to the generated `.astro/content.d.ts` in my projects and verifing the expected types to work.

## Docs

It adds missing typing.
