### PR TITLE
Pin actions/labeler to SHA

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'withastro'
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
## Summary

- Pins `actions/labeler` from mutable `@v4` tag to commit SHA `ac9175f8a1f3625fd0d4fb234536d26811351594` (v4.3.0)
- This was the only action in the repo not pinned to SHA
- This workflow runs on `pull_request_target` with write permissions, so a tag hijack would affect every PR including forks

Part of supply chain hardening in response to the [TanStack/Mini Shai-Hulud compromise](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack).