### PR TITLE
refactor: remove redudant assertions

### DIFF
--- a/packages/astro/test/astro-cookies.test.ts
+++ b/packages/astro/test/astro-cookies.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.ts';
-import { type App, type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type App, type Fixture, loadFixture } from './test-utils.ts';
 
 describe('Astro.cookies', () => {
 	let fixture: Fixture;
@@ -13,68 +13,6 @@ describe('Astro.cookies', () => {
 			output: 'server',
 			adapter: testAdapter(),
 			outDir: './dist/astro-cookies/',
-		});
-	});
-
-	describe('Development', () => {
-		let devServer: DevServer;
-
-		before(async () => {
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('is able to get cookies from the request', async () => {
-			const response = await fixture.fetch('/get-json', {
-				headers: {
-					cookie: `prefs=${encodeURIComponent(JSON.stringify({ mode: 'light' }))}`,
-				},
-			});
-			assert.equal(response.status, 200);
-			const html = await response.text();
-
-			const $ = cheerio.load(html);
-			assert.equal($('dd').text(), 'light');
-		});
-
-		it('can set the cookie value', async () => {
-			const response = await fixture.fetch('/set-value', {
-				method: 'POST',
-			});
-			assert.equal(response.status, 200);
-			// Bug in 18.14.1 where `set-cookie` will not be defined
-			// Should be fixed in 18.14.2
-			if (process.versions.node !== '18.14.1') {
-				assert.equal(response.headers.has('set-cookie'), true);
-			}
-		});
-
-		it('can set cookies in a rewritten page request', async () => {
-			const response = await fixture.fetch('/from');
-			assert.equal(response.status, 200);
-
-			assert.match(response.headers.get('set-cookie')!, /my_cookie=value/);
-		});
-
-		it('overwrites cookie values set in the source page with values from the target page', async () => {
-			const response = await fixture.fetch('/from');
-			assert.equal(response.status, 200);
-			assert.match(response.headers.get('set-cookie')!, /another=set-in-target/);
-		});
-
-		it('allows cookies to be set in the source page', async () => {
-			const response = await fixture.fetch('/from');
-			assert.equal(response.status, 200);
-			assert.match(response.headers.get('set-cookie')!, /set-in-from=yes/);
-		});
-
-		it('can set cookies in a rewritten endpoint request', async () => {
-			const response = await fixture.fetch('/from-endpoint');
-			assert.equal(response.status, 200);
-			assert.match(response.headers.get('set-cookie')!, /test=value/);
 		});
 	});
 

--- a/packages/astro/test/astro-global.test.ts
+++ b/packages/astro/test/astro-global.test.ts
@@ -27,18 +27,6 @@ describe('Astro Global', () => {
 			await devServer.stop();
 		});
 
-		it('Astro.request.url', async () => {
-			const res = await await fixture.fetch('/blog/?foo=42');
-			assert.equal(res.status, 200);
-
-			const html = await res.text();
-			const $ = cheerio.load(html);
-			assert.equal($('#pathname').text(), '/blog/');
-			assert.equal($('#searchparams').text(), '{}');
-			assert.equal($('#child-pathname').text(), '/blog/');
-			assert.equal($('#nested-child-pathname').text(), '/blog/');
-		});
-
 		it('import.meta.glob() returned `url` metadata of each markdown file extensions DOES NOT include the extension', async () => {
 			const html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
 			const $ = cheerio.load(html);
@@ -46,27 +34,6 @@ describe('Astro Global', () => {
 				$('[data-any-url-contains-extension]').data('any-url-contains-extension'),
 				false,
 			);
-		});
-
-		it('Astro.routePattern has the right value in pages and components', async () => {
-			let html = await fixture.fetch('/blog').then((res) => res.text());
-			let $ = cheerio.load(html);
-			assert.match($('#pattern').text(), /Astro route pattern: \//);
-			assert.match($('#pattern-middleware').text(), /Astro route pattern middleware: \//);
-			html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
-			$ = cheerio.load(html);
-			assert.match($('#pattern').text(), /Astro route pattern: \/omit-markdown-extensions/);
-			assert.match(
-				$('#pattern-middleware').text(),
-				/Astro route pattern middleware: \/omit-markdown-extensions/,
-			);
-		});
-
-		it('Astro.isPrerendered has the right value in pages and components', async () => {
-			let html = await fixture.fetch('/blog', {}).then((res) => res.text());
-			let $ = cheerio.load(html);
-			assert.match($('#prerender').text(), /Astro route prerender: true/);
-			assert.match($('#prerender-middleware').text(), /Astro route prerender middleware: true/);
 		});
 	});
 

--- a/packages/astro/test/astro-markdown.test.ts
+++ b/packages/astro/test/astro-markdown.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { type DevServer, type Fixture, fixLineEndings, loadFixture } from './test-utils.ts';
+import { type Fixture, fixLineEndings, loadFixture } from './test-utils.ts';
 
 const FIXTURE_ROOT = './fixtures/astro-markdown/';
 
@@ -173,26 +173,6 @@ describe('Astro Markdown', () => {
 			const { title = '' } = JSON.parse(await fixture.readFile('/vite-env-vars-glob.json'));
 			assert.ok(title.includes('import.meta.env.SITE'));
 			assert.ok(title.includes('import.meta.env.TITLE'));
-		});
-	});
-
-	describe('dev', () => {
-		let devServer: DevServer;
-
-		before(async () => {
-			devServer = await fixture.startDevServer();
-		});
-
-		it('ignores .md extensions on query params', async () => {
-			const res = await fixture.fetch('/false-positive?page=page.md');
-			assert.ok(res.ok);
-			const html = await res.text();
-			const $ = cheerio.load(html);
-			assert.equal($('p').text(), 'the page is not markdown');
-		});
-
-		after(async () => {
-			await devServer.stop();
 		});
 	});
 });

--- a/packages/astro/test/astro-not-response.test.ts
+++ b/packages/astro/test/astro-not-response.test.ts
@@ -1,23 +1,15 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
-import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
-// Asset bundling
 describe('Not returning responses', () => {
 	let fixture: Fixture;
-	let devServer: DevServer;
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/astro-not-response/',
 			outDir: './dist/astro-not-response/',
 		});
-
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
 	});
 
 	it('Does not work from a page', async () => {

--- a/packages/astro/test/debug-component.test.ts
+++ b/packages/astro/test/debug-component.test.ts
@@ -1,28 +1,23 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
-import { type DevServer, type Fixture, isMacOS, loadFixture } from './test-utils.ts';
+import { before, describe, it } from 'node:test';
+import { type Fixture, isMacOS, loadFixture } from './test-utils.ts';
 
 // TODO: fix this tests in macOS
 if (!isMacOS) {
 	describe('<Debug />', () => {
 		let fixture: Fixture;
-		let devServer: DevServer;
 
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/debug-component/',
 				outDir: './dist/debug-component/',
 			});
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
+			await fixture.build();
 		});
 
 		it('Works in markdown pages', async () => {
-			const response = await fixture.fetch('/posts/first');
-			assert.equal(response.status, 200);
+			const html = await fixture.readFile('/posts/first/index.html');
+			assert.ok(html, 'Page should build successfully');
 		});
 	});
 }

--- a/packages/astro/test/endpoint-routing.test.ts
+++ b/packages/astro/test/endpoint-routing.test.ts
@@ -31,15 +31,4 @@ describe('endpoints', () => {
 		assert.equal(res.status, 307);
 	});
 
-	it('should remove internally-used header for HTTP status 404', async () => {
-		const res = await fixture.fetch('/not-found');
-		assert.equal(res.headers.get('x-astro-reroute'), null);
-		assert.equal(res.status, 404);
-	});
-
-	it('should remove internally-used header for HTTP status 500', async () => {
-		const res = await fixture.fetch('/internal-error');
-		assert.equal(res.headers.get('x-astro-reroute'), null);
-		assert.equal(res.status, 500);
-	});
 });

--- a/packages/astro/test/endpoint-routing.test.ts
+++ b/packages/astro/test/endpoint-routing.test.ts
@@ -30,5 +30,4 @@ describe('endpoints', () => {
 		assert.equal(res.headers.get('location'), 'https://example.com/destination');
 		assert.equal(res.status, 307);
 	});
-
 });

--- a/packages/astro/test/endpoint-runtime.test.ts
+++ b/packages/astro/test/endpoint-runtime.test.ts
@@ -23,11 +23,6 @@ describe('endpoints', () => {
 		assert.equal(res.status, 500);
 	});
 
-	it('should respond with 404 if GET is not implemented', async () => {
-		const res = await fixture.fetch('/incorrect-route', { method: 'HEAD' });
-		assert.equal(res.status, 404);
-	});
-
 	it('should respond with same code as GET response', async () => {
 		const res = await fixture.fetch('/incorrect', { method: 'HEAD' });
 		assert.equal(res.status, 500);

--- a/packages/astro/test/html-component.test.ts
+++ b/packages/astro/test/html-component.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
 describe('HTML Component', () => {
 	let fixture: Fixture;
@@ -20,33 +20,6 @@ describe('HTML Component', () => {
 
 		it('works', async () => {
 			const html = await fixture.readFile('/index.html');
-			const $ = cheerio.load(html);
-
-			const h1 = $('h1');
-			const foo = $('#foo');
-
-			assert.equal(h1.text(), 'Hello component!');
-			assert.equal(foo.text(), 'bar');
-		});
-	});
-
-	describe('dev', () => {
-		let devServer: DevServer;
-
-		before(async () => {
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('works', async () => {
-			const res = await fixture.fetch('/');
-
-			assert.equal(res.status, 200);
-
-			const html = await res.text();
 			const $ = cheerio.load(html);
 
 			const h1 = $('h1');

--- a/packages/astro/test/html-escape.test.ts
+++ b/packages/astro/test/html-escape.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
 describe('HTML Escape', () => {
 	let fixture: Fixture;
@@ -63,39 +63,6 @@ describe('HTML Escape', () => {
 			const scriptOut = $b('script');
 
 			assert.equal(scriptOut.text(), scriptIn.text());
-		});
-	});
-
-	describe('dev', () => {
-		let devServer: DevServer;
-
-		before(async () => {
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('escapes template literals in HTML components', async () => {
-			const res = await fixture.fetch('/');
-			assert.equal(res.status, 200);
-
-			const html = await res.text();
-			const $ = cheerio.load(html);
-
-			// Verify that template literal characters are properly escaped and rendered
-			const div = $('div');
-			assert.equal(div.text(), '${foo}');
-
-			const span = $('span');
-			assert.equal(span.attr('${attr}'), '');
-
-			const ce = $('custom-element');
-			assert.equal(ce.attr('x-data'), '`${test}`');
-
-			const script = $('script');
-			assert.equal(script.text(), 'console.log(`hello ${"world"}!`)');
 		});
 	});
 });

--- a/packages/astro/test/html-page.test.ts
+++ b/packages/astro/test/html-page.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
 describe('HTML Page', () => {
 	let fixture: Fixture;
@@ -20,31 +20,6 @@ describe('HTML Page', () => {
 
 		it('works', async () => {
 			const html = await fixture.readFile('/index.html');
-			const $ = cheerio.load(html);
-
-			const h1 = $('h1');
-
-			assert.equal(h1.text(), 'Hello page!');
-		});
-	});
-
-	describe('dev', () => {
-		let devServer: DevServer;
-
-		before(async () => {
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('works', async () => {
-			const res = await fixture.fetch('/');
-
-			assert.equal(res.status, 200);
-
-			const html = await res.text();
 			const $ = cheerio.load(html);
 
 			const h1 = $('h1');

--- a/packages/astro/test/html-slots.test.ts
+++ b/packages/astro/test/html-slots.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
 describe('HTML Slots', () => {
 	let fixture: Fixture;
@@ -38,48 +38,6 @@ describe('HTML Slots', () => {
 
 		it('preserves inline slots', async () => {
 			const html = await fixture.readFile('/index.html');
-			const $ = cheerio.load(html);
-
-			const inline = $('#inline');
-			assert.equal(inline.html(), '<slot is:inline=""></slot>');
-		});
-	});
-
-	describe('dev', () => {
-		let devServer: DevServer;
-
-		before(async () => {
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('renders slot content from parent components', async () => {
-			const res = await fixture.fetch('/');
-			assert.equal(res.status, 200);
-
-			const html = await res.text();
-			const $ = cheerio.load(html);
-
-			// Test that slot content is properly passed and rendered
-			const slotDefault = $('#default');
-			assert.equal(slotDefault.text(), 'Default');
-
-			const a = $('#a');
-			assert.equal(a.text().trim(), 'A');
-
-			const b = $('#b');
-			assert.equal(b.text().trim(), 'B');
-
-			const c = $('#c');
-			assert.equal(c.text().trim(), 'C');
-		});
-
-		it('preserves inline slots', async () => {
-			const res = await fixture.fetch('/');
-			const html = await res.text();
 			const $ = cheerio.load(html);
 
 			const inline = $('#inline');

--- a/packages/astro/test/middleware.test.ts
+++ b/packages/astro/test/middleware.test.ts
@@ -182,4 +182,3 @@ describe('Middleware with tailwind', () => {
 		assert.equal(bundledCSS.includes('--tw'), true);
 	});
 });
-

--- a/packages/astro/test/middleware.test.ts
+++ b/packages/astro/test/middleware.test.ts
@@ -6,7 +6,7 @@ import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.ts';
 import { type App, type DevServer, type Fixture, loadFixture } from './test-utils.ts';
 
-describe('Middleware in DEV mode', () => {
+describe('Middleware in DEV mode — integration hooks', () => {
 	let fixture: Fixture;
 	let devServer: DevServer;
 
@@ -22,30 +22,16 @@ describe('Middleware in DEV mode', () => {
 		await devServer.stop();
 	});
 
-	describe('Path encoding in middleware', () => {
-		it('should reject double-encoded paths with 400', async () => {
-			const res = await fixture.fetch('/%2561dmin', { redirect: 'manual' });
-			assert.equal(res.status, 400);
-		});
-
-		it('should reject triple-encoded paths with 400', async () => {
-			const res = await fixture.fetch('/%252561dmin', { redirect: 'manual' });
-			assert.equal(res.status, 400);
-		});
+	it('Integration middleware marked as "pre" runs', async () => {
+		const res = await fixture.fetch('/integration-pre');
+		const json = await res.json();
+		assert.equal(json.pre, 'works');
 	});
 
-	describe('Integration hooks', () => {
-		it('Integration middleware marked as "pre" runs', async () => {
-			const res = await fixture.fetch('/integration-pre');
-			const json = await res.json();
-			assert.equal(json.pre, 'works');
-		});
-
-		it('Integration middleware marked as "post" runs', async () => {
-			const res = await fixture.fetch('/integration-post');
-			const json = await res.json();
-			assert.equal(json.post, 'works');
-		});
+	it('Integration middleware marked as "post" runs', async () => {
+		const res = await fixture.fetch('/integration-post');
+		const json = await res.json();
+		assert.equal(json.post, 'works');
 	});
 });
 
@@ -197,28 +183,3 @@ describe('Middleware with tailwind', () => {
 	});
 });
 
-describe('Middleware sequence rewrites', () => {
-	let fixture: Fixture;
-	let devServer: DevServer;
-
-	before(async () => {
-		fixture = await loadFixture({
-			root: './fixtures/middleware-sequence-rewrite/',
-			outDir: './dist/middleware-middleware-sequence-rewrites/',
-		});
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
-	});
-
-	it('should preserve cookies set in sequence', async () => {
-		const res = await fixture.fetch('/');
-		const html = await res.text();
-		assert.ok(html.includes('Hello Another'));
-		const setCookie = res.headers.get('set-cookie')!;
-		assert.ok(setCookie.includes('cookie1=Cookie%20from%20middleware%201'));
-		assert.ok(setCookie.includes('cookie2=Cookie%20from%20middleware%202'));
-	});
-});

--- a/packages/astro/test/partials.test.ts
+++ b/packages/astro/test/partials.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
-import * as cheerio from 'cheerio';
-import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
 
 describe('Partials', () => {
 	let fixture: Fixture;
@@ -10,29 +9,6 @@ describe('Partials', () => {
 		fixture = await loadFixture({
 			root: './fixtures/partials/',
 			outDir: './dist/partials/',
-		});
-	});
-
-	describe('dev', () => {
-		let devServer: DevServer;
-
-		before(async () => {
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('is only the written HTML', async () => {
-			const html = await fixture.fetch('/partials/item/').then((res) => res.text());
-			assert.equal(html.startsWith('<li'), true);
-		});
-
-		it('Nested conditionals render', async () => {
-			const html = await fixture.fetch('/partials/nested-conditional/').then((res) => res.text());
-			const $ = cheerio.load(html);
-			assert.equal($('#true').text(), 'test');
 		});
 	});
 

--- a/packages/astro/test/rewrite.test.ts
+++ b/packages/astro/test/rewrite.test.ts
@@ -3,66 +3,7 @@ import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
 
-describe('Dev rewrite, trailing slash -> never', () => {
-	let fixture: Fixture;
-	let devServer: DevServer;
-
-	before(async () => {
-		fixture = await loadFixture({
-			root: './fixtures/rewrite-trailing-slash-never/',
-			outDir: './dist/rewrite-dev-rewrite-trailing-slash-never/',
-		});
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
-	});
-
-	it('should rewrite to the homepage', async () => {
-		const html = await fixture.fetch('/foo').then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.equal($('h1').text(), 'Index');
-	});
-});
-
-describe('Dev rewrite, trailing slash -> never, with base', () => {
-	let fixture: Fixture;
-	let devServer: DevServer;
-
-	before(async () => {
-		fixture = await loadFixture({
-			root: './fixtures/rewrite-trailing-slash-never/',
-			base: 'base',
-			outDir: './dist/rewrite-dev-rewrite-trailing-slash-never-with-ba/',
-		});
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
-	});
-
-	it('should rewrite to the homepage', async () => {
-		const html = await fixture.fetch('/base/foo').then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.equal($('h1').text(), 'Index');
-		assert.equal($('p').text(), '/base');
-	});
-
-	it('should rewrite and always include base', async () => {
-		//rewrite('/') will rewrite to '/base'
-		const html = await fixture.fetch('/base/bar').then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.equal($('h1').text(), 'Index');
-		assert.equal($('p').text(), '/base');
-	});
-});
-
-describe('Dev rewrite, hybrid/server', () => {
+describe('Dev rewrite, hybrid/server — dev-specific errors', () => {
 	let fixture: Fixture;
 	let devServer: DevServer;
 
@@ -78,29 +19,6 @@ describe('Dev rewrite, hybrid/server', () => {
 		await devServer.stop();
 	});
 
-	it('should rewrite the [slug]/title ', async () => {
-		const html = await fixture.fetch('/').then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.match($('h1').text(), /Title/);
-		assert.match($('p').text(), /some-slug/);
-	});
-
-	it('should display an error if a rewrite is attempted after the body has been consumed', async () => {
-		const formData = new FormData();
-		formData.append('email', 'example@example.com');
-
-		const request = new Request('http://example.com/post/post-body-used', {
-			method: 'POST',
-			body: formData,
-		});
-		const response = await fixture.fetch('/post/post-body-used', request);
-		const html = await response.text();
-		const $ = cheerioLoad(html);
-
-		assert.equal($('title').text(), 'RewriteWithBodyUsed');
-	});
-
 	it('should error when rewriting from a SSR route to a SSG route', async () => {
 		const html = await fixture.fetch('/forbidden/dynamic').then((res) => res.text());
 		const $ = cheerioLoad(html);
@@ -109,57 +27,6 @@ describe('Dev rewrite, hybrid/server', () => {
 	});
 });
 
-describe('Dev rewrite URL contains base and has no trailing slash', () => {
-	let fixture: Fixture;
-	let devServer: DevServer;
-
-	before(async () => {
-		fixture = await loadFixture({
-			root: './fixtures/rewrite-with-base/',
-			trailingSlash: 'never',
-			outDir: './dist/rewrite-dev-rewrite-url-contains-base-and-has-no/',
-		});
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
-	});
-
-	it('should rewrite to homepage & url contains base', async () => {
-		const html = await fixture.fetch('/base/rewrite-to-index').then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.equal($('h1').text(), 'Index');
-		assert.equal($('p').text(), '/base');
-	});
-
-	it('should rewrite to homepage & url contains base when base is in the rewrite call', async () => {
-		const html = await fixture.fetch('/base/rewrite-with-base-to-index').then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.equal($('h1').text(), 'Index');
-		assert.equal($('p').text(), '/base');
-	});
-
-	it('should rewrite to subpage & url contains base', async () => {
-		const html = await fixture.fetch('/base/rewrite-to-subpage').then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.equal($('h1').text(), 'Page');
-		assert.equal($('p').text(), '/base/page');
-	});
-
-	it('should rewrite to page & url contains base when base is in the rewrite call', async () => {
-		const html = await fixture
-			.fetch('/base/rewrite-with-base-to-subpage')
-			.then((res) => res.text());
-		const $ = cheerioLoad(html);
-
-		assert.equal($('h1').text(), 'Page');
-		assert.equal($('p').text(), '/base/page');
-	});
-});
 describe('SSR route', () => {
 	it("should not build if a user tries to use rewrite('/404') in static pages", async () => {
 		try {
@@ -176,7 +43,7 @@ describe('SSR route', () => {
 	});
 });
 
-describe('Runtime error, default 500', () => {
+describe('Runtime error, default 500 — Vite overlay', () => {
 	let fixture: Fixture;
 	let devServer: DevServer;
 
@@ -192,34 +59,10 @@ describe('Runtime error, default 500', () => {
 		await devServer.stop();
 	});
 
-	it('should return a 500 status code, but not render the custom 500', async () => {
+	it('should return a 500 status code with Vite error overlay', async () => {
 		const response = await fixture.fetch('/errors/from');
 		assert.equal(response.status, 500);
 		const text = await response.text();
 		assert.match(text, /@vite\/client/);
-	});
-});
-
-describe('Runtime error in dev, custom 500', () => {
-	let fixture: Fixture;
-	let devServer: DevServer;
-
-	before(async () => {
-		fixture = await loadFixture({
-			root: './fixtures/rewrite-runtime-error-custom500/',
-			outDir: './dist/rewrite-runtime-error-in-dev-custom-500/',
-		});
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
-	});
-
-	it('should render the custom 500 when rewriting a page that throws an error', async () => {
-		const response = await fixture.fetch('/errors/start');
-		assert.equal(response.status, 500);
-		const html = await response.text();
-		assert.match(html, /I am the custom 500/);
 	});
 });

--- a/packages/astro/test/serializeManifest.test.ts
+++ b/packages/astro/test/serializeManifest.test.ts
@@ -1,56 +1,13 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { ServerOnlyModule } from '../dist/core/errors/errors-data.js';
 import { AstroError } from '../dist/core/errors/index.js';
 import testAdapter from './test-adapter.ts';
-import { type App, type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type App, type Fixture, loadFixture } from './test-utils.ts';
 
 describe('astro:config/client', () => {
 	let fixture: Fixture;
-	let devServer: DevServer;
-
-	describe('in dev', async () => {
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/astro-manifest/',
-				outDir: './dist/serializeManifest-in-dev/',
-			});
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('should return the expected properties', async () => {
-			const response = await fixture.fetch('/blog/');
-			const html = await response.text();
-			const $ = cheerio.load(html);
-
-			assert.deepEqual(
-				$('#config').text(),
-				JSON.stringify({
-					base: '/blog',
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['en', 'fr'],
-						routing: {
-							prefixDefaultLocale: false,
-							redirectToDefaultLocale: true,
-							fallbackType: 'redirect',
-						},
-					},
-					build: {
-						format: 'directory',
-					},
-					trailingSlash: 'always',
-					compressHTML: true,
-					site: 'https://example.com',
-				}),
-			);
-		});
-	});
 
 	describe('when the experimental flag is enabled in build', async () => {
 		before(async () => {
@@ -112,7 +69,6 @@ describe('astro:config/client in a client script', () => {
 
 describe('astro:config/server', () => {
 	let fixture: Fixture;
-	let devServer: DevServer;
 	let app: App;
 
 	describe('when build', () => {
@@ -127,35 +83,6 @@ describe('astro:config/server', () => {
 			const error = await fixture.build().catch((err) => err);
 			assert.equal(error instanceof AstroError, true);
 			assert.equal(error.name, ServerOnlyModule.name);
-		});
-	});
-
-	describe('in dev', async () => {
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/astro-manifest/',
-				outDir: './dist/serializeManifest-in-dev/',
-			});
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('should return the expected properties', async () => {
-			const response = await fixture.fetch('/blog/server/');
-			const html = await response.text();
-			const $ = cheerio.load(html);
-
-			assert.ok($('#out-dir').text().endsWith('/dist/serializeManifest-in-dev/'));
-			assert.ok($('#src-dir').text().endsWith('/src/'));
-			assert.ok($('#cache-dir').text().endsWith('/.astro/'));
-			assert.ok($('#root').text().endsWith('/'));
-			assert.ok($('#build-client').text().endsWith('/dist/serializeManifest-in-dev/client/'));
-			assert.ok($('#build-server').text().endsWith('/dist/serializeManifest-in-dev/server/'));
-			// URL
-			assert.equal($('#root-url').text(), 'true');
 		});
 	});
 

--- a/packages/astro/test/sessions.test.ts
+++ b/packages/astro/test/sessions.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as devalue from 'devalue';
 import testAdapter from './test-adapter.ts';
-import { type App, type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type App, type Fixture, loadFixture } from './test-utils.ts';
 
 describe('Astro.session', () => {
 	describe('Production', () => {
@@ -211,99 +211,4 @@ describe('Astro.session', () => {
 		});
 	});
 
-	describe('Development', () => {
-		let fixture: Fixture;
-		let devServer: DevServer;
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/sessions/',
-				output: 'server',
-				adapter: testAdapter(),
-				session: {
-					// @ts-expect-error: the default type of the TDriver in AstroUserConfig must be changed so that this can pass
-					driver: 'fs',
-					ttl: 20,
-				},
-				outDir: './dist/sessions-development/',
-			});
-			devServer = await fixture.startDevServer();
-		});
-
-		after(async () => {
-			await devServer.stop();
-		});
-
-		it('can regenerate session cookies upon request', async () => {
-			const firstResponse = await fixture.fetch('/regenerate');
-			// @ts-ignore
-			const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
-			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
-
-			const secondResponse = await fixture.fetch('/regenerate', {
-				method: 'GET',
-				headers: {
-					cookie: `astro-session=${firstSessionId}`,
-				},
-			});
-			// @ts-ignore
-			const secondHeaders = secondResponse.headers.get('set-cookie').split(',');
-			const secondSessionId = secondHeaders[0].split(';')[0].split('=')[1];
-			assert.notEqual(firstSessionId, secondSessionId);
-		});
-
-		it('defaults to non-secure cookies in development', async () => {
-			const response = await fixture.fetch('/regenerate');
-			const setCookieHeader = response.headers.get('set-cookie');
-			assert.ok(!setCookieHeader!.includes('Secure'));
-		});
-
-		it('can save session data by value', async () => {
-			const firstResponse = await fixture.fetch('/update');
-			const firstValue = await firstResponse.json();
-			assert.equal(firstValue.previousValue, 'none');
-
-			// @ts-ignore
-			const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
-			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
-			const secondResponse = await fixture.fetch('/update', {
-				method: 'GET',
-				headers: {
-					cookie: `astro-session=${firstSessionId}`,
-				},
-			});
-			const secondValue = await secondResponse.json();
-			assert.equal(secondValue.previousValue, 'expected');
-		});
-
-		it('can save and restore URLs in session data', async () => {
-			const firstResponse = await fixture.fetch('/_actions/addUrl', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({ favoriteUrl: 'https://domain.invalid' }),
-			});
-
-			assert.equal(firstResponse.ok, true);
-			// @ts-ignore
-			const firstHeaders = firstResponse.headers.get('set-cookie').split(',');
-			const firstSessionId = firstHeaders[0].split(';')[0].split('=')[1];
-
-			const data = devalue.parse(await firstResponse.text());
-			assert.equal(data.message, 'Favorite URL set to https://domain.invalid/ from nothing');
-			const secondResponse = await fixture.fetch('/_actions/addUrl', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					cookie: `astro-session=${firstSessionId}`,
-				},
-				body: JSON.stringify({ favoriteUrl: 'https://example.com' }),
-			});
-			const secondData = devalue.parse(await secondResponse.text());
-			assert.equal(
-				secondData.message,
-				'Favorite URL set to https://example.com/ from https://domain.invalid/',
-			);
-		});
-	});
 });

--- a/packages/astro/test/sessions.test.ts
+++ b/packages/astro/test/sessions.test.ts
@@ -210,5 +210,4 @@ describe('Astro.session', () => {
 			assert.deepEqual(cartData.cart, firstResponseData.cart);
 		});
 	});
-
 });

--- a/packages/astro/test/ssr-api-route.test.ts
+++ b/packages/astro/test/ssr-api-route.test.ts
@@ -186,6 +186,5 @@ describe('API routes in SSR', () => {
 			assert.equal(response.status, 500);
 			assert.equal(text, '500 Internal Server Error');
 		});
-
 	});
 });

--- a/packages/astro/test/ssr-api-route.test.ts
+++ b/packages/astro/test/ssr-api-route.test.ts
@@ -187,21 +187,5 @@ describe('API routes in SSR', () => {
 			assert.equal(text, '500 Internal Server Error');
 		});
 
-		it('Has valid api context', async () => {
-			const response = await fixture.fetch('/context/any');
-			assert.equal(response.status, 200);
-			const data = await response.json();
-			assert.ok(data.cookiesExist);
-			assert.ok(data.requestExist);
-			assert.ok(data.redirectExist);
-			assert.ok(data.propsExist);
-			assert.deepEqual(data.params, { param: 'any' });
-			assert.match(data.generator, /^Astro v/);
-			const url = new URL(data.url);
-			assert.ok(['[::1]', '127.0.0.1'].includes(url.hostname));
-			assert.equal(url.pathname, '/blog/context/any');
-			assert.ok(['::1', '127.0.0.1'].includes(data.clientAddress));
-			assert.equal(data.site, 'https://mysite.dev/subsite/');
-		});
 	});
 });


### PR DESCRIPTION
## Changes

This PR removes a bunch of tests and assertions that are already checked against unit tests, so there's so reason to use a dev server for that.

The few that were still needed, they are checked against the build because it's the same behaviour

## Testing

Green CI 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
