### PR TITLE
Publish preview releases for triage bot fixes

### DIFF
--- a/.agents/skills/astro-pr-writer/SKILL.md
+++ b/.agents/skills/astro-pr-writer/SKILL.md
@@ -114,85 +114,11 @@ Default to short. 1-2 bullets per section is normal — add more only when the c
 
 ## Changesets
 
-Every PR that modifies a package requires a changeset file. Only `examples/*` changes are exempt.
+Every PR that modifies a package requires a changeset. Only `examples/*` changes are exempt.
 
-### Format
+Load the `changeset` skill to create the changeset file and write the message. It covers file creation, format, bump types, and message conventions.
 
-Create `.changeset/<descriptive-slug>.md` with YAML front matter listing affected packages and bump type, followed by a plain-text description that becomes the changelog entry:
-
-```md
----
-'astro': patch
----
-
-Fixes a case where fonts files would unnecessarily be copied several times during the build
-```
-
-- Package names must match the `name` field in the package's `package.json` exactly (e.g., `'astro'`, `'@astrojs/node'`)
-- Bump types: `patch`, `minor`, or `major`
-- A single changeset file can cover multiple packages
-- `major` and `minor` bumps to the core `astro` package are blocked by CI and require maintainer review
-
-### Writing the Changeset Message
-
-Begin with a **present tense verb** that completes the sentence "This PR …":
-
-- Adds, Removes, Fixes, Updates, Refactors, Improves, Deprecates
-
-Describe the change **as a user of Astro will experience it**, not how it was implemented internally:
-
-```md
-// Too implementation-focused
-Logs helpful errors if content is invalid
-
-// Better — user-facing impact
-Adds logging for content collections configuration errors.
-```
-
-**Patch updates** — one line is usually enough; no end punctuation required unless writing multiple sentences:
-
-```md
----
-'astro': patch
----
-
-Fixes a bug where the toolbar audit would incorrectly flag images as above the fold
-```
-
-**New features (minor)** — start with "Adds", name the new API, and describe what users can now do. Include a code example when helpful. New features are also an opportunity to write a richer description that can feed into blog posts — see https://contribute.docs.astro.build/docs-for-code-changes/changesets/#new-features for guidance.
-
-```md
----
-'astro': minor
----
-
-Adds a new, optional property `timeout` for the `client:idle` directive
-
-This value allows you to specify a maximum time to wait, in milliseconds, before hydrating a UI framework component.
-```
-
-**Breaking changes (major)** — use verbs like "Removes", "Changes", or "Deprecates". Must include migration guidance; use diff code samples when appropriate:
-
-```md
----
-'astro': major
----
-
-Removes support for returning simple objects from endpoints. You must now return a `Response` instead.
-```
-
-**Additional rules:**
-
-- Include the specific API name (with backtick formatting) when the change is tied to a recognizable option or function
-- When the API is not user-facing, describe the use case or end result instead
-- For longer changesets, use `####` and deeper headings (never `##` or `###`) to divide sections — this keeps the CHANGELOG readable
-- Changes to default values must mention the old default, the new default, and how to restore previous behavior
-
-### Creating a Changeset
-
-Write the changeset file manually in `.changeset/` with a descriptive kebab-case slug as the filename (e.g., `.changeset/fix-font-copy-on-build.md`).
-
-### When Writing a PR
+When writing the PR body:
 
 - Always check that a changeset exists before posting the PR
 - Do not mention "added changeset" in the `Changes` section — it is process noise, not a behavior change

--- a/.agents/skills/changeset/SKILL.md
+++ b/.agents/skills/changeset/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: changeset
+description: Create a changeset for the Astro monorepo. Use this skill whenever you need to add a changeset file to a PR, write a changelog entry, or document a package version bump. Also trigger when the user says "add a changeset", "write a changeset", "create a changeset", or when another skill instructs you to create a changeset.
+---
+
+# Changeset
+
+Create changeset files for the Astro monorepo. Changesets declare which packages changed, the semver bump type, and a user-facing message that becomes the CHANGELOG entry.
+
+Every PR that modifies a package requires a changeset. Only `examples/*` changes are exempt.
+
+## Creating the File
+
+Run `pnpm changeset --empty` from the repo root. This creates a randomly-named `.md` file in `.changeset/` with empty front matter — no need to invent a filename or inspect the directory. Then edit the generated file to add the package bump and message.
+
+## Format
+
+```md
+---
+'<package-name>': patch
+---
+
+<changeset message>
+```
+
+- Package names must match the `name` field in the package's `package.json` exactly (e.g., `'astro'`, `'@astrojs/node'`)
+- Bump types: `patch`, `minor`, or `major`
+- A single changeset file can cover multiple packages
+- `major` and `minor` bumps to the core `astro` package are blocked by CI and require maintainer review
+
+## Writing the Message
+
+The changeset message is a public CHANGELOG entry. Write it for **Astro users**, not for code reviewers.
+
+Begin with a **present tense verb** that completes the sentence "This PR ...":
+
+- Adds, Removes, Fixes, Updates, Refactors, Improves, Deprecates
+
+Describe the change **as someone building an Astro site will experience it**, not how it was implemented internally:
+
+```md
+// Too implementation-focused
+Logs helpful errors if content is invalid
+
+// Better -- user-facing impact
+Adds logging for content collections configuration errors.
+```
+
+### Patch updates
+
+One line is usually enough. No end punctuation required unless writing multiple sentences.
+
+```md
+---
+'astro': patch
+---
+
+Fixes a bug where the toolbar audit would incorrectly flag images as above the fold
+```
+
+```md
+---
+'astro': patch
+---
+
+Refactors internal handling of styles and scripts for content collections to improve build performance
+```
+
+Help the reader figure out if the change matters to them. Include the specific API name (with backtick formatting) when the change is tied to a recognizable option or function. When the API is not user-facing, describe the use case or end result instead:
+
+```md
+// Vague
+Improves automatic fallbacks generation
+
+// Clear -- reader can tell if it affects them
+Improves automatic `fallbacks` generation for the experimental Fonts API
+```
+
+### New features (minor)
+
+Start with "Adds", name the new API, and describe what users can now do. Include a code example when helpful:
+
+````md
+---
+'astro': minor
+---
+
+Adds a new, optional property `timeout` for the `client:idle` directive
+
+This value allows you to specify a maximum time to wait, in milliseconds, before hydrating a UI framework component.
+
+```astro
+<Button client:idle={{ timeout: 500 }} />
+```
+````
+
+New features are an opportunity to write a richer description that can feed into blog posts. See the [Astro changeset docs](https://contribute.docs.astro.build/docs-for-code-changes/changesets/#new-features) for guidance on longer entries.
+
+### Breaking changes (major)
+
+Use verbs like "Removes", "Changes", or "Deprecates". Must include migration guidance. Use diff code samples when appropriate:
+
+````md
+---
+'astro': major
+---
+
+Removes support for Shiki custom language's `path` property. The language JSON file must now be imported and passed to the option instead.
+
+```diff
+// astro.config.js
++ import customLang from './custom.tmLanguage.json'
+
+export default defineConfig({
+  markdown: {
+    shikiConfig: {
+      langs: [
+-       { path: './custom.tmLanguage.json' },
++       customLang,
+      ],
+    },
+  },
+})
+```
+````
+
+Changes to default values must mention the old default, the new default, and how to restore previous behavior.
+
+### Longer changesets
+
+For longer descriptions, use `####` and deeper headings (never `##` or `###`) to divide sections. This keeps the CHANGELOG readable when your entry is incorporated:
+
+```md
+---
+'astro': minor
+---
+
+Adds a new Sessions API to store user state between requests for on-demand rendered pages.
+
+#### Configuring session storage
+<!-- ... -->
+
+#### Using sessions
+<!-- ... -->
+```

--- a/.agents/skills/triage/comment.md
+++ b/.agents/skills/triage/comment.md
@@ -15,6 +15,7 @@ These variables are referenced throughout this skill. They may be passed as args
 - **`report.md`** — File in `triageDir` that MAY exist. Contains the full context from all previous skills (reproduction, diagnosis, fix). Contains everything that you need to know to generate your comment successfully.
 - **`branchName`** — The branch name where a fix was pushed. If not passed as an arg, infer from previous conversation.
 - **`priorityLabels`** — An array of `{ name, description }` objects representing the available priority labels for the repository. Used to select a priority in the comment.
+- **`previewRelease`** — An object with `{ urls: string[] }` containing pkg.pr.new install URLs for the affected packages, or `null` if no preview release was published. When present, include a "Try this fix" section in the comment.
 
 ## Overview
 
@@ -68,6 +69,19 @@ The comment must start with an at-a-glance summary, followed by short explanatio
 [2-3 sentences describing the root cause or key observations, or where/when it was already fixed. Be specific about what's happening and where in the codebase.]
 
 **[See "Fix" Instructions above.]** [1-2 sentences describing the fix in more detail: what was changed, guidance on where a fix might be, or relevant code areas.]
+
+[If `previewRelease` is non-null, include the "Try this fix" section below. If `previewRelease` is null, omit it entirely.]
+
+### Try this fix
+
+You can test this fix right now without waiting for a release:
+
+```
+[For each URL in previewRelease.urls, output it as an npm install command on its own line, e.g.:]
+npm i <url>
+```
+
+[End of conditional "Try this fix" section.]
 
 <details>
 <summary><em>Full Triage Report</em></summary>

--- a/.agents/skills/triage/fix.md
+++ b/.agents/skills/triage/fix.md
@@ -143,44 +143,7 @@ This captures all your changes for the report.
 
 **Only do this if the fix was successful** (i.e., you are on the high-confidence path and the fix resolves the issue). If the fix failed or was skipped, skip this step entirely.
 
-Create a changeset file at `.changeset/<descriptive-slug>.md`. The slug should be a short kebab-case description of the fix (e.g., `fix-font-copy-on-build`, `prevent-client-only-crash`).
-
-The file format is:
-
-```md
----
-'<package-name>': patch
----
-
-<changeset message>
-```
-
-**Rules:**
-
-- The package name must match the `name` field in the affected package's `package.json` exactly (e.g., `'astro'`, `'@astrojs/node'`, `'@astrojs/mdx'`). Read the `package.json` to confirm.
-- If multiple packages were modified, list each one with its own bump type.
-- Always use `patch` as the bump type for triage fixes — these are bug fixes, not new features.
-- A single changeset file can cover multiple packages.
-- The changeset message should begin with a **present tense verb** that completes the sentence "This PR …" (e.g., "Fixes", "Resolves", "Prevents").
-- Describe the change **as a user of Astro will experience it**, not how it was implemented internally.
-- One line is usually enough for a patch. No end punctuation required unless writing multiple sentences.
-
-**Example:**
-
-```md
----
-'astro': patch
----
-
-Fixes a case where `client:only` components would crash during SSR when using content collections
-```
-
-Verify the changeset was created:
-
-```bash
-ls .changeset/
-cat .changeset/<your-slug>.md
-```
+Load the `changeset` skill and follow its instructions to create a changeset for the fix. Since this is a bug fix, the bump type will almost always be `patch`.
 
 ## Step 10: Write Output
 

--- a/.agents/skills/triage/fix.md
+++ b/.agents/skills/triage/fix.md
@@ -25,8 +25,9 @@ These variables are referenced throughout this skill. They may be passed as args
 6. Write a unit test
 7. Ensure no regressions
 8. Generate git diff
-9. Append fix details to `report.md`
-10. Clean up the working directory
+9. Create a changeset
+10. Append fix details to `report.md`
+11. Clean up the working directory
 
 ## Step 1: Review the Diagnosis
 
@@ -138,7 +139,50 @@ git diff packages/
 
 This captures all your changes for the report.
 
-## Step 9: Write Output
+## Step 9: Create a Changeset
+
+**Only do this if the fix was successful** (i.e., you are on the high-confidence path and the fix resolves the issue). If the fix failed or was skipped, skip this step entirely.
+
+Create a changeset file at `.changeset/<descriptive-slug>.md`. The slug should be a short kebab-case description of the fix (e.g., `fix-font-copy-on-build`, `prevent-client-only-crash`).
+
+The file format is:
+
+```md
+---
+'<package-name>': patch
+---
+
+<changeset message>
+```
+
+**Rules:**
+
+- The package name must match the `name` field in the affected package's `package.json` exactly (e.g., `'astro'`, `'@astrojs/node'`, `'@astrojs/mdx'`). Read the `package.json` to confirm.
+- If multiple packages were modified, list each one with its own bump type.
+- Always use `patch` as the bump type for triage fixes — these are bug fixes, not new features.
+- A single changeset file can cover multiple packages.
+- The changeset message should begin with a **present tense verb** that completes the sentence "This PR …" (e.g., "Fixes", "Resolves", "Prevents").
+- Describe the change **as a user of Astro will experience it**, not how it was implemented internally.
+- One line is usually enough for a patch. No end punctuation required unless writing multiple sentences.
+
+**Example:**
+
+```md
+---
+'astro': patch
+---
+
+Fixes a case where `client:only` components would crash during SSR when using content collections
+```
+
+Verify the changeset was created:
+
+```bash
+ls .changeset/
+cat .changeset/<your-slug>.md
+```
+
+## Step 10: Write Output
 
 Append your fix details to the existing `report.md` (written by reproduce and diagnose skills).
 
@@ -151,10 +195,11 @@ The report must include all information needed for a final GitHub comment to be 
 - Whether the fix was successful or not
 - Verification results (did the fix resolve the original error?)
 - Unit test details: what test was added, where it lives, and what it verifies. If no test was added, explain why.
+- Changeset details: what changeset file was created and which packages it covers. If no changeset was created, explain why.
 - Any alternative approaches considered and their tradeoffs
 - If the fix failed: what was tried and why it didn't work
 
-## Step 10: Clean Up the Working Directory
+## Step 11: Clean Up the Working Directory
 
 1. Run `git status` and review all changed files
 2. Revert any changes that are NOT part of the fix:

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -109,6 +109,53 @@ ${comment}
 	return [labelResult.priority, ...labelResult.packages];
 }
 
+interface PreviewRelease {
+	/** Install URLs for each published package, e.g. "https://pkg.pr.new/astro@abc1234" */
+	urls: string[];
+}
+
+async function publishPreviewRelease(session: FlueSession): Promise<PreviewRelease | null> {
+	// Determine which package directories were modified relative to main.
+	const diffResult = await session.shell('git diff main --name-only', { commands: [git] });
+	if (!diffResult.stdout.trim()) return null;
+
+	const changedFiles = diffResult.stdout.trim().split('\n');
+	const packageDirs = new Set<string>();
+	for (const file of changedFiles) {
+		// Match packages/<name>/... or packages/integrations/<name>/...
+		const match = file.match(/^(packages\/(?:integrations\/)?[^/]+)\//);
+		if (match) {
+			packageDirs.add(match[1]);
+		}
+	}
+	if (packageDirs.size === 0) return null;
+
+	const packages = [...packageDirs].join(' ');
+	const publishResult = await session.shell(
+		`pnpm dlx pkg-pr-new publish --pnpm --compact --no-template --comment=off --json preview-release.json ${packages}`,
+		{ commands: [pnpm] },
+	);
+
+	if (publishResult.exitCode !== 0) {
+		console.warn('Preview release publish failed:', publishResult.stderr);
+		return null;
+	}
+
+	// Parse the JSON output to extract package URLs.
+	const jsonResult = await session.shell(
+		"node -e \"process.stdout.write(require('fs').readFileSync('preview-release.json','utf8'))\"",
+		{ commands: [node] },
+	);
+	try {
+		const output = JSON.parse(jsonResult.stdout.trim());
+		const urls = (output.packages as Array<{ url: string }>).map((p) => p.url);
+		return urls.length > 0 ? { urls } : null;
+	} catch {
+		console.warn('Failed to parse preview release JSON output');
+		return null;
+	}
+}
+
 async function runTriagePipeline(
 	session: FlueSession,
 	issueNumber: number,
@@ -270,6 +317,16 @@ export default async function ({ init, payload }: FlueContext) {
 		}
 	}
 
+	// If a fix was successfully pushed, publish a preview release so the reporter
+	// can immediately test the fix via `npm i <url>`.
+	let previewRelease: PreviewRelease | null = null;
+	if (triageResult.fixed && isPushed) {
+		previewRelease = await publishPreviewRelease(session);
+		if (previewRelease) {
+			console.info('Preview release published:', previewRelease.urls);
+		}
+	}
+
 	// Fetch repo labels upfront so we can pass priority labels to the comment
 	// skill (which selects the priority) and package labels to the label selector.
 	const { priorityLabels, packageLabels } = await fetchRepoLabels();
@@ -278,7 +335,7 @@ export default async function ({ init, payload }: FlueContext) {
 
 	const branchName = isPushed ? branch : null;
 	const comment = await session.skill('triage/comment.md', {
-		args: { branchName, priorityLabels, issueDetails },
+		args: { branchName, priorityLabels, issueDetails, previewRelease },
 		commands: [gh, git, node, pnpm],
 		result: v.pipe(
 			v.string(),
@@ -309,5 +366,5 @@ export default async function ({ init, payload }: FlueContext) {
 		// Not reproducible: do nothing. The "needs triage" label stays on the issue
 		// so that it can continue to be worked on and triaged by the humans.
 	}
-	return { ...triageResult, isPushed };
+	return { ...triageResult, isPushed, previewRelease };
 }

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       contents: write # Push fix branches
       issues: read # Read issue details for triage
+      id-token: write # OIDC auth for pkg.pr.new preview releases
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Changes

- When the triage bot produces a high-confidence fix (fix verified + unit test created), it now publishes a preview release via pkg.pr.new so reporters can immediately test the fix with `npm i https://pkg.pr.new/astro@<sha>`.
- The fix skill now generates a changeset file (`.changeset/<slug>.md`) for every successful fix, making the branch PR-ready with proper changelog entries.
- Preview URLs are included in the triage bot issue comment under a "Try this fix" section, giving reporters a one-liner install command.

## Testing

- No test changes — this modifies CI agent infrastructure (skill instructions, Flue orchestrator, GHA workflow).

## Docs

- No docs needed — this is internal CI tooling, not user-facing.