### PR TITLE
Fix silent rendering errors in Cloudflare adapter workerd prerenderer

### DIFF
--- a/.changeset/fix-cloudflare-prerender-errors.md
+++ b/.changeset/fix-cloudflare-prerender-errors.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes silent build failures and missing error overlay when using the Cloudflare adapter's default `workerd` prerenderer. Previously, rendering errors (e.g. missing imports) would silently produce truncated HTML with a successful build exit code, and in dev mode no error overlay would appear. Now builds properly fail with a clear error message, and dev mode shows the error overlay.

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -142,6 +142,14 @@ export function createCloudflarePrerenderer({
 				redirect: 'manual',
 			});
 
+			if (!response.ok) {
+				const responseBody = await response.text();
+				const details = responseBody ? `\n${responseBody}` : '';
+				throw new Error(
+					`Failed to prerender page from the Cloudflare prerender server (${response.status}: ${response.statusText}).${details}`,
+				);
+			}
+
 			return response;
 		},
 

--- a/packages/integrations/cloudflare/src/utils/handler.ts
+++ b/packages/integrations/cloudflare/src/utils/handler.ts
@@ -33,6 +33,55 @@ declare global {
 type CfResponse = Awaited<ReturnType<Required<ExportedHandler<Env>>['fetch']>>;
 
 const app = createApp();
+// Use a non-streaming app for prerender requests so rendering errors propagate
+// synchronously via renderToString() instead of being deferred via
+// setTimeout(() => controller.error(e), 0) in renderToReadableStream().
+// This ensures errors result in a 500 response rather than a truncated 200.
+const prerenderApp = isPrerender ? createApp({ streaming: false }) : undefined;
+
+const encoder = new TextEncoder();
+
+/**
+ * Wraps a response body stream to catch rendering errors mid-stream and inject
+ * an error overlay script. In dev mode, renderToReadableStream() defers errors
+ * via setTimeout, so they fire after the 200 response has already started.
+ * This wrapper intercepts those errors and appends a script that triggers
+ * Astro's error overlay in the browser.
+ */
+function wrapStreamWithErrorHandling(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+	const reader = body.getReader();
+	return new ReadableStream({
+		async pull(controller) {
+			try {
+				const { done, value } = await reader.read();
+				if (done) {
+					controller.close();
+				} else {
+					controller.enqueue(value);
+				}
+			} catch (err: unknown) {
+				const error = err instanceof Error ? err : new Error(String(err));
+				const errorPayload = JSON.stringify({
+					message: error.message,
+					stack: error.stack,
+				});
+				const script = `<script type="module" src="/@vite/client"></script>
+<script type="module">
+const err = ${errorPayload};
+const ErrorOverlay = customElements.get('vite-error-overlay');
+if (ErrorOverlay) {
+	document.body.appendChild(new ErrorOverlay(err));
+}
+</script>`;
+				controller.enqueue(encoder.encode(script));
+				controller.close();
+			}
+		},
+		cancel() {
+			reader.cancel().catch(() => {});
+		},
+	});
+}
 
 export async function handle(
 	request: Request,
@@ -40,17 +89,17 @@ export async function handle(
 	context: ExecutionContext,
 ): Promise<CfResponse> {
 	// Handle prerender endpoints (only active during build prerender phase)
-	if (isPrerender) {
+	if (isPrerender && prerenderApp) {
 		if (compileImageConfig) {
 			const { installAddStaticImage } = await import('./static-image-collection.js');
 			installAddStaticImage(compileImageConfig);
 		}
 
 		if (isStaticPathsRequest(request)) {
-			return handleStaticPathsRequest(app) as unknown as CfResponse;
+			return handleStaticPathsRequest(prerenderApp) as unknown as CfResponse;
 		}
 		if (isPrerenderRequest(request)) {
-			return handlePrerenderRequest(app, request) as unknown as CfResponse;
+			return handlePrerenderRequest(prerenderApp, request) as unknown as CfResponse;
 		}
 		if (isStaticImagesRequest(request)) {
 			return handleStaticImagesRequest() as unknown as CfResponse;
@@ -137,6 +186,18 @@ export async function handle(
 		for (const setCookieHeader of app.setCookieHeaders(response)) {
 			response.headers.append('Set-Cookie', setCookieHeader);
 		}
+	}
+
+	// In dev mode, wrap the response body stream to catch rendering errors mid-stream
+	// and inject Astro's error overlay. Without this, errors in renderToReadableStream()
+	// silently truncate the page because the 200 response has already started.
+	if (app.isDev() && response.body) {
+		const wrappedBody = wrapStreamWithErrorHandling(response.body);
+		return new Response(wrappedBody, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
 	}
 
 	return response;

--- a/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	output: 'static',
+});

--- a/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@test/astro-cloudflare-prerenderer-render-errors",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"build": "astro build"
+	},
+	"dependencies": {
+		"@astrojs/cloudflare": "workspace:*",
+		"astro": "workspace:*"
+	}
+}

--- a/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/src/components/Broken.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/src/components/Broken.astro
@@ -1,0 +1,4 @@
+---
+// MissingComponent is intentionally not imported to trigger a ReferenceError
+---
+<div>Before error <MissingComponent /> After error</div>

--- a/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+import Broken from '../components/Broken.astro';
+---
+<html>
+<head><title>Test</title></head>
+<body>
+<div>INDEX</div>
+<Broken />
+</body>
+</html>

--- a/packages/integrations/cloudflare/test/prerenderer-render-errors.test.ts
+++ b/packages/integrations/cloudflare/test/prerenderer-render-errors.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
+import cloudflare from '../dist/index.js';
+
+describe('Cloudflare prerenderer render errors', () => {
+	let fixture: Fixture;
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/prerenderer-render-errors/', import.meta.url).toString(),
+			adapter: cloudflare(),
+		});
+	});
+
+	after(async () => {
+		await fixture.clean();
+	});
+
+	it('fails the build when a component throws during rendering', async () => {
+		await assert.rejects(
+			async () => {
+				await fixture.build({}, { teardownCompiler: true });
+			},
+			(error) => {
+				assert.ok(error instanceof Error);
+				assert.match(
+					error.message,
+					/Failed to prerender page from the Cloudflare prerender server/,
+				);
+				return true;
+			},
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4693,6 +4693,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/cloudflare/test/fixtures/prerenderer-render-errors:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/cloudflare/test/fixtures/routing-priority:
     dependencies:
       '@astrojs/cloudflare':
@@ -6925,7 +6934,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
-  triage/gh-16491:
+  triage/gh-16809:
     dependencies:
       '@astrojs/cloudflare':
         specifier: workspace:*
@@ -6933,9 +6942,6 @@ importers:
       astro:
         specifier: workspace:*
         version: link:../../packages/astro
-      fake-usd-pkg:
-        specifier: file:./fake-usd-pkg/fake-usd-pkg-1.0.1.tgz
-        version: file:triage/gh-16491/fake-usd-pkg/fake-usd-pkg-1.0.1.tgz
 
 packages:
 
@@ -12258,10 +12264,6 @@ packages:
     resolution: {directory: packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg, type: directory}
     peerDependencies:
       svelte: ^5.0.0
-
-  fake-usd-pkg@file:triage/gh-16491/fake-usd-pkg/fake-usd-pkg-1.0.1.tgz:
-    resolution: {integrity: sha512-d6wQ+zU3mEgYXII+IHC3YqIOzTgem7sLhTHF4whe4xR69/ib16dCHGRgoOjV9JGoeUUuAu96/cb/beY+qEcd1w==, tarball: file:triage/gh-16491/fake-usd-pkg/fake-usd-pkg-1.0.1.tgz}
-    version: 1.0.1
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -22421,8 +22423,6 @@ snapshots:
   fake-svelte-pkg@file:packages/integrations/cloudflare/test/fixtures/prerender-node-env/fake-svelte-pkg(svelte@5.55.3):
     dependencies:
       svelte: 5.55.3
-
-  fake-usd-pkg@file:triage/gh-16491/fake-usd-pkg/fake-usd-pkg-1.0.1.tgz: {}
 
   fast-decode-uri-component@1.0.1: {}
 


### PR DESCRIPTION
## Changes

- Builds now properly fail when components throw errors during workerd prerendering, instead of silently producing truncated HTML with exit code 0
- Dev mode now displays Astro's error overlay when rendering errors occur, matching the behavior of regular Astro dev servers
- Creates separate non-streaming app instance for prerender requests so errors propagate synchronously as 500 responses instead of being deferred
- Adds missing `!response.ok` check in prerenderer's `render()` method to detect and throw on error responses
- Wraps response body streams in dev mode to catch mid-stream errors and inject error overlay scripts

## Testing

- Added `prerenderer-render-errors.test.ts` that verifies builds fail with clear error messages when components have missing imports
- Test fixture includes intentionally broken component to trigger `ReferenceError` during rendering
- Verified fix works for both build and dev modes with the issue reporter's test case

## Docs

- No docs update needed, this fixes broken behavior to match expected Astro error handling.

Closes #16809