### PR TITLE
Fix Node adapter buffer bodies with serverless-http

### DIFF
--- a/.changeset/fix-buffer-body-in-node-adapter.md
+++ b/.changeset/fix-buffer-body-in-node-adapter.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes request body handling in the Node adapter when `req.body` is a `Buffer`, `Uint8Array`, or `ArrayBuffer`. Previously, binary body data was incorrectly JSON-stringified (producing `{"type":"Buffer","data":[...]}`) instead of being passed through directly. This affected libraries like `serverless-http` that set `req.body` to a `Buffer`.

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -331,6 +331,13 @@ function makeRequestBody(req: NodeRequest, bodySizeLimit?: number): RequestInit 
 			return { body: Buffer.from(req.body) };
 		}
 
+		// Pass through binary data directly. Buffer, Uint8Array, and other typed arrays
+		// are valid BodyInit values and must not be JSON-stringified. Without this check
+		// they fall into the plain-object branch below because typeof returns 'object'.
+		if (req.body instanceof ArrayBuffer || ArrayBuffer.isView(req.body)) {
+			return { body: req.body as BodyInit };
+		}
+
 		if (typeof req.body === 'object' && req.body !== null && Object.keys(req.body).length > 0) {
 			return { body: Buffer.from(JSON.stringify(req.body)) };
 		}

--- a/packages/astro/test/units/app/node.test.ts
+++ b/packages/astro/test/units/app/node.test.ts
@@ -857,6 +857,85 @@ describe('node', () => {
 		});
 	});
 
+	describe('request body handling', () => {
+		it('passes through Buffer body without mangling', async () => {
+			const payload = JSON.stringify({ message: 'hello' });
+			const request = createRequest(
+				{
+					...mockNodeRequest,
+					method: 'POST',
+					headers: { ...mockNodeRequest.headers, 'content-type': 'application/json' },
+					body: Buffer.from(payload),
+				},
+				{ port: 4321 },
+			);
+			const text = await request.text();
+			assert.equal(text, payload);
+		});
+
+		it('passes through Uint8Array body without mangling', async () => {
+			const payload = JSON.stringify({ message: 'hello' });
+			const request = createRequest(
+				{
+					...mockNodeRequest,
+					method: 'POST',
+					headers: { ...mockNodeRequest.headers, 'content-type': 'application/json' },
+					body: new Uint8Array(Buffer.from(payload)),
+				},
+				{ port: 4321 },
+			);
+			const text = await request.text();
+			assert.equal(text, payload);
+		});
+
+		it('passes through ArrayBuffer body without mangling', async () => {
+			const payload = JSON.stringify({ message: 'hello' });
+			const buf = Buffer.from(payload);
+			const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+			const request = createRequest(
+				{
+					...mockNodeRequest,
+					method: 'POST',
+					headers: { ...mockNodeRequest.headers, 'content-type': 'application/json' },
+					body: ab,
+				},
+				{ port: 4321 },
+			);
+			const text = await request.text();
+			assert.equal(text, payload);
+		});
+
+		it('re-serializes plain object body from middleware like express.json()', async () => {
+			const obj = { message: 'hello' };
+			const request = createRequest(
+				{
+					...mockNodeRequest,
+					method: 'POST',
+					headers: { ...mockNodeRequest.headers, 'content-type': 'application/json' },
+					body: obj,
+				},
+				{ port: 4321 },
+			);
+			const text = await request.text();
+			assert.equal(text, JSON.stringify(obj));
+		});
+
+		it('converts string body to a buffer', async () => {
+			const payload = JSON.stringify({ message: 'hello' });
+			const request = createRequest(
+				{
+					...mockNodeRequest,
+					method: 'POST',
+					headers: { ...mockNodeRequest.headers, 'content-type': 'application/json' },
+					body: payload,
+				},
+				{ port: 4321 },
+			);
+			const text = await request.text();
+			assert.equal(text, payload);
+		});
+	});
+
 	describe('body size limit', () => {
 		it('rejects request body that exceeds the configured bodySizeLimit', async () => {
 			const { Readable } = await import('node:stream');


### PR DESCRIPTION
## Changes

- Fixes Node adapter in middleware mode incorrectly JSON-stringifying `Buffer` bodies from `serverless-http`
- Adds binary data check (`ArrayBuffer.isView()` and `instanceof ArrayBuffer`) before generic object branch in `makeRequestBody`
- Buffer, Uint8Array, and other typed arrays now pass through directly as valid `BodyInit` values

## Testing

- Added 5 new test cases in `test/units/app/node.test.ts` covering Buffer, Uint8Array, ArrayBuffer, plain objects, and strings
- Verifies binary data passes through unchanged while preserving existing string/object handling
- All existing tests pass with no regressions

## Docs

- No docs update needed, this restores expected behavior for a specific integration pattern

Closes #16820