### PR TITLE
fix: cannot all action create context

### DIFF
--- a/.changeset/fluffy-cats-sit.md
+++ b/.changeset/fluffy-cats-sit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `callAction` throwing `ActionCalledFromServerError` when called on a context created via `createContext` from `astro/middleware`. The action handler is now resolved directly from the actions entrypoint module as a fallback when no pipeline is attached to the context.

--- a/packages/astro/src/actions/runtime/entrypoints/server.ts
+++ b/packages/astro/src/actions/runtime/entrypoints/server.ts
@@ -1,8 +1,12 @@
 import type { Pipeline } from '../../../core/base-pipeline.js';
 import { pipelineSymbol } from '../../../core/constants.js';
-import { ActionCalledFromServerError } from '../../../core/errors/errors-data.js';
+import {
+	ActionCalledFromServerError,
+	ActionNotFoundError,
+} from '../../../core/errors/errors-data.js';
 import { AstroError } from '../../../core/errors/errors.js';
 import { createGetActionPath, createActionsProxy } from '../client.js';
+import { ACTION_API_CONTEXT_SYMBOL } from '../server.js';
 import { shouldAppendTrailingSlash } from 'virtual:astro:actions/options';
 
 export { ACTION_QUERY_PARAMS } from '../../consts.js';
@@ -27,11 +31,30 @@ export const actions = createActionsProxy({
 		const pipeline: Pipeline | undefined = context
 			? Reflect.get(context, pipelineSymbol)
 			: undefined;
-		if (!pipeline) {
+
+		let action;
+		if (pipeline) {
+			action = await pipeline.getAction(path);
+		} else if (context && Reflect.get(context, ACTION_API_CONTEXT_SYMBOL)) {
+			// Fallback for contexts without a pipeline (e.g., createContext from astro/middleware).
+			const { server } = await import('virtual:astro:actions/entrypoint');
+			const pathKeys = path.split('.').map((key) => decodeURIComponent(key));
+			let resolved: any = server;
+			for (const key of pathKeys) {
+				if (!(key in resolved)) {
+					throw new AstroError({
+						...ActionNotFoundError,
+						message: ActionNotFoundError.message(pathKeys.join('.')),
+					});
+				}
+				resolved = resolved[key];
+			}
+			action = resolved;
+		}
+
+		if (!action) {
 			throw new AstroError(ActionCalledFromServerError);
 		}
-		const action = await pipeline.getAction(path);
-		if (!action) throw new Error(`Action not found: ${path}`);
 		return action.bind(context)(param);
 	},
 });

--- a/packages/astro/test/fixtures/middleware-call-action/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-call-action/astro.config.mjs
@@ -1,0 +1,3 @@
+export default {
+	output: 'server',
+};

--- a/packages/astro/test/fixtures/middleware-call-action/package.json
+++ b/packages/astro/test/fixtures/middleware-call-action/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/middleware-call-action",
+  "type": "module",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/middleware-call-action/src/actions/index.ts
+++ b/packages/astro/test/fixtures/middleware-call-action/src/actions/index.ts
@@ -1,0 +1,11 @@
+import { defineAction } from 'astro:actions';
+import { z } from 'astro/zod';
+
+export const server = {
+	test: defineAction({
+		input: z.object({ name: z.string() }),
+		handler: async (input) => {
+			return `Hello ${input.name}`;
+		},
+	}),
+};

--- a/packages/astro/test/fixtures/middleware-call-action/src/pages/index.astro
+++ b/packages/astro/test/fixtures/middleware-call-action/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+import { createContext } from 'astro/middleware';
+import { actions } from 'astro:actions';
+
+const context = createContext({
+	request: Astro.request,
+	defaultLocale: 'en',
+});
+
+const result = await context.callAction(actions.test, { name: 'Astro' });
+---
+
+<div id="result">{result.data}</div>

--- a/packages/astro/test/middleware-call-action.test.ts
+++ b/packages/astro/test/middleware-call-action.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import testAdapter from './test-adapter.ts';
+import { type App, type Fixture, loadFixture } from './test-utils.ts';
+
+describe('Middleware callAction', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/middleware-call-action/',
+			adapter: testAdapter(),
+		});
+	});
+
+	describe('build', () => {
+		let app: App;
+
+		before(async () => {
+			await fixture.build();
+			app = await fixture.loadTestAdapterApp();
+		});
+
+		it('can call an action from a context created via createContext', async () => {
+			const request = new Request('http://example.com/');
+			const res = await app.render(request);
+
+			assert.equal(res.status, 200);
+
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			assert.equal($('#result').text(), 'Hello Astro');
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3544,6 +3544,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/middleware-call-action:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/middleware-full-ssr:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes
close #15609 

- Added a fallback path in `handleAction`  for contexts that lack a pipeline.
- If neither a pipeline nor `ACTION_API_CONTEXT_SYMBOL` is present on the context `ActionCalledFromServerError` is still thrown as before.


## Testing

### Before implementation

<img width="931" height="521" alt="スクリーンショット 2026-05-06 6 51 54" src="https://github.com/user-attachments/assets/6ba6cd21-4a43-463b-94ed-d8fe702efdc1" />


### After implementation

<img width="888" height="205" alt="スクリーンショット 2026-05-06 6 55 00" src="https://github.com/user-attachments/assets/cb22c785-5824-44d5-b9b7-64bd067feaf9" />


## Docs