### PR TITLE
docs(logger): fix "destinatin" typo in JSDoc

### DIFF
--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -248,7 +248,7 @@ export class AstroLogger {
 	}
 
 	/**
-	 * It calls the `flush` function of the provided destinatin, if it exists.
+	 * It calls the `flush` function of the provided destination, if it exists.
 	 */
 	flush() {
 		if (this.options.destination.flush) {


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fixes a one-character typo in a JSDoc comment in `packages/astro/src/core/logger/core.ts`:

```diff
-	 * It calls the `flush` function of the provided destinatin, if it exists.
+	 * It calls the `flush` function of the provided destination, if it exists.
```

## Why

Trivial doc copy-edit. The rest of the file consistently uses `destination` (it's also the actual property name: `this.options.destination`), so the typo is clearly unintentional.

## How verified

Pure doc-comment change — no runtime / type / public-API impact. JSDoc only, no test fixtures affected.

## Maintainer note: feel free to close

If a one-character JSDoc typo isn't worth the round-trip overhead for you, please just close — zero hard feelings.
