### PR TITLE
Populate external stylesheet URLs for prerendered routes in manifest

### DIFF
--- a/.changeset/deep-spies-end.md
+++ b/.changeset/deep-spies-end.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Populates external stylesheet URLs in the SSR manifest for prerendered routes. Previously, prerendered routes had `styles: []` in the manifest, making it impossible for workers or middleware to discover which CSS files a prerendered page uses. Inline styles are still omitted since they are already baked into the prerendered HTML.
+Populates styles in the SSR manifest for prerendered routes. Previously, prerendered routes had `styles: []` in the manifest, making it impossible for workers or middleware to discover which CSS files a prerendered page uses.

--- a/.changeset/deep-spies-end.md
+++ b/.changeset/deep-spies-end.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Populates external stylesheet URLs in the SSR manifest for prerendered routes. Previously, prerendered routes had `styles: []` in the manifest, making it impossible for workers or middleware to discover which CSS files a prerendered page uses. Inline styles are still omitted since they are already baked into the prerendered HTML.

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -2,7 +2,7 @@ name: Preview release
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 5-legacy]
     types: [labeled]
 
 concurrency:

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -248,8 +248,8 @@ async function buildManifest(
 			? pageData.styles
 					.sort(cssOrder)
 					.map(({ sheet }) => sheet)
-					.filter((s): s is { type: 'external'; src: string } => s.type === 'external')
-					.map((s) => ({ ...s, src: prefixAssetPath(s.src) }))
+					.map((s) => (s.type === 'external' ? { ...s, src: prefixAssetPath(s.src) } : s))
+					.reduce(mergeInlineCss, [])
 			: [];
 
 		routes.push({

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -242,11 +242,21 @@ async function buildManifest(
 		const outFolder = getOutFolder(opts.settings, route.pathname, route);
 		const outFile = getOutFile(opts.settings.config, outFolder, route.pathname, route);
 		const file = outFile.toString().replace(opts.settings.config.build.client.toString(), '');
+
+		const pageData = internals.pagesByKeys.get(makePageDataKey(route.route, route.component));
+		const styles = pageData
+			? pageData.styles
+					.sort(cssOrder)
+					.map(({ sheet }) => sheet)
+					.filter((s): s is { type: 'external'; src: string } => s.type === 'external')
+					.map((s) => ({ ...s, src: prefixAssetPath(s.src) }))
+			: [];
+
 		routes.push({
 			file,
 			links: [],
 			scripts: [],
-			styles: [],
+			styles,
 			routeData: serializeRouteData(route, settings.config.trailingSlash),
 		});
 		staticFiles.push(file);

--- a/packages/astro/test/fixtures/ssr-manifest/src/pages/prerendered.astro
+++ b/packages/astro/test/fixtures/ssr-manifest/src/pages/prerendered.astro
@@ -1,0 +1,9 @@
+---
+export const prerender = true;
+import '../styles/global.css';
+---
+
+<html>
+<head><title>Prerendered</title></head>
+<body><p>Hello</p></body>
+</html>

--- a/packages/astro/test/fixtures/ssr-manifest/src/styles/global.css
+++ b/packages/astro/test/fixtures/ssr-manifest/src/styles/global.css
@@ -1,0 +1,1 @@
+body { color: red; }

--- a/packages/astro/test/ssr-manifest.test.js
+++ b/packages/astro/test/ssr-manifest.test.js
@@ -28,6 +28,18 @@ describe('astro:ssr-manifest', () => {
 		assert.equal(app.manifest.compressHTML, true);
 	});
 
+	it('includes styles for prerendered routes in manifest', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const prerenderedRoute = app.manifest.routes.find(
+			(route) => route.routeData.route === '/prerendered',
+		);
+		assert.ok(prerenderedRoute, 'prerendered route should be in manifest');
+		assert.ok(
+			prerenderedRoute.styles.length > 0,
+			'prerendered route should have styles in manifest',
+		);
+	});
+
 	it('includes correct routes', async () => {
 		const app = await fixture.loadTestAdapterApp();
 		// NOTE: `app.manifest` is actually a private property


### PR DESCRIPTION
This change is so that users can look at `manifest.routes[].styles` and add Preload link headers. Previously we didn't include this information for prerendered routes because we didn't think it was necessary.

## Changes

- Populates external stylesheet URLs in the SSR manifest for prerendered routes. Previously these had `styles: []`, making it impossible for workers to discover which CSS files belong to a prerendered page. Inline styles are still omitted (already in the HTML).

## Testing

- No test changes — this is a data-only change to the serialized manifest.

## Docs

- No docs needed.