### PR TITLE
refactor(astro): migrate some tests from js to ts

### DIFF
--- a/packages/astro/test/alias-path-alias-style.test.ts
+++ b/packages/astro/test/alias-path-alias-style.test.ts
@@ -1,12 +1,12 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.ts';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
 // Regression test for https://github.com/withastro/astro/issues/15963
 // <style> tags in components imported via tsconfig path aliases should compile correctly.
 describe('Style compilation with tsconfig path aliases', () => {
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({

--- a/packages/astro/test/head-propagation-prerender-env.test.ts
+++ b/packages/astro/test/head-propagation-prerender-env.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.ts';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
 
 // Regression test for https://github.com/withastro/astro/issues/16291
 //
@@ -19,8 +19,8 @@ import { loadFixture } from './test-utils.ts';
 // `@astrojs/cloudflare` does in dev (registers a `prerender` Vite
 // environment and flips on the core dev-prerender middleware).
 describe('Head propagation across ssr and prerender envs in dev', () => {
-	let fixture;
-	let devServer;
+	let fixture: Fixture;
+	let devServer: DevServer;
 
 	before(async () => {
 		fixture = await loadFixture({

--- a/packages/astro/test/partials-css-boundary.test.ts
+++ b/packages/astro/test/partials-css-boundary.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.ts';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
 describe('Partials CSS propagation', () => {
-	/** @type {import('./test-utils.ts').Fixture} */
-	let fixture;
+	let fixture: Fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -26,7 +25,7 @@ describe('Partials CSS propagation', () => {
 		const stylesheetHrefs = $('link[rel="stylesheet"]')
 			.toArray()
 			.map((el) => $(el).attr('href'))
-			.filter((href) => href && href.startsWith('/_astro/'));
+			.filter((href): href is string => !!href && href.startsWith('/_astro/'));
 
 		for (const href of stylesheetHrefs) {
 			styles += `\n${await fixture.readFile(href)}`;


### PR DESCRIPTION
## Changes

Migrate some tests from JS to TS. 

These tests come from an old pull request, which was merged into `main` after the TypeScript migration was completed.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
