### PR TITLE
ci: pin pnpm version

### DIFF
--- a/.github/workflows/merge-main-to-next.yml
+++ b/.github/workflows/merge-main-to-next.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.check-next.outputs.exists == 'true' && steps.merge.outputs.conflict == 'true'
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
-          version: 11
+          version: 11.0.9
 
       - name: Setup Node
         if: steps.check-next.outputs.exists == 'true' && steps.merge.outputs.conflict == 'true'

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
+  "//": "When updating pnpm version, update merge-main-to-next workflow too",
   "packageManager": "pnpm@11.0.9",
   "dependencies": {
     "astro-benchmark": "workspace:*"


### PR DESCRIPTION
## Changes

This PR pin the exact version used by the merge-main-to-next workflow to match the same version we use in the repository. I *should* fix the failures.

## Testing

Merge and wait once it's triggered again

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
