### PR TITLE
fix(test): ensure removeDir is properly awaited

### DIFF
--- a/packages/astro/test/core-image.test.ts
+++ b/packages/astro/test/core-image.test.ts
@@ -998,7 +998,7 @@ describe('astro:image', () => {
 				},
 			});
 			// Remove cache directory
-			removeDir(new URL('./fixtures/core-image-ssg/node_modules/.astro', import.meta.url));
+			await removeDir(new URL('./fixtures/core-image-ssg/node_modules/.astro', import.meta.url));
 
 			await fixture.build();
 		});


### PR DESCRIPTION
## Changes

Some tests in `core-image.test.ts` have been flaky in Astro's CI.
https://github.com/withastro/astro/actions/runs/25425893932/job/74579340641?pr=16579
https://github.com/withastro/astro/actions/runs/25407064617/job/74520525804?pr=16614

After investigating, I found that the `removeDir` function, which is used to clean up the cache directory before tests, was not being awaited despite returning a Promise.

This PR adds the missing `await` to address the potential race condition.

## Testing

Green CI

## Docs

N/A