### PR TITLE
Fix incorrect test-utils import in cloudflare ts-astro-import test

### DIFF
--- a/packages/integrations/cloudflare/test/ts-astro-import.test.js
+++ b/packages/integrations/cloudflare/test/ts-astro-import.test.js
@@ -1,7 +1,7 @@
 import { rmSync } from 'node:fs';
 import { describe, before, it } from 'node:test';
 import { Writable } from 'node:stream';
-import { loadFixture } from './_test-utils.js';
+import { loadFixture } from './test-utils.ts';
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
 import { AstroLogger } from '../../../astro/dist/core/logger/core.js';


### PR DESCRIPTION
## Changes

- Fixes the `_test-utils.js` import in `ts-astro-import.test.js` to `./test-utils.ts`, matching every other test file in the cloudflare package. The underscore-prefixed file does not exist, causing a knip unresolved import lint failure on main.

## Testing

- No test changes needed — this fixes the import so the existing test can actually run.

## Docs

- No docs needed; internal test fix only.