### PR TITLE
fix(core): allow encoded reserved chars after a literal % in pathnames

### DIFF
--- a/.changeset/fix-pathname-allow-encoded-reserved-after-25.md
+++ b/.changeset/fix-pathname-allow-encoded-reserved-after-25.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes dynamic route handlers returning 400 for request paths that contain a literal `%` next to a reserved character, such as the output of `encodeURIComponent('%?.pdf')` (`%25%3F.pdf`). Multi-level encoding detection is now scoped to the pre-decode signature `%25` followed by a hex pair, so legitimate `%25%XX` patterns are no longer rejected. Double-encoded paths like `/api/%2561dmin` still return 400 as before.

--- a/packages/astro/src/core/util/pathname.ts
+++ b/packages/astro/src/core/util/pathname.ts
@@ -21,24 +21,21 @@ export class MultiLevelEncodingError extends Error {
  * @throws Error if the pathname contains invalid URL encoding
  */
 export function validateAndDecodePathname(pathname: string): string {
-	let decoded: string;
-
-	try {
-		decoded = decodeURI(pathname);
-	} catch (_e) {
-		throw new Error('Invalid URL encoding');
-	}
-
-	// Check if the decoded path is different from the original
-	// AND still contains URL-encoded sequences.
-	// This indicates the original had encoding that got partially decoded, suggesting double encoding.
-	// Example: /%2561dmin -> decodeURI -> /%61dmin (different AND still has %)
-	const hasDecoding = decoded !== pathname;
-	const decodedStillHasEncoding = /%[0-9a-fA-F]{2}/.test(decoded);
-
-	if (hasDecoding && decodedStillHasEncoding) {
+	// Multi-level encoding signature: `%25` (encoded `%`) followed by a hex pair.
+	// After one decode pass, `%25XY` becomes `%XY`, which a downstream decoder
+	// could turn into the original byte — bypassing middleware checks against
+	// the final-decoded value (e.g. `%2561dmin` -> `%61dmin` -> `admin`).
+	//
+	// A `%25` followed by a non-hex character — including another `%` (as in
+	// `%25%3F` from `encodeURIComponent('%?')`) — is a legitimate literal `%`
+	// next to other encoded content, not multi-level encoding.
+	if (/%25[0-9a-fA-F]{2}/.test(pathname)) {
 		throw new MultiLevelEncodingError();
 	}
 
-	return decoded;
+	try {
+		return decodeURI(pathname);
+	} catch (_e) {
+		throw new Error('Invalid URL encoding');
+	}
 }

--- a/packages/astro/test/units/app/double-encoding-bypass.test.ts
+++ b/packages/astro/test/units/app/double-encoding-bypass.test.ts
@@ -157,4 +157,18 @@ describe('URL normalization: double-encoding middleware bypass', () => {
 		const body = await response.json();
 		assert.equal(body.path, 'users/list');
 	});
+
+	it('accepts encodeURIComponent output with a literal % next to a reserved char', async () => {
+		// encodeURIComponent('%?.pdf') -> '%25%3F.pdf'. After decodeURI, %25 -> %
+		// and %3F stays (reserved), yielding '%%3F.pdf'. The pre-decode pattern
+		// %25%3F is not multi-level encoding (the byte after %25 is `%`, not hex),
+		// so it must reach the handler instead of being rejected as a bad request.
+		const app = createApp(createAuthMiddleware());
+		const filename = encodeURIComponent('%?.pdf');
+		const request = new Request(`http://example.com/api/uploads/${filename}`);
+		const response = await app.render(request);
+		assert.equal(response.status, 200, `/api/uploads/${filename} should be accessible`);
+		const body = await response.json();
+		assert.equal(body.path, 'uploads/%%3F.pdf');
+	});
 });


### PR DESCRIPTION
Closes #16781.

`validateAndDecodePathname` rejected any pathname where decoding produced a different string that still contained `%XX` sequences. That conflated two distinct shapes:

- `/api/%2561dmin` — `%25` followed by `61` (hex pair); decodes to `%61dmin` which can be further decoded to `admin`. Real multi-level encoding.
- `/uploads/%25%3F.pdf` — `%25` followed by `%3F` (an encoded reserved char); decodes to `%%3F.pdf`. Just `encodeURIComponent` emitting an encoded literal `%` next to an encoded `?`.

After v6.3.2 (#16556), any dynamic route receiving the second shape returned 400. `encodeURIComponent('%?.pdf')` produces it, so requests like `/uploads/${encodeURIComponent('%?.pdf')}` stopped reaching their handler.

Detect multi-level encoding from the pre-decode signature directly: `%25` followed by two hex digits. A `%25` followed by a non-hex byte — another `%`, a literal letter outside `[a-f]`, end-of-string — is a legitimate encoded `%`, not double encoding. Removes the `decoded !== pathname` second pass; the regex against the input is sufficient.

### Test coverage

Existing double-encoding-bypass cases still behave as before:

| path | expected | covered by |
|---|---|---|
| `/api/admin/users` | 401 (middleware) | existing |
| `/api/%61dmin/users` | 401 (single decode → `admin`) | existing |
| `/api/%2561dmin/users` | 400 (multi-level) | existing |
| `/api/%2561dmin/%75sers` | 400 (multi-level) | existing |
| `/api/public/data` | 200 | existing |
| `/api/us%65rs/list` | 200 (single decode) | existing |

Adds one regression test for the reporter's case:

| path | expected | added |
|---|---|---|
| `/api/uploads/${encodeURIComponent('%?.pdf')}` | 200, handler sees `uploads/%%3F.pdf` | new |

All eight tests in `packages/astro/test/units/app/double-encoding-bypass.test.ts` pass locally.