### PR TITLE
chore(language-tools): remove redundant prebuild script

### DIFF
--- a/packages/language-tools/vscode/package.json
+++ b/packages/language-tools/vscode/package.json
@@ -235,8 +235,7 @@
     ]
   },
   "scripts": {
-    "prebuild": "cd ../ts-plugin && pnpm build",
-    "build": "tsc -b && pnpm prebuild && node scripts/build.mjs -- --minify",
+    "build": "tsc -b && node scripts/build.mjs -- --minify",
     "dev": "node scripts/build.mjs -- --watch",
     "build:grammar": "node scripts/build-grammar.mjs",
     "dev:grammar": "node scripts/build-grammar.mjs -- --watch",


### PR DESCRIPTION
## Changes

I don't see the purpose of the `prebuild` script in `packages/language-tools/vscode/package.json`. `packages/language-tools/vscode/package.json` already has `@astrojs/ts-plugin` in `devDependencies`, thus `turbo` can ensure that `ts-plugin` is built before `language-tools`.

This resolves the following warning when running `pnpm build`


```
 WARNING  no output files found for task astro-vscode#prebuild. Please check your `outputs` key in `turbo.json`
```

## Testing

CI should pass.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
