### PR TITLE
ci: use pinned pnpm

### DIFF
--- a/.github/workflows/merge-main-to-next.yml
+++ b/.github/workflows/merge-main-to-next.yml
@@ -77,6 +77,8 @@ jobs:
       - name: Setup PNPM
         if: steps.check-next.outputs.exists == 'true' && steps.merge.outputs.conflict == 'true'
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: 11
 
       - name: Setup Node
         if: steps.check-next.outputs.exists == 'true' && steps.merge.outputs.conflict == 'true'


### PR DESCRIPTION
## Changes

This PR fixes this failure: https://github.com/withastro/astro/actions/runs/25864427348/job/76002567202#step:7:13

It's caused by `conflicts=true`, which leaves possible conflict markers in package.json. Then the pnpm action comes, and tries to use the version from the manifest, which is broken.

This PR pins the pnpm version to use in the GH action

## Testing

Green CI. We will see if it works after the next release.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
