### PR TITLE
Harden preview-release workflow against OIDC token theft

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -23,15 +23,18 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
 
 jobs:
-  preview:
-    if: ${{ github.repository_owner == 'withastro' && github.event.label.name == 'pr preview' }}
+  build:
+    # Only allow preview releases from branches in the same repo (not forks)
+    if: >-
+      github.repository_owner == 'withastro' &&
+      github.event.label.name == 'pr preview' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
       issues: write
       pull-requests: write
-    name: Publish preview release
+    name: Build preview
     timeout-minutes: 5
     steps:
       - name: Disable git crlf
@@ -90,11 +93,55 @@ jobs:
         with:
           labels: "pr preview"
 
-      - name: Publish packages
+      - name: Stage publish artifact
         env:
           AFFECTED_PACKAGES: ${{ steps.compute-affected-packages.outputs.affected-packages }}
         run: |
-          packages=$(echo $AFFECTED_PACKAGES | jq -r '.[]' | tr '\n' ' ')
+          mkdir -p /tmp/preview-publish
+          # Copy workspace root files needed by pkg-pr-new / pnpm pack
+          cp package.json /tmp/preview-publish/
+          cp pnpm-workspace.yaml /tmp/preview-publish/
+          cp pnpm-lock.yaml /tmp/preview-publish/
+          # Copy each affected package directory (with built output)
+          for pkg in $(echo "$AFFECTED_PACKAGES" | jq -r '.[]'); do
+            mkdir -p "/tmp/preview-publish/$pkg"
+            cp -r "$pkg/." "/tmp/preview-publish/$pkg/"
+          done
+          # Save affected packages list for the publish job
+          echo "$AFFECTED_PACKAGES" > /tmp/preview-publish/affected-packages.json
+
+      - name: Upload publish artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: preview-build
+          path: /tmp/preview-publish
+          retention-days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    name: Publish preview release
+    timeout-minutes: 5
+    steps:
+      - name: Download publish artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: preview-build
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.15.0
+
+      - name: Publish packages
+        run: |
+          packages=$(cat affected-packages.json | jq -r '.[]' | tr '\n' ' ')
           if [ -n "$packages" ]; then
             pnpm dlx pkg-pr-new publish --pnpm --compact --no-template $packages
           else

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           packages=$(cat affected-packages.json | jq -r '.[]' | tr '\n' ' ')
           if [ -n "$packages" ]; then
-            pnpm dlx pkg-pr-new publish --pnpm --compact --no-template $packages
+            pnpm exec pkg-pr-new publish --pnpm --compact --no-template $packages
           else
             echo "No affected packages to publish"
           fi

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -97,24 +97,23 @@ jobs:
         env:
           AFFECTED_PACKAGES: ${{ steps.compute-affected-packages.outputs.affected-packages }}
         run: |
-          mkdir -p /tmp/preview-publish
-          # Copy workspace root files needed by pkg-pr-new / pnpm pack
-          cp package.json /tmp/preview-publish/
-          cp pnpm-workspace.yaml /tmp/preview-publish/
-          cp pnpm-lock.yaml /tmp/preview-publish/
+          staging="/tmp/preview-publish"
+          mkdir -p "$staging"
+          # Copy workspace root files needed by pnpm pack
+          cp package.json pnpm-workspace.yaml pnpm-lock.yaml "$staging/"
           # Copy each affected package directory (with built output)
           for pkg in $(echo "$AFFECTED_PACKAGES" | jq -r '.[]'); do
-            mkdir -p "/tmp/preview-publish/$pkg"
-            cp -r "$pkg/." "/tmp/preview-publish/$pkg/"
+            mkdir -p "$staging/$pkg"
+            cp -r "$pkg/." "$staging/$pkg/"
           done
-          # Save affected packages list for the publish job
-          echo "$AFFECTED_PACKAGES" > /tmp/preview-publish/affected-packages.json
+          # Save the list for the publish job
+          echo "$AFFECTED_PACKAGES" > "$staging/affected-packages.json"
 
       - name: Upload publish artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: preview-build
-          path: /tmp/preview-publish
+          path: /tmp/preview-publish/
           retention-days: 1
 
   publish:
@@ -130,6 +129,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: preview-build
+          path: workspace
 
       - name: Setup PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -140,6 +140,7 @@ jobs:
           node-version: 24.15.0
 
       - name: Publish packages
+        working-directory: workspace
         run: |
           packages=$(cat affected-packages.json | jq -r '.[]' | tr '\n' ' ')
           if [ -n "$packages" ]; then

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "only-allow": "^1.2.2",
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
+    "pkg-pr-new": "^0.0.71",
     "publint": "^0.3.17",
     "tinyglobby": "^0.2.16",
     "turbo": "^2.8.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       only-allow:
         specifier: ^1.2.2
         version: 1.2.2
+      pkg-pr-new:
+        specifier: ^0.0.71
+        version: 0.0.71
       prettier:
         specifier: ^3.8.1
         version: 3.8.2
@@ -14518,6 +14521,10 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  pkg-pr-new@0.0.71:
+    resolution: {integrity: sha512-Ln7I7NaOXN6CjBLVrNqsWOo6mIaNW4chH4eCR2t4tnQSmYtyQiWCqlMG6bL2JYCT1MOiKEiDObnnzePGh0TNFQ==}
+    hasBin: true
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -25370,6 +25377,8 @@ snapshots:
       thread-stream: 4.0.0
 
   pkce-challenge@5.0.1: {}
+
+  pkg-pr-new@0.0.71: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

Hardens the preview-release workflow against the attack vector used in the [TanStack/Mini Shai-Hulud compromise](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack).

Two changes:

- **Block fork PRs from preview releases.** Adds a `head.repo.full_name == github.repository` check so only branches within `withastro/astro` can trigger preview builds. This prevents a malicious fork from running code in a privileged context.
- **Split into two jobs to isolate OIDC token.** The `build` job runs `pnpm install` and `pnpm build` but has no `id-token: write`. The `publish` job has `id-token: write` but only downloads build artifacts and runs `pkg-pr-new` — it never executes user code. This ensures the OIDC token is never available during code execution, even for non-fork PRs.

The build job uploads only the minimal files needed for publishing (root workspace files + affected package directories), not the entire workspace.