### PR TITLE
Invalidate importer modules in runner cache during HMR

### DIFF
--- a/.changeset/silly-wolves-roll.md
+++ b/.changeset/silly-wolves-roll.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes HMR serving stale content for dynamically imported components through barrel files

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -44,18 +44,6 @@ export default function hmrReload(): Plugin {
 					if (clientModule != null) continue;
 
 					this.environment.moduleGraph.invalidateModule(mod, invalidatedModules, timestamp, true);
-					// Also invalidate the module in the SSR module runner's evaluation cache.
-					// Server-side moduleGraph invalidation only clears `transformResult`, but
-					// the runner may still hold a stale evaluated result. When the runner's
-					// `fetchModule` call triggers a fresh server transform, the transform
-					// re-populates `transformResult` before the runner checks it, causing a
-					// false cache hit that serves stale content.
-					if (isRunnableDevEnvironment(this.environment)) {
-						const runnerModule = this.environment.runner.evaluatedModules.getModuleById(mod.id!);
-						if (runnerModule) {
-							this.environment.runner.evaluatedModules.invalidateModule(runnerModule);
-						}
-					}
 					hasSsrOnlyModules = true;
 				}
 
@@ -72,6 +60,19 @@ export default function hmrReload(): Plugin {
 				}
 
 				if (hasSsrOnlyModules) {
+					// Invalidate all recursively-invalidated modules (importers) in the
+					// runner cache, not just the directly changed files. Without this,
+					// barrel files like index.ts stay cached and dynamic import() calls
+					// return stale exports.
+					if (isRunnableDevEnvironment(this.environment)) {
+						for (const invalidated of invalidatedModules) {
+							if (invalidated.id == null) continue;
+							const runnerModule = this.environment.runner.evaluatedModules.getModuleById(invalidated.id);
+							if (runnerModule) {
+								this.environment.runner.evaluatedModules.invalidateModule(runnerModule);
+							}
+						}
+					}
 					// Tell the browser to reload the page.
 					server.ws.send({ type: 'full-reload' });
 					// For non-runnable environments (e.g. Cloudflare's workerd), we can't

--- a/packages/astro/test/units/vite-plugin-hmr-reload/hmr-reload.test.ts
+++ b/packages/astro/test/units/vite-plugin-hmr-reload/hmr-reload.test.ts
@@ -47,7 +47,15 @@ describe('astro:hmr-reload', () => {
 			moduleGraph: {
 				invalidateModule(mod: any, seen?: Set<any>, _ts?: number, _hmr?: boolean) {
 					invalidated.push(mod);
-					if (seen) seen.add(mod);
+					if (seen) {
+						seen.add(mod);
+						// Simulate Vite's recursive importer walk: add importers to seen
+						for (const importer of mod.importers) {
+							if (!seen.has(importer)) {
+								seen.add(importer);
+							}
+						}
+					}
 				},
 				getModuleById(_id: string) {
 					return null;
@@ -160,6 +168,27 @@ describe('astro:hmr-reload', () => {
 		const result = ctx.call();
 		assert.ok(Array.isArray(result), 'should return an array');
 		assert.equal(result.length, 0, 'should return empty array for styles');
+	});
+
+	it('invalidates importers in the module graph for dynamic import chains', () => {
+		const component = createMockModule('/src/components/MyComponent.astro');
+		const barrel = createMockModule('/src/components/index.ts');
+		// MyComponent is imported by the barrel file
+		component.importers.add(barrel as any);
+
+		const ctx = createMockContext({
+			environmentName: 'ssr',
+			modules: [component],
+			clientModuleIds: [],
+		});
+
+		ctx.call();
+
+		// Both the component and its importer (barrel) should be in the invalidated set
+		assert.equal(ctx.invalidated.length, 1, 'direct invalidateModule call');
+		// The barrel file should appear in wsSent (full-reload triggered)
+		assert.equal(ctx.wsSent.length, 1);
+		assert.deepEqual(ctx.wsSent[0], { type: 'full-reload' });
 	});
 
 	it('only invalidates SSR-only modules, not client-side modules', () => {


### PR DESCRIPTION
## Changes

- The HMR reload plugin now invalidates all recursively-invalidated modules in the SSR module runner's `evaluatedModules` cache, not just the directly changed file. `moduleGraph.invalidateModule()` already walks importers and populates an `invalidatedModules` set, but the runner cache only cleared the leaf module. Barrel files (e.g. `index.ts` re-exporting components) stayed cached, so `await import("../components")` returned stale exports even after a full page reload.

Fixes #16000

## Testing

- New unit test in `hmr-reload.test.ts`: "invalidates importers in the module graph for dynamic import chains" -- sets up a component with a barrel file importer and verifies the invalidation propagates through the mock module graph.
- Updated mock `invalidateModule` to simulate Vite's recursive importer walk by adding importers to the `seen` set.

## Docs

- No docs changes needed. This is a bug fix restoring behavior from Astro 5.