### PR TITLE
fix(cloudflare): preserve user-defined image service across all image…

### DIFF
--- a/.changeset/cloudflare-respect-custom-image-service.md
+++ b/.changeset/cloudflare-respect-custom-image-service.md
@@ -3,3 +3,5 @@
 ---
 
 Preserve user-defined image services when the Cloudflare adapter is used. Previously, the adapter's `imageService` mode (including the default `'cloudflare-binding'` and `'compile'`) would silently overwrite a custom `image.service` configured in `astro.config.*`, replacing it with the workerd image service. Custom services (e.g., third-party CDNs) are now preserved across all modes, matching the behavior of the explicit `'custom'` mode.
+
+Additionally, the workerd prerenderer no longer hard-swaps `globalThis.astroAsset.imageService` to `astro/assets/services/sharp` for byte-level static image generation when a custom service is in use. Previously the `'compile'` mode bypassed the preserved service during the Node-side image generation pass; it now uses the user's configured service throughout the build.

--- a/.changeset/cloudflare-respect-custom-image-service.md
+++ b/.changeset/cloudflare-respect-custom-image-service.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Preserve user-defined image services when the Cloudflare adapter is used. Previously, the adapter's `imageService` mode (including the default `'cloudflare-binding'` and `'compile'`) would silently overwrite a custom `image.service` configured in `astro.config.*`, replacing it with the workerd image service. Custom services (e.g., third-party CDNs) are now preserved across all modes, matching the behavior of the explicit `'custom'` mode.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -123,6 +123,11 @@ export default function createIntegration({
 	let _routes: IntegrationResolvedRoute[];
 	let _isFullyStatic = false;
 	let cfPluginConfig: PluginConfig;
+	// True when the user provided a non-default `image.service`, which `setImageConfig`
+	// preserves across all `imageService` modes. In that case the workerd stub never
+	// becomes the active service, so the Node-side `collectStaticImages` path (which
+	// hard-swaps to sharp) must not run — it would clobber the user's service.
+	let _hasCustomImageService = false;
 
 	const { buildService, runtimeService } = normalizeImageServiceConfig(imageService);
 	const needsImagesBinding = runtimeService === 'cloudflare-binding';
@@ -134,6 +139,11 @@ export default function createIntegration({
 				if (!!process.versions.webcontainer) {
 					throw new Error('`workerd` does not run on Stackblitz.');
 				}
+
+				// Read this from the user's pre-`updateConfig` image config, since
+				// `setImageConfig` below may replace `service` with the workerd stub.
+				_hasCustomImageService =
+					config.image.service.entrypoint !== 'astro/assets/services/sharp';
 
 				let session = config.session;
 				const isCompile = buildService === 'compile';
@@ -417,7 +427,7 @@ export default function createIntegration({
 							base: _config.base,
 							trailingSlash: _config.trailingSlash,
 							cfPluginConfig,
-							hasCompileImageService: buildService === 'compile',
+							hasCompileImageService: buildService === 'compile' && !_hasCustomImageService,
 						}),
 					);
 				}

--- a/packages/integrations/cloudflare/src/utils/image-config.ts
+++ b/packages/integrations/cloudflare/src/utils/image-config.ts
@@ -56,6 +56,19 @@ export function setImageConfig(
 ) {
 	const { buildService, runtimeService } = normalizeImageServiceConfig(service);
 
+	// If the user has configured a non-default image service, preserve it across
+	// all `imageService` modes. This matches the explicit `'custom'` mode and the
+	// fallback branch below, and prevents the adapter from silently overriding a
+	// user-defined service (e.g., a third-party CDN) when the default mode is in
+	// effect or `'compile'`/`'cloudflare-binding'` is selected.
+	const hasCustomService = config.service.entrypoint !== 'astro/assets/services/sharp';
+	if (hasCustomService && buildService !== 'custom') {
+		logger.info(
+			`Detected a custom image service (${config.service.entrypoint}). Preserving it instead of applying the '${buildService}' mode override. Set \`imageService: 'custom'\` to silence this notice.`,
+		);
+		return { ...config };
+	}
+
 	switch (buildService) {
 		case 'passthrough':
 			return {

--- a/packages/integrations/cloudflare/test/image-config.test.ts
+++ b/packages/integrations/cloudflare/test/image-config.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { AstroConfig, AstroIntegrationLogger } from 'astro';
+import { setImageConfig } from '../src/utils/image-config.ts';
+
+const SHARP_ENTRYPOINT = 'astro/assets/services/sharp';
+const CUSTOM_ENTRYPOINT = 'my-app/image-services/cdn';
+const WORKERD_ENTRYPOINT = '@astrojs/cloudflare/image-service-workerd';
+
+function createNoopLogger(): AstroIntegrationLogger {
+	const noop = () => {};
+	const logger = {
+		options: {} as never,
+		label: 'test',
+		fork: () => logger,
+		info: noop,
+		warn: noop,
+		error: noop,
+		debug: noop,
+	};
+	return logger as unknown as AstroIntegrationLogger;
+}
+
+function makeConfig(entrypoint: string): AstroConfig['image'] {
+	return { service: { entrypoint, config: {} } } as AstroConfig['image'];
+}
+
+describe('setImageConfig — custom image service preservation', () => {
+	for (const mode of [
+		undefined, // default → 'cloudflare-binding'
+		'passthrough',
+		'cloudflare',
+		'cloudflare-binding',
+		'compile',
+		{ build: 'compile' as const },
+		{ build: 'compile' as const, runtime: 'cloudflare-binding' as const },
+	]) {
+		it(`preserves a user-defined service when imageService = ${JSON.stringify(mode)}`, () => {
+			const customConfig = makeConfig(CUSTOM_ENTRYPOINT);
+			const result = setImageConfig(mode as any, customConfig, 'build', createNoopLogger());
+			assert.equal(
+				result.service.entrypoint,
+				CUSTOM_ENTRYPOINT,
+				`Expected custom service to be preserved for mode ${JSON.stringify(mode)}`,
+			);
+		});
+	}
+
+	it("does not preserve when user has the default sharp service (mode 'cloudflare-binding')", () => {
+		const sharpConfig = makeConfig(SHARP_ENTRYPOINT);
+		const result = setImageConfig('cloudflare-binding', sharpConfig, 'build', createNoopLogger());
+		assert.equal(
+			result.service.entrypoint,
+			WORKERD_ENTRYPOINT,
+			'Expected adapter to override default sharp for cloudflare-binding mode',
+		);
+	});
+
+	it("does not preserve when user has the default sharp service (mode 'compile')", () => {
+		const sharpConfig = makeConfig(SHARP_ENTRYPOINT);
+		const result = setImageConfig('compile', sharpConfig, 'build', createNoopLogger());
+		assert.equal(
+			result.service.entrypoint,
+			WORKERD_ENTRYPOINT,
+			'Expected adapter to override default sharp for compile mode',
+		);
+	});
+
+	it("respects an explicit 'custom' mode regardless of service", () => {
+		const customConfig = makeConfig(CUSTOM_ENTRYPOINT);
+		const result = setImageConfig('custom', customConfig, 'build', createNoopLogger());
+		assert.equal(result.service.entrypoint, CUSTOM_ENTRYPOINT);
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes [#16201](https://github.com/withastro/astro/issues/16201) — the Cloudflare adapter silently replaced a user-defined `image.service` with `@astrojs/cloudflare/image-service-workerd` whenever `imageService` was unset (default `'cloudflare-binding'`) or set to `'compile'`/`'cloudflare-binding'`/`'cloudflare'`/`'passthrough'`. Custom services (e.g., a third-party CDN service) are now preserved across all modes.
- Added a guard at the top of `setImageConfig` that detects a non-default `image.service` (entrypoint ≠ `astro/assets/services/sharp`) and returns the config untouched, mirroring the precedent in the existing fallback `default:` branch and the explicit `'custom'` mode.
- Emits a single `logger.info` line when this preservation kicks in, telling the user the override was skipped and pointing them at `imageService: 'custom'` to silence the notice.
- Added a `.changeset` (`@astrojs/cloudflare` patch).

## Testing

- New unit test: `packages/integrations/cloudflare/test/image-config.test.ts` (10 cases) covering preservation across `undefined`, `'passthrough'`, `'cloudflare'`, `'cloudflare-binding'`, `'compile'`, and the compound `{ build: 'compile' }` / `{ build: 'compile', runtime: 'cloudflare-binding' }` configs. Also asserts the existing override of default sharp in `'cloudflare-binding'` and `'compile'` is preserved (no regression) and that explicit `'custom'` continues to work.
- Existing image-related fixture tests run clean: `external-image-service.test.ts` (2/2), `binding-image-service.test.ts` (7/7), `compile-image-service.test.ts` (5/5).
- `pnpm run build` succeeds; `tsc -b` clean.

## Docs

No user-facing docs changes needed. Behavior aligns with what the existing docs already imply (a custom `image.service` should be respected); this PR brings the Cloudflare adapter into line. Worth a brief note in the Cloudflare adapter README that custom services are preserved alongside `imageService` modes — happy to follow up in withastro/docs if maintainers prefer.

Closes #16201
