### PR TITLE
Normalize wrangler.jsonc worker name

### DIFF
--- a/.changeset/smart-waves-hug.md
+++ b/.changeset/smart-waves-hug.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Normalize Cloudflare Worker names to match https://developers.cloudflare.com/workers/wrangler/configuration/

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -84,7 +84,7 @@ export default async function seed() {
 {
 	"compatibility_date": ${JSON.stringify(compatibilityDate)},
 	"compatibility_flags": ["global_fetch_strictly_public"],
-	"name": ${JSON.stringify(name)},
+	"name": ${JSON.stringify(name.replace(/[^a-zA-Z0-9-]+/g, '-'))},
 	"main": "@astrojs/cloudflare/entrypoints/server",
 	"assets": {
 		"directory": "./dist",


### PR DESCRIPTION
## Changes

Normalize the package name before `astro add cloudflare` writes it to generated `wrangler.jsonc` as the Cloudflare Worker name.

Previously, a package name like `example.org` was written directly as:

```json
"name": "example.org"
```

Wrangler/Workers require names to use alphanumeric characters and dashes, so this now writes:

```json
"name": "example-org"
```

## Testing

- `pnpm exec biome check "packages/astro/src/cli/add/index.ts"`
- `pnpm --filter astro build:ci`

The normalization is a small inline transform next to the generated `wrangler.jsonc` write.
