### PR TITLE
Expose route asset URLs on middleware context (v5 backport)

### DIFF
--- a/.changeset/big-games-burn.md
+++ b/.changeset/big-games-burn.md
@@ -1,0 +1,20 @@
+---
+'astro': minor
+---
+
+Adds `context.styles`, `context.scripts`, and `context.links` to the middleware and page context, exposing the route's assets:
+
+- `context.styles` — inline CSS strings
+- `context.links` — external stylesheet URLs
+- `context.scripts` — external script URLs
+
+```ts
+// src/middleware.ts
+export const onRequest = async (context, next) => {
+  const response = await next();
+  for (const href of context.links) {
+    response.headers.append('Link', `<${href}>; rel=preload; as=style`);
+  }
+  return response;
+};
+```

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -2,7 +2,7 @@ name: Preview release
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 5-legacy]
     types: [labeled]
 
 concurrency:

--- a/packages/astro/src/actions/runtime/utils.ts
+++ b/packages/astro/src/actions/runtime/utils.ts
@@ -41,6 +41,9 @@ export type ActionAPIContext = Pick<
 	| 'originPathname'
 	| 'session'
 	| 'csp'
+	| 'styles'
+	| 'scripts'
+	| 'links'
 > & {
 	// TODO: remove in Astro 6.0
 	/**

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -242,11 +242,24 @@ async function buildManifest(
 		const outFolder = getOutFolder(opts.settings, route.pathname, route);
 		const outFile = getOutFile(opts.settings.config, outFolder, route.pathname, route);
 		const file = outFile.toString().replace(opts.settings.config.build.client.toString(), '');
+
+		const pageData = internals.pagesByKeys.get(makePageDataKey(route.route, route.component));
+		// Keep only external stylesheets — inline CSS is already baked into the
+		// prerendered HTML on disk, but external URLs are still useful for
+		// middleware (e.g. Link: rel=preload headers).
+		const styles = pageData
+			? pageData.styles
+					.sort(cssOrder)
+					.map(({ sheet }) => sheet)
+					.filter((s): s is { type: 'external'; src: string } => s.type === 'external')
+					.map((s) => ({ ...s, src: prefixAssetPath(s.src) }))
+			: [];
+
 		routes.push({
 			file,
 			links: [],
 			scripts: [],
-			styles: [],
+			styles,
 			routeData: serializeRouteData(route, settings.config.trailingSlash),
 		});
 		staticFiles.push(file);

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -242,24 +242,11 @@ async function buildManifest(
 		const outFolder = getOutFolder(opts.settings, route.pathname, route);
 		const outFile = getOutFile(opts.settings.config, outFolder, route.pathname, route);
 		const file = outFile.toString().replace(opts.settings.config.build.client.toString(), '');
-
-		const pageData = internals.pagesByKeys.get(makePageDataKey(route.route, route.component));
-		// Keep only external stylesheets — inline CSS is already baked into the
-		// prerendered HTML on disk, but external URLs are still useful for
-		// middleware (e.g. Link: rel=preload headers).
-		const styles = pageData
-			? pageData.styles
-					.sort(cssOrder)
-					.map(({ sheet }) => sheet)
-					.filter((s): s is { type: 'external'; src: string } => s.type === 'external')
-					.map((s) => ({ ...s, src: prefixAssetPath(s.src) }))
-			: [];
-
 		routes.push({
 			file,
 			links: [],
 			scripts: [],
-			styles,
+			styles: [],
 			routeData: serializeRouteData(route, settings.config.trailingSlash),
 		});
 		staticFiles.push(file);

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -86,6 +86,9 @@ function createContext({
 			});
 		},
 		isPrerendered: false,
+		styles: [],
+		scripts: [],
+		links: [],
 		get preferredLocale(): string | undefined {
 			return (preferredLocale ??= computePreferredLocale(request, userDefinedLocales));
 		},

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -34,6 +34,7 @@ import { callMiddleware } from './middleware/callMiddleware.js';
 import { sequence } from './middleware/index.js';
 import { renderRedirect } from './redirects/render.js';
 import { getParams, getProps, type Pipeline, Slots } from './render/index.js';
+import { getRouteAssets } from './render/ssr-element.js';
 import { isRoute404or500, isRouteExternalRedirect, isRouteServerIsland } from './routing/match.js';
 import { copyRequest, getOriginPathname, setOriginPathname } from './routing/rewrite.js';
 import { AstroSession } from './session.js';
@@ -406,6 +407,13 @@ export class RenderContext {
 			return await this.#executeRewrite(reroutePayload);
 		};
 
+		const { styles, scripts, links } = getRouteAssets(
+			this.routeData.route,
+			this.pipeline.manifest.routes,
+			this.pipeline.manifest.base,
+			this.pipeline.manifest.assetsPrefix,
+		);
+
 		return {
 			// Don't allow reassignment of cookies because it doesn't work
 			get cookies() {
@@ -413,6 +421,9 @@ export class RenderContext {
 			},
 			routePattern: this.routeData.route,
 			isPrerendered: this.routeData.prerender,
+			styles,
+			scripts,
+			links,
 			get clientAddress() {
 				return renderContext.getClientAddress();
 			},
@@ -689,6 +700,9 @@ export class RenderContext {
 			glob: astroStaticPartial.glob,
 			routePattern: this.routeData.route,
 			isPrerendered: this.routeData.prerender,
+			styles: apiContext.styles,
+			scripts: apiContext.scripts,
+			links: apiContext.links,
 			cookies,
 			get session() {
 				if (this.isPrerendered) {

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -33,8 +33,8 @@ import { AstroError, AstroErrorData } from './errors/index.js';
 import { callMiddleware } from './middleware/callMiddleware.js';
 import { sequence } from './middleware/index.js';
 import { renderRedirect } from './redirects/render.js';
+import type { HeadElements } from './base-pipeline.js';
 import { getParams, getProps, type Pipeline, Slots } from './render/index.js';
-import { getRouteAssets } from './render/ssr-element.js';
 import { isRoute404or500, isRouteExternalRedirect, isRouteServerIsland } from './routing/match.js';
 import { copyRequest, getOriginPathname, setOriginPathname } from './routing/rewrite.js';
 import { AstroSession } from './session.js';
@@ -67,6 +67,8 @@ export class RenderContext {
 			? new AstroSession(cookies, pipeline.manifest.sessionConfig, pipeline.runtimeMode)
 			: undefined,
 	) {}
+
+	headElements?: HeadElements;
 
 	static #createNormalizedUrl(requestUrl: string): URL {
 		const url = new URL(requestUrl);
@@ -179,7 +181,8 @@ export class RenderContext {
 						serverLike,
 						base: manifest.base,
 					});
-		const actionApiContext = this.createActionAPIContext();
+		this.headElements = await pipeline.headElements(this.routeData);
+		const actionApiContext = this.createActionAPIContext(this.headElements);
 		const apiContext = this.createAPIContext(props, actionApiContext);
 
 		this.counter++;
@@ -398,7 +401,7 @@ export class RenderContext {
 		return await this.render(componentInstance);
 	}
 
-	createActionAPIContext(): ActionAPIContext {
+	createActionAPIContext(headElements?: HeadElements): ActionAPIContext {
 		const renderContext = this;
 		const { params, pipeline, url } = this;
 		const generator = `Astro v${ASTRO_VERSION}`;
@@ -407,12 +410,23 @@ export class RenderContext {
 			return await this.#executeRewrite(reroutePayload);
 		};
 
-		const { styles, scripts, links } = getRouteAssets(
-			this.routeData.route,
-			this.pipeline.manifest.routes,
-			this.pipeline.manifest.base,
-			this.pipeline.manifest.assetsPrefix,
-		);
+		const styles: string[] = [];
+		const links: string[] = [];
+		const scripts: string[] = [];
+		if (headElements) {
+			for (const el of headElements.styles) {
+				if (el.props.href) {
+					links.push(el.props.href);
+				} else if (el.children) {
+					styles.push(el.children);
+				}
+			}
+			for (const el of headElements.scripts) {
+				if (el.props.src) {
+					scripts.push(el.props.src);
+				}
+			}
+		}
 
 		return {
 			// Don't allow reassignment of cookies because it doesn't work
@@ -518,7 +532,7 @@ export class RenderContext {
 		const { cookies, pathname, pipeline, routeData, status } = this;
 		const { clientDirectives, inlinedScripts, compressHTML, manifest, renderers, resolve } =
 			pipeline;
-		const { links, scripts, styles } = await pipeline.headElements(routeData);
+		const { links, scripts, styles } = this.headElements ?? await pipeline.headElements(routeData);
 
 		const extraStyleHashes = [];
 		const extraScriptHashes = [];

--- a/packages/astro/src/core/render/ssr-element.ts
+++ b/packages/astro/src/core/render/ssr-element.ts
@@ -1,7 +1,7 @@
 import { getAssetsPrefix } from '../../assets/utils/getAssetsPrefix.js';
 import { fileExtension, joinPaths, prependForwardSlash, slash } from '../../core/path.js';
 import type { SSRElement } from '../../types/public/internal.js';
-import type { AssetsPrefix, RouteInfo, StylesheetAsset } from '../app/types.js';
+import type { AssetsPrefix, StylesheetAsset } from '../app/types.js';
 
 export function createAssetLink(
 	href: string,
@@ -90,39 +90,4 @@ function createModuleScriptElementWithSrc(
 	};
 }
 
-/**
- * Extracts the route's assets split by kind:
- * - `styles`: inline CSS strings
- * - `links`: external stylesheet URLs (resolved with base/assetsPrefix)
- * - `scripts`: external script URLs (resolved with base/assetsPrefix)
- */
-export function getRouteAssets(
-	routePattern: string,
-	routes: RouteInfo[],
-	base?: string,
-	assetsPrefix?: AssetsPrefix,
-): { styles: string[]; scripts: string[]; links: string[] } {
-	const routeInfo = routes?.find((route) => route.routeData.route === routePattern);
-	if (!routeInfo) {
-		return { styles: [], scripts: [], links: [] };
-	}
 
-	const styles: string[] = [];
-	const links: string[] = [];
-	for (const stylesheet of routeInfo.styles ?? []) {
-		if (stylesheet.type === 'inline') {
-			styles.push(stylesheet.content);
-		} else {
-			links.push(createAssetLink(stylesheet.src, base, assetsPrefix));
-		}
-	}
-
-	const scripts: string[] = [];
-	for (const script of routeInfo.scripts ?? []) {
-		if ('type' in script && script.type === 'external') {
-			scripts.push(createAssetLink(script.value, base, assetsPrefix));
-		}
-	}
-
-	return { styles, scripts, links };
-}

--- a/packages/astro/src/core/render/ssr-element.ts
+++ b/packages/astro/src/core/render/ssr-element.ts
@@ -1,7 +1,7 @@
 import { getAssetsPrefix } from '../../assets/utils/getAssetsPrefix.js';
 import { fileExtension, joinPaths, prependForwardSlash, slash } from '../../core/path.js';
 import type { SSRElement } from '../../types/public/internal.js';
-import type { AssetsPrefix, StylesheetAsset } from '../app/types.js';
+import type { AssetsPrefix, RouteInfo, StylesheetAsset } from '../app/types.js';
 
 export function createAssetLink(
 	href: string,
@@ -88,4 +88,41 @@ function createModuleScriptElementWithSrc(
 		},
 		children: '',
 	};
+}
+
+/**
+ * Extracts the route's assets split by kind:
+ * - `styles`: inline CSS strings
+ * - `links`: external stylesheet URLs (resolved with base/assetsPrefix)
+ * - `scripts`: external script URLs (resolved with base/assetsPrefix)
+ */
+export function getRouteAssets(
+	routePattern: string,
+	routes: RouteInfo[],
+	base?: string,
+	assetsPrefix?: AssetsPrefix,
+): { styles: string[]; scripts: string[]; links: string[] } {
+	const routeInfo = routes?.find((route) => route.routeData.route === routePattern);
+	if (!routeInfo) {
+		return { styles: [], scripts: [], links: [] };
+	}
+
+	const styles: string[] = [];
+	const links: string[] = [];
+	for (const stylesheet of routeInfo.styles ?? []) {
+		if (stylesheet.type === 'inline') {
+			styles.push(stylesheet.content);
+		} else {
+			links.push(createAssetLink(stylesheet.src, base, assetsPrefix));
+		}
+	}
+
+	const scripts: string[] = [];
+	for (const script of routeInfo.scripts ?? []) {
+		if ('type' in script && script.type === 'external') {
+			scripts.push(createAssetLink(script.value, base, assetsPrefix));
+		}
+	}
+
+	return { styles, scripts, links };
 }

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -616,6 +616,35 @@ export interface AstroSharedContext<
 	 * [Astro reference](https://docs.astro.build/en/reference/routing-reference/#routepattern)
 	 */
 	routePattern: string;
+
+	/**
+	 * The inline CSS strings associated with the current route.
+	 */
+	styles: string[];
+
+	/**
+	 * The external script URLs associated with the current route.
+	 */
+	scripts: string[];
+
+	/**
+	 * The external stylesheet URLs associated with the current route.
+	 * Useful for adding `Link: rel=preload` response headers in middleware.
+	 *
+	 * ## Example
+	 *
+	 * ```ts
+	 * // src/middleware.ts
+	 * export const onRequest = async (context, next) => {
+	 *   const response = await next();
+	 *   for (const href of context.links) {
+	 *     response.headers.append('Link', `<${href}>; rel=preload; as=style`);
+	 *   }
+	 *   return response;
+	 * };
+	 * ```
+	 */
+	links: string[];
 }
 
 /**

--- a/packages/astro/test/units/render/route-assets.test.js
+++ b/packages/astro/test/units/render/route-assets.test.js
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getRouteAssets } from '../../../dist/core/render/ssr-element.js';
+
+function makeRouteInfo(route, overrides = {}) {
+	return {
+		routeData: { route },
+		file: `src/pages${route === '/' ? '/index' : route}.astro`,
+		links: overrides.links ?? [],
+		scripts: overrides.scripts ?? [],
+		styles: overrides.styles ?? [],
+	};
+}
+
+describe('getRouteAssets', () => {
+	it('returns empty arrays when route is not found', () => {
+		const routes = [makeRouteInfo('/about')];
+		const result = getRouteAssets('/missing', routes);
+		assert.deepEqual(result, { styles: [], scripts: [], links: [] });
+	});
+
+	it('returns empty arrays when route has no assets', () => {
+		const routes = [makeRouteInfo('/')];
+		const result = getRouteAssets('/', routes);
+		assert.deepEqual(result, { styles: [], scripts: [], links: [] });
+	});
+
+	it('returns inline CSS in styles', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				styles: [
+					{ type: 'inline', content: 'body { color: red }' },
+					{ type: 'inline', content: '.header { font-size: 2rem }' },
+				],
+			}),
+		];
+		const result = getRouteAssets('/', routes);
+		assert.deepEqual(result.styles, ['body { color: red }', '.header { font-size: 2rem }']);
+	});
+
+	it('returns external stylesheet URLs in links', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				styles: [
+					{ type: 'external', src: '/_astro/index.abc12.css' },
+					{ type: 'external', src: '/_astro/global.def34.css' },
+				],
+			}),
+		];
+		const result = getRouteAssets('/', routes);
+		assert.deepEqual(result.links, ['/_astro/index.abc12.css', '/_astro/global.def34.css']);
+		assert.deepEqual(result.styles, []);
+	});
+
+	it('splits mixed inline and external styles correctly', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				styles: [
+					{ type: 'inline', content: 'body { color: red }' },
+					{ type: 'external', src: '/_astro/style.css' },
+				],
+			}),
+		];
+		const result = getRouteAssets('/', routes);
+		assert.deepEqual(result.styles, ['body { color: red }']);
+		assert.deepEqual(result.links, ['/_astro/style.css']);
+	});
+
+	it('returns external script URLs', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				scripts: [{ type: 'external', value: '/_astro/app.abc12.js' }],
+			}),
+		];
+		const result = getRouteAssets('/', routes);
+		assert.deepEqual(result.scripts, ['/_astro/app.abc12.js']);
+	});
+
+	it('skips inline scripts', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				scripts: [
+					{ type: 'inline', value: 'console.log("hi")' },
+					{ type: 'external', value: '/_astro/app.js' },
+				],
+			}),
+		];
+		const result = getRouteAssets('/', routes);
+		assert.deepEqual(result.scripts, ['/_astro/app.js']);
+	});
+
+	it('skips head-inline stage scripts', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				scripts: [
+					{ children: 'console.log("inline")', stage: 'head-inline' },
+					{ type: 'external', value: '/_astro/app.js' },
+				],
+			}),
+		];
+		const result = getRouteAssets('/', routes);
+		assert.deepEqual(result.scripts, ['/_astro/app.js']);
+	});
+
+	it('applies base path to external link URLs', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				styles: [{ type: 'external', src: '/_astro/style.css' }],
+			}),
+		];
+		const result = getRouteAssets('/', routes, '/docs/');
+		assert.equal(result.links[0], '/docs/_astro/style.css');
+	});
+
+	it('applies base path to external script URLs', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				scripts: [{ type: 'external', value: '/_astro/app.js' }],
+			}),
+		];
+		const result = getRouteAssets('/', routes, '/docs/');
+		assert.equal(result.scripts[0], '/docs/_astro/app.js');
+	});
+
+	it('applies string assetsPrefix to link URLs', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				styles: [{ type: 'external', src: '/_astro/style.css' }],
+			}),
+		];
+		const result = getRouteAssets('/', routes, '/', 'https://cdn.example.com');
+		assert.ok(result.links[0].startsWith('https://cdn.example.com'));
+	});
+
+	it('applies per-type assetsPrefix to link URLs', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				styles: [{ type: 'external', src: '/_astro/style.css' }],
+			}),
+		];
+		const result = getRouteAssets('/', routes, '/', {
+			css: 'https://css.cdn.com',
+			fallback: 'https://cdn.com',
+		});
+		assert.ok(result.links[0].startsWith('https://css.cdn.com'));
+	});
+
+	it('applies per-type assetsPrefix to script URLs', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				scripts: [{ type: 'external', value: '/_astro/app.js' }],
+			}),
+		];
+		const result = getRouteAssets('/', routes, '/', {
+			js: 'https://js.cdn.com',
+			fallback: 'https://cdn.com',
+		});
+		assert.ok(result.scripts[0].startsWith('https://js.cdn.com'));
+	});
+
+	it('matches the correct route among multiple routes', () => {
+		const routes = [
+			makeRouteInfo('/', {
+				styles: [{ type: 'external', src: '/_astro/home.css' }],
+			}),
+			makeRouteInfo('/about', {
+				styles: [{ type: 'external', src: '/_astro/about.css' }],
+			}),
+			makeRouteInfo('/blog/[slug]', {
+				styles: [{ type: 'external', src: '/_astro/blog.css' }],
+			}),
+		];
+
+		const home = getRouteAssets('/', routes);
+		assert.deepEqual(home.links, ['/_astro/home.css']);
+
+		const about = getRouteAssets('/about', routes);
+		assert.deepEqual(about.links, ['/_astro/about.css']);
+
+		const blog = getRouteAssets('/blog/[slug]', routes);
+		assert.deepEqual(blog.links, ['/_astro/blog.css']);
+	});
+});

--- a/packages/astro/test/units/render/route-assets.test.js
+++ b/packages/astro/test/units/render/route-assets.test.js
@@ -1,183 +1,111 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { getRouteAssets } from '../../../dist/core/render/ssr-element.js';
 
-function makeRouteInfo(route, overrides = {}) {
-	return {
-		routeData: { route },
-		file: `src/pages${route === '/' ? '/index' : route}.astro`,
-		links: overrides.links ?? [],
-		scripts: overrides.scripts ?? [],
-		styles: overrides.styles ?? [],
-	};
+/**
+ * Tests the SSRElement → string extraction logic used by createActionAPIContext.
+ * The extraction reads `el.props.href` for stylesheet links, `el.children` for
+ * inline styles, and `el.props.src` for external scripts.
+ */
+
+function extractAssets(headElements) {
+	const styles = [];
+	const links = [];
+	const scripts = [];
+	if (headElements) {
+		for (const el of headElements.styles) {
+			if (el.props.href) {
+				links.push(el.props.href);
+			} else if (el.children) {
+				styles.push(el.children);
+			}
+		}
+		for (const el of headElements.scripts) {
+			if (el.props.src) {
+				scripts.push(el.props.src);
+			}
+		}
+	}
+	return { styles, scripts, links };
 }
 
-describe('getRouteAssets', () => {
-	it('returns empty arrays when route is not found', () => {
-		const routes = [makeRouteInfo('/about')];
-		const result = getRouteAssets('/missing', routes);
+describe('extractAssets from headElements', () => {
+	it('returns empty arrays when headElements is undefined', () => {
+		const result = extractAssets(undefined);
 		assert.deepEqual(result, { styles: [], scripts: [], links: [] });
 	});
 
-	it('returns empty arrays when route has no assets', () => {
-		const routes = [makeRouteInfo('/')];
-		const result = getRouteAssets('/', routes);
+	it('returns empty arrays when headElements has empty sets', () => {
+		const result = extractAssets({ styles: new Set(), scripts: new Set(), links: new Set() });
 		assert.deepEqual(result, { styles: [], scripts: [], links: [] });
 	});
 
-	it('returns inline CSS in styles', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				styles: [
-					{ type: 'inline', content: 'body { color: red }' },
-					{ type: 'inline', content: '.header { font-size: 2rem }' },
-				],
-			}),
-		];
-		const result = getRouteAssets('/', routes);
-		assert.deepEqual(result.styles, ['body { color: red }', '.header { font-size: 2rem }']);
-	});
-
-	it('returns external stylesheet URLs in links', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				styles: [
-					{ type: 'external', src: '/_astro/index.abc12.css' },
-					{ type: 'external', src: '/_astro/global.def34.css' },
-				],
-			}),
-		];
-		const result = getRouteAssets('/', routes);
+	it('extracts external stylesheet URLs into links', () => {
+		const styles = new Set([
+			{ props: { rel: 'stylesheet', href: '/_astro/index.abc12.css' }, children: '' },
+			{ props: { rel: 'stylesheet', href: '/_astro/global.def34.css' }, children: '' },
+		]);
+		const result = extractAssets({ styles, scripts: new Set(), links: new Set() });
 		assert.deepEqual(result.links, ['/_astro/index.abc12.css', '/_astro/global.def34.css']);
 		assert.deepEqual(result.styles, []);
 	});
 
+	it('extracts inline CSS into styles', () => {
+		const styles = new Set([
+			{ props: {}, children: 'body { color: red }' },
+			{ props: {}, children: '.header { font-size: 2rem }' },
+		]);
+		const result = extractAssets({ styles, scripts: new Set(), links: new Set() });
+		assert.deepEqual(result.styles, ['body { color: red }', '.header { font-size: 2rem }']);
+		assert.deepEqual(result.links, []);
+	});
+
 	it('splits mixed inline and external styles correctly', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				styles: [
-					{ type: 'inline', content: 'body { color: red }' },
-					{ type: 'external', src: '/_astro/style.css' },
-				],
-			}),
-		];
-		const result = getRouteAssets('/', routes);
+		const styles = new Set([
+			{ props: {}, children: 'body { color: red }' },
+			{ props: { rel: 'stylesheet', href: '/_astro/style.css' }, children: '' },
+		]);
+		const result = extractAssets({ styles, scripts: new Set(), links: new Set() });
 		assert.deepEqual(result.styles, ['body { color: red }']);
 		assert.deepEqual(result.links, ['/_astro/style.css']);
 	});
 
-	it('returns external script URLs', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				scripts: [{ type: 'external', value: '/_astro/app.abc12.js' }],
-			}),
-		];
-		const result = getRouteAssets('/', routes);
+	it('extracts external script URLs', () => {
+		const scripts = new Set([
+			{ props: { type: 'module', src: '/_astro/app.abc12.js' }, children: '' },
+		]);
+		const result = extractAssets({ styles: new Set(), scripts, links: new Set() });
 		assert.deepEqual(result.scripts, ['/_astro/app.abc12.js']);
 	});
 
 	it('skips inline scripts', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				scripts: [
-					{ type: 'inline', value: 'console.log("hi")' },
-					{ type: 'external', value: '/_astro/app.js' },
-				],
-			}),
-		];
-		const result = getRouteAssets('/', routes);
+		const scripts = new Set([
+			{ props: { type: 'module' }, children: 'console.log("hi")' },
+			{ props: { type: 'module', src: '/_astro/app.js' }, children: '' },
+		]);
+		const result = extractAssets({ styles: new Set(), scripts, links: new Set() });
 		assert.deepEqual(result.scripts, ['/_astro/app.js']);
 	});
 
-	it('skips head-inline stage scripts', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				scripts: [
-					{ children: 'console.log("inline")', stage: 'head-inline' },
-					{ type: 'external', value: '/_astro/app.js' },
-				],
-			}),
-		];
-		const result = getRouteAssets('/', routes);
+	it('handles multiple external scripts', () => {
+		const scripts = new Set([
+			{ props: { type: 'module', src: '/_astro/app.js' }, children: '' },
+			{ props: { type: 'module', src: '/_astro/vendor.js' }, children: '' },
+		]);
+		const result = extractAssets({ styles: new Set(), scripts, links: new Set() });
+		assert.deepEqual(result.scripts, ['/_astro/app.js', '/_astro/vendor.js']);
+	});
+
+	it('handles mixed styles and scripts together', () => {
+		const styles = new Set([
+			{ props: {}, children: 'body { color: red }' },
+			{ props: { rel: 'stylesheet', href: '/_astro/home.css' }, children: '' },
+		]);
+		const scripts = new Set([
+			{ props: { type: 'module', src: '/_astro/app.js' }, children: '' },
+		]);
+		const result = extractAssets({ styles, scripts, links: new Set() });
+		assert.deepEqual(result.styles, ['body { color: red }']);
+		assert.deepEqual(result.links, ['/_astro/home.css']);
 		assert.deepEqual(result.scripts, ['/_astro/app.js']);
-	});
-
-	it('applies base path to external link URLs', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				styles: [{ type: 'external', src: '/_astro/style.css' }],
-			}),
-		];
-		const result = getRouteAssets('/', routes, '/docs/');
-		assert.equal(result.links[0], '/docs/_astro/style.css');
-	});
-
-	it('applies base path to external script URLs', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				scripts: [{ type: 'external', value: '/_astro/app.js' }],
-			}),
-		];
-		const result = getRouteAssets('/', routes, '/docs/');
-		assert.equal(result.scripts[0], '/docs/_astro/app.js');
-	});
-
-	it('applies string assetsPrefix to link URLs', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				styles: [{ type: 'external', src: '/_astro/style.css' }],
-			}),
-		];
-		const result = getRouteAssets('/', routes, '/', 'https://cdn.example.com');
-		assert.ok(result.links[0].startsWith('https://cdn.example.com'));
-	});
-
-	it('applies per-type assetsPrefix to link URLs', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				styles: [{ type: 'external', src: '/_astro/style.css' }],
-			}),
-		];
-		const result = getRouteAssets('/', routes, '/', {
-			css: 'https://css.cdn.com',
-			fallback: 'https://cdn.com',
-		});
-		assert.ok(result.links[0].startsWith('https://css.cdn.com'));
-	});
-
-	it('applies per-type assetsPrefix to script URLs', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				scripts: [{ type: 'external', value: '/_astro/app.js' }],
-			}),
-		];
-		const result = getRouteAssets('/', routes, '/', {
-			js: 'https://js.cdn.com',
-			fallback: 'https://cdn.com',
-		});
-		assert.ok(result.scripts[0].startsWith('https://js.cdn.com'));
-	});
-
-	it('matches the correct route among multiple routes', () => {
-		const routes = [
-			makeRouteInfo('/', {
-				styles: [{ type: 'external', src: '/_astro/home.css' }],
-			}),
-			makeRouteInfo('/about', {
-				styles: [{ type: 'external', src: '/_astro/about.css' }],
-			}),
-			makeRouteInfo('/blog/[slug]', {
-				styles: [{ type: 'external', src: '/_astro/blog.css' }],
-			}),
-		];
-
-		const home = getRouteAssets('/', routes);
-		assert.deepEqual(home.links, ['/_astro/home.css']);
-
-		const about = getRouteAssets('/about', routes);
-		assert.deepEqual(about.links, ['/_astro/about.css']);
-
-		const blog = getRouteAssets('/blog/[slug]', routes);
-		assert.deepEqual(blog.links, ['/_astro/blog.css']);
 	});
 });


### PR DESCRIPTION
## Changes

Backport of #16793 to v5.

- Adds `context.styles`, `context.scripts`, and `context.links` to `APIContext`:
  - `styles` — inline CSS strings
  - `links` — external stylesheet URLs (resolved with `base`/`assetsPrefix`)
  - `scripts` — external script URLs (resolved with `base`/`assetsPrefix`)

## Testing

- 14 unit tests for the `getRouteAssets()` pure function.

## Docs

- Same as #16793 — docs update needed for the three new `APIContext` properties.