### PR TITLE
Fix issue with dynamic routes in complex projects using workerd

### DIFF
--- a/.changeset/lazy-jeans-brake.md
+++ b/.changeset/lazy-jeans-brake.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix an issue where dynamic routes in complex projects return the string [object Object] instead of the expected content

--- a/.changeset/lazy-jeans-brake.md
+++ b/.changeset/lazy-jeans-brake.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix an issue where dynamic routes in complex projects return the string [object Object] instead of the expected content
+Fix an issue where dynamic routes would return the string `[object Object]` instead of the expected content, in certain runtimes.

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -274,8 +274,9 @@ export interface RendererFlusher {
 	flush(): void | Promise<void>;
 }
 
-export const isNode =
-	typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]';
+const isNode = typeof process !== "undefined"
+  && Object.prototype.toString.call(process) === "[object process]"
+  && !(typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
 // @ts-expect-error: Deno is not part of the types.
 export const isDeno = typeof Deno !== 'undefined';
 

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -274,7 +274,7 @@ export interface RendererFlusher {
 	flush(): void | Promise<void>;
 }
 
-const isNode = typeof process !== "undefined"
+export const isNode = typeof process !== "undefined"
   && Object.prototype.toString.call(process) === "[object process]"
   && !(typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
 // @ts-expect-error: Deno is not part of the types.


### PR DESCRIPTION
## Changes

Fixes dynamic routes returning the string `[object Object]` under the following conditions:

1. when used with Cloudflare Workers with the `nodejs_compat` flag. The affected projects all use compatibility dates of `2025-04-01` or newer, not sure if older dates are affected.
2. only for large, complex projects where Rollup splits code in a way that triggers it. The exact level of complexity/size required is unknown. The fix should work for projects of all sizes though.

This was a very difficult issue to track down. Static routes were fine, and in the Worker logs I could see that the dynamic routes were being processed correctly (I see things like logs indicating success for loading external content and other expected internal logging from the build process) but the returned response was just the string `[object Object]` regardless of which page or what content was expected -- no error messages of any kind.

I did not open an issue for this because by the time I had enough detail to do so, Claude Code had provided a fix, so I'm just going straight to a PR.

See included Claude Code analysis below for full details. 

## Testing

I did not add tests because I'm not sure how to provide a sufficiently complicated test project -- this problem only surfaces in larger projects. I'm happy to assist adding tests if I can get some help.

I do have this fix running in 3 separate projects ranging in size and complexity from a stripped down copy of the Astro blog starter template for Workers (where the problem never exhibited but this fix does not cause any issues), up to a 1000-page hybrid site with upwards of 100 Astro components and a mix of dynamic and static routes (where the problem surfaced and the fix works). 

Claude Code's explanation of the issue and proposed fix were arrived at after several rounds of analysis and refinements, and its explanation makes sense and matches what I've been experiencing. I specifically asked it to check that the changes do not affect anything for Deno or Node prerendering environments, only workerd.

## Docs

I don't believe docs updates are needed because this fixes an issue with expected functionality with no changes needed by the user.


## Claude's analysis, RCA, and proposed fix, which I've implemented in this PR

<details>
<summary>If you're interested, here's what my AI agent found</summary>
This analysis was done with Astro 6.2.x and Cloudflare 13.3.x, but I've confirmed the problem still exists in the current versions. I'm barred by work policy from installing packages newer than 7 days so I cannot test the latest versions directly, but the problem code still exists in the latest version, unchanged.

This analysis was done by comparing two projects:

- `astro-blog-starter-template` which is a copy of the Astro starter for Workers, stripped of all but one dynamic and one static test page
- `web-dev-collibra-astro` which is our largest, most complicated project where the problem surfaced

This is its final summary, verbatim:


# Fix Summary — Astro `isNode` false-positive in workerd

## Symptom

In an Astro 6.2.x project deployed to Cloudflare Workers via `@astrojs/cloudflare` 13.3.x with `nodejs_compat`, any route with `prerender: false` returns an `HTTP 200`, `content-type: text/html` response whose body is the 15-byte string `[object Object]`. Static / prerendered routes are unaffected. Reproducible locally with `astro build && astro preview`.

## Root cause

`astro/dist/runtime/server/render/util.js` defines:

```js
const isNode = typeof process !== "undefined"
  && Object.prototype.toString.call(process) === "[object process]";
```

`astro/dist/runtime/server/render/page.js` then chooses the response body shape:

```js
if (isNode && !isDeno) {
  body = await renderToAsyncIterable(...);   // Node-only async iterable
} else {
  body = await renderToReadableStream(...);  // standard ReadableStream
}
```

With `nodejs_compat`, workerd's `process` reports `Object.prototype.toString.call(process) === "[object process]"` until the `@cloudflare/unenv-preset` polyfill replaces it with a plain object. The output of `renderToAsyncIterable` is an object exposing `Symbol.asyncIterator`. Node's `undici` accepts async iterables as a Response body; workerd's `Response` does not, and falls back to `String(body)` → `"[object Object]"`.

## Why the bug surfaces in some projects but not others

The bug is a module-initialization-order race that only manifests once Rollup decides to code-split Astro's shared runtime.

Both the failing project and the working starter contain the same two pieces of code in the worker bundle:

```js
// A — unenv polyfill assignment (replaces workerd's raw process)
globalThis.process = _process;

// B — Astro's isNode evaluation (reads process)
const isNode = typeof process !== "undefined"
  && Object.prototype.toString.call(process) === "[object process]";
```

The order in which A and B run depends on whether Rollup keeps them in one chunk or splits them across two:

**`astro-blog-starter-template`** (2 pages, almost no Astro internals reused) — Rollup keeps everything in one chunk, `worker-entry_DEEjL72T.mjs`:

```
line  558:  globalThis.process = _process;       ← A runs first
line 5864:  const isNode = ...                   ← B sees the unenv polyfill
```

Single module body, top-down execution → `process` is the plain-object unenv polyfill by the time `isNode` runs → `isNode = false` → `renderToReadableStream` → works.

**`web-dev-collibra-astro`** (many pages and components importing from `astro/runtime/server/*`) — Rollup factors Astro's shared runtime into its own chunk:

```
transition_DTdhAtUt.mjs:814    const isNode = ...                ← B
worker-entry_2ArJYird.mjs:1282 globalThis.process = _process;    ← A
```

`worker-entry` imports `transition`. ES Module spec executes imported module bodies *before* the importer's body, so B runs before A. `isNode` is evaluated against workerd's *raw* `nodejs_compat` process, latches to `true`, and `renderToAsyncIterable` is selected → broken response.

The threshold is whatever pushes Rollup over its code-splitting heuristic for shared dependencies. Any project with enough reuse of `astro/runtime/server/*` across pages or components will eventually trip it — it's not specific to Vue, custom integrations, or middleware.

I confirmed module init order is the differentiator by logging `Object.prototype.toString.call(process)` at module init vs. request time in the failing project: `"[object process]"` at init, `"[object Object]"` at request time — proving the polyfill assignment happens *between* the two, after `isNode` has already been frozen.

## The fix

One line in `packages/astro/src/runtime/server/render/util.ts`:

```js
const isNode = typeof process !== "undefined"
  && Object.prototype.toString.call(process) === "[object process]"
  && !(typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
```

Workerd's `navigator.userAgent === "Cloudflare-Workers"` is documented, stable, and present from t=0 — so the check is immune to the module-init-order race that broke the original `process`-only detection.

## Behavior matrix

| Environment | `process` toString | `navigator.userAgent` | `isNode` before | `isNode` after | Behavior change |
|---|---|---|---|---|---|
| Node.js | `"[object process]"` | undefined / Node ua | `true` | `true` | None |
| Deno | `"[object process]"` (Node compat shim) | `"Deno/x.y.z"` | `true` | `true` | None — also gated by `!isDeno` in `renderPage` |
| Browser | undefined | various, never `"Cloudflare-Workers"` | `false` | `false` | None |
| Cloudflare Workers (workerd) without `nodejs_compat` | undefined | `"Cloudflare-Workers"` | `false` | `false` | None |
| Cloudflare Workers (workerd) with `nodejs_compat`, polyfill already installed before `isNode` eval | `"[object Object]"` | `"Cloudflare-Workers"` | `false` | `false` | None (incidentally-correct case — the starter) |
| **Cloudflare Workers (workerd) with `nodejs_compat`, polyfill not yet installed** | `"[object process]"` | `"Cloudflare-Workers"` | **`true` (wrong)** | **`false` (correct)** | **Bug fixed** |

The change only flips behavior in the row where the original heuristic is wrong.

### Cross-checks against the prerender flow

`@astrojs/cloudflare` exposes `prerenderEnvironment: "node" | "workerd"` (default `"workerd"`).

- `prerenderEnvironment: "node"`: prerender runs in real Node. No `navigator` global, original `isNode = true` preserved. Same as before. ✓
- `prerenderEnvironment: "workerd"` (default): prerender runs in workerd. New check correctly returns `false`. The `renderToReadableStream` path produces a `ReadableStream` body, which Astro's prerender pipeline consumes the same way it consumes an async iterable. ✓

## Verification performed

1. Reproduced locally on `web-dev-collibra-astro` with `astro build` + `astro preview` — `curl /dev/dynamic` returns `[object Object]` (15 bytes).
2. Confirmed the path by logging `isNode`, `streaming`, and `body.constructor.name` inside the bundled `renderPage` — `isNode=true`, body constructor is `Object` (the async iterable), not `ReadableStream`.
4. Confirmed module-init-order theory by logging `Object.prototype.toString.call(process)` both at module init (`"[object process]"`) and at request time (`"[object Object]"`) — proves the polyfill assignment happens between the two.
5. Confirmed `astro-blog-starter-template` evaluates `isNode = false` because the unenv polyfill assignment (line 558) precedes the `isNode` evaluation (line 5864) in the same chunk.
6. Applied the patch via `build-scripts/patch-astro-renderer.mjs`; re-ran preview; dynamic route returns `<!DOCTYPE html>...<div>TEST</div>`, static route unchanged.
<details>