### PR TITLE
fix(cli): Add project name normalization in `astro add cloudflare`

### DIFF
--- a/.changeset/thirty-pants-judge.md
+++ b/.changeset/thirty-pants-judge.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Add project name normalization in `astro add cloudflare`
+
+When `astro add cloudflare` generates a Wrangler config, the project name from `package.json` is now normalized to comply with Cloudflare's naming rules. Underscores are replaced with dashes, special characters are removed, leading/trailing dashes are trimmed, and the name is truncated to 63 characters. Previously, names like `my_project!` would be written as-is, causing Wrangler to reject the config.

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -216,11 +216,23 @@ export async function add(names: string[], { flags }: AddOptions) {
 
 					if (await askToContinue({ flags, logger })) {
 						const data = await getPackageJson();
-						let compatibilityDate = new Date().toISOString().slice(0, 10);
+
+						// Normalize the project name, in the same way Wrangler does: https://github.com/cloudflare/workers-sdk/blob/e04e180d/packages/wrangler/src/autoconfig/details/index.ts#L360-L368
+						const workerName = (data?.name ?? 'example')
+							// Replace all underscores with dashes
+							.replaceAll('_', '-')
+							// Replace all the special characters (besides dashes) with dashes
+							.replace(/[^a-z0-9- ]/g, '-')
+							// Remove invalid start/end dashes
+							.replace(/^-+|-+$/g, '')
+							// If the name is longer than the limit let's truncate it to that
+							.slice(0, 63);
+
+						const compatibilityDate = new Date().toISOString().slice(0, 10);
 
 						await fs.writeFile(
 							wranglerConfigURL,
-							STUBS.CLOUDFLARE_WRANGLER_CONFIG(data?.name ?? 'example', compatibilityDate),
+							STUBS.CLOUDFLARE_WRANGLER_CONFIG(workerName, compatibilityDate),
 							'utf-8',
 						);
 					}


### PR DESCRIPTION
## Changes
- normalizes the `name` field of wrangler.jsonc files that `astro add cloudflare` creates, ensuring that even if a project has a name incompatible with Cloudflare Worker's name constraint the command still produces a working project

## Testing

- manually I created a new astro project via `npm create astro` called `"astro.app"`, I run `npx astro add cloudflare` on it and it generated a wrangler.jsonc file with the invalid name `"astro.app"`, then I locally build astro and retried again with my version and the name in the wrangler.jsonc is now a correct `"astro-app"`
- The `astro add cloudflare` command doesn't seem to be test covered

## Docs

This is a self explanatory/minimal fix

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
