### PR TITLE
fix(build): strip client:only imports from prerender graph

### DIFF
--- a/.changeset/dark-owls-lay.md
+++ b/.changeset/dark-owls-lay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Strips `client:only` component imports from the Rollup graph during prerender builds, preventing build errors from client-side-only dependencies being processed in SSR context

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -43,7 +43,7 @@ export async function compileAstro({
 			sourcemap: 'external',
 			tsconfigRaw: {
 				compilerOptions: {
-					// Ensure client:only imports are treeshaken
+					// Allow esbuild to remove type-only imports
 					verbatimModuleSyntax: false,
 					importsNotUsedAsValues: 'remove',
 				},

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -283,11 +283,48 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 
 					const transformResult = await compile(source, filename);
 
+					let code = transformResult.code;
+
+					const clientOnlyComponents = transformResult.clientOnlyComponents.filter(notAstroComponent);
+					const hydratedComponents = transformResult.hydratedComponents.filter(notAstroComponent);
+
+					// In prerender/SSR, strip imports for client:only components whose
+					// specifier does not also appear in hydratedComponents or
+					// serverComponents. The compiler emits `import Foo from './Foo'`
+					// but passes `null` to $$renderComponent for client:only — the
+					// import is dead code. Removing it prevents Rollup from traversing
+					// the component's dependency tree (e.g. React) during prerender.
+					// Component metadata is preserved in meta.astro.clientOnlyComponents
+					// for the plugin-analyzer to feed into the client build.
+					if (
+						this.environment?.name === ASTRO_VITE_ENVIRONMENT_NAMES.prerender ||
+						this.environment?.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr
+					) {
+						const liveSpecifiers = new Set([
+							...hydratedComponents.map((c) => c.specifier),
+							...transformResult.serverComponents.map((c) => c.specifier),
+						]);
+
+						const { init, parse } = await import('es-module-lexer');
+						await init;
+						const [imports] = parse(code);
+						const s = new (await import('magic-string')).default(code);
+
+						for (const c of clientOnlyComponents) {
+							if (liveSpecifiers.has(c.specifier)) continue;
+							for (const imp of imports) {
+								if (imp.n === c.specifier) {
+									s.remove(imp.ss, imp.se + 1);
+								}
+							}
+						}
+
+						code = s.toString();
+					}
+
 					const astroMetadata: AstroPluginMetadata['astro'] = {
-						// Remove Astro components that have been mistakenly given client directives
-						// We'll warn the user about this later, but for now we'll prevent them from breaking the build
-						clientOnlyComponents: transformResult.clientOnlyComponents.filter(notAstroComponent),
-						hydratedComponents: transformResult.hydratedComponents.filter(notAstroComponent),
+						clientOnlyComponents,
+						hydratedComponents,
 						serverComponents: transformResult.serverComponents,
 						scripts: transformResult.scripts,
 						containsHead: transformResult.containsHead,
@@ -296,7 +333,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 					};
 
 					return {
-						code: transformResult.code,
+						code,
 						map: transformResult.map,
 						meta: {
 							astro: astroMetadata,

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -314,7 +314,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 							if (liveSpecifiers.has(c.specifier)) continue;
 							for (const imp of imports) {
 								if (imp.n === c.specifier) {
-									s.remove(imp.ss, imp.se + 1);
+									s.remove(imp.ss, Math.min(imp.se + 1, code.length));
 								}
 							}
 						}

--- a/packages/astro/test/fixtures/hmr-markdown/src/content/blog/post.md
+++ b/packages/astro/test/fixtures/hmr-markdown/src/content/blog/post.md
@@ -2,4 +2,4 @@
 title: HMR Markdown
 ---
 
-Original content
+Updated content


### PR DESCRIPTION
## Summary
- Strip `client:only` component imports from the Rollup graph during prerender builds, preventing build errors from client-side-only dependencies being processed in SSR context
- Guard `magic-string` remove against out-of-bounds when an import statement lacks a trailing semicolon

## Test plan
- Prerender builds with `client:only` components no longer fail
- Existing HMR and compilation tests pass