### PR TITLE
fix(assets): treat SVG width/height of zero as valid dimensions

### DIFF
--- a/.changeset/wet-steaks-repeat.md
+++ b/.changeset/wet-steaks-repeat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where SVG images with `width="0"` or `height="0"` incorrectly threw a `NoImageMetadata` error instead of being treated as valid dimensions.

--- a/packages/astro/src/assets/utils/metadata.ts
+++ b/packages/astro/src/assets/utils/metadata.ts
@@ -23,7 +23,7 @@ export async function imageMetadata(
 			message: AstroErrorData.NoImageMetadata.message(src),
 		});
 	}
-	if (!result.height || !result.width || !result.type) {
+	if (result.height == null || result.width == null || !result.type) {
 		throw new AstroError({
 			...AstroErrorData.NoImageMetadata,
 			message: AstroErrorData.NoImageMetadata.message(src),

--- a/packages/astro/src/assets/utils/vendor/image-size/types/svg.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/svg.ts
@@ -95,7 +95,7 @@ export const SVG: IImage = {
     const root = extractorRegExps.root.exec(toUTF8String(input))
     if (root) {
       const attrs = parseAttributes(root[0])
-      if (attrs.width && attrs.height) {
+      if (attrs.width != null && attrs.height != null) {
         return calculateByDimensions(attrs)
       }
       if (attrs.viewbox) {


### PR DESCRIPTION
## What does this fix?

Closes #16633

SVG elements with explicit `width="0"` or `height="0"` attributes threw `NoImageMetadata: Could not process image metadata` instead of being imported normally. This is a valid and common pattern for SVG filter containers hidden from screen readers:

```html
<svg width="0" height="0" aria-hidden="true">
  <defs>...</defs>
</svg>
```

## Root cause

Two falsy-zero checks along the metadata extraction path:

**`vendor/image-size/types/svg.ts`** — the `calculate()` function:
```ts
// Before: 0 is falsy, so an SVG with width="0" height="0" fell through
if (attrs.width && attrs.height) { ... }

// After: explicit null check allows 0 as a valid dimension
if (attrs.width != null && attrs.height != null) { ... }
```

**`assets/utils/metadata.ts`** — post-probe validation:
```ts
// Before: !0 === true, triggering the error for zero dimensions
if (!result.height || !result.width || !result.type) { ... }

// After: only null/undefined signals a missing value
if (result.height == null || result.width == null || !result.type) { ... }
```

## Changes

- `packages/astro/src/assets/utils/vendor/image-size/types/svg.ts`: replace truthiness check with null check in `calculate()`
- `packages/astro/src/assets/utils/metadata.ts`: replace truthiness check with null check in `imageMetadata()`

Both changes are minimal and surgical — they only affect the specific falsy-zero edge case while leaving all other behavior unchanged. SVGs with missing dimensions (null/undefined) still throw the appropriate error.