### PR TITLE
Fix preview release to compare against PR base branch

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Get changeset status
         id: changeset-status
         run: |
-          pnpm changeset status --output changes.json
+          pnpm changeset status --since=origin/${{ github.event.pull_request.base.ref }} --output changes.json
           echo "changes-output=$(cat changes.json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Get pnpm packages


### PR DESCRIPTION
## Changes

- Passes `--since=origin/${{ github.event.pull_request.base.ref }}` to `pnpm changeset status` so that preview releases for PRs targeting `5-legacy` (or any non-main branch) only include changesets from that branch, not all pending changesets from `main`.

## Testing

- No test changes.

## Docs

- No docs needed.