### PR TITLE
Allow preview releases for 5-legacy PRs

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -2,7 +2,7 @@ name: Preview release
 
 on:
   pull_request:
-    branches: [main, next]
+    branches: [main, next, 5-legacy]
     types: [labeled]
 
 concurrency:


### PR DESCRIPTION
## Changes

- Adds `5-legacy` to the `branches` filter on the preview release workflow so PRs targeting `5-legacy` can get preview releases via the `pr preview` label.

## Testing

- No test changes.

## Docs

- No docs needed.