### PR TITLE
fix(cloudflare): respect remoteBindings during prerender build

### DIFF
--- a/.changeset/cloudflare-prerender-remote-bindings.md
+++ b/.changeset/cloudflare-prerender-remote-bindings.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes `remoteBindings: false` being ignored during `astro build`. The Cloudflare prerenderer's internal Vite preview server now receives the user's adapter options, so remote-flagged bindings (e.g. a D1 database with `remote: true` in `wrangler.toml`) are emulated locally during build, matching the existing `astro dev` behavior.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -429,6 +429,7 @@ export default function createIntegration({
 				if (prerenderEnvironment === 'workerd') {
 					setPrerenderer(
 						createCloudflarePrerenderer({
+							cloudflareOptions,
 							root: _config.root,
 							serverDir: _config.build.server,
 							clientDir: _config.build.client,

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -21,6 +21,7 @@ import {
 } from './utils/prerender-constants.js';
 
 interface CloudflarePrerendererOptions {
+	cloudflareOptions: Partial<PluginConfig>;
 	root: AstroConfig['root'];
 	serverDir: AstroConfig['build']['server'];
 	clientDir: AstroConfig['build']['client'];
@@ -35,6 +36,7 @@ interface CloudflarePrerendererOptions {
  * This allows prerendering to happen in the same runtime that will serve the pages.
  */
 export function createCloudflarePrerenderer({
+	cloudflareOptions,
 	root,
 	serverDir,
 	clientDir,
@@ -82,7 +84,13 @@ export function createCloudflarePrerenderer({
 					port: 0, // Let the OS pick a free port
 					open: false,
 				},
-				plugins: [cfVitePlugin({ ...cfPluginConfig, viteEnvironment: { name: 'prerender' } })],
+				plugins: [
+					cfVitePlugin({
+						...cloudflareOptions,
+						...cfPluginConfig,
+						viteEnvironment: { name: 'prerender' },
+					}),
+				],
 			});
 
 			const address = previewServer.httpServer.address();


### PR DESCRIPTION
## Summary

Fixes #16705


Fixes `remoteBindings: false` being ignored during `astro build`. The Cloudflare prerenderer's internal Vite preview server now receives the user's adapter options, so remote-flagged bindings (e.g. a D1 database with `remote: true` in `wrangler.toml`) are emulated locally during build, matching the existing `astro dev` behavior.

## Changes

The fix is accomplished by forwarding cloudflareOptions (which include remoteBindings setting) to `createCloudflarePrerenderer()`

