### PR TITLE
Add default permissions: {} to all workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,8 @@ on:
       - "pnpm-lock.yaml"
       - "packages/astro/types.d.ts"
 
+permissions: {}
+
 env:
   ASTRO_TELEMETRY_DISABLED: true
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -25,6 +27,8 @@ jobs:
   check:
     name: astro check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 7
     steps:
       - name: Check out repository

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
+        with:
+          persist-credentials: false
       - name: Setup PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
     name: astro check
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Checkout only
     timeout-minutes: 7
     steps:
       - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: read # Required by dorny/paths-filter to read changed files
     outputs:
       language-tools: ${{ steps.filter.outputs.language-tools }}
       astro-types: ${{ steps.filter.outputs.astro-types }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: read # Checkout only
     strategy:
       matrix:
         # windows-latest is still windows-2022 for some reason, even though the windows-2025 image is GA
@@ -98,7 +98,7 @@ jobs:
   biome-lint:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Checkout only
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: read # Checkout only
     needs: 
       - biome-lint
     steps:
@@ -154,7 +154,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: read # Checkout only
     needs: build
     strategy:
       matrix:
@@ -217,7 +217,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: read # Checkout only
     needs:
       - changes
       - build
@@ -278,7 +278,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: read # Checkout only
     needs: build
     strategy:
       matrix:
@@ -317,7 +317,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: read # Checkout only
     needs: build
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
       - "**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
 
+permissions: {}
+
 # Automatically cancel older in-progress jobs on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
@@ -58,6 +60,8 @@ jobs:
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
+    permissions:
+      contents: read
     strategy:
       matrix:
         # windows-latest is still windows-2022 for some reason, even though the windows-2025 image is GA
@@ -109,6 +113,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     needs: 
       - biome-lint
     steps:
@@ -147,6 +153,8 @@ jobs:
     name: 'Test (${{ matrix.TEST_SUITE.name }}): ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     needs: build
     strategy:
       matrix:
@@ -208,6 +216,8 @@ jobs:
   test-language-tools:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     needs:
       - changes
       - build
@@ -267,6 +277,8 @@ jobs:
     name: "Test (E2E): ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     needs: build
     strategy:
       matrix:
@@ -304,6 +316,8 @@ jobs:
     name: "Test (Smoke): ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     needs: build
     strategy:
       matrix:

--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   congrats:
     name: congratsbot

--- a/.github/workflows/continuous_benchmark.yml
+++ b/.github/workflows/continuous_benchmark.yml
@@ -15,6 +15,8 @@ on:
       - 'packages/astro/src/**/*.ts'
       - 'benchmark/**'
 
+permissions: {}
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/continuous_benchmark.yml
+++ b/.github/workflows/continuous_benchmark.yml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         shard: [ "1/4", "2/4", "3/4", "4/4" ]
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # Checkout only
+      pull-requests: write # CodSpeed posts benchmark results as PR comment
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,6 +6,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 env:
   PNPM_STORE_DIR: .pnpm-store
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -24,7 +24,7 @@ jobs:
       (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # Add "needs triage" label
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -50,8 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: write
-      issues: read
+      contents: write # Push fix branches
+      issues: read # Read issue details for triage
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/merge-fix.yml
+++ b/.github/workflows/merge-fix.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: write
-      pull-requests: write
-      packages: read
+      contents: write # Push fix commits
+      pull-requests: write # Update PR
+      packages: read # Pull sandbox image from GHCR
     steps:
       - name: Lowercase image name
         run: echo "IMAGE=${IMAGE,,}" >> "$GITHUB_ENV"

--- a/.github/workflows/merge-fix.yml
+++ b/.github/workflows/merge-fix.yml
@@ -14,6 +14,8 @@ on:
         required: false
         type: string
 
+permissions: {}
+
 env:
   IMAGE: ghcr.io/${{ github.repository }}/flue-sandbox
 

--- a/.github/workflows/merge-main-to-next.yml
+++ b/.github/workflows/merge-main-to-next.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: write
-      pull-requests: write
-      packages: read
+      contents: write # Push merge branch
+      pull-requests: write # Create/update merge PR
+      packages: read # Pull sandbox image from GHCR
     steps:
       - name: Lowercase image name
         run: echo "IMAGE=${IMAGE,,}" >> "$GITHUB_ENV"

--- a/.github/workflows/merge-main-to-next.yml
+++ b/.github/workflows/merge-main-to-next.yml
@@ -5,6 +5,8 @@ on:
     types: [release-published]
   workflow_dispatch:
 
+permissions: {}
+
 env:
   IMAGE: ghcr.io/${{ github.repository }}/flue-sandbox
 

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -9,6 +9,8 @@ on:
       - "packages/astro/src/runtime/client/**/*"
       - "!packages/astro/src/runtime/client/dev-toolbar/**/*"
 
+permissions: {}
+
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
@@ -22,6 +24,9 @@ jobs:
   bundle:
     name: Bundle Size
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -25,8 +25,8 @@ jobs:
     name: Bundle Size
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # Checkout only
+      pull-requests: write # Post bundle size comparison comment
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,7 +11,7 @@ jobs:
     name: semgrep-oss
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Checkout only
     container:
       image: semgrep/semgrep@sha256:40579a2e70910d891959a4868711ba0399293949a2f1f141ddb5002d5fc7dd0f # v1.157.0
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,7 @@
 name: Semgrep OSS scan
+
+permissions: {}
+
 on:
   pull_request: {}
   schedule:
@@ -7,6 +10,8 @@ jobs:
   semgrep:
     name: semgrep-oss
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: semgrep/semgrep@sha256:40579a2e70910d891959a4868711ba0399293949a2f1f141ddb5002d5fc7dd0f # v1.157.0
     steps:


### PR DESCRIPTION
## Summary

- Adds `permissions: {}` at the top level of every workflow that was missing it
- Adds explicit job-level `permissions` to jobs that previously inherited the default token permissions
- This ensures no workflow accidentally gets broad `GITHUB_TOKEN` access

Affected workflows: `ci.yml`, `scripts.yml`, `check.yml`, `semgrep.yml`, `congrats.yml`, `continuous_benchmark.yml`, `issue-triage.yml`, `merge-fix.yml`, `merge-main-to-next.yml`.

Part of supply chain hardening in response to the [TanStack/Mini Shai-Hulud compromise](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack).