### PR TITLE
Invalidate route cache when module identity changes after HMR

### DIFF
--- a/.changeset/ninety-views-cover.md
+++ b/.changeset/ninety-views-cover.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes HMR serving stale content when components are passed as props via `getStaticPaths()`

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -35,7 +35,10 @@ export async function callGetStaticPaths({
 	if (!mod) {
 		throw new Error('This is an error caused by Astro and not your code. Please file an issue.');
 	}
-	if (cached?.staticPaths) {
+	// After HMR, `mod` is a new object from a fresh import(). If the cached
+	// entry was produced by a previous module instance, treat it as stale so
+	// getStaticPaths() is re-called with the updated module.
+	if (cached?.staticPaths && cached.mod === mod) {
 		return cached.staticPaths;
 	}
 
@@ -73,11 +76,12 @@ export async function callGetStaticPaths({
 		keyedStaticPaths.keyed.set(paramsKey, sp);
 	}
 
-	routeCache.set(route, { ...cached, staticPaths: keyedStaticPaths });
+	routeCache.set(route, { ...cached, mod, staticPaths: keyedStaticPaths });
 	return keyedStaticPaths;
 }
 
 interface RouteCacheEntry {
+	mod?: ComponentInstance;
 	staticPaths: GetStaticPathsResultKeyed;
 }
 

--- a/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
+++ b/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
@@ -130,4 +130,67 @@ describe('getStaticPaths caching behavior', () => {
 
 		assert.equal(callCount, 2, 'getStaticPaths called again after cache clear');
 	});
+
+	it('re-calls getStaticPaths when module identity changes (HMR)', async () => {
+		const route = makeRoute({
+			segments: [[dynamicPart('slug')]],
+			trailingSlash: 'never',
+			route: '/[slug]',
+			pathname: undefined,
+			type: 'page',
+			prerender: true,
+		});
+
+		const oldMod = mod({
+			getStaticPaths: async () => {
+				callCount++;
+				return [{ params: { slug: 'one' }, props: { title: 'old' } }];
+			},
+		});
+
+		// First call with original module
+		const result1 = await callGetStaticPaths({
+			mod: oldMod,
+			route,
+			routeCache,
+			ssr: false,
+			base: '/',
+			trailingSlash: 'never',
+		});
+
+		assert.equal(callCount, 1);
+		assert.equal(result1.length, 1);
+
+		// Same module should hit cache
+		const _result2 = await callGetStaticPaths({
+			mod: oldMod,
+			route,
+			routeCache,
+			ssr: false,
+			base: '/',
+			trailingSlash: 'never',
+		});
+
+		assert.equal(callCount, 1, 'same module should use cache');
+
+		// Simulate HMR: a new module object with updated getStaticPaths
+		const newMod = mod({
+			getStaticPaths: async () => {
+				callCount++;
+				return [{ params: { slug: 'one' }, props: { title: 'new' } }];
+			},
+		});
+
+		const result3 = await callGetStaticPaths({
+			mod: newMod,
+			route,
+			routeCache,
+			ssr: false,
+			base: '/',
+			trailingSlash: 'never',
+		});
+
+		assert.equal(callCount, 2, 'new module should bypass cache');
+		assert.equal(result3.keyed.get('/one')?.props?.title, 'new');
+	});
 });


### PR DESCRIPTION
## Changes

- The route cache (`callGetStaticPaths`) now stores the module reference alongside cached static paths and compares identity on lookup. After HMR, `mod` is a new object from a fresh `import()`, so the cache treats the old entry as stale and re-calls `getStaticPaths()` with updated component references. This fixes the case where components passed as props via `getStaticPaths()` served stale content in dev — even on manual refresh.

Fixes #16522

## Testing

- New unit test in `getstaticpaths-cache.test.ts`: "re-calls getStaticPaths when module identity changes (HMR)" — calls `callGetStaticPaths` with one module, confirms cache hit on same module, then passes a different module object and asserts the cache is bypassed and fresh props are returned.

## Docs

- No docs changes needed. This is a bug fix restoring existing behavior from Astro 5.