### PR TITLE
fix: build times timestamp

### DIFF
--- a/.changeset/rare-owls-care.md
+++ b/.changeset/rare-owls-care.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improved the printing of the build time if it goes over the 60 seconds.

--- a/packages/astro/src/core/build/util.ts
+++ b/packages/astro/src/core/build/util.ts
@@ -4,7 +4,14 @@ import type { ViteBuildReturn } from './types.js';
 
 export function getTimeStat(timeStart: number, timeEnd: number) {
 	const buildTime = timeEnd - timeStart;
-	return buildTime < 1000 ? `${Math.round(buildTime)}ms` : `${(buildTime / 1000).toFixed(2)}s`;
+	if (buildTime < 1000) {
+		return `${Math.round(buildTime)}ms`;
+	} else if (buildTime < 60_000) {
+		return `${(buildTime / 1000).toFixed(2)}s`;
+	}
+	const mins = Math.floor(buildTime / 60_000);
+	const secs = Math.round((buildTime % 60_000) / 1000);
+	return `${mins}min ${secs}s`;
 }
 
 /**

--- a/packages/astro/src/core/build/util.ts
+++ b/packages/astro/src/core/build/util.ts
@@ -11,7 +11,7 @@ export function getTimeStat(timeStart: number, timeEnd: number) {
 	}
 	const mins = Math.floor(buildTime / 60_000);
 	const secs = Math.round((buildTime % 60_000) / 1000);
-	return `${mins}min ${secs}s`;
+	return `${mins}m ${secs}s`;
 }
 
 /**

--- a/packages/astro/test/units/build/static-build.test.ts
+++ b/packages/astro/test/units/build/static-build.test.ts
@@ -23,18 +23,18 @@ describe('astro/src/core/build', () => {
 			assert.equal(getTimeStat(0, 59999), '60.00s');
 		});
 
-		it('formats durations >= 60s with minutes and rounded seconds', () => {
-			assert.equal(getTimeStat(0, 60000), '1min 0s');
-			assert.equal(getTimeStat(0, 90000), '1min 30s');
-			assert.equal(getTimeStat(0, 125400), '2min 5s');
-			assert.equal(getTimeStat(0, 600000), '10min 0s');
-			assert.equal(getTimeStat(0, 754000), '12min 34s');
+		it('formats durations >= 60s with mutes and rounded seconds', () => {
+			assert.equal(getTimeStat(0, 60000), '1m 0s');
+			assert.equal(getTimeStat(0, 90000), '1m 30s');
+			assert.equal(getTimeStat(0, 125400), '2m 5s');
+			assert.equal(getTimeStat(0, 600000), '10m 0s');
+			assert.equal(getTimeStat(0, 754000), '12m 34s');
 		});
 
 		it('works with non-zero start times', () => {
 			assert.equal(getTimeStat(1000, 1500), '500ms');
 			assert.equal(getTimeStat(5000, 8000), '3.00s');
-			assert.equal(getTimeStat(1000, 91000), '1min 30s');
+			assert.equal(getTimeStat(1000, 91000), '1m 30s');
 		});
 	});
 

--- a/packages/astro/test/units/build/static-build.test.ts
+++ b/packages/astro/test/units/build/static-build.test.ts
@@ -1,10 +1,43 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { makeAstroPageEntryPointFileName } from '../../../dist/core/build/static-build.js';
-import { cleanChunkName } from '../../../dist/core/build/util.js';
+import { cleanChunkName, getTimeStat } from '../../../dist/core/build/util.js';
 import type { RouteData } from '../../../dist/types/public/internal.js';
 
 describe('astro/src/core/build', () => {
+	describe('getTimeStat', () => {
+		it('formats sub-second durations in milliseconds', () => {
+			assert.equal(getTimeStat(0, 0), '0ms');
+			assert.equal(getTimeStat(0, 500), '500ms');
+			assert.equal(getTimeStat(0, 999), '999ms');
+		});
+
+		it('rounds milliseconds to the nearest integer', () => {
+			assert.equal(getTimeStat(0, 499.5), '500ms');
+			assert.equal(getTimeStat(0, 0.4), '0ms');
+		});
+
+		it('formats durations >= 1s and < 60s in seconds with two decimals', () => {
+			assert.equal(getTimeStat(0, 1000), '1.00s');
+			assert.equal(getTimeStat(0, 1500), '1.50s');
+			assert.equal(getTimeStat(0, 59999), '60.00s');
+		});
+
+		it('formats durations >= 60s with minutes and rounded seconds', () => {
+			assert.equal(getTimeStat(0, 60000), '1min 0s');
+			assert.equal(getTimeStat(0, 90000), '1min 30s');
+			assert.equal(getTimeStat(0, 125400), '2min 5s');
+			assert.equal(getTimeStat(0, 600000), '10min 0s');
+			assert.equal(getTimeStat(0, 754000), '12min 34s');
+		});
+
+		it('works with non-zero start times', () => {
+			assert.equal(getTimeStat(1000, 1500), '500ms');
+			assert.equal(getTimeStat(5000, 8000), '3.00s');
+			assert.equal(getTimeStat(1000, 91000), '1min 30s');
+		});
+	});
+
 	describe('cleanChunkName', () => {
 		it('passes through safe names unchanged', () => {
 			assert.equal(cleanChunkName('page'), 'page');


### PR DESCRIPTION
## Changes

This PR improves the printed time stamp of the build

## Testing

Added unit tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
