### PR TITLE
refactor: address floating promises in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,6 +59,22 @@ const configs = [
 			'@typescript-eslint/switch-exhaustiveness-check': 'error',
 			'@typescript-eslint/no-shadow': 'error',
 
+			'@typescript-eslint/no-floating-promises': [
+				'error',
+				{
+					ignoreIIFE: true,
+					allowForKnownSafeCalls: [
+						// `describe`, `it`, and `test` functions imported from `node:test` return a promise, but it's safe to ignore them in most cases.
+						// See https://github.com/nodejs/node/issues/51292
+						{
+							from: 'package',
+							name: ['suite', 'test', 'it', 'describe', 'skip'],
+							package: 'node:test',
+						},
+					],
+				},
+			],
+
 			// Disabled - now handled by Biome
 			'no-console': 'off', // Biome: suspicious.noConsole
 			'@typescript-eslint/no-unused-vars': 'off', // Biome: correctness.noUnusedVariables
@@ -74,7 +90,6 @@ const configs = [
 			'@typescript-eslint/no-inferrable-types': 'off',
 			'@typescript-eslint/no-base-to-string': 'off',
 			'@typescript-eslint/no-empty-function': 'off',
-			'@typescript-eslint/no-floating-promises': 'off',
 			'@typescript-eslint/no-misused-promises': 'off',
 			'@typescript-eslint/no-redundant-type-constituents': 'off',
 			'@typescript-eslint/no-this-alias': 'off',
@@ -109,6 +124,13 @@ const configs = [
 			globals: {
 				browser: true,
 			},
+		},
+	},
+	{
+		files: ['packages/**/src/**/*.ts'],
+		rules: {
+			// Disable "no-floating-promises" rule for all source files until we have the bandwidth to address all the errors.
+			'@typescript-eslint/no-floating-promises': 'off',
 		},
 	},
 	{

--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -57,7 +57,7 @@ test.describe('Dev Toolbar - Audits', () => {
 		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
 		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
 
-		expect(auditHighlights).toHaveCount(1);
+		await expect(auditHighlights).toHaveCount(1);
 
 		await page.click('body');
 
@@ -67,7 +67,7 @@ test.describe('Dev Toolbar - Audits', () => {
 
 		await appButton.click();
 
-		expect(auditHighlights).toHaveCount(1);
+		await expect(auditHighlights).toHaveCount(1);
 	});
 
 	test('does not warn about perf issue for below the fold image in relative container', async ({
@@ -83,7 +83,7 @@ test.describe('Dev Toolbar - Audits', () => {
 		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
 		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
 
-		expect(auditHighlights).toHaveCount(0);
+		await expect(auditHighlights).toHaveCount(0);
 	});
 
 	test('can warn about perf issue for below the fold image in absolute container', async ({
@@ -99,7 +99,7 @@ test.describe('Dev Toolbar - Audits', () => {
 		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
 		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
 
-		expect(auditHighlights).toHaveCount(1);
+		await expect(auditHighlights).toHaveCount(1);
 	});
 
 	test('does not warn about image inside framework component', async ({ page, astro }) => {

--- a/packages/astro/e2e/view-transitions.test.ts
+++ b/packages/astro/e2e/view-transitions.test.ts
@@ -1510,7 +1510,7 @@ test.describe('View Transitions', () => {
 		const expectedAnimations = new Set();
 		const checkName = async (selector: string, name: string) => {
 			expectedAnimations.add(name);
-			expect(page.locator(selector), 'should be escaped correctly').toHaveCSS(
+			await expect(page.locator(selector), 'should be escaped correctly').toHaveCSS(
 				'view-transition-name',
 				name,
 			);

--- a/packages/astro/test/build-readonly-file.test.ts
+++ b/packages/astro/test/build-readonly-file.test.ts
@@ -22,9 +22,9 @@ describe('When a read-only file exists in /public (static)', () => {
 		await fixture.build();
 	});
 
-	after(() => {
+	after(async () => {
 		fs.chmodSync(testFilePath, 0o666);
-		fixture.clean();
+		await fixture.clean();
 	});
 });
 
@@ -47,8 +47,8 @@ describe('When a read-only file exists in /public (server)', () => {
 		await fixture.build();
 	});
 
-	after(() => {
+	after(async () => {
 		fs.chmodSync(testFilePath, 0o666);
-		fixture.clean();
+		await fixture.clean();
 	});
 });

--- a/packages/astro/test/content-collection-references.test.ts
+++ b/packages/astro/test/content-collection-references.test.ts
@@ -72,7 +72,7 @@ describe('Content Collections - references', () => {
 			});
 
 			after(async () => {
-				if (mode === 'dev') devServer?.stop();
+				if (mode === 'dev') await devServer?.stop();
 			});
 
 			describe(`JSON result`, () => {

--- a/packages/astro/test/data-collections-schema.test.ts
+++ b/packages/astro/test/data-collections-schema.test.ts
@@ -10,7 +10,7 @@ describe('Content Collections - data collections', () => {
 			root: './fixtures/data-collections-schema/',
 			outDir: './dist/data-collections-schema/',
 		});
-		removeDir(new URL('./fixtures/data-collections-schema/.astro', import.meta.url));
+		await removeDir(new URL('./fixtures/data-collections-schema/.astro', import.meta.url));
 		await fixture.build({});
 	});
 

--- a/packages/astro/test/live-loaders.test.ts
+++ b/packages/astro/test/live-loaders.test.ts
@@ -36,7 +36,7 @@ describe('Live content collections', () => {
 		});
 
 		after(async () => {
-			devServer?.stop();
+			await devServer?.stop();
 		});
 
 		it('can load live data', async () => {

--- a/packages/astro/test/request-signal.test.ts
+++ b/packages/astro/test/request-signal.test.ts
@@ -4,7 +4,7 @@ import { after, before, describe, it } from 'node:test';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { createRequestAndResponse } from './integration-test-helpers.ts';
-import { type Fixture, loadFixture } from './test-utils.ts';
+import { type Fixture, loadFixture, type RequestHandler } from './test-utils.ts';
 
 type MockSocket = EventEmitter & {
 	encrypted: boolean;
@@ -42,7 +42,7 @@ const attachSocket = (socket: MockSocket, req: IncomingMessage, res: ServerRespo
 
 describe('Node request abort integration', () => {
 	let fixture: Fixture;
-	let handle: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+	let handle: RequestHandler;
 
 	const resetAbortState = async () => {
 		const resetRequest = createRequestAndResponse({

--- a/packages/astro/test/test-utils.ts
+++ b/packages/astro/test/test-utils.ts
@@ -38,7 +38,9 @@ export type RequestHandler = (
 	res: ServerResponse,
 	next?: (err?: unknown) => void,
 	locals?: object,
-) => void | Promise<void>;
+	// We use `PromiseLike` instead of `Promise` as the return type to bypass the `no-floating-promises` eslint rule.
+	// See https://typescript-eslint.io/rules/no-floating-promises/
+) => void | PromiseLike<void>;
 
 // `startServer` is defined in `@astrojs/node` so we cannot import it directly.
 // See https://github.com/withastro/astro/blob/astro@6.0.0/packages/integrations/node/src/server.ts#L21

--- a/packages/astro/test/units/config/config-validate.test.ts
+++ b/packages/astro/test/units/config/config-validate.test.ts
@@ -340,8 +340,8 @@ describe('Config Validation', () => {
 	});
 
 	describe('env', () => {
-		it('Should allow not providing a schema', () => {
-			assert.doesNotThrow(() =>
+		it('Should allow not providing a schema', async () => {
+			await assert.doesNotReject(() =>
 				validateConfig({
 					env: {
 						schema: undefined,
@@ -350,8 +350,8 @@ describe('Config Validation', () => {
 			);
 		});
 
-		it('Should allow schema variables with numbers', () => {
-			assert.doesNotThrow(() =>
+		it('Should allow schema variables with numbers', async () => {
+			await assert.doesNotReject(() =>
 				validateConfig({
 					env: {
 						schema: {
@@ -401,8 +401,8 @@ describe('Config Validation', () => {
 	});
 
 	describe('fonts', () => {
-		it('Should allow empty fonts', () => {
-			assert.doesNotThrow(() =>
+		it('Should allow empty fonts', async () => {
+			await assert.doesNotReject(() =>
 				validateConfig({
 					fonts: [],
 				}),
@@ -478,7 +478,7 @@ describe('Config Validation', () => {
 				true,
 			);
 
-			assert.doesNotThrow(() =>
+			await assert.doesNotReject(() =>
 				validateConfig({
 					fonts: [
 						{
@@ -491,8 +491,8 @@ describe('Config Validation', () => {
 			);
 		});
 
-		it('Should allow empty font fallbacks', () => {
-			assert.doesNotThrow(() =>
+		it('Should allow empty font fallbacks', async () => {
+			await assert.doesNotReject(() =>
 				validateConfig({
 					fonts: [
 						{
@@ -506,8 +506,8 @@ describe('Config Validation', () => {
 			);
 		});
 
-		it('Should allow family options', () => {
-			assert.doesNotThrow(() =>
+		it('Should allow family options', async () => {
+			await assert.doesNotReject(() =>
 				validateConfig({
 					fonts: [
 						{
@@ -578,7 +578,7 @@ describe('Config Validation', () => {
 		});
 
 		it('should not throw an error for correct hashes', async () => {
-			assert.doesNotThrow(() => {
+			await assert.doesNotReject(async () =>
 				validateConfig({
 					security: {
 						csp: {
@@ -587,19 +587,19 @@ describe('Config Validation', () => {
 							},
 						},
 					},
-				});
-			});
+				}),
+			);
 		});
 
-		it('should throw an error when the directives are correct', () => {
-			assert.doesNotThrow(() =>
+		it('should throw an error when the directives are correct', async () => {
+			await assert.doesNotReject(() =>
 				validateConfig({
 					security: {
 						csp: {
-							directives: ["image-src 'self'"],
+							directives: ["img-src 'self'"],
 						},
 					},
-				}).catch((err) => err),
+				}),
 			);
 		});
 

--- a/packages/create-astro/create-astro.mjs
+++ b/packages/create-astro/create-astro.mjs
@@ -12,4 +12,4 @@ if (requiredMajorVersion < minimumMajorVersion) {
 	process.exit(1);
 }
 
-import('./dist/index.js').then(({ main }) => main());
+void import('./dist/index.js').then(({ main }) => main());

--- a/packages/integrations/markdoc/test/propagated-assets.test.ts
+++ b/packages/integrations/markdoc/test/propagated-assets.test.ts
@@ -36,7 +36,7 @@ describe('Markdoc - propagated assets', () => {
 			});
 
 			after(async () => {
-				if (mode === 'dev') devServer?.stop();
+				if (mode === 'dev') await devServer?.stop();
 			});
 
 			it('Bundles styles', async () => {

--- a/packages/integrations/node/test/node-middleware-listener-cleanup.test.ts
+++ b/packages/integrations/node/test/node-middleware-listener-cleanup.test.ts
@@ -32,7 +32,7 @@ describe('Node middleware socket listener cleanup', () => {
 	});
 
 	after(async () => {
-		server.close();
+		await server.close();
 		await fixture.clean();
 	});
 

--- a/packages/integrations/node/test/node-middleware.test.ts
+++ b/packages/integrations/node/test/node-middleware.test.ts
@@ -154,7 +154,7 @@ describe('behavior from middleware, middleware with fastify', () => {
 	});
 
 	after(async () => {
-		server.close();
+		await server.close();
 		await fixture.clean();
 	});
 
@@ -244,7 +244,7 @@ describe('middleware with fastify and catch-all route: SSR assets in manifest', 
 	});
 
 	after(async () => {
-		server.close();
+		await server.close();
 		await fixture.clean();
 	});
 

--- a/packages/language-tools/vscode/scripts/build.mjs
+++ b/packages/language-tools/vscode/scripts/build.mjs
@@ -72,8 +72,8 @@ export default async function build() {
 	await builder.watch();
 
 	process.on('beforeExit', () => {
-		builder.dispose && builder.dispose();
+		void builder.dispose?.();
 	});
 }
 
-build();
+void build();

--- a/packages/language-tools/vscode/test/grammar/test.mjs
+++ b/packages/language-tools/vscode/test/grammar/test.mjs
@@ -56,4 +56,4 @@ async function snapShotTest() {
 	}
 }
 
-snapShotTest();
+void snapShotTest();

--- a/packages/upgrade/upgrade.mjs
+++ b/packages/upgrade/upgrade.mjs
@@ -12,4 +12,4 @@ if (requiredMajorVersion < minimumMajorVersion) {
 	process.exit(1);
 }
 
-import('./dist/index.js').then(({ main }) => main());
+void import('./dist/index.js').then(({ main }) => main());


### PR DESCRIPTION
## Changes

- Applied `@typescript-eslint/no-floating-promises` rule to all tests;
- Fixed all issues to pass ESLint. Check my code comments / PR comments for details. 
- This PR is the first step. I eventually want to apply the rule to all code, including package sources.

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
