### PR TITLE
Preserve empty alt attributes for markdown images in content collections

### DIFF
--- a/.changeset/fix-empty-alt-content-collections.md
+++ b/.changeset/fix-empty-alt-content-collections.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes markdown images with empty alt text (`![](image.jpg)`) in content collections dropping the `alt` attribute entirely. The `alt=""` attribute is now correctly preserved in the rendered HTML output, which is important for accessibility (indicating decorative images).

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -501,7 +501,8 @@ async function updateImageReferencesInBody(html: string, fileName: string) {
 			// This attribute is used by the toolbar audit
 			...(import.meta.env.DEV ? { 'data-image-component': 'true' } : {}),
 		})
-			.map(([key, value]) => (value ? `${key}="${escape(value)}"` : ''))
+			.filter(([, value]) => value != null)
+			.map(([key, value]) => (value === '' ? `${key}=""` : `${key}="${escape(String(value))}"`))
 			.join(' ');
 	});
 }

--- a/packages/astro/test/core-image.test.ts
+++ b/packages/astro/test/core-image.test.ts
@@ -1139,6 +1139,18 @@ describe('build ssg', () => {
 		assert.equal(datanested instanceof Buffer, true);
 	});
 
+	it('content collection images with empty alt preserve the alt attribute', async () => {
+		const html = await fixture.readFile('/blog/empty-alt/index.html');
+
+		const $ = cheerio.load(html);
+		const $contentImg = $('img').filter(function () {
+			// Find the image rendered from markdown content (not the frontmatter images)
+			return !$(this).closest('#direct-image, #nested-image').length;
+		});
+		assert.equal($contentImg.length, 1, 'should have one content image');
+		assert.equal($contentImg.attr('alt'), '', 'alt attribute should be empty string, not missing');
+	});
+
 	it('quality attribute produces a different file', async () => {
 		const html = await fixture.readFile('/quality/index.html');
 		const $ = cheerio.load(html);

--- a/packages/astro/test/fixtures/core-image-ssg/src/content/blog/empty-alt.md
+++ b/packages/astro/test/fixtures/core-image-ssg/src/content/blog/empty-alt.md
@@ -1,0 +1,10 @@
+---
+title: Empty Alt
+image: ~/assets/penguin2.jpg
+cover:
+  image: ../../assets/penguin1.jpg
+---
+
+# Empty alt test
+
+![](../../assets/penguin1.jpg)


### PR DESCRIPTION
## Changes

- Fixes markdown images with empty alt text (`![](image.jpg)`) in content collections to render `alt=""` instead of dropping the attribute entirely
- Replaces JavaScript truthiness check with explicit `value != null` filtering to preserve empty string attributes
- Only affects content collections markdown path — pages-based markdown already handled this correctly

## Testing

- Added test `'content collection images with empty alt preserve the alt attribute'` in `packages/astro/test/core-image.test.ts` to verify empty alt attributes are preserved
- Verified all existing image, markdown, and content collection tests still pass

## Docs

- No docs update needed, this fixes a regression to match existing expected behavior

Closes #16621