### PR TITLE
feat: advanced routing types and config gaps

### DIFF
--- a/.changeset/advanced-routing-fetchfile.md
+++ b/.changeset/advanced-routing-fetchfile.md
@@ -1,0 +1,15 @@
+---
+'astro': patch
+---
+
+Adds `fetchFile` option to `experimental.advancedRouting` to customize or disable the entrypoint file
+
+```js
+export default defineConfig({
+  experimental: {
+    advancedRouting: {
+      fetchFile: 'fetch.ts',
+    },
+  },
+});
+```

--- a/.changeset/advanced-routing-hono-cache.md
+++ b/.changeset/advanced-routing-hono-cache.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Hono `cache()` middleware to follow the standard wrapper pattern

--- a/.changeset/advanced-routing-providers.md
+++ b/.changeset/advanced-routing-providers.md
@@ -1,0 +1,13 @@
+---
+'astro': patch
+---
+
+Adds `App.Providers` interface for typing custom context providers on `Astro` and `ctx`
+
+```ts
+declare namespace App {
+  interface Providers {
+    oauth: import('./lib/oauth').OAuthSession;
+  }
+}
+```

--- a/.changeset/advanced-routing-state-response.md
+++ b/.changeset/advanced-routing-state-response.md
@@ -1,0 +1,10 @@
+---
+'astro': patch
+---
+
+Adds `FetchState.response` property, set automatically after `pages()` or `middleware()` completes
+
+```ts
+const response = await middleware(state, (s) => pages(s));
+console.log(state.response === response); // true
+```

--- a/.changeset/advanced-routing-types.md
+++ b/.changeset/advanced-routing-types.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds missing types and config for advanced routing: `Fetchable` export, `FetchState.response`, `App.Providers` for typed context providers, and `fetchFile` config option. Fixes Hono `cache()` middleware to follow the standard wrapper pattern.

--- a/.changeset/advanced-routing-types.md
+++ b/.changeset/advanced-routing-types.md
@@ -2,4 +2,14 @@
 'astro': patch
 ---
 
-Adds missing types and config for advanced routing: `Fetchable` export, `FetchState.response`, `App.Providers` for typed context providers, and `fetchFile` config option. Fixes Hono `cache()` middleware to follow the standard wrapper pattern.
+Adds `Fetchable` type export for typing the advanced routing entrypoint
+
+```ts
+import type { Fetchable } from 'astro';
+
+export default {
+  async fetch(request) {
+    return new Response('ok');
+  },
+} satisfies Fetchable;
+```

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -183,6 +183,11 @@ export const AstroConfigSchema = z.object({
 		.union([z.literal('always'), z.literal('never'), z.literal('ignore')])
 		.optional()
 		.default(ASTRO_CONFIG_DEFAULTS.trailingSlash),
+	fetchFile: z
+		.string()
+		.nullable()
+		.optional()
+		.default('app'),
 	output: z
 		.union([z.literal('static'), z.literal('server'), z.literal('hybrid')])
 		.optional()

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -183,11 +183,6 @@ export const AstroConfigSchema = z.object({
 		.union([z.literal('always'), z.literal('never'), z.literal('ignore')])
 		.optional()
 		.default(ASTRO_CONFIG_DEFAULTS.trailingSlash),
-	fetchFile: z
-		.string()
-		.nullable()
-		.optional()
-		.default('app'),
 	output: z
 		.union([z.literal('static'), z.literal('server'), z.literal('hybrid')])
 		.optional()
@@ -538,7 +533,12 @@ export const AstroConfigSchema = z.object({
 	experimental: z
 		.strictObject({
 			advancedRouting: z
-				.boolean()
+				.union([
+					z.boolean(),
+					z.strictObject({
+						fetchFile: z.string().nullable().optional().default('app'),
+					}),
+				])
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.advancedRouting),
 			clientPrerender: z

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -79,6 +79,8 @@ export interface AstroFetchState {
 	readonly locals: App.Locals;
 	/** Route params derived from routeData + pathname. */
 	readonly params: Params | undefined;
+	/** The `Response` produced by handlers, if any. Set after rendering. */
+	response: Response | undefined;
 	/** Default HTTP status for the rendered response. */
 	status: number;
 
@@ -168,6 +170,11 @@ export class FetchState implements AstroFetchState {
 	 * allocate an empty object per request.
 	 */
 	slots: Record<string, any> | undefined;
+	/**
+	 * The `Response` produced by handlers, if any. Set after page
+	 * rendering or middleware completes.
+	 */
+	response: Response | undefined;
 	/**
 	 * Default HTTP status for the rendered response. Callers override
 	 * before rendering runs (e.g. `AstroHandler` sets this from

--- a/packages/astro/src/core/fetch/index.ts
+++ b/packages/astro/src/core/fetch/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Public `astro/fetch` API.
+ *
+ * Every exported function here is a thin wrapper that resolves the
+ * correct handler instance and delegates to it. **Do not add logic
+ * here** — keep behaviour inside the handler modules so it stays
+ * unit-testable without the virtual-module wiring.
+ */
 import { ActionHandler } from '../../actions/handler.js';
 import type { BaseApp } from '../app/base.js';
 import type { Pipeline } from '../base-pipeline.js';

--- a/packages/astro/src/core/fetch/types.ts
+++ b/packages/astro/src/core/fetch/types.ts
@@ -4,3 +4,23 @@
  * lets handlers compose easily with other middleware systems later.
  */
 export type FetchHandler = (request: Request) => Promise<Response>;
+
+/**
+ * An object with a `fetch` method that handles incoming requests.
+ * This is the shape expected by `src/app.ts` and aligns with the
+ * convention used by Cloudflare Workers, Bun, and Hono.
+ *
+ * @example
+ * ```ts
+ * import type { Fetchable } from 'astro';
+ *
+ * export default {
+ *   async fetch(request) {
+ *     return new Response('ok');
+ *   }
+ * } satisfies Fetchable;
+ * ```
+ */
+export interface Fetchable {
+	fetch(request: Request): Response | Promise<Response>;
+}

--- a/packages/astro/src/core/fetch/vite-plugin.ts
+++ b/packages/astro/src/core/fetch/vite-plugin.ts
@@ -20,14 +20,17 @@ import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../constants.js';
  */
 const FETCHABLE_MODULE_ID = 'virtual:astro:fetchable';
 const FETCHABLE_RESOLVED_MODULE_ID = '\0' + FETCHABLE_MODULE_ID;
-// Segment under `srcDir` to probe for the user's handler module.
+// Default segment under `srcDir` to probe for the user's handler module.
 // Matches how `vitePluginMiddleware` resolves `src/middleware`.
-const APP_PATH_SEGMENT_NAME = 'app';
+const DEFAULT_FETCH_FILE = 'app';
 
 export function vitePluginFetchable({ settings }: { settings: AstroSettings }): VitePlugin {
 	let resolvedUserAppId: string | undefined;
 	let userAppPresent = false;
 	const advancedRoutingEnabled = settings.config.experimental.advancedRouting;
+	const fetchFile = settings.config.fetchFile ?? DEFAULT_FETCH_FILE;
+	// When fetchFile is null the feature is explicitly disabled.
+	const fetchFileDisabled = settings.config.fetchFile === null;
 
 	const normalizedSrcDir = viteNormalizePath(fileURLToPath(settings.config.srcDir));
 
@@ -44,9 +47,9 @@ export function vitePluginFetchable({ settings }: { settings: AstroSettings }): 
 			server.watcher.on('change', (path) => {
 				const normalizedPath = viteNormalizePath(path);
 				if (!normalizedPath.startsWith(normalizedSrcDir)) return;
-				const relativePath = normalizedPath.slice(normalizedSrcDir.length);
-				// Dot-prefix guard: match `app.ts` but not e.g. `app-utils.ts`.
-				if (!relativePath.startsWith(`${APP_PATH_SEGMENT_NAME}.`)) return;
+			const relativePath = normalizedPath.slice(normalizedSrcDir.length);
+			// Dot-prefix guard: match `app.ts` but not e.g. `app-utils.ts`.
+			if (!relativePath.startsWith(`${fetchFile}.`)) return;
 
 				for (const name of [
 					ASTRO_VITE_ENVIRONMENT_NAMES.ssr,
@@ -66,8 +69,12 @@ export function vitePluginFetchable({ settings }: { settings: AstroSettings }): 
 			filter: {
 				id: new RegExp(`^${FETCHABLE_MODULE_ID}$`),
 			},
-			async handler() {
-				const resolved = await this.resolve(`${normalizedSrcDir}${APP_PATH_SEGMENT_NAME}`);
+		async handler() {
+				if (fetchFileDisabled) {
+					userAppPresent = false;
+					return FETCHABLE_RESOLVED_MODULE_ID;
+				}
+				const resolved = await this.resolve(`${normalizedSrcDir}${fetchFile}`);
 				userAppPresent = advancedRoutingEnabled && !!resolved;
 				resolvedUserAppId = resolved?.id;
 				return FETCHABLE_RESOLVED_MODULE_ID;

--- a/packages/astro/src/core/fetch/vite-plugin.ts
+++ b/packages/astro/src/core/fetch/vite-plugin.ts
@@ -27,10 +27,11 @@ const DEFAULT_FETCH_FILE = 'app';
 export function vitePluginFetchable({ settings }: { settings: AstroSettings }): VitePlugin {
 	let resolvedUserAppId: string | undefined;
 	let userAppPresent = false;
-	const advancedRoutingEnabled = settings.config.experimental.advancedRouting;
-	const fetchFile = settings.config.fetchFile ?? DEFAULT_FETCH_FILE;
+	const advancedRoutingConfig = settings.config.experimental.advancedRouting;
+	const advancedRoutingEnabled = !!advancedRoutingConfig;
+	const fetchFile = (typeof advancedRoutingConfig === 'object' ? advancedRoutingConfig.fetchFile : undefined) ?? DEFAULT_FETCH_FILE;
 	// When fetchFile is null the feature is explicitly disabled.
-	const fetchFileDisabled = settings.config.fetchFile === null;
+	const fetchFileDisabled = typeof advancedRoutingConfig === 'object' && advancedRoutingConfig.fetchFile === null;
 
 	const normalizedSrcDir = viteNormalizePath(fileURLToPath(settings.config.srcDir));
 

--- a/packages/astro/src/core/hono/index.ts
+++ b/packages/astro/src/core/hono/index.ts
@@ -101,9 +101,12 @@ export function sessions(): HonoMiddlewareHandler {
 	};
 }
 
-export function cache(next: () => Promise<Response>): HonoMiddlewareHandler {
-	return async (context, _honoNext) => {
-		return fetchCache(getFetchState(context), next);
+export function cache(): HonoMiddlewareHandler {
+	return async (context, honoNext) => {
+		return fetchCache(getFetchState(context), async () => {
+			await honoNext();
+			return context.res;
+		});
 	};
 }
 

--- a/packages/astro/src/core/middleware/astro-middleware.ts
+++ b/packages/astro/src/core/middleware/astro-middleware.ts
@@ -71,7 +71,9 @@ export class AstroMiddleware {
 			const composed = sequence(...pipeline.internalMiddleware, pipelineMiddleware);
 			response = await callMiddleware(composed, apiContext, next);
 		}
-		return this.#finalize(state, response);
+		response = this.#finalize(state, response);
+		state.response = response;
+		return response;
 	}
 
 	#finalize(state: FetchState, response: Response): Response {

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -91,12 +91,13 @@ export class PagesHandler {
 				return new Response(null, { status: 500, headers: { [ROUTE_TYPE_HEADER]: 'fallback' } });
 			}
 		}
-		// We need to merge the cookies from the response back into the cookies
-		// because they may need to be passed along from a rewrite.
-		const responseCookies = getCookiesFromResponse(response);
-		if (responseCookies) {
-			state.cookies!.merge(responseCookies);
-		}
-		return response;
+	// We need to merge the cookies from the response back into the cookies
+	// because they may need to be passed along from a rewrite.
+	const responseCookies = getCookiesFromResponse(response);
+	if (responseCookies) {
+		state.cookies!.merge(responseCookies);
+	}
+	state.response = response;
+	return response;
 	}
 }

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -256,6 +256,28 @@ export interface AstroUserConfig<
 	trailingSlash?: 'always' | 'never' | 'ignore';
 
 	/**
+	 * @name fetchFile
+	 * @type {string | null}
+	 * @default `'app'`
+	 * @description
+	 * Customize the filename (without extension) used as the advanced routing entrypoint
+	 * inside `srcDir`. Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
+	 *
+	 * Set to `null` to disable the feature, which is useful if you already have a
+	 * `src/app.ts` file used for other purposes.
+	 *
+	 * ```js
+	 * export default defineConfig({
+	 *   fetchFile: 'fetch',
+	 *   experimental: {
+	 *     advancedRouting: true,
+	 *   },
+	 * });
+	 * ```
+	 */
+	fetchFile?: string | null;
+
+	/**
 	 * @docs
 	 * @name redirects
 	 * @type {Record<string, RedirectConfig>}

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2810,17 +2810,6 @@ export interface AstroUserConfig<
 		 *   },
 		 * });
 		 * ```
-		 *
-		 * ### experimental.advancedRouting.fetchFile
-		 *
-		 * **Type:** `string | null`
-		 * **Default:** `'app'`
-		 *
-		 * Customize the file used as the advanced routing entrypoint inside `srcDir`.
-		 * Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
-		 *
-		 * Set to `null` to disable the entrypoint, which is useful if you already
-		 * have a `src/app.ts` file used for other purposes.
 		 */
 		advancedRouting?: boolean | {
 			/**

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2813,9 +2813,15 @@ export interface AstroUserConfig<
 		 */
 		advancedRouting?: boolean | {
 			/**
-			 * Customize the file used as the advanced routing entrypoint inside `srcDir`.
+			 * @name experimental.advancedRouting.fetchFile
+			 * @type {string | null}
+			 * @default 'app'
+			 * @description
+			 * 
+			 * Customizes the file used as the advanced routing entrypoint inside `srcDir`.
 			 * Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
-			 * Set to `null` to disable the entrypoint.
+			 * 
+			 * If you already have a `src/app.ts` file in use for other purposes, define a different filename or set the value to `null` to disable the entrypoint.
 			 */
 			fetchFile?: string | null;
 		};

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -256,28 +256,6 @@ export interface AstroUserConfig<
 	trailingSlash?: 'always' | 'never' | 'ignore';
 
 	/**
-	 * @name fetchFile
-	 * @type {string | null}
-	 * @default `'app'`
-	 * @description
-	 * Customize the filename (without extension) used as the advanced routing entrypoint
-	 * inside `srcDir`. Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
-	 *
-	 * Set to `null` to disable the feature, which is useful if you already have a
-	 * `src/app.ts` file used for other purposes.
-	 *
-	 * ```js
-	 * export default defineConfig({
-	 *   fetchFile: 'fetch',
-	 *   experimental: {
-	 *     advancedRouting: true,
-	 *   },
-	 * });
-	 * ```
-	 */
-	fetchFile?: string | null;
-
-	/**
 	 * @docs
 	 * @name redirects
 	 * @type {Record<string, RedirectConfig>}
@@ -2815,21 +2793,43 @@ export interface AstroUserConfig<
 	experimental?: {
 		/**
 		 * @name experimental.advancedRouting
-		 * @type {boolean}
+		 * @type {boolean | object}
 		 * @default `false`
 		 * @description
 		 * Enables `src/app.ts` as an advanced routing entrypoint, allowing you to
 		 * compose Astro's request pipeline with the Web Fetch standard or your own Hono middleware.
 		 *
+		 * Pass `true` to enable with default settings, or an object to customize:
+		 *
 		 * ```js
 		 * export default defineConfig({
 		 *   experimental: {
-		 *     advancedRouting: true,
+		 *     advancedRouting: {
+		 *       fetchFile: 'fetch.ts',
+		 *     },
 		 *   },
 		 * });
 		 * ```
+		 *
+		 * ### experimental.advancedRouting.fetchFile
+		 *
+		 * **Type:** `string | null`
+		 * **Default:** `'app'`
+		 *
+		 * Customize the file used as the advanced routing entrypoint inside `srcDir`.
+		 * Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
+		 *
+		 * Set to `null` to disable the entrypoint, which is useful if you already
+		 * have a `src/app.ts` file used for other purposes.
 		 */
-		advancedRouting?: boolean;
+		advancedRouting?: boolean | {
+			/**
+			 * Customize the file used as the advanced routing entrypoint inside `srcDir`.
+			 * Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
+			 * Set to `null` to disable the entrypoint.
+			 */
+			fetchFile?: string | null;
+		};
 
 		/**
 		 *

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -138,7 +138,7 @@ export interface AstroGlobal<
 export interface APIContext<
 	Props extends Record<string, any> = Record<string, any>,
 	Params extends Record<string, string | undefined> = Record<string, string | undefined>,
-> {
+> extends App.Providers {
 	/**
 	 * The site provided in the astro config, parsed as an instance of `URL`, without base.
 	 * `undefined` if the site is not provided in the config.

--- a/packages/astro/src/types/public/extendables.ts
+++ b/packages/astro/src/types/public/extendables.ts
@@ -15,6 +15,25 @@ declare global {
 		 * Optionally type the data stored in the session
 		 */
 		export interface SessionData {}
+
+		/**
+		 * Declare custom context providers to get typed access on `Astro` and `ctx`.
+		 * Libraries and users register providers via `state.provide(key, { create, finalize? })`,
+		 * and the corresponding types are declared here using module augmentation.
+		 *
+		 * Built-in providers like `session` are already typed by Astro and don't
+		 * need to be declared here.
+		 *
+		 * @example
+		 * ```ts
+		 * declare namespace App {
+		 *   interface Providers {
+		 *     oauth: import('./lib/oauth').OAuthSession;
+		 *   }
+		 * }
+		 * ```
+		 */
+		export interface Providers {}
 	}
 
 	namespace Astro {

--- a/packages/astro/src/types/public/index.ts
+++ b/packages/astro/src/types/public/index.ts
@@ -37,6 +37,7 @@ export type { AstroIntegrationLogger } from '../../core/logger/core.js';
 export type { AstroSession } from '../../core/session/runtime.js';
 export type { ToolbarServerHelpers } from '../../runtime/client/dev-toolbar/helpers.js';
 export type { AstroEnvironmentNames } from '../../core/constants.js';
+export type { Fetchable } from '../../core/fetch/types.js';
 export type { SessionDriver, SessionDriverConfig } from '../../core/session/types.js';
 export type {
 	CacheProvider,

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -436,3 +436,103 @@ describe('Composed pipeline', () => {
 });
 
 // #endregion
+
+// #region state.response
+
+describe('state.response', () => {
+	it('is set after pages() renders', async () => {
+		const app = createTestApp([createPage(simplePage, { route: '/' })]);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		assert.equal(state.response, undefined, 'response should be undefined before rendering');
+
+		const response = await pages(state);
+
+		assert.ok(state.response, 'response should be set after pages()');
+		assert.equal(state.response, response, 'state.response should be the same object returned by pages()');
+	});
+
+	it('is set after middleware() completes', async () => {
+		const app = createTestApp([createPage(simplePage, { route: '/' })]);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		const response = await middleware(state, () => pages(state));
+
+		assert.ok(state.response, 'response should be set after middleware()');
+		assert.equal(state.response, response, 'state.response should be the same object returned by middleware()');
+	});
+});
+
+// #endregion
+
+// #region Context providers
+
+describe('Context providers', () => {
+	it('resolve returns undefined for an unregistered key', () => {
+		const app = createTestApp([createPage(simplePage, { route: '/' })]);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		assert.equal(state.resolve('missing'), undefined);
+	});
+
+	it('provide + resolve lazily creates and caches the value', () => {
+		const app = createTestApp([createPage(simplePage, { route: '/' })]);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		let createCalls = 0;
+		state.provide('counter', {
+			create() {
+				createCalls++;
+				return { count: 42 };
+			},
+		});
+
+		const first = state.resolve('counter');
+		const second = state.resolve('counter');
+
+		assert.deepEqual(first, { count: 42 });
+		assert.equal(first, second, 'resolve should return the cached instance');
+		assert.equal(createCalls, 1, 'create should only be called once');
+	});
+
+	it('finalizeAll runs finalize callbacks for resolved providers', async () => {
+		const app = createTestApp([createPage(simplePage, { route: '/' })]);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		let finalized = false;
+		state.provide('session', {
+			create: () => ({ data: 'test' }),
+			finalize: () => { finalized = true; },
+		});
+
+		// Resolve it so finalize will run
+		state.resolve('session');
+		await state.finalizeAll();
+
+		assert.ok(finalized, 'finalize should have been called');
+	});
+
+	it('finalizeAll skips providers that were never resolved', async () => {
+		const app = createTestApp([createPage(simplePage, { route: '/' })]);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		let finalized = false;
+		state.provide('unused', {
+			create: () => 'value',
+			finalize: () => { finalized = true; },
+		});
+
+		// Don't resolve — finalize should not run
+		await state.finalizeAll();
+
+		assert.equal(finalized, false, 'finalize should not run for unresolved providers');
+	});
+});
+
+// #endregion


### PR DESCRIPTION
## Changes

- **`Fetchable` type**: Exported from `astro` so users can type `src/app.ts` with `satisfies Fetchable`.
- **`FetchState.response`**: Set by `PagesHandler` and `AstroMiddleware` after rendering so callers can read `state.response`.
- **`App.Providers`**: New extendable interface for typing custom context providers on `ctx` and `Astro`.
- **`fetchFile` config**: Lets users rename the entrypoint away from `src/app.ts`, or set `null` to disable.
- **Hono `cache()` wrapper**: Now follows the standard middleware pattern like the other Hono wrappers.

## Testing

Added 6 unit tests in `test/units/fetch/index.test.ts`:
- `state.response` is set after `pages()` and `middleware()`
- Context provider `provide`/`resolve` lazy creation and caching
- `finalizeAll` runs finalize for resolved providers, skips unresolved ones

## Docs

Added here: https://github.com/withastro/docs/pull/13890