### PR TITLE
Fix preview release publish job failing to detect pnpm version

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -125,6 +125,11 @@ jobs:
     name: Publish preview release
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
+
       - name: Download publish artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:


### PR DESCRIPTION
## Changes

- Adds a sparse checkout step to the `publish` job in the preview release workflow so `pnpm/action-setup` can read the `packageManager` field from `package.json`. The `publish` job previously had no checkout, so pnpm setup failed with "No pnpm version is specified."

## Testing

- No test changes. This is a CI workflow fix — validation is the next preview release run succeeding.

## Docs

- No docs needed — internal CI change only.