### PR TITLE
Fix session ID format in issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -96,5 +96,5 @@ jobs:
         run: |
           pnpm exec flue run issue-triage \
             --target node \
-            --session-id "issue-triage-$ISSUE_NUMBER" \
+            --id "issue-triage-$ISSUE_NUMBER" \
             --payload "{\"issueNumber\": $ISSUE_NUMBER}"


### PR DESCRIPTION
## Changes

The Houston bot for the triage workflow is currently not working.
https://github.com/withastro/astro/actions/runs/25424727887/job/74575139340

The log shows the following:

```
pnpm exec flue run issue-triage \
    --target node \
    --session-id "issue-triage-$ISSUE_NUMBER" \
    --payload "{\"issueNumber\": $ISSUE_NUMBER}"

Unknown argument: --session-id
```

Looking into the flue repository, I couldn't find the `--session-id` argument anywhere.
Instead, I found that `--id` is defined as the correct argument.
https://github.com/withastro/flue/blob/808b34ee154b94025d5cb2b45288d88b7766ae0f/packages/cli/bin/flue.ts#L95-L108

I also confirmed that commit [8388ed1](https://github.com/withastro/flue/commit/8388ed11ff403e013b3b44d9b6eb80d9a7186c2d#diff-2b2387f60c2db7e6319aa1eba7e1b81b1b135363fabab078ff674e24ce2ae1c4) in the flue repository changed `--session-id` to `--id`.
Based on this, I concluded that `--id` should be used instead of `--session-id`, and updated it accordingly.


## Testing

I don't know how to do it 😔

## Docs

N/A
