### PR TITLE
chore: add prebuild task before build in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,22 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "tasks": {
+    "prebuild": {
+      "dependsOn": ["^prebuild"],
+      "inputs": [
+        "**/*",
+        "!test/**/*",
+        "!e2e/**/*",
+        "!performance/**/*",
+        "!.astro/**/*",
+        "!.cache/**/*",
+        "!.turbo/**/*",
+        "!mod.js",
+        "!mod.js.map"
+      ],
+      "outputs": ["src/**/*.prebuilt*"]},
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "prebuild"],
       "inputs": [
         "**/*",
         "!test/**/*",
@@ -19,7 +33,7 @@
       "passThroughEnv": ["SKIP_OG", "PUBLIC_TWO_LANG"]
     },
     "build:ci": {
-      "dependsOn": ["^build:ci"],
+      "dependsOn": ["^build:ci", "prebuild"],
       "inputs": [
         "**/*",
         "!test/**/*",


### PR DESCRIPTION
## Changes

Update `turbo.json` so that Turborepo will add prebuilt files as part of the cache.

You will find the following warning when running `pnpm build`:

```
 WARNING  no output files found for task astro-vscode#prebuild. Please check your `outputs` key in `turbo.json`
```

That's because we have two `prebuild` scripts, one in `package/astro/package.json` and another in `packages/language-tools/vscode/package.json`. The second one doesn't emit `prebuilt` files. It's okay to ignore this warning for now.


## Testing

CI should pass 
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->



## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
