### PR TITLE
Restore missing token in issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -91,6 +91,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FREDKBOT_GITHUB_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |


### PR DESCRIPTION
## Changes

- Restores the `FREDKBOT_GITHUB_TOKEN` env var mapping that was accidentally dropped in the flue 0.3 upgrade (#16441). Without it, `postGitHubComment` fails at the end of every triage run.

## Testing

- No test changes. Verified by inspecting the [failing run](https://github.com/withastro/astro/actions/runs/25509458930/job/74864022359).

## Docs

- No docs needed — CI-only change.