### PR TITLE
Remove all caching from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           mv ../../../package.json ../../../package.temp.json
           rm -rf ../../../node_modules
           sleep 60s # wait for npm registry to update
-          npm i --workspaces=false # vsce does not support pnpm, so we need to pretend this is not a monorepo and use npm
+          npm ci --workspaces=false # vsce does not support pnpm, so we need to pretend this is not a monorepo and use npm
           mv ./astro-ts-plugin-bundle ./node_modules/astro-ts-plugin-bundle
 
       - name: Publish to VSCode Marketplace
@@ -98,7 +98,7 @@ jobs:
         if: steps.vscode-published.outputs.published == 'true'
         run: |
           mv ./package.temp.json ./package.json
-          pnpm install
+          pnpm install --frozen-lockfile
           
       - name: Generate Announcement
         id: message

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ defaults:
     shell: bash
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
   FORCE_COLOR: true
 
 jobs:
@@ -38,13 +36,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.15.0
-          cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Packages
-        run: pnpm run build
+        run: pnpm run build --force
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## Summary

- Removes pnpm store cache (`cache: "pnpm"`) from the release workflow
- Removes Turbo remote cache (`TURBO_TOKEN`/`TURBO_TEAM`)
- Adds `--force` to the build step to skip any local Turbo cache
- Adds `--frozen-lockfile` to ensure the lockfile is the source of truth

The release workflow now does a fully clean install and build from scratch every time. This eliminates cache poisoning as an attack vector for the publish pipeline.

Part of supply chain hardening in response to the [TanStack/Mini Shai-Hulud compromise](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack).