### PR TITLE
fix(astro): fix broken `Map` and `Set` in content collections

### DIFF
--- a/.changeset/plain-sites-dress.md
+++ b/.changeset/plain-sites-dress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `Map` and `Set` instances saved in a content collection being broken when retrieving entries.

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -206,9 +206,10 @@ export function createGetEntry({ liveCollections }: { liveCollections: LiveColle
 
 			// @ts-expect-error	virtual module
 			const { default: imageAssetMap } = await import('astro:asset-imports');
-			entry.data = updateImageReferencesInData(entry.data, entry.filePath, imageAssetMap);
+			const data = updateImageReferencesInData(entry.data, entry.filePath, imageAssetMap);
 			const result = {
 				...entry,
+				data,
 				collection,
 			} as DataEntryResult | ContentEntryResult;
 			// TODO: remove in Astro 7
@@ -510,7 +511,8 @@ export function updateImageReferencesInData<T extends Record<string, unknown>>(
 	fileName?: string,
 	imageAssetMap?: Map<string, ImageMetadata>,
 ): T {
-	return new Traverse(data).map(function (ctx, val) {
+	const copy = structuredClone(data);
+	new Traverse(copy).forEach(function (ctx, val) {
 		if (typeof val === 'string' && val.startsWith(IMAGE_IMPORT_PREFIX)) {
 			const src = val.replace(IMAGE_IMPORT_PREFIX, '');
 
@@ -544,6 +546,7 @@ export function updateImageReferencesInData<T extends Record<string, unknown>>(
 			}
 		}
 	});
+	return copy;
 }
 
 export async function renderEntry(entry: DataEntry) {

--- a/packages/astro/test/units/content-collections/image-references.test.ts
+++ b/packages/astro/test/units/content-collections/image-references.test.ts
@@ -99,4 +99,27 @@ describe('updateImageReferencesInData', () => {
 		assert.deepEqual(result.hero, heroMeta);
 		assert.deepEqual(result.thumb, thumbMeta);
 	});
+
+	it('preserves Map instances', () => {
+		const data = {
+			metadata: new Map([
+				['title', 'Hello'],
+				['description', 'World'],
+			]),
+		};
+		const result = updateImageReferencesInData(data, FILE_NAME, new Map());
+		assert.equal(result.metadata.get('title'), 'Hello');
+		assert.equal(result.metadata.get('description'), 'World');
+		assert.equal(result.metadata.get('cover'), undefined);
+		assert.equal(result.metadata.size, 2);
+	});
+
+	it('preserves Set instances', () => {
+		const data = { flags: new Set(['showTitle', 'showDescription']) };
+		const result = updateImageReferencesInData(data, FILE_NAME, new Map());
+		assert.equal(result.flags.has('showTitle'), true);
+		assert.equal(result.flags.has('showDescription'), true);
+		assert.equal(result.flags.has('showCover'), false);
+		assert.equal(result.flags.size, 2);
+	});
 });


### PR DESCRIPTION
The `updateImageReferencesInData` function uses `Traverse.map` which uses a custom cloning algorithm and as such does not copy correctly instances of native objects such as `Map` and `Set` rendering them unusable.

Instead `Travserse.forEach` can be used after cloning the data object beforehand with the native `structuredClone` function.

Closes #16682

## Changes

- Use `Travserse.forEach` instead of `Traverse.map` in `updateImageReferencesInData`
- Clone data before updating image references
- Update getEntry to not mutate data in store when updating image references

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- 2 new tests added to cover Map/Set regressions

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
- no docs changes, this is a bug fix
