### PR TITLE
Fix verification agent: check for existing PR before creating a new one

### DIFF
--- a/.flue/agents/fix-verification.ts
+++ b/.flue/agents/fix-verification.ts
@@ -6,6 +6,7 @@ import {
 	addPullRequestLabels,
 	createPullRequest,
 	fetchIssueDetails,
+	findPullRequest,
 	postGitHubComment,
 	removeGitHubLabel,
 } from '../lib/github.ts';
@@ -102,6 +103,20 @@ Return your classification.`,
 
 	// The fix is verified! Remove the label and create a PR.
 	await removeGitHubLabel(issueNumber, 'fix pending verification');
+
+	// Check if a PR already exists for this branch.
+	const existingPr = await findPullRequest(branch);
+
+	if (existingPr) {
+		console.info(`PR already exists: ${existingPr.html_url}`);
+
+		await postGitHubComment(
+			issueNumber,
+			`The fix has been verified! A pull request already exists: ${existingPr.html_url}`,
+		);
+
+		return { verified: true, prNumber: existingPr.number, prUrl: existingPr.html_url };
+	}
 
 	// Use the astro-pr-writer skill to generate a good PR title and body.
 	const prContent = await session.skill('astro-pr-writer/SKILL.md', {

--- a/.flue/lib/github.ts
+++ b/.flue/lib/github.ts
@@ -180,8 +180,9 @@ export async function findPullRequest(head: string): Promise<PullRequest | null>
 	if (!res.ok) {
 		throw new Error(`Failed to search pull requests (HTTP ${res.status}): ${await res.text()}`);
 	}
-	const pulls = (await res.json()) as PullRequest[];
-	return pulls[0] ?? null;
+	const pulls = await res.json();
+	if (!Array.isArray(pulls)) return null;
+	return (pulls[0] as PullRequest) ?? null;
 }
 
 /** Add labels to a pull request (same endpoint as issues). */

--- a/.flue/lib/github.ts
+++ b/.flue/lib/github.ts
@@ -170,6 +170,20 @@ export async function createPullRequest(options: {
 	return (await res.json()) as PullRequest;
 }
 
+/** Find an open pull request from the given head branch. */
+export async function findPullRequest(head: string): Promise<PullRequest | null> {
+	assert(GITHUB_TOKEN_BASE, `GITHUB_TOKEN env token is required.`);
+	const res = await fetch(
+		`https://api.github.com/repos/${REPO}/pulls?head=withastro:${encodeURIComponent(head)}&state=open`,
+		{ headers: headers(GITHUB_TOKEN_BASE) },
+	);
+	if (!res.ok) {
+		throw new Error(`Failed to search pull requests (HTTP ${res.status}): ${await res.text()}`);
+	}
+	const pulls = (await res.json()) as PullRequest[];
+	return pulls[0] ?? null;
+}
+
 /** Add labels to a pull request (same endpoint as issues). */
 export async function addPullRequestLabels(prNumber: number, labels: string[]): Promise<void> {
 	return addGitHubLabels(prNumber, labels);

--- a/.flue/lib/github.ts
+++ b/.flue/lib/github.ts
@@ -173,16 +173,20 @@ export async function createPullRequest(options: {
 /** Find an open pull request from the given head branch. */
 export async function findPullRequest(head: string): Promise<PullRequest | null> {
 	assert(GITHUB_TOKEN_BASE, `GITHUB_TOKEN env token is required.`);
-	const res = await fetch(
-		`https://api.github.com/repos/${REPO}/pulls?head=withastro:${encodeURIComponent(head)}&state=open`,
-		{ headers: headers(GITHUB_TOKEN_BASE) },
-	);
-	if (!res.ok) {
-		throw new Error(`Failed to search pull requests (HTTP ${res.status}): ${await res.text()}`);
+	try {
+		const res = await fetch(
+			`https://api.github.com/repos/${REPO}/pulls?head=withastro:${encodeURIComponent(head)}&state=open`,
+			{ headers: headers(GITHUB_TOKEN_BASE) },
+		);
+		if (!res.ok) {
+			throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+		}
+		const pulls = await res.json();
+		if (!Array.isArray(pulls)) return null;
+		return (pulls[0] as PullRequest) ?? null;
+	} catch (e) {
+		throw new Error(`Failed to check for existing PR on branch "${head}": ${e}`);
 	}
-	const pulls = await res.json();
-	if (!Array.isArray(pulls)) return null;
-	return (pulls[0] as PullRequest) ?? null;
 }
 
 /** Add labels to a pull request (same endpoint as issues). */


### PR DESCRIPTION
## Changes

- Before creating a PR, the fix-verification agent now checks if one already exists for the `flue/fix-{issueNumber}` branch. If a PR exists, it posts a comment linking to it instead of failing with a 422 from the GitHub API.
- Adds a `findPullRequest` helper to `.flue/lib/github.ts` that queries open PRs by head branch.

## Testing

- No automated tests; this is CI workflow glue code. Verified the logic matches the [GitHub Pulls API](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests) behavior.

## Docs

- No docs needed — internal CI change only.