### PR TITLE
fix(language-tools): fix MDX syntax highlighting for indented astro codeblocks

### DIFF
--- a/.changeset/flat-tires-roll.md
+++ b/.changeset/flat-tires-roll.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+fix MDX syntax highlighting for indented astro codeblocks

--- a/packages/language-tools/vscode/syntaxes/mdx.astro.tmLanguage.json
+++ b/packages/language-tools/vscode/syntaxes/mdx.astro.tmLanguage.json
@@ -17,9 +17,9 @@
           "name": "entity.name.function.markdown"
         }
       },
-      "end": "(^\\1)\\s*$",
+      "end": "(?:^|\\G)[\\t ]*(\\1)(?:[\\t ]*$)",
       "endCaptures": {
-        "3": {
+        "1": {
           "name": "punctuation.definition.markdown"
         }
       },
@@ -27,7 +27,7 @@
       "patterns": [
         {
           "begin": "(^|\\G)(\\s*)(.*)",
-          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "while": "(^|\\G)(?![\\t ]*([`~]{3,})[\\t ]*$)",
           "patterns": [
             {
               "begin": "^\\s*---\\s*$",


### PR DESCRIPTION
## Changes

Bug reported: https://github.com/withastro/astro/issues/16667
FIXES #16667 

The Astro extension was causing MDX highlighting errors, but only when the code snippets were **indented**:

### BEFORE FIX:
<img width="960" alt="Image" src="https://github.com/user-attachments/assets/97da0cf4-c6d1-40a2-9e09-b47960e84910" />

### AFTER FIX:
<img width="1175" height="767" alt="Screenshot 2026-05-12 at 16 09 35" src="https://github.com/user-attachments/assets/5861ada1-ab29-4120-8028-97f81a1fb396" />


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

1. `pnpm install`
2. `pnpm -C packages/language-tools/vscode build`
3. In Cursor: Run and Debug → Launch Client
4. Opened an MDX file and tested an indented astro codeblock

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs necessary