### PR TITLE
fix(build): strip client:only imports from prerender Rollup graph

### DIFF
--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -43,7 +43,7 @@ export async function compileAstro({
 			sourcemap: 'external',
 			tsconfigRaw: {
 				compilerOptions: {
-					// Ensure client:only imports are treeshaken
+					// Allow esbuild to remove type-only imports
 					verbatimModuleSyntax: false,
 					importsNotUsedAsValues: 'remove',
 				},

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -283,11 +283,48 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 
 					const transformResult = await compile(source, filename);
 
+					let code = transformResult.code;
+
+					const clientOnlyComponents = transformResult.clientOnlyComponents.filter(notAstroComponent);
+					const hydratedComponents = transformResult.hydratedComponents.filter(notAstroComponent);
+
+					// In prerender/SSR, strip imports for client:only components whose
+					// specifier does not also appear in hydratedComponents or
+					// serverComponents. The compiler emits `import Foo from './Foo'`
+					// but passes `null` to $$renderComponent for client:only — the
+					// import is dead code. Removing it prevents Rollup from traversing
+					// the component's dependency tree (e.g. React) during prerender.
+					// Component metadata is preserved in meta.astro.clientOnlyComponents
+					// for the plugin-analyzer to feed into the client build.
+					if (
+						this.environment?.name === ASTRO_VITE_ENVIRONMENT_NAMES.prerender ||
+						this.environment?.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr
+					) {
+						const liveSpecifiers = new Set([
+							...hydratedComponents.map((c) => c.specifier),
+							...transformResult.serverComponents.map((c) => c.specifier),
+						]);
+
+						const { init, parse } = await import('es-module-lexer');
+						await init;
+						const [imports] = parse(code);
+						const s = new (await import('magic-string')).default(code);
+
+						for (const c of clientOnlyComponents) {
+							if (liveSpecifiers.has(c.specifier)) continue;
+							for (const imp of imports) {
+								if (imp.n === c.specifier) {
+									s.remove(imp.ss, imp.se + 1);
+								}
+							}
+						}
+
+						code = s.toString();
+					}
+
 					const astroMetadata: AstroPluginMetadata['astro'] = {
-						// Remove Astro components that have been mistakenly given client directives
-						// We'll warn the user about this later, but for now we'll prevent them from breaking the build
-						clientOnlyComponents: transformResult.clientOnlyComponents.filter(notAstroComponent),
-						hydratedComponents: transformResult.hydratedComponents.filter(notAstroComponent),
+						clientOnlyComponents,
+						hydratedComponents,
 						serverComponents: transformResult.serverComponents,
 						scripts: transformResult.scripts,
 						containsHead: transformResult.containsHead,
@@ -296,7 +333,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 					};
 
 					return {
-						code: transformResult.code,
+						code,
 						map: transformResult.map,
 						meta: {
 							astro: astroMetadata,


### PR DESCRIPTION
## Changes

Strips `client:only` component imports from compiled `.astro` output when building for prerender/SSR. The Astro compiler emits `import Foo from './Foo'` for `client:only` components but passes `null` to `$$renderComponent` — the import value is dead code in the prerender environment. However, Rollup still resolves the import and traverses the component's dependency tree (e.g. React, CodeMirror), inflating prerender build time for island-heavy sites.

### What this PR does

In the Vite plugin transform handler (`vite-plugin-astro/index.ts`), after the Astro compiler runs, if the environment is `prerender` or `ssr`:

1. Collects specifiers that are **live** (appear in `hydratedComponents` or `serverComponents`)
2. For each `client:only` component whose specifier is **not** live, removes its import using `es-module-lexer` (structural parsing) and `MagicString` (sourcemap-safe removal)
3. Preserves the component metadata in `meta.astro.clientOnlyComponents` so `plugin-analyzer` can still feed entries into the client build

This follows the same principle as the existing client-environment stub (lines 271–282), which returns empty modules for `.astro` files in the client build. Both exclude unnecessary modules from a build environment.

### Why this is safe

- The compiled code passes `null` as the component arg for `client:only`: `$$renderComponent($$result,'Repl',null,{...})`. The import value is provably dead.
- Dual-use is handled: if a component appears in both `clientOnlyComponents` **and** `hydratedComponents` or `serverComponents`, the import is kept.
- Component metadata flows through `meta.astro.clientOnlyComponents` → `plugin-analyzer` → `internals.discoveredClientOnlyComponents` → `getClientInput()` → client build. The metadata doesn't depend on the import existing in the compiled code.

Also fixes a misleading comment in `compile.ts`: `importsNotUsedAsValues: 'remove'` only removes type-only imports, not value imports — so the existing comment "Ensure client:only imports are treeshaken" is inaccurate.

### Measured impact

906-page static site (Astro 6.1.2), 472 pages with 2,055 `client:only` React islands:

| Experiment | Pages | Prerender (ms) | Delta |
|---|---|---|---|
| Baseline | 906 | 4,338 | — |
| Remove reading pages entirely | 433 | 1,012 | -3,326 (-77%) |
| **Trivial reading pages (no React imports)** | **906** | **2,203** | **-2,135 (-49%)** |
| Switch to `client:only="react"` | 906 | 4,390 | +52 (noise) |

The trivial-pages experiment (same page count, no React imports) confirms that ~2,135ms of prerender time is attributable to dead `client:only` import graph traversal. Switching directives alone has no effect because Rollup still resolves the imports.

### Compiled output reference

For `<Repl client:only="react" />`, the compiler generates:

```javascript
import Repl from './Repl';  // ← dead import (value never used)

$$renderComponent($$result, 'Repl', null, {  // ← null, not Repl
  "client:only": "react",
  "client:component-hydration": "only",
  "client:component-path": ($$metadata.resolvePath("Repl")),
  "client:component-export": "default"
})
```

This patch removes the `import Repl from './Repl'` line during prerender/SSR compilation so Rollup never traverses the React dependency tree.

## Testing

All 8 existing `astro-client-only` tests pass (CSS inclusion, hydration, subpath components, TSX):

```
▶ Client only components
  ✔ Loads pages using client:only hydrator
  ✔ Adds the CSS to the page
  ✔ Adds the CSS to the page - standalone svelte component
  ✔ Includes CSS from components that use CSS modules
  ✔ Includes CSS from package components
▶ Client only components subpath
  ✔ Loads pages using client:only hydrator
  ✔ Adds the CSS to the page
  ✔ Adds the CSS to the page for TSX components
```

## Docs

No user-facing API change. Could note in the `client:only` docs that this directive now also reduces prerender build time by excluding the component from the server module graph.