### PR TITLE
Escape slot names in hydration template attributes

### DIFF
--- a/.changeset/escape-slot-names.md
+++ b/.changeset/escape-slot-names.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a reflected XSS vulnerability where slot names on hydrated components were not HTML-escaped in SSR output

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -6,7 +6,7 @@ import type {
 	SSRLoadedRenderer,
 	SSRResult,
 } from '../../../types/public/internal.js';
-import { markHTMLString } from '../escape.js';
+import { escapeHTML, markHTMLString } from '../escape.js';
 import { extractDirectives, generateHydrateScript } from '../hydration.js';
 import { serializeProps } from '../serialize.js';
 import { shorthash } from '../shorthash.js';
@@ -354,7 +354,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 						? 'astro-slot'
 						: 'astro-static-slot'
 					: 'astro-slot';
-				let expectedHTML = key === 'default' ? `<${tagName}>` : `<${tagName} name="${key}">`;
+				let expectedHTML = key === 'default' ? `<${tagName}>` : `<${tagName} name="${escapeHTML(key)}">`;
 				if (!html.includes(expectedHTML)) {
 					unrenderedSlots.push(key);
 				}
@@ -368,7 +368,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 			? unrenderedSlots
 					.map(
 						(key) =>
-							`<template data-astro-template${key !== 'default' ? `="${key}"` : ''}>${
+							`<template data-astro-template${key !== 'default' ? `="${escapeHTML(key)}"` : ''}>${
 								children[key]
 							}</template>`,
 					)

--- a/packages/astro/test/astro-children.test.ts
+++ b/packages/astro/test/astro-children.test.ts
@@ -98,4 +98,23 @@ describe('Component children', () => {
 		assert.equal($('#client-no-children').parent().children().length, 1);
 		assert.equal($('#client-no-children').parent().find('template').length, 0);
 	});
+
+	it('Escapes slot names in data-astro-template attributes to prevent XSS', async () => {
+		const html = await fixture.readFile('/slot-name-escape/index.html');
+		const $ = cheerio.load(html);
+
+		// The malicious slot name should NOT break out of the attribute to inject an <img> tag.
+		assert.equal($('img[src="x"]').length, 0, 'No injected <img> element should exist');
+
+		// Verify the template element exists with properly escaped content.
+		const templates = $('template[data-astro-template]');
+		assert.equal(templates.length, 1, 'Should have exactly one template element');
+
+		// The raw HTML should contain escaped entities in the data-astro-template attribute,
+		// not raw double quotes or angle brackets that would allow attribute breakout.
+		assert.ok(
+			html.includes('data-astro-template="abc&quot;&gt;&lt;img'),
+			'Slot name should be HTML-escaped in the data-astro-template attribute',
+		);
+	});
 });

--- a/packages/astro/test/fixtures/astro-children/src/pages/slot-name-escape.astro
+++ b/packages/astro/test/fixtures/astro-children/src/pages/slot-name-escape.astro
@@ -1,0 +1,12 @@
+---
+import PreactComponent from '../components/NoRender.jsx';
+const maliciousSlotName = 'abc"><img src=x onerror=alert(1)><x y="';
+---
+<html>
+<head><title>Slot Name Escape</title></head>
+<body>
+  <PreactComponent id="escaped-slot" client:load>
+    <h1 slot={maliciousSlotName}>content</h1>
+  </PreactComponent>
+</body>
+</html>


### PR DESCRIPTION
## Changes

- Fixes a reflected XSS where slot names on hydrated (`client:*`) components were interpolated raw into `data-astro-template` and `astro-slot name` HTML attributes during SSR. An attacker could break out of the attribute context and inject arbitrary HTML when a slot name is derived from user input. Applies `escapeHTML()` to the slot name key at both interpolation points in `component.ts`.

## Testing

- Added `slot-name-escape.astro` fixture page that uses a slot name containing `"><img src=x onerror=alert(1)>` on a `client:load` component
- Added test case in `astro-children.test.ts` verifying no injected `<img>` element exists and the attribute value contains properly escaped entities

## Docs

- No docs update needed — this is an internal security fix with no user-facing API change.