### PR TITLE
triage: add server bail-out rules to prevent timeout loops

### DIFF
--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -7,6 +7,10 @@ description: Triage a bug report. Reproduces the bug, diagnoses the root cause, 
 
 Triage a bug report end-to-end: reproduce the bug, diagnose the root cause, verify whether the behavior is intentional, and attempt a fix.
 
+## General Rules
+
+**Do not get stuck on infrastructure problems.** If a server won't start, a port is blocked, or a tool is unavailable in the CI environment — bail out after 2 attempts and write your report with the data you already have. Looping on server restarts or missing CLI tools wastes your entire time budget. A partial report with solid findings is infinitely more valuable than no report because you ran out of time fighting a stale process.
+
 ## Input
 
 You need either:

--- a/.agents/skills/triage/diagnose.md
+++ b/.agents/skills/triage/diagnose.md
@@ -55,6 +55,8 @@ After adding logs:
 2. Re-run the reproduction (Example: `pnpm -C <triageDir> build|dev|preview`)
 3. Observe the debug output.
 
+**Server management:** If re-running requires a dev/preview server, always stop existing servers first (`bgproc stop --all`). If the server fails to start twice, bail out — write your diagnosis with the data you have rather than looping on server restarts. Prefer `astro build` over dev/preview when possible.
+
 Iterate until you understand:
 
 - What code path is executing

--- a/.agents/skills/triage/diagnose.md
+++ b/.agents/skills/triage/diagnose.md
@@ -55,7 +55,7 @@ After adding logs:
 2. Re-run the reproduction (Example: `pnpm -C <triageDir> build|dev|preview`)
 3. Observe the debug output.
 
-**Server management:** If re-running requires a dev/preview server, always stop existing servers first (`bgproc stop --all`). If the server fails to start twice, bail out — write your diagnosis with the data you have rather than looping on server restarts. Prefer `astro build` over dev/preview when possible.
+**Server management:** If re-running requires a dev/preview server, always stop existing servers first (`bgproc stop --all`). If the server fails to start twice, bail out — write your diagnosis with the data you have rather than looping on server restarts. Prefer `astro build` over dev/preview when possible. Never background servers with `&` — always use `bgproc`.
 
 Iterate until you understand:
 

--- a/.agents/skills/triage/reproduce.md
+++ b/.agents/skills/triage/reproduce.md
@@ -144,6 +144,15 @@ Use all of the tools at your disposal — `pnpm run dev|build|preview|test`, `cu
 2. **Verify the baseline.** Remove or reverse the triggering code and confirm the project works without the bug. This guards against false positives — if the project is still broken without the triggering code, the issue may be in your setup, not the reported bug.
 3. **Document what you observe.** Record exact error messages and stack traces, which command triggers the issue, and whether it's consistent or intermittent.
 
+### Server Management Rules
+
+Running dev/preview servers is often necessary for reproduction, but server problems must not consume your time budget. Follow these rules:
+
+- **Bail out after 2 failed server starts.** If `bgproc start` or a manual server command fails twice in a row, stop trying. Do NOT loop endlessly with variations. Write your report with what you already know.
+- **Always stop servers before restarting.** Run `bgproc stop -n <name>` (or `bgproc stop --all`) before starting a new server. If `bgproc` doesn't work, try `pkill -f "astro dev\|astro preview\|node.*entry.mjs"` as a fallback. If that also fails, use a different port (`--port 4322`) rather than fighting the stale process.
+- **One reproduction run is enough.** Once you have confirmed or denied the bug, do NOT restart the server to re-test with minor config variations. Additional testing belongs in the diagnose step, not here. Write your findings and move on.
+- **Prefer `astro build` over dev/preview when possible.** Build-time reproduction avoids server lifecycle issues entirely. Only use dev/preview servers when the bug specifically requires a running server (e.g., HMR, runtime SSR, request handling).
+
 ## Step 5: Write Output
 
 Write `report.md` to the triage directory:

--- a/.agents/skills/triage/reproduce.md
+++ b/.agents/skills/triage/reproduce.md
@@ -152,6 +152,7 @@ Running dev/preview servers is often necessary for reproduction, but server prob
 - **Always stop servers before restarting.** Run `bgproc stop -n <name>` (or `bgproc stop --all`) before starting a new server. If `bgproc` doesn't work, try `pkill -f "astro dev\|astro preview\|node.*entry.mjs"` as a fallback. If that also fails, use a different port (`--port 4322`) rather than fighting the stale process.
 - **One reproduction run is enough.** Once you have confirmed or denied the bug, do NOT restart the server to re-test with minor config variations. Additional testing belongs in the diagnose step, not here. Write your findings and move on.
 - **Prefer `astro build` over dev/preview when possible.** Build-time reproduction avoids server lifecycle issues entirely. Only use dev/preview servers when the bug specifically requires a running server (e.g., HMR, runtime SSR, request handling).
+- **Always use `bgproc` for servers — never `&`.** Do not background servers with `&` (e.g., `pnpm dev &`). This hangs in CI. Always use `bgproc start` / `bgproc stop` for server lifecycle management.
 
 ## Step 5: Write Output
 


### PR DESCRIPTION
Adds guardrails to the triage skill so the agent bails out after 2 failed server starts instead of looping until timeout.

Prompted by [this run](https://github.com/withastro/astro/actions/runs/26140789637/job/76885703448) where the agent confirmed the bug early but wasted ~10 minutes fighting a stale server process and ran out of time before writing its report.

Changes:
- **SKILL.md**: General "don't get stuck" rule at the top level
- **reproduce.md**: Server Management Rules subsection (bail after 2 failures, stop before restart, one repro run is enough, prefer build over dev/preview)
- **diagnose.md**: Brief server management reminder in the instrumentation step