### PR TITLE
Fix preview release publish job

### DIFF
--- a/scripts/stage-preview-publish.test.ts
+++ b/scripts/stage-preview-publish.test.ts
@@ -15,11 +15,17 @@ describe('stage-preview-publish', () => {
 		rmSync(outputDir, { recursive: true, force: true });
 
 		mkdirSync(join(fixtureDir, 'packages', 'astro', 'dist'), { recursive: true });
+		mkdirSync(join(fixtureDir, 'packages', 'astro', 'test'), { recursive: true });
+		mkdirSync(join(fixtureDir, 'packages', 'astro', 'src'), { recursive: true });
+		mkdirSync(join(fixtureDir, 'packages', 'astro', 'node_modules'), { recursive: true });
 		writeFileSync(
 			join(fixtureDir, 'packages', 'astro', 'package.json'),
 			JSON.stringify({ name: 'astro', version: '1.0.0' }),
 		);
 		writeFileSync(join(fixtureDir, 'packages', 'astro', 'dist', 'index.js'), '// built');
+		writeFileSync(join(fixtureDir, 'packages', 'astro', 'test', 'test.js'), '// test');
+		writeFileSync(join(fixtureDir, 'packages', 'astro', 'src', 'index.ts'), '// src');
+		writeFileSync(join(fixtureDir, 'packages', 'astro', 'node_modules', 'dep.js'), '// dep');
 	});
 
 	after(() => {
@@ -56,6 +62,11 @@ describe('stage-preview-publish', () => {
 
 		// Built output was copied
 		assert.ok(existsSync(join(outputDir, 'packages', 'astro', 'dist', 'index.js')));
+
+		// Excluded directories were not copied
+		assert.ok(!existsSync(join(outputDir, 'packages', 'astro', 'test')));
+		assert.ok(!existsSync(join(outputDir, 'packages', 'astro', 'src')));
+		assert.ok(!existsSync(join(outputDir, 'packages', 'astro', 'node_modules')));
 
 		// affected-packages.json was written
 		const affected: string[] = JSON.parse(

--- a/scripts/stage-preview-publish.ts
+++ b/scripts/stage-preview-publish.ts
@@ -11,7 +11,7 @@
  * Expects AFFECTED_PACKAGES env var as a JSON array of relative package paths.
  */
 
-import { cpSync, mkdirSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const stagingDir: string | undefined = process.argv[2];
@@ -40,11 +40,21 @@ writeFileSync(
 // etc. that require files/config not present in this minimal workspace.
 writeFileSync(join(stagingDir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/**/*"\n');
 
-// Copy each affected package directory (including built output)
+// Copy each affected package directory, excluding directories that are never
+// part of the published tarball. This keeps the artifact small enough for
+// upload-artifact to handle without timing out.
+const EXCLUDE_DIRS = new Set(['test', 'e2e', 'src', 'node_modules', '.turbo']);
+
 for (const pkg of affectedPackages) {
 	const dest = join(stagingDir, pkg);
 	mkdirSync(dest, { recursive: true });
-	cpSync(pkg, dest, { recursive: true });
+
+	for (const entry of readdirSync(pkg, { withFileTypes: true })) {
+		const srcPath = join(pkg, entry.name);
+		const destPath = join(dest, entry.name);
+		if (entry.isDirectory() && EXCLUDE_DIRS.has(entry.name)) continue;
+		cpSync(srcPath, destPath, { recursive: true });
+	}
 }
 
 // Save the affected packages list for the publish job


### PR DESCRIPTION
## Changes

The hardened preview-release workflow (#16710) combined with the pnpm v11 upgrade broke preview releases. This generates a synthetic minimal workspace for the publish artifact and uses `pnpm dlx` to run pkg-pr-new without triggering workspace resolution. Also excludes test/src/e2e directories from the artifact to prevent upload timeouts.

## Testing

- Added smoke tests for the staging script (`scripts/stage-preview-publish.test.ts`).

## Docs

No docs needed — internal CI change.