### PR TITLE
fix(node): match static-header routes by equality instead of substring

### DIFF
--- a/.changeset/node-static-headers-substring-match.md
+++ b/.changeset/node-static-headers-substring-match.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes per-route static headers (e.g. `Content-Security-Policy`) being applied to the wrong prerendered response when one route's pathname is a substring of another's. The static handler was matching header entries with `.includes()` instead of equality, so e.g. a request for `/users` could pick up the headers stored for `/users/profile` depending on Map insertion order.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -74,8 +74,8 @@ export function createStaticHandler(
 					// must strip config.base from the incoming URL before matching, just as
 					// we do for filesystem access above.
 					const baselessPathname = prependForwardSlash(app.removeBase(urlPath));
-					const matchedRoute = headersMap.find((header) =>
-						header.pathname.includes(baselessPathname),
+					const matchedRoute = headersMap.find(
+						(header) => header.pathname === baselessPathname,
 					);
 					if (matchedRoute) {
 						for (const header of matchedRoute.headers) {


### PR DESCRIPTION
## Summary

`createStaticHandler` in `@astrojs/node` looks up per-route static headers (e.g. `Content-Security-Policy`) using `header.pathname.includes(baselessPathname)`. The headers map is keyed by exact prerendered route pathnames written by `core/build/generate.ts` (`routeToHeaders.set(pathname, ...)`), and the comment immediately above the lookup states that headers are *"keyed by base-less route paths"* — so the intent is keyed lookup, not substring matching.

Substring matching causes the wrong headers to be applied whenever one prerendered route's path is a substring of another's:

- Two prerendered routes `/users` and `/users/profile`, each with a different CSP.
- `/users/profile` is inserted into `routeToHeaders` first → it ends up first in the JSON array.
- A request for `/users` matches the route correctly via `app.match`, but `headersMap.find(h => h.pathname.includes("/users"))` returns the `/users/profile` entry.
- The wrong CSP is sent on the `/users` response.

The fix is a one-line change to use `===` instead of `.includes()`.

## Changes

- `packages/integrations/node/src/serve-static.ts`: match `header.pathname` by equality.
- Changeset: `@astrojs/node` patch.

## Test plan

- [ ] `pnpm -C packages/integrations/node test` passes.
- [ ] Manual: build a project with two prerendered routes where one path is a prefix of the other, both emitting different CSPs via the static-headers feature; confirm each route receives its own CSP under `@astrojs/node` standalone.