### PR TITLE
fix(astro): match case-mismatched project paths in normalizeFilename

### DIFF
--- a/.changeset/fix-issue-14013-style-path-case.md
+++ b/.changeset/fix-issue-14013-style-path-case.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes styles being stripped when the project root is started with a path whose case differs from the actual filesystem case (e.g. running `astro dev` from `d:\dev\app` while the folder on disk is `D:\dev\app`). `normalizeFilename` now treats absolute paths inside the project as project-internal even when their case does not exactly match the configured root, so the cached compile metadata lookup no longer misses and the virtual style module resolves correctly.

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -46,11 +46,24 @@ export function normalizeFilename(filename: string, root: URL) {
 		// is imported via a TypeScript path alias and Vite produces a relative virtual module ID.
 		const url = new URL(filename, root);
 		filename = viteID(url);
-	} else if (filename.startsWith('/') && !commonAncestorPath(filename, fileURLToPath(root))) {
+	} else if (filename.startsWith('/') && !isPathInRoot(filename, fileURLToPath(root))) {
 		const url = new URL('.' + filename, root);
 		filename = viteID(url);
 	}
 	return removeLeadingForwardSlashWindows(filename);
+}
+
+/**
+ * Check whether `filename` lives under `rootPath`. Falls back to a case-insensitive
+ * comparison so that paths whose case differs from `rootPath` (e.g. a `d:\dev\foo`
+ * cwd versus a `D:\dev\foo` filesystem on Windows, or any case-insensitive macOS
+ * volume) are still recognized as project-internal absolute paths.
+ */
+function isPathInRoot(filename: string, rootPath: string) {
+	return (
+		commonAncestorPath(filename, rootPath) ||
+		commonAncestorPath(filename.toLowerCase(), rootPath.toLowerCase())
+	);
 }
 
 const postfixRE = /[?#].*$/s;

--- a/packages/astro/test/units/vite-plugin-utils/normalize-filename.test.ts
+++ b/packages/astro/test/units/vite-plugin-utils/normalize-filename.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { describe, it } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { normalizeFilename } from '../../../dist/vite-plugin-utils/index.js';
+
+// Build a fixture path that is absolute on both POSIX and Windows. On POSIX,
+// `path.resolve('/Users/me/project')` is `/Users/me/project`; on Windows it
+// becomes something like `D:\\Users\\me\\project` (the CWD drive gets
+// prepended). Using this lets tests that pass the resolved path to Node's URL
+// machinery behave identically on both platforms.
+const projectRoot = path.resolve('/Users/me/project');
+const projectRootUrl = pathToFileURL(projectRoot + path.sep);
+// `normalizeFilename` returns paths with forward slashes (it runs the result
+// through `viteID`/`slash`), so build expectations the same way.
+const projectRootSlash = projectRoot.replaceAll(path.sep, '/');
+
+describe('normalizeFilename', () => {
+	it('strips the /@fs prefix from filesystem paths', () => {
+		const root = pathToFileURL('/Users/me/project/');
+		const result = normalizeFilename('/@fs/Users/me/project/src/pages/index.astro', root);
+		assert.equal(result, '/Users/me/project/src/pages/index.astro');
+	});
+
+	it('resolves relative paths against root', () => {
+		const result = normalizeFilename('./src/components/Foo.astro', projectRootUrl);
+		assert.equal(result, `${projectRootSlash}/src/components/Foo.astro`);
+	});
+
+	it('preserves absolute paths that live inside root', () => {
+		const root = pathToFileURL('/Users/me/project/');
+		const result = normalizeFilename('/Users/me/project/src/pages/index.astro', root);
+		assert.equal(result, '/Users/me/project/src/pages/index.astro');
+	});
+
+	it('preserves absolute paths when their case differs from root (issue #14013)', () => {
+		// Reproduces the case-insensitive filesystem scenario (Windows or macOS) where
+		// the user starts the dev server from a path whose case differs from disk.
+		// `root` comes from process.cwd() with one case, but Vite resolves modules with
+		// the canonical filesystem case. The two must still be treated as the same path.
+		const root = pathToFileURL('/users/me/project/');
+		const result = normalizeFilename('/Users/me/project/src/pages/index.astro', root);
+		assert.equal(result, '/Users/me/project/src/pages/index.astro');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #14013.

On case-insensitive filesystems (Windows, macOS), starting `astro dev` from a working directory whose case differs from the actual filesystem case (e.g. `d:\dev\app` vs `D:\dev\app`) causes styles to be stripped from Astro components.

## Root Cause

`normalizeFilename` in `vite-plugin-utils/index.ts` uses `commonAncestorPath` to decide whether an absolute path lives inside the project root. `commonAncestorPath` performs a case-sensitive string comparison. When the CWD (`root`) and the Vite-resolved module path (`filename`) disagree on case, the check fails and the path is incorrectly rewritten — producing a path that misses the compile-metadata cache and causes the virtual style module to be generated with no styles.

## Fix

A small helper `isPathInRoot` is introduced. It first attempts an exact (fast) match via `commonAncestorPath`. If that fails, it retries with both paths lower-cased, matching the semantics of case-insensitive filesystems. The change is limited to this one fallback; it does not alter any other behaviour and has no performance impact on correct (same-case) paths.

```ts
function isPathInRoot(filename: string, rootPath: string) {
  return (
    commonAncestorPath(filename, rootPath) ||
    commonAncestorPath(filename.toLowerCase(), rootPath.toLowerCase())
  );
}
```

## Tests

Added a unit test in `test/units/vite-plugin-utils/normalize-filename.test.ts` that directly reproduces the issue: `normalizeFilename` is called with a filename whose case differs from the root URL, and the function should return the original filename unchanged (i.e. not rewrite it onto the root).

---

*This fix was contributed with AI assistance by SwarmFix (sulphur-swarm).*