### PR TITLE
fix: warn when partials strip component assets

### DIFF
--- a/.changeset/warn-page-partials-stripped-assets.md
+++ b/.changeset/warn-page-partials-stripped-assets.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Warn when page partials contain component assets that will be stripped from the partial HTML output.

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -31,6 +31,7 @@ const EMPTY_SLOTS: Record<string, never> = Object.freeze({});
  */
 export class PagesHandler {
 	#pipeline: Pipeline;
+	#warnedPartialAssets = new Set<string>();
 
 	constructor(pipeline: Pipeline) {
 		this.#pipeline = pipeline;
@@ -71,6 +72,21 @@ export class PagesHandler {
 					// we signal to the rest of the internals that we can ignore the results of existing renders and avoid kicking off more of them.
 					result.cancelled = true;
 					throw e;
+				}
+
+				// Partial pages strip `<head>` content (scoped styles, hoisted scripts,
+				// and other propagated head parts) from the response. Warn once per
+				// route component when the rendered tree contained such assets so the
+				// loss isn't silent.
+				if (result.partial && result._metadata.propagators.size > 0) {
+					const componentKey = state.routeData!.component;
+					if (!this.#warnedPartialAssets.has(componentKey)) {
+						this.#warnedPartialAssets.add(componentKey);
+						logger.warn(
+							null,
+							`The page ${componentKey} is a partial but its component tree includes Astro component scripts or scoped styles. These will be stripped from the HTML output. See https://docs.astro.build/en/basics/astro-pages/#page-partials for more information.`,
+						);
+					}
 				}
 
 				// Signal to the i18n middleware to maybe act on this response

--- a/packages/astro/test/units/render/partials-warnings.test.ts
+++ b/packages/astro/test/units/render/partials-warnings.test.ts
@@ -1,0 +1,142 @@
+import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { FetchState } from '../../../dist/core/fetch/fetch-state.js';
+import {
+	createComponent,
+	createHeadAndContent,
+	render,
+	renderComponent,
+	renderUniqueStylesheet,
+	unescapeHTML,
+} from '../../../dist/runtime/server/index.js';
+import type { AstroComponentFactory } from '../../../dist/runtime/server/render/index.js';
+import type { Pipeline } from '../../../dist/core/render/index.js';
+import { AstroMiddleware } from '../../../dist/core/middleware/astro-middleware.js';
+import { ActionHandler } from '../../../dist/actions/handler.js';
+import { PagesHandler } from '../../../dist/core/pages/handler.js';
+import { createBasicPipeline, SpyLogger } from '../test-utils.ts';
+
+const createAstroModule = (AstroComponent: AstroComponentFactory, partial = false) => ({
+	default: AstroComponent,
+	partial,
+});
+
+async function renderPartialPage(
+	pipeline: Pipeline,
+	pagesHandler: PagesHandler,
+	Component: AstroComponentFactory,
+	{
+		component = 'src/pages/partial.astro',
+		partial = true,
+	}: { component?: string; partial?: boolean } = {},
+) {
+	const request = new Request(`http://example.com/partial`);
+	const routeData = {
+		type: 'page',
+		pathname: '/partial',
+		component,
+		params: {},
+	};
+	const state = new FetchState(pipeline, request);
+	state.routeData = routeData as any;
+	state.pathname = '/partial';
+	state.componentInstance = createAstroModule(Component, partial) as any;
+	state.slots = {};
+	const middleware = new AstroMiddleware(pipeline);
+	const actionHandler = new ActionHandler();
+	return middleware.handle(state, (s, ctx) => {
+		if (!s.skipMiddleware) {
+			const actionResult = actionHandler.handle(ctx, s);
+			if (actionResult) {
+				return actionResult.then((r) => r ?? pagesHandler.handle(s, ctx));
+			}
+		}
+		return pagesHandler.handle(s, ctx);
+	});
+}
+
+describe('Partials warn about stripped component assets', () => {
+	let logger: SpyLogger;
+	let pipeline: Pipeline;
+	let pagesHandler: PagesHandler;
+
+	function freshPipeline() {
+		logger = new SpyLogger({ level: 'warn' });
+		pipeline = createBasicPipeline({ logger });
+		pipeline.headElements = () => ({
+			links: new Set(),
+			scripts: new Set(),
+			styles: new Set(),
+		});
+		pagesHandler = new PagesHandler(pipeline);
+		return pipeline;
+	}
+
+	before(() => {
+		freshPipeline();
+	});
+
+	function makePropagatingPartial(): AstroComponentFactory {
+		const HeadEntry = createComponent({
+			factory(result: any, _props: any, _slots: any) {
+				const link = renderUniqueStylesheet(result, {
+					type: 'external',
+					src: '/some/fake/styles.css',
+				});
+				return createHeadAndContent(
+					unescapeHTML(link) as unknown as string,
+					render`<div id="other">Other</div>`,
+				);
+			},
+			propagation: 'self',
+		});
+
+		return createComponent(
+			(result: any) => render`<li>${renderComponent(result, 'HeadEntry', HeadEntry, {}, {})}</li>`,
+		);
+	}
+
+	it('warns when a partial page contains components with scoped styles or scripts', async () => {
+		freshPipeline();
+		const Partial = makePropagatingPartial();
+		await renderPartialPage(pipeline, pagesHandler, Partial);
+
+		const warnings = logger.logs.filter((entry) => entry.level === 'warn');
+		assert.equal(warnings.length, 1, 'expected exactly one warning');
+		assert.match(warnings[0].message, /partial/);
+		assert.match(warnings[0].message, /scoped styles/);
+		assert.match(warnings[0].message, /src\/pages\/partial\.astro/);
+	});
+
+	it('does not warn when a partial page has no stripped assets', async () => {
+		freshPipeline();
+		const Partial = createComponent(() => render`<li>Plain partial</li>`);
+		await renderPartialPage(pipeline, pagesHandler, Partial);
+
+		const warnings = logger.logs.filter((entry) => entry.level === 'warn');
+		assert.equal(warnings.length, 0);
+	});
+
+	it('does not warn when the page is not a partial', async () => {
+		freshPipeline();
+		const Page = makePropagatingPartial();
+		await renderPartialPage(pipeline, pagesHandler, Page, {
+			partial: false,
+			component: 'src/pages/not-partial.astro',
+		});
+
+		const warnings = logger.logs.filter((entry) => entry.level === 'warn');
+		assert.equal(warnings.length, 0);
+	});
+
+	it('warns only once per route component across repeated renders', async () => {
+		freshPipeline();
+		const Partial = makePropagatingPartial();
+		await renderPartialPage(pipeline, pagesHandler, Partial);
+		await renderPartialPage(pipeline, pagesHandler, Partial);
+		await renderPartialPage(pipeline, pagesHandler, Partial);
+
+		const warnings = logger.logs.filter((entry) => entry.level === 'warn');
+		assert.equal(warnings.length, 1, 'expected dedupe across repeated renders');
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a warning when a page partial's rendered component tree includes Astro component scripts or scoped styles that get stripped from the partial HTML output.
- Warning fires once per route component per `PagesHandler` lifetime (deduped), so dev users see it on first request and prerender users see it once during build.
- Detects via `result._metadata.propagators.size > 0` after `renderPage`, which is exactly the runtime set populated by components the compiler marked as propagating (i.e. components with scoped `<style>` or hoisted `<script>` blocks).
- Adds 4 regression unit tests using the existing `SpyLogger` + `createBasicPipeline` helpers.

Fixes #11885

## Tests run

- `astro-scripts test "test/units/**/*.test.ts" --strip-types --teardown ./test/units/teardown.ts` — 2622 passing, 0 failing
- `astro-scripts test "test/units/render/**/*.test.ts" --strip-types --teardown ./test/units/teardown.ts` — 273 passing
- `astro-scripts test "test/partials*.test.ts" --strip-types --parallel` — 3 passing (existing fixtures)
- New `test/units/render/partials-warnings.test.ts` — 4 passing, covering:
  - warns when the tree includes propagating components
  - does not warn when the partial has no stripped assets
  - does not warn when the page is not a partial
  - warns exactly once across repeated renders
- `biome check` and `prettier -c` clean on touched files.

## Docs

No docs change strictly needed — the [existing partials docs](https://docs.astro.build/en/basics/astro-pages/#page-partials) already describe the stripping behavior, and the warning links back to that section. Happy to add a note there if maintainers prefer.