### PR TITLE
chore: clean up redundant minimumReleaseAgeExclude items

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,16 +29,6 @@ minimumReleaseAgeExclude:
   # TODO: remove once more stable
   - '@flue/*'
   - '@astrojs/*'
-  # Netlify Vite Plugin and deps. New version required for bug fix.
-  # TODO: remove this block after 2026/05/15
-  - '@netlify/vite-plugin@2.12.3'
-  - '@netlify/dev@4.18.3'
-  - '@netlify/runtime@4.1.21'
-  - '@netlify/edge-functions-dev@1.0.17'
-  - '@netlify/blobs@10.7.5'
-  - '@netlify/functions-dev@1.2.8'
-  - '@netlify/otel@6.0.0'
-  - '@netlify/zip-it-and-ship-it@14.5.6'
 peerDependencyRules:
   allowAny:
     - 'astro'


### PR DESCRIPTION
## Changes

A follow-up to https://github.com/withastro/astro/pull/16716#issuecomment-4442812732. Remove minimum release age config that’s no longer necessary

## Testing

CI should pass 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
