### PR TITLE
fix(astro): use prerender loader environment for metadata

### DIFF
--- a/.changeset/fix-module-loader-prerender-env.md
+++ b/.changeset/fix-module-loader-prerender-env.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the per-environment module loader returning the wrong Vite dev environment from `getSSREnvironment()`. With adapters like `@astrojs/cloudflare` configured with `prerenderEnvironment: 'node'`, a separate `prerender` Vite environment is created and a dedicated loader is built for it; the loader now correctly returns the environment it was constructed for, so `getComponentMetadata()` crawls the right module graph for prerendered routes in dev.

--- a/packages/astro/src/core/module-loader/vite.ts
+++ b/packages/astro/src/core/module-loader/vite.ts
@@ -6,7 +6,6 @@ import type { RunnableDevEnvironment } from 'vite';
 import { collectErrorMetadata } from '../errors/dev/utils.js';
 import { getViteErrorPayload } from '../errors/dev/vite.js';
 import type { ModuleLoader, ModuleLoaderEventEmitter } from './runner.js';
-import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../constants.js';
 
 export function createViteLoader(
 	viteServer: vite.ViteDevServer,
@@ -110,7 +109,8 @@ export function createViteLoader(
 			return viteServer.environments.client.hot.send(msg);
 		},
 		getSSREnvironment() {
-			return viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.ssr] as RunnableDevEnvironment;
+			// Use the loader's actual environment so prerender handlers crawl the correct module graph.
+			return ssrEnvironment;
 		},
 		isHttps() {
 			return !!ssrEnvironment.config.server.https;


### PR DESCRIPTION
## Changes

- Fixes `ModuleLoader.getSSREnvironment()` to return the `ssrEnvironment` parameter the loader was constructed with, instead of always looking up `viteServer.environments.ssr`.
- With adapters that register a separate `prerender` Vite dev environment (notably `@astrojs/cloudflare` with `prerenderEnvironment: 'node'`), `createViteLoader` builds a dedicated loader per environment. Every other method already uses the constructor parameter - only `getSSREnvironment()` ignored it, so the prerender handler's loader returned the unrelated `ssr` environment and `getComponentMetadata()` walked the wrong module graph in dev. With Cloudflare's default workerd `ssr`, that env is also non-runnable, making the `as RunnableDevEnvironment` cast unsafe.
- Removes the now-unused `ASTRO_VITE_ENVIRONMENT_NAMES` import.
- Changeset: `astro: patch` (`.changeset/fix-module-loader-prerender-env.md`).
- Closes #16436. Follow-up to #16292, which fixed the visible style-into-`<template>` symptom in `astro:head-metadata` but did not touch this separate correctness bug in the per-environment module loader.

## Testing

- `tsc --noEmit` on `packages/astro` passes cleanly.
- Existing regression test `packages/astro/test/head-propagation-prerender-env.test.js` still passes (1/1) - confirms no regression on the `astro:head-metadata` path that #16292 fixed.
- No new test added: `loader.getSSREnvironment()` has a single caller (`getComponentMetadata`), and when only the `ssr` env exists `ssrEnvironment === viteServer.environments.ssr`, so the new behaviour is a strict superset of the old correct behaviour. Happy to extend the `head-propagation-prerender-env` fixture with a prerendered route to exercise the prerender handler's loader directly if maintainers prefer.

## Docs

No docs change needed - this is a dev-server-internal correctness fix with no user-facing API or behaviour change. Users on adapters with a separate prerender env (e.g. `@astrojs/cloudflare` with `prerenderEnvironment: 'node'`) will simply see correct head metadata for prerendered routes in dev.
