### PR TITLE
chore: remove deprecation warning for Astro locals

### DIFF
--- a/.changeset/silly-spoons-write.md
+++ b/.changeset/silly-spoons-write.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Removes deprecations warnings added in Astro v6 for Cloudflare specific Astro.locals properties.

--- a/packages/integrations/cloudflare/src/utils/handler.ts
+++ b/packages/integrations/cloudflare/src/utils/handler.ts
@@ -94,31 +94,6 @@ export async function handle(
 	const locals: Runtime = {
 		cfContext: context,
 	};
-	Object.defineProperty(locals, 'runtime', {
-		enumerable: false,
-		value: {
-			get env(): never {
-				throw new Error(
-					`Astro.locals.runtime.env has been removed in Astro v6. Use 'import { env } from "cloudflare:workers"' instead.`,
-				);
-			},
-			get cf(): never {
-				throw new Error(
-					`Astro.locals.runtime.cf has been removed in Astro v6. Use 'Astro.request.cf' instead.`,
-				);
-			},
-			get caches(): never {
-				throw new Error(
-					`Astro.locals.runtime.caches has been removed in Astro v6. Use the global 'caches' object instead.`,
-				);
-			},
-			get ctx(): never {
-				throw new Error(
-					`Astro.locals.runtime.ctx has been removed in Astro v6. Use 'Astro.locals.cfContext' instead.`,
-				);
-			},
-		},
-	});
 
 	const waitUntil: RenderOptions['waitUntil'] = context.waitUntil.bind(context);
 


### PR DESCRIPTION
- removes deprecrations warning added in v6, for Cloudflare specific Astro.locals properties
- Since v7 is the following major, we can remove the warnings

## Testing

- warnings were not tested
- exisiting test should still succeedd

## Docs

- nothing special needed, just normal v7 migration docs