### PR TITLE
Triage bot: add unit test step and document shared test utilities

### DIFF
--- a/.agents/skills/triage/comment.md
+++ b/.agents/skills/triage/comment.md
@@ -62,6 +62,7 @@ The comment must start with an at-a-glance summary, followed by short explanatio
 ```markdown
 - **Reproduced:** [Yes / No / Skipped — reason]
 - **Exploration:** [Yes / No / Partial / Already fixed on main] [If `branchName` is non-null: — [View branch](https://github.com/withastro/astro/compare/{branchName}?expand=1)]
+- **Unit Test:** [Yes — `path/to/test.test.ts` / No — reason]
 - **Priority:** [See "Priority" Instructions above. Keep to one line explaining why this priority was chosen, who is likely to be affected, and under what conditions (this section should answer the question: "how bad is it?")]
 
 [2-3 sentences describing the root cause or key observations, or where/when it was already fixed. Be specific about what's happening and where in the codebase.]

--- a/.agents/skills/triage/fix.md
+++ b/.agents/skills/triage/fix.md
@@ -22,10 +22,11 @@ These variables are referenced throughout this skill. They may be passed as args
 3. Implement a minimal fix in `packages/`
 4. Rebuild the affected package(s)
 5. Verify the fix resolves the reproduction
-6. Ensure no regressions
-7. Generate git diff
-8. Append fix details to `report.md`
-9. Clean up the working directory
+6. Write a unit test
+7. Ensure no regressions
+8. Generate git diff
+9. Append fix details to `report.md`
+10. Clean up the working directory
 
 ## Step 1: Review the Diagnosis
 
@@ -40,7 +41,7 @@ Read `report.md` from the `triageDir` directory to understand:
 **Low-confidence path:** If diagnosis confidence is `low` or `null`, or no clear root cause was found → do NOT attempt a code fix. Instead:
 
 1. Identify the most likely area(s) of the codebase related to the issue (files, functions, code paths).
-2. If possible, write a failing test that demonstrates the expected behavior described in the issue. Place it alongside existing tests for that area.
+2. If possible, write a failing unit test that demonstrates the expected behavior described in the issue. Place it in `test/units/` inside the affected package (see Step 6 for conventions and placement rules). A failing test is valuable even without a fix — it documents the bug and prevents it from being forgotten.
 3. If you identified specific code paths, add brief inline comments (prefixed `// TRIAGE:`) near the most relevant lines in `packages/` to help the implementor orient quickly. Keep to 2-3 comments max — these are signposts, not a diagnosis.
 4. Append to `report.md`: the areas you identified, why they seem relevant, and any failing test or comments you added.
 5. Return `fixed: false`.
@@ -109,11 +110,25 @@ Watch for build errors — fix any TypeScript issues before proceeding.
 
 Re-run the reproduction, often using `pnpm run build`/`astro build` or `pnpm run dev`/`astro dev`.
 
-## Step 6: Check for Regressions
+## Step 6: Write a Unit Test
+
+Write a unit test that covers the bug you just fixed. The test should fail without the fix and pass with it. This prevents regressions and documents the expected behavior for maintainers.
+
+Read [`reference/unit-testing.md`](../../reference/unit-testing.md) for conventions, file placement, shared test utilities, and mocks. Name your `it` block after the specific behavior being verified, referencing the issue number for traceability (e.g. `it('handles edge case from issue #1234')`).
+
+Run the test in isolation to confirm it passes:
+
+```bash
+pnpm -C <package-dir> exec astro-scripts test "test/units/<path-to-your-test>.test.ts"
+```
+
+If the test fails, fix either the test or the implementation until it passes. If you cannot write a meaningful unit test (e.g. the bug is in template compilation, requires a full dev server, or the affected code has no importable API), document why in `report.md` and move on — do not force a test that doesn't make sense.
+
+## Step 7: Check for Regressions
 
 Test that you didn't break anything new, and that normal cases still work. If you find regressions, refine the fix to handle all cases.
 
-## Step 7: Generate Git Diff
+## Step 8: Generate Git Diff
 
 From the repository root, generate the diff:
 
@@ -123,7 +138,7 @@ git diff packages/
 
 This captures all your changes for the report.
 
-## Step 8: Write Output
+## Step 9: Write Output
 
 Append your fix details to the existing `report.md` (written by reproduce and diagnose skills).
 
@@ -135,10 +150,11 @@ The report must include all information needed for a final GitHub comment to be 
 - The full git diff (unless it is massive, if it is)
 - Whether the fix was successful or not
 - Verification results (did the fix resolve the original error?)
+- Unit test details: what test was added, where it lives, and what it verifies. If no test was added, explain why.
 - Any alternative approaches considered and their tradeoffs
 - If the fix failed: what was tried and why it didn't work
 
-## Step 9: Clean Up the Working Directory
+## Step 10: Clean Up the Working Directory
 
 1. Run `git status` and review all changed files
 2. Revert any changes that are NOT part of the fix:

--- a/.agents/skills/triage/fix.md
+++ b/.agents/skills/triage/fix.md
@@ -114,7 +114,7 @@ Re-run the reproduction, often using `pnpm run build`/`astro build` or `pnpm run
 
 Write a unit test that covers the bug you just fixed. The test should fail without the fix and pass with it. This prevents regressions and documents the expected behavior for maintainers.
 
-Read [`reference/unit-testing.md`](../../reference/unit-testing.md) for conventions, file placement, shared test utilities, and mocks. Name your `it` block after the specific behavior being verified, referencing the issue number for traceability (e.g. `it('handles edge case from issue #1234')`).
+Read [`reference/unit-testing.md`](../../reference/unit-testing.md) for conventions, file placement, shared test utilities, and mocks. Name your `it` block after the specific behavior being verified (e.g. `it('preserves query params in redirects')`).
 
 Run the test in isolation to confirm it passes:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,10 @@ Note: `agent-browser` should be installed globally, and is not a dependency of t
 
 Detailed reference documents on specific subsystems. Read the relevant section before diving into a bug or feature in that area.
 
+## Unit Testing
+
+When writing unit tests, read [`reference/unit-testing.md`](./reference/unit-testing.md) for conventions, file placement, and the shared test utilities and mocks available in the repo. Do not duplicate existing helpers.
+
 ## Vite Dep Optimizer (`optimizeDeps`)
 
 When a bug works in `astro build` but fails in `astro dev` with errors like `require is not defined`, the root cause is almost always Vite's dep optimizer failing to pre-bundle a CJS dependency. `astro build` uses Rollup and handles CJS→ESM reliably; `astro dev` relies on esbuild's optimizer scan, which is intentionally shallow and will miss deps that are only reachable through non-JS files (like `.astro` components in `node_modules`). The key files are `packages/astro/src/vite-plugin-environment/index.ts` (sets `optimizeDeps.entries`) and `packages/astro/src/core/create-vite.ts` (wires up `vitefu`/`crawlFrameworkPkgs`). For a full deep-dive including a debugging playbook and potential fixes, see [`reference/optimize-deps.md`](./reference/optimize-deps.md).

--- a/reference/unit-testing.md
+++ b/reference/unit-testing.md
@@ -1,0 +1,90 @@
+# Unit Testing
+
+Guide for writing unit tests in the Astro monorepo.
+
+## Location
+
+Unit tests live in `test/units/` inside each package — typically `packages/astro/test/units/`. Tests are organized into subfolders by area (e.g. `render/`, `middleware/`, `content-layer/`, `app/`, `cli/`).
+
+- If a test file already exists for the module you're testing, **add your test case(s) to that file**.
+- If no existing file covers the module, **create a new test file** named `<module-or-feature>.test.ts` in the appropriate subfolder. If no subfolder fits, create one named after the module or feature area.
+
+## Conventions
+
+- Use `node:test` (`describe`, `it`) and `node:assert/strict` — do NOT use vitest, jest, or other test frameworks.
+- Import from the package's **built output** (`../../../dist/...`), not from source (`../../../src/...`). The package must be built before tests run.
+- Keep tests focused and minimal. Test specific behavior, not entire modules.
+
+## Running unit tests
+
+```bash
+# Run a single test file
+pnpm -C <package-dir> exec astro-scripts test "test/units/<path-to-test>.test.ts"
+
+# Run all unit tests for a package
+pnpm -C <package-dir> exec astro-scripts test "test/units/**/*.test.ts"
+
+# Filter by test name
+pnpm -C <package-dir> exec astro-scripts test "test/units/<path>.test.ts" --match "some pattern"
+```
+
+## Shared test utilities
+
+The repo has shared test helpers and mocks. **Always check these before writing your own setup code.** Also browse the existing test files in the relevant `test/units/` subfolder to see what utilities they import and how they use them.
+
+### `test/units/test-utils.ts` — Core infrastructure
+
+| Export | Use when… |
+|---|---|
+| `defaultLogger` | You need a logger instance (pre-configured at `'error'` level). |
+| `SpyLogger` | You need to assert on log output (captures all writes into a `.logs` array). |
+| `createBasicSettings(inlineConfig?)` | You need a real `AstroSettings` object without a full project. |
+| `createBasicPipeline(options?)` | You need a rendering pipeline without a dev server or build. |
+| `createFixture(tree)` | You need real files on disk (creates a temp directory from a file tree object). |
+| `createRequestAndResponse(reqOptions?)` | You need mock HTTP `req`/`res` objects with `.text()` and `.json()` helpers. |
+| `renderThroughMiddleware(state, component, slots?)` | You need to render through the full middleware chain. |
+| `createMockNext(response?)` | You need a mock `next()` for middleware testing. |
+
+### `test/units/mocks.ts` — Mock factories
+
+| Export | Use when… |
+|---|---|
+| `createMockAPIContext(overrides?)` | You need a mock `APIContext` with real cookies, redirect, rewrite. |
+| `createMockFetchState(overrides?)` | You need a minimal `FetchState` for functions that take one. |
+| `createResponseFunction(body?, init?)` | You need a page-rendering function for `callMiddleware`. |
+| `createTestApp(pages, manifestOverrides?)` | You need a real `App` instance with routes wired up. |
+| `createPage(component, routeConfig)` | You need a page entry for `createTestApp`. |
+| `createRedirect(routeConfig)` | You need a redirect route entry for `createTestApp`. |
+| `createEndpoint(handlers, routeConfig)` | You need an endpoint route entry for `createTestApp`. |
+| `createRouteData(overrides)` | You need a `RouteData` object with auto-generated segments. |
+| `spreadPropsSpan` | You need a simple component factory that renders `<span {...props}>`. |
+| `installImageService(overrides?)` | You need to set up a test image service on `globalThis.astroAsset`. |
+| `createMockAstroSource(html)` | You need a minimal `.astro` source string. |
+
+### Domain-specific helpers
+
+Some subfolders have their own `test-helpers.ts` or `utils.ts` with more targeted factories. **Check for these in the subfolder you're writing tests in before creating new mocks:**
+
+- `test/units/app/test-helpers.ts` — `createManifest()`, `createRouteInfo()`
+- `test/units/routing/test-helpers.ts` — `makeRoute()`, `staticPart()`, `dynamicPart()`, `spreadPart()`
+- `test/units/build/test-helpers.ts` — `createSettings()`, `virtualAstroModules()`, `createStaticBuildOptions()`, `createMockPrerenderer()`
+- `test/units/i18n/test-helpers.ts` — `makeI18nRouterConfig()`, `makeRouterContext()`, `createManualRoutingContext()`
+- `test/units/content-layer/test-helpers.ts` — `createTempDir()`, `createTestConfigObserver()`, `createMinimalSettings()`
+- `test/units/cli/utils.ts` — Spy/fake implementations for CLI testing (`SpyCommandExecutor`, `FakePrompt`, etc.)
+
+## Example
+
+```typescript
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { someFunction } from '../../../dist/core/some-module.js';
+import { createBasicSettings } from '../test-utils.ts';
+
+describe('someFunction', () => {
+  it('handles edge case from issue #1234', async () => {
+    const settings = await createBasicSettings({ root: '/tmp/test' });
+    const result = someFunction(settings, edgeCaseInput);
+    assert.equal(result, expectedOutput);
+  });
+});
+```


### PR DESCRIPTION
## Changes

- Adds a new "Write a Unit Test" step to the triage bot's fix skill, so it produces a regression test alongside every fix attempt.
- Creates `reference/unit-testing.md` documenting unit test conventions, file placement, and the shared test utilities/mocks available in the repo. Referenced from `AGENTS.md` so any agent (not just triage) can use it.
- Adds a **Unit Test** line to the triage bot's GitHub comment template.

## Testing

- No test changes — this PR only modifies agent instructions and reference docs.

## Docs

- No user-facing docs needed. `reference/unit-testing.md` is agent-facing only.