### PR TITLE
fix(csp): improve error messages for invalid directives in security.csp.directives

### DIFF
--- a/.changeset/improve-csp-directive-error-messages.md
+++ b/.changeset/improve-csp-directive-error-messages.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves error messages when an invalid or managed directive (e.g. `script-src`, `style-src`) is used in `security.csp.directives`. The error now clearly explains which directive is problematic and, for Astro-managed directives, points to the correct config option (`security.csp.scriptDirective` or `security.csp.styleDirective`).

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -66,11 +66,24 @@ const ALLOWED_DIRECTIVES = [
 type AllowedDirectives = (typeof ALLOWED_DIRECTIVES)[number];
 export type CspDirective = `${AllowedDirectives}${string | undefined}`;
 
-export const allowedDirectivesSchema = z.custom<CspDirective>((value) => {
-	if (typeof value !== 'string') {
-		return false;
-	}
-	return ALLOWED_DIRECTIVES.some((allowedValue) => {
-		return value.startsWith(allowedValue);
-	});
-});
+const MANAGED_DIRECTIVES = ['script-src', 'style-src'] as const;
+
+export const allowedDirectivesSchema = z
+	.string()
+	.superRefine((value, ctx) => {
+		const managed = MANAGED_DIRECTIVES.find((directive) => value.startsWith(directive));
+		if (managed) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: `The \`${managed}\` directive is managed by Astro and cannot be set in \`security.csp.directives\`. Use \`security.csp.${managed === 'script-src' ? 'scriptDirective' : 'styleDirective'}\` instead.`,
+			});
+			return;
+		}
+		const isValid = ALLOWED_DIRECTIVES.some((allowedValue) => value.startsWith(allowedValue));
+		if (!isValid) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: `Invalid CSP directive "${value}". Allowed directives are: ${ALLOWED_DIRECTIVES.join(', ')}.`,
+			});
+		}
+	}) as z.ZodType<CspDirective>;


### PR DESCRIPTION
## What''s wrong?

When a developer adds a `script-src` or `style-src` entry to `security.csp.directives`, Astro rejects it with a generic Zod "Did not match" error that gives no actionable guidance.

Closes #16663

## What changed?

Replaced the bare `z.custom()` validator in `packages/astro/src/core/csp/config.ts` with a `z.string().superRefine()` that emits two distinct, actionable errors:

1. **Managed directive** (`script-src`, `style-src`): tells the user which directive is managed by Astro and points them to the correct config key (`security.csp.scriptDirective` or `security.csp.styleDirective`).
2. **Unknown directive**: lists all allowed directives so the user knows exactly what is valid.

## Before / After

**Before**
```
[ConfigError] Did not match union
```

**After (script-src example)**
```
[ConfigError] The `script-src` directive is managed by Astro and cannot be set in `security.csp.directives`. Use `security.csp.scriptDirective` instead.
```

## Checklist

- [x] Added changeset (patch for `astro`)
- [x] No behaviour change for valid configs — only the error path is affected
- [x] Follows existing `superRefine` + `z.ZodIssueCode.custom` pattern used in the codebase