### PR TITLE
fix(content): add `render()` type overload for live collection entries

### DIFF
--- a/.changeset/ninety-windows-rule.md
+++ b/.changeset/ninety-windows-rule.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a type error when calling `render(entry)` with a `LiveDataEntry`.

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -85,6 +85,10 @@ declare module 'astro:content' {
 		entry: DataEntryMap[C][string],
 	): Promise<RenderResult>;
 
+	export function render<C extends keyof LiveContentConfig['collections']>(
+		entry: import('astro').LiveDataEntry<LiveLoaderDataType<C>>,
+	): Promise<RenderResult>;
+
 	export function reference<
 		C extends
 			| keyof DataEntryMap

--- a/packages/astro/test/live-loaders.test.ts
+++ b/packages/astro/test/live-loaders.test.ts
@@ -4,7 +4,8 @@ import { after, before, describe, it } from 'node:test';
 import { AstroLogger, type AstroLoggerMessage } from '../dist/core/logger/core.js';
 
 import testAdapter from './test-adapter.ts';
-import { type App, type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { type App, cli, type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+import { fileURLToPath } from 'node:url';
 
 describe('Live content collections', () => {
 	let fixture: Fixture;
@@ -159,6 +160,21 @@ describe('Live content collections', () => {
 			const html = await response.text();
 			assert.ok(html.includes('<h1>Page 123</h1>'));
 			assert.ok(html.includes('<p>This is rendered content.</p>'));
+		});
+
+		// ref: https://github.com/withastro/astro/issues/16688
+		it('astro check no errors', {
+			timeout: 35000,
+		}, async () => {
+			const projectRootURL = fixture.config.root;
+			const result = await cli(
+				'check',
+				'--root',
+				fileURLToPath(projectRootURL),
+				'--noSync',
+			).getResult();
+
+			assert.equal(result.stdout.includes('0 errors'), true);
 		});
 	});
 


### PR DESCRIPTION
fixes: #16688

## Changes
There was an issue where passing the `entry` property, returned by the `getLiveEntry` function imported from `astro:content`, to the `render` function caused a type error.
This pull request adds tests and a changeset to the fix originally authored by Houston bot.

[Houston bot comment](https://github.com/withastro/astro/issues/16688#issuecomment-4419508070):
> The `render()` function type in `packages/astro/templates/content/types.d.ts` only has an overload for regular content collection entries (`DataEntryMap[C][string]`), but no overload for `LiveDataEntry`. When a project uses only `live.config.ts`, `DataEntryMap` is empty, so `render()` accepts `never`. The live collections RFC and the existing test fixture both show `render(entry)` being used with live entries — the type overload was simply missed when live collections were added in PR #13685.

> **I found a potential fix for this issue.** The fix adds a `render()` overload for `LiveDataEntry<LiveLoaderDataType<C>>` to the type template. It's a 4-line change that brings the type declarations in line with the runtime behavior. All existing tests (live loaders, content collections, type inference, render) continue to pass.

## Testing
Added a test using the `astro check` command to verify that no type errors occur.
No changes were made to the test fixtures themselves. The error was originally occurring at the following location.
https://github.com/withastro/astro/blob/c0db63dd9659317e503dfce2d8eb50d6d67be34d/packages/astro/test/fixtures/live-loaders/src/pages/rendered.astro#L2-L10
```bash
src/pages/index.astro:10:34 - error ts(2345): Argument of type 'LiveDataEntry<{ ... }>' is not assignable to parameter of type 'never'.

10 const { Content } = await render(entry);
                                    ~~~~~
```

## Docs
N/A, bug fix
