### PR TITLE
feat(astro-vscode): adds a file association for `.dev.vars` to render it as a .env file

### DIFF
--- a/.changeset/orange-bats-punch.md
+++ b/.changeset/orange-bats-punch.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': minor
+---
+
+Adds a file association for `.dev.vars` to render it as a .env file

--- a/packages/language-tools/vscode/package.json
+++ b/packages/language-tools/vscode/package.json
@@ -162,6 +162,11 @@
         }
       }
     },
+    "configurationDefaults": {
+      "files.associations": {
+        ".dev.vars": "dotenv"
+      }
+    },
     "languages": [
       {
         "id": "astro",


### PR DESCRIPTION
## Changes

Assigns VS Code's registered `dotenv` language to `.dev.vars` env file used in the Cloudflare adapter.

Astro [recommends](https://docs.astro.build/en/guides/integrations-guide/cloudflare/#environment-variables-and-bindings) using this file to store development-only environment variables when using the Cloudflare adapter, but VS Code displays it as plaintext rather than a dotenv file. This is the fix.

- [X] I included a changeset with this change

### Before / After

<img width="147" height="83" alt="Screenshot 2026-05-16 at 8 47 08 AM" src="https://github.com/user-attachments/assets/5c01d09a-9b8c-4e8c-bdd5-d355594c4934" />
<img width="198" height="90" alt="Screenshot 2026-05-16 at 8 46 33 AM" src="https://github.com/user-attachments/assets/c5cf81c5-065b-4b6a-96e1-b3e6aa4abfc2" />

## Testing

Tested using VS Code extension test runner. 

## Docs

Documentation exists for this file. Syntax highlighting will reassure new developers using Astro & Cloudflare workers that they are following documentation correctly.