### PR TITLE
ci: harden actions

### DIFF
--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Send a POST request to Netlify to rebuild preview.astro.new
-        run: 'curl -X POST -d {} ${{ env.BUILD_HOOK }}'
+        run: 'curl -X POST -d {} ${BUILD_HOOK}'
         env:
           BUILD_HOOK: ${{ secrets.NETLIFY_PREVIEWS_BUILD_HOOK }}

--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -1,4 +1,4 @@
-# HACKED: https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
+# Action taken down due to https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
 #name: "Issue: Needs Repro"
 #
 #on:

--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -1,34 +1,35 @@
-name: "Issue: Needs Repro"
-
-on:
-  issues:
-    types: [labeled]
-  schedule:
-    - cron: "0 0 * * *"
-
-jobs:
-  on-labeled:
-    if: github.event_name == 'issues' && github.event.label.name == 'needs repro'
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-        with:
-          actions: "create-comment, remove-labels"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new/repro). Issues marked with `needs repro` will be closed if they have no activity within 3 days.
-          labels: "needs triage"
-
-  close-stale:
-    if: github.event_name == 'schedule' && github.repository == 'withastro/astro'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-        with:
-          actions: "close-issues"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "needs repro"
-          inactive-day: 3
+# HACKED: https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
+#name: "Issue: Needs Repro"
+#
+#on:
+#  issues:
+#    types: [labeled]
+#  schedule:
+#    - cron: "0 0 * * *"
+#
+#jobs:
+#  on-labeled:
+#    if: github.event_name == 'issues' && github.event.label.name == 'needs repro'
+#    runs-on: ubuntu-latest
+#    permissions:
+#      issues: write
+#    steps:
+#      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
+#        with:
+#          actions: "create-comment, remove-labels"
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          issue-number: ${{ github.event.issue.number }}
+#          body: |
+#            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new/repro). Issues marked with `needs repro` will be closed if they have no activity within 3 days.
+#          labels: "needs triage"
+#
+#  close-stale:
+#    if: github.event_name == 'schedule' && github.repository == 'withastro/astro'
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
+#        with:
+#          actions: "close-issues"
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          labels: "needs repro"
+#          inactive-day: 3

--- a/.github/workflows/issue-wontfix.yml
+++ b/.github/workflows/issue-wontfix.yml
@@ -1,28 +1,29 @@
-name: "Issue: Wontfix"
-
-on:
-  issues:
-    types: [labeled]
-
-jobs:
-  wontfix:
-    if: github.event.label.name == 'wontfix'
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-        with:
-          actions: "create-comment, close-issue"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello! 
-
-            This is an automated message to let you know that we've triaged this issue and unfortunately, we will be closing it as "not planned".
-
-            We sometimes have to close good ideas (even great ones!) because our limited resources simply do not allow us to pursue all possible features and improvements, and when fixing bugs we have to balance the impact of the bug against the effort required for the fix. Before closing this we considered several factors such as the amount of work involved, the severity of the problem, the number of people affected, whether a workaround is available, and the ongoing cost of maintenance.
-
-            If you're seeing this message and believe you can contribute to this issue, please consider submitting a PR yourself. Astro encourages [community contributions](https://docs.astro.build/en/contribute/)!
-
-            If you have more questions, come and say hi in the [Astro Discord](https://astro.build/chat).
+# HACKED: https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
+#name: "Issue: Wontfix"
+#
+#on:
+#  issues:
+#    types: [labeled]
+#
+#jobs:
+#  wontfix:
+#    if: github.event.label.name == 'wontfix'
+#    runs-on: ubuntu-latest
+#    permissions:
+#      issues: write
+#    steps:
+#      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
+#        with:
+#          actions: "create-comment, close-issue"
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          issue-number: ${{ github.event.issue.number }}
+#          body: |
+#            Hello! 
+#
+#            This is an automated message to let you know that we've triaged this issue and unfortunately, we will be closing it as "not planned".
+#
+#            We sometimes have to close good ideas (even great ones!) because our limited resources simply do not allow us to pursue all possible features and improvements, and when fixing bugs we have to balance the impact of the bug against the effort required for the fix. Before closing this we considered several factors such as the amount of work involved, the severity of the problem, the number of people affected, whether a workaround is available, and the ongoing cost of maintenance.
+#
+#            If you're seeing this message and believe you can contribute to this issue, please consider submitting a PR yourself. Astro encourages [community contributions](https://docs.astro.build/en/contribute/)!
+#
+#            If you have more questions, come and say hi in the [Astro Discord](https://astro.build/chat).

--- a/.github/workflows/issue-wontfix.yml
+++ b/.github/workflows/issue-wontfix.yml
@@ -1,4 +1,4 @@
-# HACKED: https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
+# Action taken down due to https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
 #name: "Issue: Wontfix"
 #
 #on:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -93,10 +93,8 @@ jobs:
 
       # This step doesn't work for forks
       - name: Remove Preview Label
-        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        with:
-          labels: "pr preview"
-
+        run: gh pr edit ${{ github.event.number }} --remove-label "pr preview"
+        
       - name: Publish packages
         run: |
           packages=$(echo '${{ steps.compute-affected-packages.outputs.affected-packages }}' | jq -r '.[]' | tr '\n' ' ')

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-        with: 
+        with:
           inputs: '.github/workflows/'
           min-confidence: high
           min-severity: high

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main", "next"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Only needed for private repos. Needed to clone the repo.
+      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with: 
+          inputs: '.github/workflows/'
+          min-confidence: high
+          min-severity: high


### PR DESCRIPTION
## Changes

This PR adds:
- [zizmor](https://docs.zizmor.sh/) to our CI to check for incorrect usage of our workflows. As for now, I tuned the tool to target high confidence and high severity
- I run the tool in our actions, and applied the suggestions
	- removed an action from our preview release
	- removed a possible template injection

There's still a warning

```
warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> .github/workflows/format.yml:12:11
   |
12 |     uses: withastro/automation/.github/workflows/format.yml@497c9268ad4267c842a8f6c4d830ad0182d6f6b3 # main
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this reusable workflow
...
15 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High
```

However it's not easy fixable at the moment

> [!NOTE]
> I plan to address even warnings, but for now I'll focus on high profile errors.

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
