### PR TITLE
fix(logger): add flush/close to AstroIntegrationLogger

### DIFF
--- a/.changeset/fix-integration-logger-flush-close.md
+++ b/.changeset/fix-integration-logger-flush-close.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds `flush()` and `close()` methods to `AstroIntegrationLogger`, mirroring `AstroLogger`. Both delegate to the underlying destination's optional `flush`/`close` hooks. Previously, only `AstroLogger` exposed these methods, so any code path that put an `AstroIntegrationLogger` instance where an `AstroLogger` was expected (e.g. `App.#prepareResponse` calling `this.logger.flush()`) would crash with `TypeError: this.logger.flush is not a function`. The two logger classes now have a symmetric public surface.

--- a/.changeset/fix-integration-logger-flush-close.md
+++ b/.changeset/fix-integration-logger-flush-close.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds `flush()` and `close()` methods to `AstroIntegrationLogger`, mirroring `AstroLogger`. Both delegate to the underlying destination's optional `flush`/`close` hooks. Previously, only `AstroLogger` exposed these methods, so any code path that put an `AstroIntegrationLogger` instance where an `AstroLogger` was expected (e.g. `App.#prepareResponse` calling `this.logger.flush()`) would crash with `TypeError: this.logger.flush is not a function`. The two logger classes now have a symmetric public surface.
+Fixes a bug where SSR responses in `astro dev` could crash with `TypeError: this.logger.flush is not a function`.

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -285,4 +285,22 @@ export class AstroIntegrationLogger {
 	debug(message: string) {
 		debug(this.label, message);
 	}
+
+	/**
+	 * It calls the `flush` function of the provided destination, if it exists.
+	 */
+	flush() {
+		if (this.options.destination.flush) {
+			this.options.destination.flush();
+		}
+	}
+
+	/**
+	 * It calls the `close` function of the provided destination, if it exists.
+	 */
+	close() {
+		if (this.options.destination.close) {
+			this.options.destination.close();
+		}
+	}
 }

--- a/packages/astro/test/units/logger/logger.test.ts
+++ b/packages/astro/test/units/logger/logger.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { AstroLoggerMessage, AstroLoggerDestination } from '../../../dist/core/logger/core.js';
-import { AstroLogger } from '../../../dist/core/logger/core.js';
+import { AstroIntegrationLogger, AstroLogger } from '../../../dist/core/logger/core.js';
 
 describe('AstroLogger', () => {
 	function createSpyDestination() {
@@ -82,6 +82,79 @@ describe('AstroLogger', () => {
 			assert.equal(writes.length, 2);
 			assert.match(writes[0], /^original:/);
 			assert.match(writes[1], /^new:/);
+		});
+	});
+});
+
+describe('AstroIntegrationLogger', () => {
+	function createSpyDestination() {
+		const calls: { method: string }[] = [];
+		const destination: AstroLoggerDestination<AstroLoggerMessage> = {
+			write: () => {},
+			flush: () => {
+				calls.push({ method: 'flush' });
+			},
+			close: () => {
+				calls.push({ method: 'close' });
+			},
+		};
+		return { destination, calls };
+	}
+
+	describe('flush', () => {
+		it('calls destination.flush when present', () => {
+			const { destination, calls } = createSpyDestination();
+			const logger = new AstroIntegrationLogger({ destination, level: 'info' }, 'test');
+
+			logger.flush();
+
+			assert.equal(calls.length, 1);
+			assert.equal(calls[0].method, 'flush');
+		});
+
+		it('does not throw when destination has no flush', () => {
+			const destination: AstroLoggerDestination<AstroLoggerMessage> = {
+				write: () => {},
+			};
+			const logger = new AstroIntegrationLogger({ destination, level: 'info' }, 'test');
+
+			assert.doesNotThrow(() => logger.flush());
+		});
+	});
+
+	describe('close', () => {
+		it('calls destination.close when present', () => {
+			const { destination, calls } = createSpyDestination();
+			const logger = new AstroIntegrationLogger({ destination, level: 'info' }, 'test');
+
+			logger.close();
+
+			assert.equal(calls.length, 1);
+			assert.equal(calls[0].method, 'close');
+		});
+
+		it('does not throw when destination has no close', () => {
+			const destination: AstroLoggerDestination<AstroLoggerMessage> = {
+				write: () => {},
+			};
+			const logger = new AstroIntegrationLogger({ destination, level: 'info' }, 'test');
+
+			assert.doesNotThrow(() => logger.close());
+		});
+	});
+
+	describe('fork', () => {
+		it('shares the destination so flush/close still delegate after forking', () => {
+			const { destination, calls } = createSpyDestination();
+			const parent = new AstroIntegrationLogger({ destination, level: 'info' }, 'parent');
+			const child = parent.fork('child');
+
+			child.flush();
+			child.close();
+
+			assert.equal(calls.length, 2);
+			assert.equal(calls[0].method, 'flush');
+			assert.equal(calls[1].method, 'close');
 		});
 	});
 });


### PR DESCRIPTION
## Description

Adds `flush()` and `close()` methods to `AstroIntegrationLogger`, mirroring `AstroLogger`. Both delegate to the underlying destination's optional `flush` / `close` hooks.

`AstroLogger` already exposes `flush()` and `close()` (added in #16404). `AstroIntegrationLogger` did not, so any code path that placed an `AstroIntegrationLogger` where an `AstroLogger` was expected — e.g. `App.#prepareResponse` calling `this.logger.flush()` — would crash with `TypeError: this.logger.flush is not a function`. The two logger classes now have a symmetric public surface.

Closes #16622.

## Changes

- `packages/astro/src/core/logger/core.ts`: add `flush()` and `close()` to `AstroIntegrationLogger`, identical shape to the methods on `AstroLogger`.
- `packages/astro/test/units/logger/logger.test.ts`: cover `AstroIntegrationLogger.flush()` / `.close()` (delegation, no-throw, fork inheritance).
- changeset: `patch`.

## Testing

```
pnpm --filter astro build:ci
pnpm --filter astro exec astro-scripts test test/units/logger/logger.test.ts --strip-types --teardown ./test/units/teardown.ts
# 10 pass, 0 fail
```

## Docs

No public API docs change required — `AstroIntegrationLogger.flush()` / `.close()` mirror the existing `AstroLogger` methods (no behaviour change for destinations that don't define `flush`/`close`).
