### PR TITLE
fix(docs): missing version and verb tense

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1723,9 +1723,10 @@ export interface AstroUserConfig<
 		 * @name image.dangerouslyProcessSVG
 		 * @type {boolean}
 		 * @default `false`
+		 * @version 6.3.0
 		 * @description
 		 *
-		 * Allow SVG source images to be processed by the image optimization pipeline.
+		 * Allows SVG source images to be processed by the image optimization pipeline.
 		 *
 		 * This is disabled by default as specifically formed SVGs can be prohibitively expensive to process and used by malicious actors to execute denial of service attacks. Only enable this option if you trust the source of your SVG images and understand the risks of processing them.
 		 */


### PR DESCRIPTION
## Changes

Updates `types/public/config.ts` to add the missing version for `dangerouslyProcessSVG` and fixes the verb tense.

## Testing

N/A

## Docs

This is docs.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
