### PR TITLE
Treat the internal 'astro' Vite environment as a server environment

### DIFF
--- a/.changeset/astro-env-treated-as-server.md
+++ b/.changeset/astro-env-treated-as-server.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `HTMLElement is not defined` error during HMR when using components with client-side scripts (e.g. Starlight `<Tabs>`) and the Cloudflare adapter

--- a/packages/astro/src/environments.ts
+++ b/packages/astro/src/environments.ts
@@ -4,7 +4,8 @@ import { ASTRO_VITE_ENVIRONMENT_NAMES } from './core/constants.js';
 export function isAstroServerEnvironment(environment: Environment) {
 	return (
 		environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr ||
-		environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.prerender
+		environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.prerender ||
+		environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.astro
 	);
 }
 

--- a/packages/astro/test/units/environments.test.ts
+++ b/packages/astro/test/units/environments.test.ts
@@ -1,0 +1,39 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { Environment } from 'vite';
+import { isAstroClientEnvironment, isAstroServerEnvironment } from '../../dist/environments.js';
+
+/** Create a minimal mock Environment with only the `name` property. */
+function env(name: string) {
+	return { name } as unknown as Environment;
+}
+
+describe('isAstroServerEnvironment', () => {
+	it('should return true for the ssr environment', () => {
+		assert.equal(isAstroServerEnvironment(env('ssr')), true);
+	});
+
+	it('should return true for the prerender environment', () => {
+		assert.equal(isAstroServerEnvironment(env('prerender')), true);
+	});
+
+	it('should return true for the astro environment', () => {
+		assert.equal(isAstroServerEnvironment(env('astro')), true);
+	});
+
+	it('should return false for the client environment', () => {
+		assert.equal(isAstroServerEnvironment(env('client')), false);
+	});
+});
+
+describe('isAstroClientEnvironment', () => {
+	it('should return true for the client environment', () => {
+		assert.equal(isAstroClientEnvironment(env('client')), true);
+	});
+
+	it('should return false for server environments', () => {
+		assert.equal(isAstroClientEnvironment(env('ssr')), false);
+		assert.equal(isAstroClientEnvironment(env('prerender')), false);
+		assert.equal(isAstroClientEnvironment(env('astro')), false);
+	});
+});


### PR DESCRIPTION
## Changes

- Adds `ASTRO_VITE_ENVIRONMENT_NAMES.astro` to `isAstroServerEnvironment()` in `packages/astro/src/environments.ts`. The internal `'astro'` environment is a Node.js fallback used when the `'ssr'` environment is not runnable (e.g. Cloudflare adapter with workerd). Without this, Vite plugins like the script loader served actual client-side script content in this environment, causing `HTMLElement is not defined` crashes on HMR reload.

Closes #16626

## Testing

- New unit test `packages/astro/test/units/environments.test.ts` covering `isAstroServerEnvironment` and `isAstroClientEnvironment` for all four environment names (`ssr`, `prerender`, `astro`, `client`).

## Docs

- No docs update needed — this is an internal bug fix with no API change.