### PR TITLE
fix(@astrojs/node): return null from resolveClientDir instead of throwing when server dir not found

### DIFF
--- a/.changeset/node-firebase-graceful-clientdir.md
+++ b/.changeset/node-firebase-graceful-clientdir.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes a crash on startup when deploying to Firebase Hosting. `resolveClientDir()` now returns `null` instead of throwing when the `server` directory segment cannot be found in the runtime path (e.g. Firebase flattens `dist/server/` contents to a root directory). Disk-based prerendered error pages are skipped gracefully in that case.

--- a/.changeset/node-firebase-graceful-clientdir.md
+++ b/.changeset/node-firebase-graceful-clientdir.md
@@ -2,4 +2,4 @@
 '@astrojs/node': patch
 ---
 
-Fixes a crash on startup when deploying to Firebase Hosting. `resolveClientDir()` now returns `null` instead of throwing when the `server` directory segment cannot be found in the runtime path (e.g. Firebase flattens `dist/server/` contents to a root directory). Disk-based prerendered error pages are skipped gracefully in that case.
+Fixes a 503 crash on every request when deploying an Astro SSR site to Firebase Hosting with the `webframeworks` experiment. The server no longer crashes on startup when the runtime path does not contain the expected directory structure.

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -66,19 +66,23 @@ export function createAppHandler(app: BaseApp, options: Options): RequestHandler
 
 	// Read prerendered error pages directly from disk instead of fetching over HTTP.
 	// This avoids SSRF risks and is more efficient.
-	const prerenderedErrorPageFetch = async (url: string): Promise<Response> => {
-		const { pathname } = new URL(url);
-		if (pathname.endsWith('/404.html') || pathname.endsWith('/404/index.html')) {
-			const response = await readErrorPageFromDisk(client, 404);
-			if (response) return response;
-		}
-		if (pathname.endsWith('/500.html') || pathname.endsWith('/500/index.html')) {
-			const response = await readErrorPageFromDisk(client, 500);
-			if (response) return response;
-		}
-		// No file found and no fallback configured - return empty response
-		return new Response(null, { status: 404 });
-	};
+	// client is null when the server directory can't be located at runtime (e.g. Firebase
+	// flattens dist/server/ contents), so we skip disk-based error pages in that case.
+	const prerenderedErrorPageFetch = client
+		? async (url: string): Promise<Response> => {
+				const { pathname } = new URL(url);
+				if (pathname.endsWith('/404.html') || pathname.endsWith('/404/index.html')) {
+					const response = await readErrorPageFromDisk(client, 404);
+					if (response) return response;
+				}
+				if (pathname.endsWith('/500.html') || pathname.endsWith('/500/index.html')) {
+					const response = await readErrorPageFromDisk(client, 500);
+					if (response) return response;
+				}
+				// No file found and no fallback configured - return empty response
+				return new Response(null, { status: 404 });
+			}
+		: undefined;
 
 	// Use the configured body size limit. A value of 0 or Infinity disables the limit.
 	const effectiveBodySizeLimit =

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -50,6 +50,9 @@ export function createStaticHandler(
 	 * @param ssr The SSR handler to be called if the static handler does not find a matching file.
 	 */
 	return (req: IncomingMessage, res: ServerResponse, ssr: () => unknown) => {
+		if (!client) {
+			return ssr();
+		}
 		if (req.url) {
 			// There might be cases where the incoming URL has the #, which we want to remove.
 			let fullUrl = req.url;

--- a/packages/integrations/node/src/shared.ts
+++ b/packages/integrations/node/src/shared.ts
@@ -12,11 +12,11 @@ export const STATIC_HEADERS_FILE = '_headers.json';
  * At build time, we know the relative path between server and client directories.
  * At runtime, we need to find the actual location based on where the server entry is running.
  *
- * ## Error
- *
- * It throws an error if it can't find the directory while walking the parent directories.
+ * Returns null when the server directory segment cannot be found in the runtime path
+ * (e.g. Firebase Hosting flattens dist/server/ contents so the "server" segment is absent).
+ * Callers must handle null gracefully.
  */
-export function resolveClientDir(options: Options) {
+export function resolveClientDir(options: Options): string | null {
 	// options.client and options.server are file:// URLs set at build time
 	// e.g., "file:///project/dist/client/" and "file:///project/dist/server/"
 	const clientURLRaw = new URL(options.client);
@@ -34,14 +34,11 @@ export function resolveClientDir(options: Options) {
 	while (!serverEntryFolderURL.endsWith(serverFolder)) {
 		// Guard against infinite loop
 		if (serverEntryFolderURL === previous) {
-			throw new Error(
-				`[@astrojs/node] Could not find the server directory "${serverFolder}" ` +
-					`by walking up from "${import.meta.url}". This can happen when the server ` +
-					`entry point is bundled into a single file (e.g. with esbuild) so that ` +
-					`import.meta.url no longer contains the original "${serverFolder}" path segment. ` +
-					`When bundling the server entry, make sure the output path contains a ` +
-					`"${serverFolder}" directory segment, or avoid bundling the server entry entirely.`,
-			);
+			// Can't find the server directory — this happens when a hosting provider
+			// (e.g. Firebase) copies the contents of dist/server/ to a flat root so
+			// the "server" path segment is absent at runtime.  Return null so callers
+			// can skip disk-based features gracefully instead of crashing on startup.
+			return null;
 		}
 		previous = serverEntryFolderURL;
 		serverEntryFolderURL = path.dirname(serverEntryFolderURL);

--- a/packages/integrations/node/test/units/resolve-client-dir.test.ts
+++ b/packages/integrations/node/test/units/resolve-client-dir.test.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { resolveClientDir } from '../../dist/shared.js';
 
 describe('resolveClientDir', () => {
-	it('throws a descriptive error when the server folder is not found in the path', () => {
+	it('returns null when the server folder is not found in the path', () => {
 		// Use pathToFileURL to build platform-valid file:// URLs. On Windows,
 		// file URLs require a drive letter (e.g. file:///C:/…); bare
 		// file:///project/… would cause fileURLToPath() to throw before the
@@ -14,23 +14,18 @@ describe('resolveClientDir', () => {
 		const server = new URL('server/', root).href;
 
 		// When import.meta.url (of shared.js) does not contain a "server" segment,
-		// the while loop should terminate and throw instead of looping forever.
-		// This simulates what happens when the entry point is bundled with esbuild
-		// into a path that lacks the expected "server" directory segment.
-		assert.throws(
-			() =>
-				resolveClientDir({
-					client,
-					server,
-					mode: 'middleware',
-					host: false,
-					port: 4321,
-					staticHeaders: false,
-					bodySizeLimit: 0,
-				}),
-			{
-				message: /Could not find the server directory "server".*bundled into a single file/,
-			},
-		);
+		// the while loop should terminate and return null instead of throwing.
+		// This simulates what happens when a hosting provider (e.g. Firebase) copies
+		// the contents of dist/server/ to a flat root, removing the "server" segment.
+		const result = resolveClientDir({
+			client,
+			server,
+			mode: 'middleware',
+			host: false,
+			port: 4321,
+			staticHeaders: false,
+			bodySizeLimit: 0,
+		});
+		assert.equal(result, null);
 	});
 });


### PR DESCRIPTION
## Summary

- fixes: https://github.com/withastro/astro/issues/16806

 Firebase Hosting (with the `webframeworks` experiment) copies the **contents** of `dist/server/` to the Cloud Functions root — the `server/` directory name
  is not preserved. At runtime, `import.meta.url` inside the server chunk is `file:///workspace/chunks/server_XYZ.mjs` — no `server` segment in the path.

 `resolveClientDir()` in `packages/integrations/node/src/shared.ts` walked up from `import.meta.url` looking for a directory named `server`. When it couldn't
   find it, it threw a fatal error **at module initialization time**, crashing the Cloud Function before any request was handled (503 on every request).

  ## Changes

  - `shared.ts` — `resolveClientDir` returns `string | null` instead of throwing when the server directory segment is not found in the runtime path
  - `serve-app.ts` — `prerenderedErrorPageFetch` is set to `undefined` when `client` is `null`; `app.render` already accepts `prerenderedErrorPageFetch?: ...`
   so this is a no-op fallback, not a regression
  - `serve-static.ts` — static handler falls through to SSR when `client` is `null`
  - `test/units/resolve-client-dir.test.ts` — updated to assert `null` return instead of a thrown error

  On CDN-backed deployments like Firebase Hosting, static files (including prerendered 404/500 pages) are served by the CDN layer — skipping disk-based error
  pages in that case is the correct graceful fallback.

  ## Testing

  Existing unit test in `test/units/resolve-client-dir.test.ts` updated and passing. The test simulates the Firebase scenario: `import.meta.url` at runtime
  does not contain the expected `server` path segment, and `resolveClientDir` now returns `null` instead of throwing.

  ## Docs

  No docs update needed — this is a bug fix for a crash at startup. The feature behavior (disk-based prerendered error pages) is unchanged for standard
  deployments where the `server/` directory segment is present at runtime.