### PR TITLE
fix(docs): replace last occurrences of `withastro/adapters`

### DIFF
--- a/.changeset/thick-trains-talk.md
+++ b/.changeset/thick-trains-talk.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/netlify': patch
+---
+
+Fixes a link in the documentation specifying where to open an issue for the adapter.

--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -34,5 +34,5 @@ Copyright (c) 2023–present [Astro][astro]
 [coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
 [community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md
 [discord]: https://astro.build/chat/
-[issues]: https://github.com/withastro/adapter/issues
+[issues]: https://github.com/withastro/astro/issues
 [astro-integration]: https://docs.astro.build/en/guides/integrations/

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -34,5 +34,5 @@ Copyright (c) 2023–present [Astro][astro]
 [coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
 [community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md
 [discord]: https://astro.build/chat/
-[issues]: https://github.com/withastro/adapter/issues
+[issues]: https://github.com/withastro/astro/issues
 [astro-integration]: https://docs.astro.build/en/guides/integrations/


### PR DESCRIPTION
## Changes

Replaces two links saying to open an issue in the `withastro/adapters` repo for Cloudflare and Netlify. I guess we miss them because of the typo! (`withastro/adapter` instead of `withastro/adapters`).

For context I was looking why the triage bot said that the adapter was not living in this repository in #16692. Except those two occurrences, I couldn't find much: the remaining `withastro/adapters` mentions are in the CHANGELOGs and we do not want to replace those links.

## Testing

N/A

## Docs

Changeset added because we'll need a new version to ship the fixed READMEs.
