### PR TITLE
Pin Vite 7 when running `astro add tailwind`

### DIFF
--- a/.changeset/pin-vite-7-on-add-tailwind.md
+++ b/.changeset/pin-vite-7-on-add-tailwind.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds a `"overrides": { "vite": "^7" }` entry to `package.json` when running `astro add tailwind`. Prevents npm from hoisting Vite 8 via `@tailwindcss/vite`'s permissive peer-dependency range, which causes `astro build` to fail with `Missing field 'tsconfigPaths' on BindingViteResolvePluginConfig.resolveOptions`. Mirrors #16062 for the tailwind case.

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -265,6 +265,13 @@ export async function add(names: string[], { flags }: AddOptions) {
 				} else {
 					logger.debug('add', `Using existing tailwind configuration`);
 				}
+
+				await updatePackageJsonOverrides({
+					configURL,
+					flags,
+					logger,
+					overrides: { vite: '^7' },
+				});
 			}
 			if (integrations.find((integration) => integration.id === 'svelte')) {
 				await setupIntegrationConfig({


### PR DESCRIPTION
## Changes

`astro add tailwind` now adds `"overrides": { "vite": "^7" }` to the user's `package.json`. Without the override, `astro build` fails on a fresh project with:

```
[vite] ✗ Build failed
[@tailwindcss/vite:generate:build] Missing field `tsconfigPaths` on
  BindingViteResolvePluginConfig.resolveOptions
```

Root cause: `@tailwindcss/vite@4.2.4` declares `peerDependencies.vite = "^5.2.0 || ^6 || ^7 || ^8"`. With npm's flat `node_modules` layout, npm picks the latest matching version (`vite@8.0.11` today) and hoists it to the project root, overriding Astro's required `vite@^7.3.2`. Vite 8 uses rolldown, which `@tailwindcss/vite` is not yet compatible with.

This is the symmetrical fix to #16062, which shipped the same `updatePackageJsonOverrides({ vite: '^7' })` call for `astro add cloudflare`. The Cloudflare PR's own description names `@tailwindcss/vite` as a package that triggers the hoist; this PR addresses the case where tailwind is added without (or before) the Cloudflare adapter.

The change is a single block in `packages/astro/src/cli/add/index.ts`, inside the existing tailwind branch, immediately after the CSS scaffolding closes. No new imports. `updatePackageJsonOverrides` is the private helper already defined at line 708 of the same file.

## Testing

Reproduced manually on `astro@6.3.1` against a fresh `npm create astro@latest` minimal template:

| Step | Without patch | With patch |
|---|---|---|
| `npm install` | hoists `vite@8.0.11` | hoists `vite@8.0.11` |
| `npx astro add tailwind --yes` | adds `@tailwindcss/vite`, no `overrides` block | adds `@tailwindcss/vite` + writes `"overrides": { "vite": "^7" }` |
| `npm install` (re-run) | `vite@8.0.11` still wins | `vite@7.3.3` wins |
| `npm run build` | fails with `tsconfigPaths` error | succeeds |

`pnpm` and `yarn` users are unaffected by the hoist either way; this change does no harm to them. The `overrides` block in `package.json` is respected by npm; pnpm and yarn ignore the npm-style key, but they already resolve nested vite correctly.

The existing `packages/astro/test/tailwindcss.test.ts` continues to pass (it uses pnpm and a workspace-linked vite, so it does not exercise the hoisting path). No new tests added — `astro add` has no existing test coverage in the repo (#16062 also shipped without one).

`pnpm run build` and `pnpm typecheck` clean against the patched tree.

## Docs

No docs change. The existing `clack.box` prompt in `updatePackageJsonOverrides` explains the change inline at run-time, matching the `astro add cloudflare` UX.

## Refs

- Mirrors #16062 (`astro add cloudflare` shipped the same mechanism).
- Closes #16542 (the closed-as-needs-repro tailwind half; reproduction is inline above).
- Related: #16029 (the Cloudflare-half issue).
