### PR TITLE
Fix VSCode extension release by reverting npm ci to npm i

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           mv ../../../package.json ../../../package.temp.json
           rm -rf ../../../node_modules
           sleep 60s # wait for npm registry to update
-          npm ci --workspaces=false # vsce does not support pnpm, so we need to pretend this is not a monorepo and use npm
+          npm i --workspaces=false # vsce does not support pnpm, so we need to pretend this is not a monorepo and use npm
           mv ./astro-ts-plugin-bundle ./node_modules/astro-ts-plugin-bundle
 
       - name: Publish to VSCode Marketplace


### PR DESCRIPTION
## Changes

- Reverts `npm ci` back to `npm i` in the VSCode extension publish step of the release workflow. `npm ci` requires a `package-lock.json` which does not exist in `packages/language-tools/vscode/` (and is globally gitignored). This was broken by #16711.

## Testing

- No test changes. This is a CI workflow fix — validated by the next release that publishes the VSCode extension.

## Docs

- No docs needed — internal CI change only.