### PR TITLE
fix: support i18n on the client

### DIFF
--- a/.changeset/yellow-sites-sink.md
+++ b/.changeset/yellow-sites-sink.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a v6 regression where `astro:i18n` could not be imported from client `<script>` blocks.

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -28,7 +28,8 @@ export default function virtualModulePlugin({ settings }: { settings: AstroSetti
   defaultLocale: ${JSON.stringify(config.i18n.defaultLocale)},
   locales: ${JSON.stringify(config.i18n.locales)},
   routing: ${JSON.stringify(routing)},
-  fallback: ${JSON.stringify(config.i18n.fallback)}
+  fallback: ${JSON.stringify(config.i18n.fallback)},
+  domains: ${JSON.stringify(config.i18n.domains)}
 };`;
 	}
 

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -1,5 +1,5 @@
 // @ts-expect-error This is an internal module
-import * as config from 'astro:config/server';
+import * as config from 'astro:config/client';
 import { toFallbackType } from '../core/app/common.js';
 import { toRoutingStrategy } from '../core/app/entrypoints/index.js';
 import type { SSRManifest } from '../core/app/types.js';
@@ -13,9 +13,9 @@ import * as I18nInternals from '../i18n/index.js';
 import type { MiddlewareHandler } from '../types/public/common.js';
 import type { AstroConfig, ValidRedirectStatus } from '../types/public/config.js';
 import type { APIContext } from '../types/public/context.js';
-import type { ServerDeserializedManifest } from '../types/public/index.js';
+import type { ClientDeserializedManifest } from '../types/public/index.js';
 
-const { trailingSlash, site, i18n, build } = config as ServerDeserializedManifest;
+const { trailingSlash, site, i18n, build } = config as ClientDeserializedManifest;
 const { format } = build;
 const isBuild = import.meta.env.PROD;
 const { defaultLocale, locales, domains, fallback, routing } = i18n!;

--- a/packages/astro/test/astro-i18n-client.test.ts
+++ b/packages/astro/test/astro-i18n-client.test.ts
@@ -1,0 +1,18 @@
+import { before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('i18n client import', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/i18n-client-import/',
+			outDir: './dist/i18n-client-import/',
+			cacheDir: './node_modules/.astro-test/i18n-client-import/',
+		});
+	});
+
+	it('builds successfully when astro:i18n is imported from a client <script>', async () => {
+		await fixture.build();
+	});
+});

--- a/packages/astro/test/fixtures/i18n-client-import/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-client-import/astro.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	i18n: {
+		defaultLocale: 'en',
+		locales: ['en', 'es'],
+		routing: {
+			prefixDefaultLocale: false,
+		},
+	},
+});

--- a/packages/astro/test/fixtures/i18n-client-import/package.json
+++ b/packages/astro/test/fixtures/i18n-client-import/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/i18n-client-import",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/i18n-client-import/src/pages/index.astro
+++ b/packages/astro/test/fixtures/i18n-client-import/src/pages/index.astro
@@ -1,0 +1,18 @@
+---
+---
+<html>
+	<head>
+		<title>i18n client import test</title>
+	</head>
+	<body>
+		<h1 id="title">Test</h1>
+		<span id="locale-url" data-testid="locale-url"></span>
+		<script>
+			import { getRelativeLocaleUrl } from 'astro:i18n';
+			const el = document.getElementById('locale-url');
+			if (el) {
+				el.textContent = getRelativeLocaleUrl('es', 'test');
+			}
+		</script>
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3283,6 +3283,12 @@ importers:
         specifier: ^10.29.0
         version: 10.29.0
 
+  packages/astro/test/fixtures/i18n-client-import:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/i18n-css-leak-basic:
     dependencies:
       astro:


### PR DESCRIPTION
Closes #15919

## Changes

- adds the missing `domains`
- `astro:config/server` → `astro:config/client` 


## Testing

<!-- How was this change tested? -->
- The regression test and fixture were drafted with AI assistance and reviewed before commit.
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
