### PR TITLE
fix: support multi-line lang attribute detection in style/script tags

### DIFF
--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
@@ -780,7 +780,7 @@
       "name": "meta.scope.tag.$1.astro meta.$1.astro",
       "patterns": [
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
+          "begin": "\\G(?=\\s*[\\s\\S]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.json.astro",
           "patterns": [
@@ -790,7 +790,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
+          "begin": "\\G(?=\\s*[\\s\\S]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.javascript.astro",
           "patterns": [
@@ -800,7 +800,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
+          "begin": "\\G(?=\\s*[\\s\\S]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.$3.astro",
           "patterns": [

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -505,17 +505,17 @@ repository:
     name: meta.scope.tag.$1.astro meta.$1.astro
     patterns:
       # Injecting into `meta.lang.ld+json` doesn't seem possible, so we set it to `meta.lang.json`
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2)
+      - begin: \G(?=\s*[\s\S]*?(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2)
         end: (?=</|/>)
         name: meta.lang.json.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Treat 'module' as JavaScript
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(module)\2)
+      - begin: \G(?=\s*[\s\S]*?(type|lang)\s*=\s*(['"]|)(module)\2)
         end: (?=</|/>)
         name: meta.lang.javascript.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Tags with a language specified.
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2)
+      - begin: \G(?=\s*[\s\S]*?(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2)
         end: (?=</|/>)
         name: meta.lang.$3.astro
         patterns: [include: '#tags-lang-start-attributes']

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro
@@ -1,0 +1,52 @@
+<style lang="scss">
+  $primary: red;
+  .bar {
+    &-inner { color: $primary; }
+  }
+</style>
+
+<style
+  lang="scss"
+>
+  $primary: red;
+  .bar {
+    &-inner { color: $primary; }
+  }
+</style>
+
+<style lang="less">
+  @base: #f938ab;
+  .bar { color: @base; }
+</style>
+
+<style
+  lang="less"
+>
+  @base: #f938ab;
+  .bar { color: @base; }
+</style>
+
+<style lang="sass" define:vars={{ foo }}>
+  .bar
+    color: var(--foo)
+</style>
+
+<style
+  lang="sass"
+  define:vars={{
+    foo: '#fff',
+  }}
+>
+  .bar
+    color: var(--foo)
+</style>
+
+<style lang="css">
+  .bar { color: green; }
+</style>
+
+<style
+  lang="css"
+>
+  .bar { color: green; }
+</style>


### PR DESCRIPTION
## Summary

Fix syntax highlighting for `<style>` and `<script>` tags when the `lang` or `type` attribute is on a different line from the opening tag.

## Root Cause

The TextMate grammar regex used `[^>]*?` to scan for `lang`/`type` attributes within style/script tags. In Oniguruma (VS Code's regex engine), `[^>]` does not reliably match across newlines in all configurations, causing the language detection to fail when attributes span multiple lines. The content then falls back to default CSS highlighting.

## Changes

- **`astro.tmLanguage.src.yaml`**: Changed `[^>]*?` → `[\s\S]*?` in all three language-detection patterns (JSON-LD, module/JS, and generic language)
- **`astro.tmLanguage.json`**: Same change in compiled grammar
- **Test fixture**: Added `sass-multiline.astro` covering SCSS, LESS, SASS, and CSS with both single-line and multi-line attribute layouts

## Testing

- Manually verified the regex matches using Node.js and Python
- Added test fixture covering all style language types with both single-line and multi-line `<style>` tag layouts
- Existing grammar snapshot tests should continue to pass (`pnpm test:grammar`)

## Related

Fixes #14657
Closes draft PR #15066 (supersedes with proper YAML source + JSON update)