### PR TITLE
fix: svg dimmensions bug

### DIFF
--- a/packages/astro/src/assets/utils/metadata.ts
+++ b/packages/astro/src/assets/utils/metadata.ts
@@ -23,7 +23,7 @@ export async function imageMetadata(
 			message: AstroErrorData.NoImageMetadata.message(src),
 		});
 	}
-	if (!result.height || !result.width || !result.type) {
+	if (result.height === null || result.width === null || !result.type) {
 		throw new AstroError({
 			...AstroErrorData.NoImageMetadata,
 			message: AstroErrorData.NoImageMetadata.message(src),

--- a/packages/astro/src/assets/utils/vendor/image-size/types/svg.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/svg.ts
@@ -95,7 +95,7 @@ export const SVG: IImage = {
     const root = extractorRegExps.root.exec(toUTF8String(input))
     if (root) {
       const attrs = parseAttributes(root[0])
-      if (attrs.width && attrs.height) {
+      if (attrs.width !== null && attrs.height !== null) {
         return calculateByDimensions(attrs)
       }
       if (attrs.viewbox) {

--- a/packages/astro/test/core-image-svg.test.ts
+++ b/packages/astro/test/core-image-svg.test.ts
@@ -150,6 +150,37 @@ describe('astro:assets - SVG Components', () => {
 				assert.ok(json.image.src.startsWith('/'));
 			});
 		});
+
+		// test for the components has no dimensions and the metadata is correct
+		describe('Metadata with zero dimensions svg image', () => {
+			it('successfully processes SVG with width="0" and height="0"', async () => {
+      	const res = await fixture.fetch('/zero-dimensions');
+				assert.equal(res.status, 200);
+
+				const html = await res.text();
+				const $ = cheerio.load(html, { xml: true });  
+
+      	const $svg = $('#zero-svg svg');
+				// svg should be rendered with the width and height of 0 as specified in the source file, not overridden by default dimensions
+				assert.equal($svg.length, 1);
+      	assert.equal($svg.attr('width'), '0');
+      	assert.equal($svg.attr('height'), '0');
+    	});
+
+			it('successfully returns metadata for an SVG image with zero dimensions', async () => {
+				const res = await fixture.fetch('/metadata-zero-dimensions.json');
+				const json = await res.json();
+
+				assert.equal(json.image.width, 0);
+				assert.equal(json.image.height, 0);
+				assert.equal(json.image.format, 'svg');
+			});
+
+			it('should not log NoImageMetadata errors for zero dimension svgs', () => {
+				const hasMetadataErrors = logs.some(log => log.message.includes('NoImageMetadata'));
+				assert.equal(hasMetadataErrors, false);
+			})
+		});
 	});
 
 	describe('SVGO optimization', () => {

--- a/packages/astro/test/fixtures/core-image-svg/src/assets/zero.svg
+++ b/packages/astro/test/fixtures/core-image-svg/src/assets/zero.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0">
+  <defs>
+    <filter id="blur">
+      <feGaussianBlur stdDeviation="3"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/astro/test/fixtures/core-image-svg/src/pages/metadata-zero-dimensions.json.ts
+++ b/packages/astro/test/fixtures/core-image-svg/src/pages/metadata-zero-dimensions.json.ts
@@ -1,0 +1,4 @@
+import type { APIRoute } from 'astro';
+import image from '../assets/zero.svg';
+
+export const GET: APIRoute = async () => Response.json({ image });

--- a/packages/astro/test/fixtures/core-image-svg/src/pages/zero-dimensions.astro
+++ b/packages/astro/test/fixtures/core-image-svg/src/pages/zero-dimensions.astro
@@ -1,0 +1,10 @@
+---
+import ZeroSvg from '../assets/zero.svg';
+---
+<html>
+<body>
+	<div id="zero-svg">
+		<ZeroSvg />
+	</div>
+</body>
+</html>


### PR DESCRIPTION
## Changes

issus: #16633

## Testing

### Befor implement testing

<img width="633" height="278" alt="スクリーンショット 2026-05-10 21 18 10" src="https://github.com/user-attachments/assets/5235fcb1-8964-4f26-996f-a448a59f0dfe" />


### After implement testing

<img width="651" height="298" alt="スクリーンショット 2026-05-10 21 13 38" src="https://github.com/user-attachments/assets/1cf3466b-23a4-47e6-93f9-700e5c7786b6" />


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
