### PR TITLE
refactor: make build `dist/` directory portable

### DIFF
--- a/.changeset/sour-plums-brush.md
+++ b/.changeset/sour-plums-brush.md
@@ -2,8 +2,20 @@
 'astro': minor
 ---
 
-Makes the build `dist/` directory portable
+Adds `experimental.portableOutput` option to make the build `dist/` directory portable
 
-The `dist/` output can now be moved to a different machine or directory and run with `node dist/server/entry.mjs` without rebuilding. This enables building in CI and deploying the artifact elsewhere, cross-platform builds (e.g., build on Windows, deploy on Linux), and caching build outputs across CI runs with tools like Turborepo.
+When enabled, the `dist/` output can be moved to a different machine or directory and run
+with `node dist/server/entry.mjs` without rebuilding. This enables building in CI and
+deploying the artifact elsewhere, cross-platform builds (e.g., build on Windows, deploy on
+Linux), and caching build outputs across CI runs with tools like Turborepo.
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  experimental: {
+    portableOutput: true,
+  },
+});
+```
 
 `node_modules/` must be co-located with `dist/` at the deployment target.

--- a/.changeset/sour-plums-brush.md
+++ b/.changeset/sour-plums-brush.md
@@ -1,0 +1,9 @@
+---
+'astro': minor
+---
+
+Makes the build `dist/` directory portable
+
+The `dist/` output can now be moved to a different machine or directory and run with `node dist/server/entry.mjs` without rebuilding. This enables building in CI and deploying the artifact elsewhere, cross-platform builds (e.g., build on Windows, deploy on Linux), and caching build outputs across CI runs with tools like Turborepo.
+
+`node_modules/` must be co-located with `dist/` at the deployment target.

--- a/packages/astro/src/core/app/manifest.ts
+++ b/packages/astro/src/core/app/manifest.ts
@@ -12,10 +12,40 @@ import type {
 
 export type { SerializedRouteData } from '../../types/astro.js';
 
+/**
+ * Deserializes a serialized SSR manifest back into the runtime SSRManifest type.
+ *
+ * Directory paths in the manifest are stored as relative paths from the server
+ * entry directory for portability. The `serverEntryUrl` parameter (typically
+ * `import.meta.url` of the server entry) is used as the base to resolve these
+ * relative paths back into absolute `file://` URLs at runtime. This allows the
+ * built output to be moved to any location and still work correctly.
+ */
 export function deserializeManifest(
 	serializedManifest: SerializedSSRManifest,
+	serverEntryUrl?: string | RoutesList,
 	routesList?: RoutesList,
 ): SSRManifest {
+	// Support both (manifest, url, routesList) and legacy (manifest, routesList) signatures
+	if (serverEntryUrl && typeof serverEntryUrl !== 'string') {
+		routesList = serverEntryUrl;
+		serverEntryUrl = undefined;
+	}
+
+	// Resolve relative directory paths against the server entry's actual location.
+	// In production, serverEntryUrl is import.meta.url of the SSR entry (e.g.,
+	// file:///deployed/app/dist/server/entry.mjs). We use its parent directory
+	// as the base for resolution, since all relative paths in the manifest are
+	// expressed relative to buildServerDir.
+	const serverBaseUrl = serverEntryUrl ? new URL('./', serverEntryUrl) : undefined;
+	const resolveDir = (relativePath: string): URL => {
+		if (serverBaseUrl) {
+			return new URL(relativePath, serverBaseUrl);
+		}
+		// Fallback: treat as absolute URL (legacy behavior for callers that don't pass serverEntryUrl)
+		return new URL(relativePath);
+	};
+
 	const routes: RouteInfo[] = [];
 	if (serializedManifest.routes) {
 		for (const serializedRoute of serializedManifest.routes) {
@@ -52,13 +82,13 @@ export function deserializeManifest(
 		},
 
 		...serializedManifest,
-		rootDir: new URL(serializedManifest.rootDir),
-		srcDir: new URL(serializedManifest.srcDir),
-		publicDir: new URL(serializedManifest.publicDir),
-		outDir: new URL(serializedManifest.outDir),
-		cacheDir: new URL(serializedManifest.cacheDir),
-		buildClientDir: new URL(serializedManifest.buildClientDir),
-		buildServerDir: new URL(serializedManifest.buildServerDir),
+		rootDir: resolveDir(serializedManifest.rootDir),
+		srcDir: resolveDir(serializedManifest.srcDir),
+		publicDir: resolveDir(serializedManifest.publicDir),
+		outDir: resolveDir(serializedManifest.outDir),
+		cacheDir: resolveDir(serializedManifest.cacheDir),
+		buildClientDir: resolveDir(serializedManifest.buildClientDir),
+		buildServerDir: resolveDir(serializedManifest.buildServerDir),
 		assets,
 		componentMetadata,
 		inlinedScripts,

--- a/packages/astro/src/core/app/manifest.ts
+++ b/packages/astro/src/core/app/manifest.ts
@@ -37,13 +37,26 @@ export function deserializeManifest(
 	// file:///deployed/app/dist/server/entry.mjs). We use its parent directory
 	// as the base for resolution, since all relative paths in the manifest are
 	// expressed relative to buildServerDir.
-	const serverBaseUrl = serverEntryUrl ? new URL('./', serverEntryUrl) : undefined;
+	//
+	// On runtimes where import.meta.url is not a parseable URL (e.g., Cloudflare
+	// Workers/workerd), serverBaseUrl stays undefined and resolveDir falls back to
+	// treating each path as an absolute URL or a dummy — those runtimes don't use
+	// filesystem paths from the manifest.
+	const serverBaseUrl =
+		serverEntryUrl && URL.canParse(serverEntryUrl)
+			? new URL('./', serverEntryUrl)
+			: undefined;
 	const resolveDir = (relativePath: string): URL => {
 		if (serverBaseUrl) {
 			return new URL(relativePath, serverBaseUrl);
 		}
-		// Fallback: treat as absolute URL (legacy behavior for callers that don't pass serverEntryUrl)
-		return new URL(relativePath);
+		// Dev mode: paths are already absolute file:// URLs.
+		// Non-filesystem runtimes (Cloudflare Workers): paths are relative but
+		// unused — return a dummy URL so deserialization doesn't throw.
+		if (URL.canParse(relativePath)) {
+			return new URL(relativePath);
+		}
+		return new URL('file:///');
 	};
 
 	const routes: RouteInfo[] = [];

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -452,11 +452,10 @@ async function buildManifest(
 		componentMetadata: Array.from(internals.componentMetadata).map(([key, value]) => {
 			// Relativize absolute module IDs to root-relative paths for portability.
 			// This must match the moduleId normalization done in vite-plugin-astro's transform.
-			const normalizedRoot = normalizePath(fileURLToPath(settings.config.root));
-			const normalizedKey = normalizePath(key);
-			const relativeKey = normalizedKey.startsWith(normalizedRoot)
-				? normalizedKey.slice(normalizedRoot.length - 1)
-				: normalizedKey;
+			const nk = normalizePath(key);
+			const relativeKey = nk.startsWith(normalizedRoot)
+				? nk.slice(normalizedRoot.length - 1)
+				: nk;
 			return [relativeKey, value] as [string, typeof value];
 		}),
 		renderers: [],

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -1,5 +1,7 @@
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'tinyglobby';
+import { normalizePath } from 'vite';
 import { getAssetsPrefix } from '../../../assets/utils/getAssetsPrefix.js';
 import { normalizeTheLocale } from '../../../i18n/index.js';
 import { resolveMiddlewareMode } from '../../../integrations/adapter-utils.js';
@@ -100,7 +102,14 @@ export async function manifestBuildPostHook(
 		// these routes. Stripping keeps the entry chunk small on platforms like
 		// Cloudflare Workers that re-parse it on every cold isolate start.
 		const ssrManifest = stripPrerenderedRouteStyles(manifest);
-		const code = injectManifest(ssrManifest, ssrManifestChunk.code);
+		// The manifest's relative directory paths are computed from buildServerDir, but the
+		// manifest chunk may be nested deeper (e.g., in chunks/). Adjust paths to be
+		// relative to the chunk's actual directory so import.meta.url resolution works.
+		const adjustedSsrManifest = adjustManifestPathsForChunk(
+			ssrManifest,
+			ssrManifestChunk.fileName,
+		);
+		const code = injectManifest(adjustedSsrManifest, ssrManifestChunk.code);
 		mutate(ssrManifestChunk.fileName, code, false);
 	}
 
@@ -110,7 +119,20 @@ export async function manifestBuildPostHook(
 	);
 
 	if (prerenderManifestChunk) {
-		const code = injectManifest(manifest, prerenderManifestChunk.code);
+		// The prerender manifest runs during the build (not at deployment), so it needs
+		// absolute paths to resolve files on the build machine's filesystem.
+		// Unlike the SSR manifest which uses relative paths for portability.
+		const prerenderManifest: SerializedSSRManifest = {
+			...manifest,
+			rootDir: options.settings.config.root.toString(),
+			cacheDir: options.settings.config.cacheDir.toString(),
+			outDir: options.settings.config.outDir.toString(),
+			srcDir: options.settings.config.srcDir.toString(),
+			publicDir: options.settings.config.publicDir.toString(),
+			buildClientDir: options.settings.config.build.client.toString(),
+			buildServerDir: options.settings.config.build.server.toString(),
+		};
+		const code = injectManifest(prerenderManifest, prerenderManifestChunk.code);
 		mutate(prerenderManifestChunk.fileName, code, true);
 	}
 }
@@ -144,6 +166,40 @@ async function createManifest(
 	const encodedKey = await encodeKey(await buildOpts.key);
 	const manifest = await buildManifest(buildOpts, internals, Array.from(staticFiles), encodedKey);
 	return manifest;
+}
+
+/**
+ * Adjusts the manifest's relative directory paths to account for the chunk's depth
+ * within buildServerDir. The manifest paths are relative to buildServerDir (e.g., `../../`
+ * for rootDir), but the chunk may be nested deeper (e.g., `chunks/entry.mjs`). This
+ * function prepends the necessary `../` segments so that resolving against the chunk's
+ * import.meta.url produces the correct absolute paths.
+ */
+function adjustManifestPathsForChunk(
+	manifest: SerializedSSRManifest,
+	chunkFileName: string,
+): SerializedSSRManifest {
+	// chunkFileName is relative to buildServerDir, e.g., "chunks/foo.mjs" or "entry.mjs"
+	const chunkDir = path.posix.dirname(chunkFileName);
+	if (chunkDir === '.' || chunkDir === '') {
+		// Chunk is directly in buildServerDir — no adjustment needed
+		return manifest;
+	}
+	// Compute the prefix needed to go from the chunk's directory back to buildServerDir
+	// e.g., for "chunks/foo.mjs", chunkDir is "chunks", prefix is "../"
+	const depth = chunkDir.split('/').length;
+	const prefix = '../'.repeat(depth);
+
+	return {
+		...manifest,
+		rootDir: prefix + manifest.rootDir,
+		cacheDir: prefix + manifest.cacheDir,
+		outDir: prefix + manifest.outDir,
+		srcDir: prefix + manifest.srcDir,
+		publicDir: prefix + manifest.publicDir,
+		buildClientDir: prefix + manifest.buildClientDir,
+		buildServerDir: prefix + manifest.buildServerDir,
+	};
 }
 
 /**
@@ -187,11 +243,19 @@ async function buildManifest(
 	const assetQueryString = assetQueryParams ? assetQueryParams.toString() : undefined;
 
 	const appendAssetQuery = (pth: string) => (assetQueryString ? `${pth}?${assetQueryString}` : pth);
+	// Relativize any absolute filesystem paths in entryModules keys for portability.
+	// Some keys are virtual module IDs (e.g., "\0virtual:...") or package specifiers
+	// that should stay as-is. Only absolute filesystem paths need normalization.
+	const normalizedRoot = normalizePath(fileURLToPath(settings.config.root));
 	const entryModules = Object.fromEntries(
-		Object.entries(rawEntryModules).map(([key, value]) => [
-			key,
-			value ? appendAssetQuery(value) : value,
-		]),
+		Object.entries(rawEntryModules).map(([key, value]) => {
+			let normalizedKey = key;
+			const nk = normalizePath(key);
+			if (nk.startsWith(normalizedRoot)) {
+				normalizedKey = nk.slice(normalizedRoot.length - 1);
+			}
+			return [normalizedKey, value ? appendAssetQuery(value) : value];
+		}),
 	);
 	if (settings.scripts.some((script) => script.stage === 'page')) {
 		staticFiles.push(rawEntryModules[PAGE_SCRIPT_ID]);
@@ -350,14 +414,25 @@ async function buildManifest(
 		experimentalLogger = settings.config.experimental.logger;
 	}
 
+	// Compute directory paths relative to buildServerDir so that the built output
+	// is portable — it can be moved to a different machine or directory and still work.
+	// At runtime, these relative paths are resolved against import.meta.url (the actual
+	// location of the server entry) in deserializeManifest().
+	const serverDir = fileURLToPath(opts.settings.config.build.server);
+	const relativeDir = (dir: URL) => {
+		const rel = path.relative(serverDir, fileURLToPath(dir));
+		// Ensure trailing slash and use posix separators for cross-platform consistency
+		return rel.split(path.sep).join('/') + '/';
+	};
+
 	return {
-		rootDir: opts.settings.config.root.toString(),
-		cacheDir: opts.settings.config.cacheDir.toString(),
-		outDir: opts.settings.config.outDir.toString(),
-		srcDir: opts.settings.config.srcDir.toString(),
-		publicDir: opts.settings.config.publicDir.toString(),
-		buildClientDir: opts.settings.config.build.client.toString(),
-		buildServerDir: opts.settings.config.build.server.toString(),
+		rootDir: relativeDir(opts.settings.config.root),
+		cacheDir: relativeDir(opts.settings.config.cacheDir),
+		outDir: relativeDir(opts.settings.config.outDir),
+		srcDir: relativeDir(opts.settings.config.srcDir),
+		publicDir: relativeDir(opts.settings.config.publicDir),
+		buildClientDir: relativeDir(opts.settings.config.build.client),
+		buildServerDir: './',
 		adapterName: opts.settings.adapter?.name ?? '',
 		assetsDir: opts.settings.config.build.assets,
 		routes,
@@ -374,7 +449,16 @@ async function buildManifest(
 			poolSize: 0,
 			contentCache: false,
 		},
-		componentMetadata: Array.from(internals.componentMetadata),
+		componentMetadata: Array.from(internals.componentMetadata).map(([key, value]) => {
+			// Relativize absolute module IDs to root-relative paths for portability.
+			// This must match the moduleId normalization done in vite-plugin-astro's transform.
+			const normalizedRoot = normalizePath(fileURLToPath(settings.config.root));
+			const normalizedKey = normalizePath(key);
+			const relativeKey = normalizedKey.startsWith(normalizedRoot)
+				? normalizedKey.slice(normalizedRoot.length - 1)
+				: normalizedKey;
+			return [relativeKey, value] as [string, typeof value];
+		}),
 		renderers: [],
 		clientDirectives: Array.from(settings.clientDirectives),
 		entryModules,

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -462,7 +462,13 @@ async function buildManifest(
 		renderers: [],
 		clientDirectives: Array.from(settings.clientDirectives),
 		entryModules,
-		inlinedScripts: Array.from(internals.inlinedScripts),
+		inlinedScripts: Array.from(internals.inlinedScripts).map(([key, value]) => {
+			const nk = normalizePath(key);
+			const relativeKey = nk.startsWith(normalizedRoot)
+				? nk.slice(normalizedRoot.length - 1)
+				: nk;
+			return [relativeKey, value] as [string, typeof value];
+		}),
 		assets: staticFiles.map(prefixAssetPath),
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -102,14 +102,14 @@ export async function manifestBuildPostHook(
 		// these routes. Stripping keeps the entry chunk small on platforms like
 		// Cloudflare Workers that re-parse it on every cold isolate start.
 		const ssrManifest = stripPrerenderedRouteStyles(manifest);
-		// The manifest's relative directory paths are computed from buildServerDir, but the
-		// manifest chunk may be nested deeper (e.g., in chunks/). Adjust paths to be
-		// relative to the chunk's actual directory so import.meta.url resolution works.
-		const adjustedSsrManifest = adjustManifestPathsForChunk(
-			ssrManifest,
-			ssrManifestChunk.fileName,
-		);
-		const code = injectManifest(adjustedSsrManifest, ssrManifestChunk.code);
+		// When portableOutput is enabled, the manifest's relative directory paths are
+		// computed from buildServerDir, but the chunk may be nested deeper (e.g., in
+		// chunks/). Adjust paths to be relative to the chunk's actual directory.
+		const finalSsrManifest =
+			options.settings.config.experimental.portableOutput
+				? adjustManifestPathsForChunk(ssrManifest, ssrManifestChunk.fileName)
+				: ssrManifest;
+		const code = injectManifest(finalSsrManifest, ssrManifestChunk.code);
 		mutate(ssrManifestChunk.fileName, code, false);
 	}
 
@@ -119,19 +119,21 @@ export async function manifestBuildPostHook(
 	);
 
 	if (prerenderManifestChunk) {
-		// The prerender manifest runs during the build (not at deployment), so it needs
-		// absolute paths to resolve files on the build machine's filesystem.
-		// Unlike the SSR manifest which uses relative paths for portability.
-		const prerenderManifest: SerializedSSRManifest = {
-			...manifest,
-			rootDir: options.settings.config.root.toString(),
-			cacheDir: options.settings.config.cacheDir.toString(),
-			outDir: options.settings.config.outDir.toString(),
-			srcDir: options.settings.config.srcDir.toString(),
-			publicDir: options.settings.config.publicDir.toString(),
-			buildClientDir: options.settings.config.build.client.toString(),
-			buildServerDir: options.settings.config.build.server.toString(),
-		};
+		// When portableOutput is enabled, the prerender manifest needs absolute paths
+		// since it runs during the build (not at deployment).
+		const prerenderManifest =
+			options.settings.config.experimental.portableOutput
+				? {
+						...manifest,
+						rootDir: options.settings.config.root.toString(),
+						cacheDir: options.settings.config.cacheDir.toString(),
+						outDir: options.settings.config.outDir.toString(),
+						srcDir: options.settings.config.srcDir.toString(),
+						publicDir: options.settings.config.publicDir.toString(),
+						buildClientDir: options.settings.config.build.client.toString(),
+						buildServerDir: options.settings.config.build.server.toString(),
+					}
+				: manifest;
 		const code = injectManifest(prerenderManifest, prerenderManifestChunk.code);
 		mutate(prerenderManifestChunk.fileName, code, true);
 	}
@@ -243,16 +245,18 @@ async function buildManifest(
 	const assetQueryString = assetQueryParams ? assetQueryParams.toString() : undefined;
 
 	const appendAssetQuery = (pth: string) => (assetQueryString ? `${pth}?${assetQueryString}` : pth);
-	// Relativize any absolute filesystem paths in entryModules keys for portability.
-	// Some keys are virtual module IDs (e.g., "\0virtual:...") or package specifiers
-	// that should stay as-is. Only absolute filesystem paths need normalization.
-	const normalizedRoot = normalizePath(fileURLToPath(settings.config.root));
+	const portable = settings.config.experimental.portableOutput;
+	// When portableOutput is enabled, relativize absolute filesystem paths in
+	// entryModules keys so the manifest doesn't contain machine-specific paths.
+	const normalizedRoot = portable ? normalizePath(fileURLToPath(settings.config.root)) : '';
 	const entryModules = Object.fromEntries(
 		Object.entries(rawEntryModules).map(([key, value]) => {
 			let normalizedKey = key;
-			const nk = normalizePath(key);
-			if (nk.startsWith(normalizedRoot)) {
-				normalizedKey = nk.slice(normalizedRoot.length - 1);
+			if (portable) {
+				const nk = normalizePath(key);
+				if (nk.startsWith(normalizedRoot)) {
+					normalizedKey = nk.slice(normalizedRoot.length - 1);
+				}
 			}
 			return [normalizedKey, value ? appendAssetQuery(value) : value];
 		}),
@@ -414,25 +418,27 @@ async function buildManifest(
 		experimentalLogger = settings.config.experimental.logger;
 	}
 
-	// Compute directory paths relative to buildServerDir so that the built output
-	// is portable — it can be moved to a different machine or directory and still work.
-	// At runtime, these relative paths are resolved against import.meta.url (the actual
-	// location of the server entry) in deserializeManifest().
-	const serverDir = fileURLToPath(opts.settings.config.build.server);
-	const relativeDir = (dir: URL) => {
-		const rel = path.relative(serverDir, fileURLToPath(dir));
-		// Ensure trailing slash and use posix separators for cross-platform consistency
-		return rel.split(path.sep).join('/') + '/';
-	};
+	// When portableOutput is enabled, compute directory paths relative to
+	// buildServerDir so that the built output can be moved to a different machine
+	// or directory. At runtime, these are resolved against import.meta.url.
+	const dirToString = portable
+		? (() => {
+				const serverDir = fileURLToPath(opts.settings.config.build.server);
+				return (dir: URL) => {
+					const rel = path.relative(serverDir, fileURLToPath(dir));
+					return rel.split(path.sep).join('/') + '/';
+				};
+			})()
+		: (dir: URL) => dir.toString();
 
 	return {
-		rootDir: relativeDir(opts.settings.config.root),
-		cacheDir: relativeDir(opts.settings.config.cacheDir),
-		outDir: relativeDir(opts.settings.config.outDir),
-		srcDir: relativeDir(opts.settings.config.srcDir),
-		publicDir: relativeDir(opts.settings.config.publicDir),
-		buildClientDir: relativeDir(opts.settings.config.build.client),
-		buildServerDir: './',
+		rootDir: dirToString(opts.settings.config.root),
+		cacheDir: dirToString(opts.settings.config.cacheDir),
+		outDir: dirToString(opts.settings.config.outDir),
+		srcDir: dirToString(opts.settings.config.srcDir),
+		publicDir: dirToString(opts.settings.config.publicDir),
+		buildClientDir: dirToString(opts.settings.config.build.client),
+		buildServerDir: portable ? './' : opts.settings.config.build.server.toString(),
 		adapterName: opts.settings.adapter?.name ?? '',
 		assetsDir: opts.settings.config.build.assets,
 		routes,
@@ -449,25 +455,27 @@ async function buildManifest(
 			poolSize: 0,
 			contentCache: false,
 		},
-		componentMetadata: Array.from(internals.componentMetadata).map(([key, value]) => {
-			// Relativize absolute module IDs to root-relative paths for portability.
-			// This must match the moduleId normalization done in vite-plugin-astro's transform.
-			const nk = normalizePath(key);
-			const relativeKey = nk.startsWith(normalizedRoot)
-				? nk.slice(normalizedRoot.length - 1)
-				: nk;
-			return [relativeKey, value] as [string, typeof value];
-		}),
+		componentMetadata: portable
+			? Array.from(internals.componentMetadata).map(([key, value]) => {
+					const nk = normalizePath(key);
+					const relativeKey = nk.startsWith(normalizedRoot)
+						? nk.slice(normalizedRoot.length - 1)
+						: nk;
+					return [relativeKey, value] as [string, typeof value];
+				})
+			: Array.from(internals.componentMetadata),
 		renderers: [],
 		clientDirectives: Array.from(settings.clientDirectives),
 		entryModules,
-		inlinedScripts: Array.from(internals.inlinedScripts).map(([key, value]) => {
-			const nk = normalizePath(key);
-			const relativeKey = nk.startsWith(normalizedRoot)
-				? nk.slice(normalizedRoot.length - 1)
-				: nk;
-			return [relativeKey, value] as [string, typeof value];
-		}),
+		inlinedScripts: portable
+			? Array.from(internals.inlinedScripts).map(([key, value]) => {
+					const nk = normalizePath(key);
+					const relativeKey = nk.startsWith(normalizedRoot)
+						? nk.slice(normalizedRoot.length - 1)
+						: nk;
+					return [relativeKey, value] as [string, typeof value];
+				})
+			: Array.from(internals.inlinedScripts),
 		assets: staticFiles.map(prefixAssetPath),
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -111,6 +111,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 		clientPrerender: false,
 		contentIntellisense: false,
 		chromeDevtoolsWorkspace: false,
+		portableOutput: false,
 		rustCompiler: false,
 		queuedRendering: {
 			enabled: false,
@@ -553,6 +554,10 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.chromeDevtoolsWorkspace),
+			portableOutput: z
+				.boolean()
+				.optional()
+				.default(ASTRO_CONFIG_DEFAULTS.experimental.portableOutput),
 			svgOptimizer: SvgOptimizerSchema.optional(),
 			cache: CacheSchema.optional(),
 			routeRules: RouteRulesSchema.optional(),

--- a/packages/astro/src/core/routing/default.ts
+++ b/packages/astro/src/core/routing/default.ts
@@ -18,7 +18,7 @@ export interface DefaultRouteParams {
 export const DEFAULT_COMPONENTS = [DEFAULT_404_COMPONENT, SERVER_ISLAND_COMPONENT];
 
 export function createDefaultRoutes(manifest: SSRManifest): DefaultRouteParams[] {
-	const root = new URL(manifest.rootDir);
+	const root = manifest.rootDir;
 	return [
 		{
 			instance: default404Instance,

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -98,12 +98,14 @@ export function vitePluginServerIslands({
 					command === 'build' && this.environment?.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr;
 
 				if (astro) {
-					// During build, normalize resolvedPath to root-relative to match the
-					// paths in compiled output (normalized by vite-plugin-astro). This
-					// ensures the serverIslandNameMap keys match server:component-path values.
-					const normalizedRoot = command === 'build'
-						? normalizePath(fileURLToPath(settings.config.root))
-						: undefined;
+					// When portableOutput is enabled during build, normalize resolvedPath to
+					// root-relative to match the paths in compiled output (normalized by
+					// vite-plugin-astro). This ensures the serverIslandNameMap keys match
+					// server:component-path values.
+					const normalizedRoot =
+						command === 'build' && settings.config.experimental.portableOutput
+							? normalizePath(fileURLToPath(settings.config.root))
+							: undefined;
 					const normalizeResolved = (p: string) => {
 						if (normalizedRoot && p.startsWith(normalizedRoot)) {
 							return p.slice(normalizedRoot.length - 1);

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -1,4 +1,5 @@
-import type { ConfigEnv, DevEnvironment, Plugin as VitePlugin } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { normalizePath, type ConfigEnv, type DevEnvironment, type Plugin as VitePlugin } from 'vite';
 import type { AstroPluginOptions } from '../../types/astro.js';
 import type { AstroPluginMetadata } from '../../vite-plugin-astro/index.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../constants.js';
@@ -97,26 +98,40 @@ export function vitePluginServerIslands({
 					command === 'build' && this.environment?.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr;
 
 				if (astro) {
+					// During build, normalize resolvedPath to root-relative to match the
+					// paths in compiled output (normalized by vite-plugin-astro). This
+					// ensures the serverIslandNameMap keys match server:component-path values.
+					const normalizedRoot = command === 'build'
+						? normalizePath(fileURLToPath(settings.config.root))
+						: undefined;
+					const normalizeResolved = (p: string) => {
+						if (normalizedRoot && p.startsWith(normalizedRoot)) {
+							return p.slice(normalizedRoot.length - 1);
+						}
+						return p;
+					};
+
 					for (const comp of astro.serverComponents) {
 						if (!settings.adapter) {
 							throw new AstroError(AstroErrorData.NoAdapterInstalledServerIslands);
 						}
 
+						const resolvedPath = normalizeResolved(comp.resolvedPath);
 						const island = serverIslandsState.discover({
-							resolvedPath: comp.resolvedPath,
+							resolvedPath,
 							localName: comp.localName,
 							specifier: comp.specifier ?? comp.resolvedPath,
 							importer: id,
 						});
 
-						if (isBuildSsr && !serverIslandsState.hasReferenceId(comp.resolvedPath)) {
+						if (isBuildSsr && !serverIslandsState.hasReferenceId(resolvedPath)) {
 							const referenceId = this.emitFile({
 								type: 'chunk',
 								id: island.specifier,
 								importer: island.importer,
 								name: island.islandName,
 							});
-							serverIslandsState.setReferenceId(comp.resolvedPath, referenceId);
+							serverIslandsState.setReferenceId(resolvedPath, referenceId);
 						}
 					}
 				}

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -115,7 +115,7 @@ export function serializedManifestPlugin({
 					import { routes } from '${ASTRO_ROUTES_MODULE_ID}';
 					import { pageMap } from '${VIRTUAL_PAGES_MODULE_ID}';
 
-					const _manifest = _deserializeManifest((${manifestData}));
+					const _manifest = _deserializeManifest((${manifestData}), import.meta.url);
 
 				  // _manifest.routes contains enriched route info with scripts and styles,
 				  // TODO port this info over to virtual:astro:routes to prevent the need to
@@ -177,6 +177,9 @@ async function createSerializedManifest(
 		experimentalLogger = settings.config.experimental.logger;
 	}
 
+	// Dev/sync manifests use absolute file:// URLs since they run on the build
+	// machine with full filesystem access. Production manifests (in plugin-manifest.ts)
+	// use relative paths for portability.
 	return {
 		rootDir: settings.config.root.toString(),
 		srcDir: settings.config.srcDir.toString(),

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -115,7 +115,7 @@ export function serializedManifestPlugin({
 					import { routes } from '${ASTRO_ROUTES_MODULE_ID}';
 					import { pageMap } from '${VIRTUAL_PAGES_MODULE_ID}';
 
-					const _manifest = _deserializeManifest((${manifestData}), import.meta.url);
+					const _manifest = _deserializeManifest((${manifestData})${settings.config.experimental.portableOutput ? ', import.meta.url' : ''});
 
 				  // _manifest.routes contains enriched route info with scripts and styles,
 				  // TODO port this info over to virtual:astro:routes to prevent the need to

--- a/packages/astro/src/manifest/virtual-module.ts
+++ b/packages/astro/src/manifest/virtual-module.ts
@@ -116,17 +116,17 @@ if (manifest.image) {
 
 const base = manifest.base;
 const build = {
-  server: new URL(manifest.buildServerDir),
-  client: new URL(manifest.buildClientDir),
+  server: manifest.buildServerDir,
+  client: manifest.buildClientDir,
   format: manifest.buildFormat,
   assetsPrefix: manifest.assetsPrefix,
 };
 
-const cacheDir = new URL(manifest.cacheDir);
-const outDir = new URL(manifest.outDir);
-const publicDir = new URL(manifest.publicDir);
-const srcDir = new URL(manifest.srcDir);
-const root = new URL(manifest.rootDir);
+const cacheDir = manifest.cacheDir;
+const outDir = manifest.outDir;
+const publicDir = manifest.publicDir;
+const srcDir = manifest.srcDir;
+const root = manifest.rootDir;
 const trailingSlash = manifest.trailingSlash;
 const site = manifest.site;
 const compressHTML = manifest.compressHTML;

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -2915,6 +2915,30 @@ export interface AstroUserConfig<
 		chromeDevtoolsWorkspace?: boolean;
 
 		/**
+		 * @name experimental.portableOutput
+		 * @type {boolean}
+		 * @default `false`
+		 * @description
+		 * Makes the build `dist/` directory portable. When enabled, the built output
+		 * can be moved to a different machine or directory and run with
+		 * `node dist/server/entry.mjs` without rebuilding.
+		 *
+		 * This replaces absolute filesystem paths in the SSR manifest with relative
+		 * paths that are resolved at runtime against the server entry's location.
+		 *
+		 * `node_modules/` must be co-located with `dist/` at the deployment target.
+		 *
+		 * ```js
+		 * {
+		 *   experimental: {
+		 *     portableOutput: true,
+		 *   },
+		 * }
+		 * ```
+		 */
+		portableOutput?: boolean;
+
+		/**
 		 * @name experimental.svgOptimizer
 		 * @type {SvgOptimizer}
 		 * @default `undefined`

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -284,14 +284,15 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 
 					const transformResult = await compile(source, filename);
 
-					// During production builds only, replace absolute filesystem paths
-					// in the compiled output with root-relative paths for portability.
-					// The compiler embeds the absolute `filename` in string literals for
-					// $$createComponent, $$createMetadata, and $$renderScript calls
-					// (including variants with query strings). This must match the keys
-					// in the componentMetadata and entryModules maps (relativized in
-					// plugin-manifest.ts). In dev mode, both sides use absolute paths.
-					if (this.environment.config.command === 'build') {
+					// When portableOutput is enabled during build, replace absolute filesystem
+					// paths in the compiled output with root-relative paths. The compiler embeds
+					// the absolute `filename` in string literals for $$createComponent,
+					// $$createMetadata, and $$renderScript calls. This must match the keys in
+					// the componentMetadata and entryModules maps (relativized in plugin-manifest.ts).
+					const portableBuild =
+						this.environment.config.command === 'build' &&
+						config.experimental.portableOutput;
+					if (portableBuild) {
 						const normalizedRoot = normalizePath(fileURLToPath(config.root));
 						if (filename.startsWith(normalizedRoot)) {
 							const escaped = normalizedRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -300,10 +301,10 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 						}
 					}
 
-					// During build, normalize resolvedPath in component metadata to match
-					// the root-relative paths used in the compiled output and manifest.
+					// When portableOutput is enabled during build, normalize resolvedPath in
+					// component metadata to match the root-relative paths in the compiled output.
 					const normalizeResolvedPath = (comp: (typeof transformResult.serverComponents)[number]) => {
-						if (this.environment.config.command === 'build') {
+						if (portableBuild) {
 							const nr = normalizePath(fileURLToPath(config.root));
 							if (comp.resolvedPath.startsWith(nr)) {
 								return { ...comp, resolvedPath: comp.resolvedPath.slice(nr.length - 1) };

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import type { HydratedComponent } from '@astrojs/compiler/types';
 import type { SourceDescription } from 'rollup';
 import type * as vite from 'vite';
@@ -283,12 +284,40 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 
 					const transformResult = await compile(source, filename);
 
+					// During production builds only, replace absolute filesystem paths
+					// in the compiled output with root-relative paths for portability.
+					// The compiler embeds the absolute `filename` in string literals for
+					// $$createComponent, $$createMetadata, and $$renderScript calls
+					// (including variants with query strings). This must match the keys
+					// in the componentMetadata and entryModules maps (relativized in
+					// plugin-manifest.ts). In dev mode, both sides use absolute paths.
+					if (this.environment.config.command === 'build') {
+						const normalizedRoot = normalizePath(fileURLToPath(config.root));
+						if (filename.startsWith(normalizedRoot)) {
+							const escaped = normalizedRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+							const re = new RegExp(`(["'])${escaped}`, 'g');
+							transformResult.code = transformResult.code.replace(re, '$1/');
+						}
+					}
+
+					// During build, normalize resolvedPath in component metadata to match
+					// the root-relative paths used in the compiled output and manifest.
+					const normalizeResolvedPath = (comp: (typeof transformResult.serverComponents)[number]) => {
+						if (this.environment.config.command === 'build') {
+							const nr = normalizePath(fileURLToPath(config.root));
+							if (comp.resolvedPath.startsWith(nr)) {
+								return { ...comp, resolvedPath: comp.resolvedPath.slice(nr.length - 1) };
+							}
+						}
+						return comp;
+					};
+
 					const astroMetadata: AstroPluginMetadata['astro'] = {
 						// Remove Astro components that have been mistakenly given client directives
 						// We'll warn the user about this later, but for now we'll prevent them from breaking the build
-						clientOnlyComponents: transformResult.clientOnlyComponents.filter(notAstroComponent),
-						hydratedComponents: transformResult.hydratedComponents.filter(notAstroComponent),
-						serverComponents: transformResult.serverComponents,
+						clientOnlyComponents: transformResult.clientOnlyComponents.filter(notAstroComponent).map(normalizeResolvedPath),
+						hydratedComponents: transformResult.hydratedComponents.filter(notAstroComponent).map(normalizeResolvedPath),
+						serverComponents: transformResult.serverComponents.map(normalizeResolvedPath),
 						scripts: transformResult.scripts,
 						containsHead: transformResult.containsHead,
 						propagation: transformResult.propagation ? 'self' : 'none',

--- a/packages/astro/test/units/manifest/serialized.test.ts
+++ b/packages/astro/test/units/manifest/serialized.test.ts
@@ -7,6 +7,23 @@ import {
 import { createBasicSettings, type AstroSettings } from '../test-utils.ts';
 
 /**
+ * Extracts a top-level JSON object from `code` starting at `offset`.
+ * Walks the string counting `{` / `}` to find the matching close brace.
+ * Returns the substring including both braces, or `undefined` if the
+ * input doesn't start with `{` or braces are unbalanced.
+ */
+function extractJsonObject(code: string, offset: number): string | undefined {
+	if (code[offset] !== '{') return undefined;
+	let depth = 0;
+	for (let i = offset; i < code.length; i++) {
+		if (code[i] === '{') depth++;
+		else if (code[i] === '}') depth--;
+		if (depth === 0) return code.slice(offset, i + 1);
+	}
+	return undefined;
+}
+
+/**
  * Invoke the plugin's load handler (as it runs in dev mode) and return the
  * parsed SerializedSSRManifest that is embedded in the generated module code.
  */
@@ -15,10 +32,13 @@ async function getManifest(settings: AstroSettings) {
 	const load = plugin.load;
 	// @ts-expect-error: Property `handler` does not exist on `load`
 	const result = await load.handler.call({}, SERIALIZED_MANIFEST_RESOLVED_ID);
-	// The generated code contains: _deserializeManifest((<json>))
-	const match = /_deserializeManifest\(\((.+)\)\)/s.exec(result.code);
-	assert.ok(match, 'Could not find manifest JSON in plugin output');
-	return JSON.parse(match[1]);
+	// The generated code contains: _deserializeManifest(({...}), import.meta.url)
+	const marker = '_deserializeManifest((';
+	const start = result.code.indexOf(marker);
+	assert.ok(start !== -1, 'Could not find manifest call in plugin output');
+	const json = extractJsonObject(result.code, start + marker.length);
+	assert.ok(json, 'Could not extract manifest JSON from plugin output');
+	return JSON.parse(json);
 }
 
 describe('serializedManifestPlugin - dev mode', () => {
@@ -224,5 +244,36 @@ describe('serializedManifestPlugin - dev mode', () => {
 			assert.equal(typeof manifest.buildClientDir, 'string');
 			assert.equal(typeof manifest.buildServerDir, 'string');
 		});
+	});
+});
+
+describe('extractJsonObject', () => {
+	it('extracts a flat object', () => {
+		const code = 'foo({"a":1})';
+		assert.equal(extractJsonObject(code, 4), '{"a":1}');
+	});
+
+	it('extracts a nested object', () => {
+		const code = 'x({"a":{"b":2},"c":3}), other)';
+		assert.equal(extractJsonObject(code, 2), '{"a":{"b":2},"c":3}');
+	});
+
+	it('returns undefined when offset is not at {', () => {
+		assert.equal(extractJsonObject('foo', 0), undefined);
+	});
+
+	it('returns undefined for unbalanced braces', () => {
+		assert.equal(extractJsonObject('{"a":1', 0), undefined);
+	});
+
+	it('handles empty object', () => {
+		assert.equal(extractJsonObject('{}', 0), '{}');
+	});
+
+	it('stops at the correct closing brace with trailing content', () => {
+		const code = 'call({"k":"v"}), import.meta.url)';
+		const json = extractJsonObject(code, 5);
+		assert.equal(json, '{"k":"v"}');
+		assert.deepEqual(JSON.parse(json!), { k: 'v' });
 	});
 });

--- a/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
+++ b/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
@@ -35,11 +35,11 @@ export function vitePluginMdxPostprocess(astroConfig: AstroConfig): Plugin {
 					imports,
 				);
 
-				// During build, replace absolute filesystem paths in string literals
-				// with root-relative paths for dist/ portability. This normalizes
-				// server:component-path attributes and moduleId values to match the
-				// manifest keys (see plugin-manifest.ts).
-				if (this.environment.config.command === 'build') {
+				// When portableOutput is enabled during build, replace absolute filesystem
+				// paths in string literals with root-relative paths for dist/ portability.
+				// This normalizes server:component-path attributes and moduleId values to
+				// match the manifest keys (see plugin-manifest.ts).
+				if (this.environment.config.command === 'build' && astroConfig.experimental.portableOutput) {
 					const normalizedRoot = normalizePath(fileURLToPath(astroConfig.root));
 					if (id.startsWith(normalizedRoot)) {
 						const escaped = normalizedRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
+++ b/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
@@ -1,6 +1,7 @@
+import { fileURLToPath } from 'node:url';
 import type { AstroConfig } from 'astro';
 import { type ExportSpecifier, type ImportSpecifier, parse } from 'es-module-lexer';
-import type { Plugin } from 'vite';
+import { normalizePath, type Plugin } from 'vite';
 import {
 	ASTRO_IMAGE_ELEMENT,
 	ASTRO_IMAGE_IMPORT,
@@ -33,6 +34,19 @@ export function vitePluginMdxPostprocess(astroConfig: AstroConfig): Plugin {
 					this.environment.name === 'ssr' || this.environment.name === 'prerender',
 					imports,
 				);
+
+				// During build, replace absolute filesystem paths in string literals
+				// with root-relative paths for dist/ portability. This normalizes
+				// server:component-path attributes and moduleId values to match the
+				// manifest keys (see plugin-manifest.ts).
+				if (this.environment.config.command === 'build') {
+					const normalizedRoot = normalizePath(fileURLToPath(astroConfig.root));
+					if (id.startsWith(normalizedRoot)) {
+						const escaped = normalizedRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+						const re = new RegExp(`(["'])${escaped}`, 'g');
+						code = code.replace(re, '$1/');
+					}
+				}
 
 				// The code transformations above are append-only, so the line/column mappings are the same
 				// and we can omit the sourcemap for performance.

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { writeJson } from '@astrojs/internal-helpers/fs';
 import type { AstroAdapter, AstroConfig, AstroIntegration, RouteToHeaders } from 'astro';
@@ -70,8 +71,17 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 						plugins: [
 							createConfigPlugin({
 								...userOptions,
-								client: _config.build.client?.toString(),
-								server: _config.build.server?.toString(),
+								// Use paths relative to outDir for portability. resolveClientDir()
+								// computes the relative offset between these and resolves against
+								// import.meta.url at runtime.
+								client: './' + path.relative(
+									fileURLToPath(_config.outDir),
+									fileURLToPath(_config.build.client),
+								).split(path.sep).join('/') + '/',
+								server: './' + path.relative(
+									fileURLToPath(_config.outDir),
+									fileURLToPath(_config.build.server),
+								).split(path.sep).join('/') + '/',
 								host: _config.server.host,
 								port: _config.server.port,
 								staticHeaders: userOptions.staticHeaders ?? false,

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -43,22 +43,31 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 			'astro:config:setup': async ({ updateConfig, config, logger, command }) => {
 				let session = config.session;
 				_config = config;
+				const portable = config.experimental.portableOutput;
 				if (!session?.driver) {
 					logger.info('Enabling sessions with filesystem storage');
-					// Store the path relative to the project root for portability.
-					// The Node adapter's server entry resolves this against
-					// manifest.rootDir at runtime (which itself is resolved from
-					// import.meta.url). This works as long as node_modules/ is
-					// co-located with dist/.
-					const absBase = fileURLToPath(new URL('sessions', config.cacheDir));
-					const rootBase = path.relative(fileURLToPath(config.root), absBase);
-					session = {
-						driver: sessionDrivers.fsLite({
-							base: rootBase.split(path.sep).join('/'),
-						}),
-						cookie: session?.cookie,
-						ttl: session?.ttl,
-					};
+					if (portable) {
+						// Store the path relative to the project root for portability.
+						// The Node adapter's server entry resolves this against
+						// manifest.rootDir at runtime.
+						const absBase = fileURLToPath(new URL('sessions', config.cacheDir));
+						const rootBase = path.relative(fileURLToPath(config.root), absBase);
+						session = {
+							driver: sessionDrivers.fsLite({
+								base: rootBase.split(path.sep).join('/'),
+							}),
+							cookie: session?.cookie,
+							ttl: session?.ttl,
+						};
+					} else {
+						session = {
+							driver: sessionDrivers.fsLite({
+								base: fileURLToPath(new URL('sessions', config.cacheDir)),
+							}),
+							cookie: session?.cookie,
+							ttl: session?.ttl,
+						};
+					}
 				}
 
 				updateConfig({
@@ -78,11 +87,13 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 						plugins: [
 							createConfigPlugin({
 								...userOptions,
-								// Pass just the folder names for portability. resolveClientDir()
-								// uses these to compute a relative offset and locate the server
-								// directory via import.meta.url at runtime.
-								client: path.basename(fileURLToPath(_config.build.client)),
-								server: path.basename(fileURLToPath(_config.build.server)),
+								portableOutput: portable,
+								client: portable
+									? path.basename(fileURLToPath(_config.build.client))
+									: _config.build.client?.toString(),
+								server: portable
+									? path.basename(fileURLToPath(_config.build.server))
+									: _config.build.server?.toString(),
 								host: _config.server.host,
 								port: _config.server.port,
 								staticHeaders: userOptions.staticHeaders ?? false,

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -78,17 +78,11 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 						plugins: [
 							createConfigPlugin({
 								...userOptions,
-								// Use paths relative to outDir for portability. resolveClientDir()
-								// computes the relative offset between these and resolves against
-								// import.meta.url at runtime.
-								client: './' + path.relative(
-									fileURLToPath(_config.outDir),
-									fileURLToPath(_config.build.client),
-								).split(path.sep).join('/') + '/',
-								server: './' + path.relative(
-									fileURLToPath(_config.outDir),
-									fileURLToPath(_config.build.server),
-								).split(path.sep).join('/') + '/',
+								// Pass just the folder names for portability. resolveClientDir()
+								// uses these to compute a relative offset and locate the server
+								// directory via import.meta.url at runtime.
+								client: path.basename(fileURLToPath(_config.build.client)),
+								server: path.basename(fileURLToPath(_config.build.server)),
 								host: _config.server.host,
 								port: _config.server.port,
 								staticHeaders: userOptions.staticHeaders ?? false,

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -45,9 +45,16 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 				_config = config;
 				if (!session?.driver) {
 					logger.info('Enabling sessions with filesystem storage');
+					// Store the path relative to the project root for portability.
+					// The Node adapter's server entry resolves this against
+					// manifest.rootDir at runtime (which itself is resolved from
+					// import.meta.url). This works as long as node_modules/ is
+					// co-located with dist/.
+					const absBase = fileURLToPath(new URL('sessions', config.cacheDir));
+					const rootBase = path.relative(fileURLToPath(config.root), absBase);
 					session = {
 						driver: sessionDrivers.fsLite({
-							base: fileURLToPath(new URL('sessions', config.cacheDir)),
+							base: rootBase.split(path.sep).join('/'),
 						}),
 						cookie: session?.cookie,
 						ttl: session?.ttl,

--- a/packages/integrations/node/src/server.ts
+++ b/packages/integrations/node/src/server.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { createApp } from 'astro/app/entrypoint';
 import { setGetEnv } from 'astro/env/setup';
 import * as options from 'virtual:astro-node:config';
@@ -8,6 +10,17 @@ import _startServer, { createStandaloneHandler } from './standalone.js';
 setGetEnv((key) => process.env[key]);
 
 const app = createApp({ streaming: !options.experimentalDisableStreaming });
+
+// Resolve the session storage base path at runtime. The manifest stores a path
+// relative to the project root (e.g., "node_modules/.astro/sessions") for
+// portability. Resolve it against manifest.rootDir which is itself resolved
+// from import.meta.url — so it points to the correct location as long as
+// node_modules/ is co-located with dist/.
+if (app.manifest.sessionConfig?.options?.base && !path.isAbsolute(app.manifest.sessionConfig.options.base)) {
+	app.manifest.sessionConfig.options.base = fileURLToPath(
+		new URL(app.manifest.sessionConfig.options.base, app.manifest.rootDir),
+	);
+}
 
 const headersMap = options.staticHeaders ? readHeadersJson(app.manifest.outDir) : undefined;
 

--- a/packages/integrations/node/src/server.ts
+++ b/packages/integrations/node/src/server.ts
@@ -11,12 +11,11 @@ setGetEnv((key) => process.env[key]);
 
 const app = createApp({ streaming: !options.experimentalDisableStreaming });
 
-// Resolve the session storage base path at runtime. The manifest stores a path
-// relative to the project root (e.g., "node_modules/.astro/sessions") for
-// portability. Resolve it against manifest.rootDir which is itself resolved
-// from import.meta.url — so it points to the correct location as long as
-// node_modules/ is co-located with dist/.
-if (app.manifest.sessionConfig?.options?.base && !path.isAbsolute(app.manifest.sessionConfig.options.base)) {
+// When portableOutput is enabled, the session storage base path is stored
+// relative to the project root (e.g., "node_modules/.astro/sessions").
+// Resolve it against manifest.rootDir which is itself resolved from
+// import.meta.url at runtime.
+if (options.portableOutput && app.manifest.sessionConfig?.options?.base && !path.isAbsolute(app.manifest.sessionConfig.options.base)) {
 	app.manifest.sessionConfig.options.base = fileURLToPath(
 		new URL(app.manifest.sessionConfig.options.base, app.manifest.rootDir),
 	);

--- a/packages/integrations/node/src/shared.ts
+++ b/packages/integrations/node/src/shared.ts
@@ -17,13 +17,20 @@ export const STATIC_HEADERS_FILE = '_headers.json';
  * It throws an error if it can't find the directory while walking the parent directories.
  */
 export function resolveClientDir(options: Options) {
-	// options.client and options.server are folder names (e.g., "client" and "server").
-	// Compute the sibling relationship (e.g., "../client") so we can resolve the
-	// client directory relative to the server directory at runtime.
-	const rel = path.relative(options.server, options.client);
-
-	// Find the server entry folder by walking up from this file's location.
-	const serverFolder = options.server;
+	// options.client and options.server are either:
+	// - folder names like "client"/"server" (when portableOutput is enabled)
+	// - absolute file:// URLs (default mode)
+	// Detect the format and extract what we need: a relative offset and a folder name.
+	const isFileUrl = URL.canParse(options.server);
+	const rel = isFileUrl
+		? path.relative(
+				url.fileURLToPath(new URL(options.server)),
+				url.fileURLToPath(new URL(options.client)),
+			)
+		: path.relative(options.server, options.client);
+	const serverFolder = isFileUrl
+		? path.basename(url.fileURLToPath(new URL(options.server)))
+		: options.server;
 	let serverEntryFolderURL = path.dirname(import.meta.url);
 	let previous = '';
 	while (!serverEntryFolderURL.endsWith(serverFolder)) {

--- a/packages/integrations/node/src/shared.ts
+++ b/packages/integrations/node/src/shared.ts
@@ -17,18 +17,14 @@ export const STATIC_HEADERS_FILE = '_headers.json';
  * It throws an error if it can't find the directory while walking the parent directories.
  */
 export function resolveClientDir(options: Options) {
-	// options.client and options.server are file:// URLs set at build time
-	// e.g., "file:///project/dist/client/" and "file:///project/dist/server/"
-	const clientURLRaw = new URL(options.client);
-	const serverURLRaw = new URL(options.server);
-
+	// options.client and options.server are relative paths from outDir
+	// (e.g., "./client/" and "./server/") for portability.
 	// Calculate relative path from server to client (e.g., "../client")
-	// This relative path is stable regardless of where the build output is deployed
-	const rel = path.relative(url.fileURLToPath(serverURLRaw), url.fileURLToPath(clientURLRaw));
+	const rel = path.relative(options.server, options.client);
 
 	// Find the server entry folder by walking up from this file's location
 	// We need to find the actual runtime location, not the build-time paths
-	const serverFolder = path.basename(options.server);
+	const serverFolder = path.basename(options.server.replace(/\/$/, ''));
 	let serverEntryFolderURL = path.dirname(import.meta.url);
 	let previous = '';
 	while (!serverEntryFolderURL.endsWith(serverFolder)) {

--- a/packages/integrations/node/src/shared.ts
+++ b/packages/integrations/node/src/shared.ts
@@ -17,14 +17,13 @@ export const STATIC_HEADERS_FILE = '_headers.json';
  * It throws an error if it can't find the directory while walking the parent directories.
  */
 export function resolveClientDir(options: Options) {
-	// options.client and options.server are relative paths from outDir
-	// (e.g., "./client/" and "./server/") for portability.
-	// Calculate relative path from server to client (e.g., "../client")
+	// options.client and options.server are folder names (e.g., "client" and "server").
+	// Compute the sibling relationship (e.g., "../client") so we can resolve the
+	// client directory relative to the server directory at runtime.
 	const rel = path.relative(options.server, options.client);
 
-	// Find the server entry folder by walking up from this file's location
-	// We need to find the actual runtime location, not the build-time paths
-	const serverFolder = path.basename(options.server.replace(/\/$/, ''));
+	// Find the server entry folder by walking up from this file's location.
+	const serverFolder = options.server;
 	let serverEntryFolderURL = path.dirname(import.meta.url);
 	let previous = '';
 	while (!serverEntryFolderURL.endsWith(serverFolder)) {

--- a/packages/integrations/node/src/types.ts
+++ b/packages/integrations/node/src/types.ts
@@ -39,6 +39,7 @@ export interface Options extends UserOptions {
 	client: string;
 	staticHeaders: boolean;
 	bodySizeLimit: number;
+	portableOutput: boolean;
 }
 
 export type RequestHandler = (...args: RequestHandlerParams) => void | Promise<void>;

--- a/packages/integrations/node/test/units/resolve-client-dir.test.ts
+++ b/packages/integrations/node/test/units/resolve-client-dir.test.ts
@@ -1,18 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { pathToFileURL } from 'node:url';
 import { resolveClientDir } from '../../dist/shared.js';
 
 describe('resolveClientDir', () => {
 	it('throws a descriptive error when the server folder is not found in the path', () => {
-		// Use pathToFileURL to build platform-valid file:// URLs. On Windows,
-		// file URLs require a drive letter (e.g. file:///C:/…); bare
-		// file:///project/… would cause fileURLToPath() to throw before the
-		// loop guard is reached.
-		const root = new URL('project/dist/', pathToFileURL('/'));
-		const client = new URL('client/', root).href;
-		const server = new URL('server/', root).href;
-
+		// The adapter now bakes plain folder names (e.g., "client", "server")
+		// into the config, not absolute file:// URLs.
 		// When import.meta.url (of shared.js) does not contain a "server" segment,
 		// the while loop should terminate and throw instead of looping forever.
 		// This simulates what happens when the entry point is bundled with esbuild
@@ -20,8 +13,8 @@ describe('resolveClientDir', () => {
 		assert.throws(
 			() =>
 				resolveClientDir({
-					client,
-					server,
+					client: 'client',
+					server: 'server',
 					mode: 'middleware',
 					host: false,
 					port: 4321,

--- a/packages/integrations/node/test/units/resolve-client-dir.test.ts
+++ b/packages/integrations/node/test/units/resolve-client-dir.test.ts
@@ -1,25 +1,41 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { pathToFileURL } from 'node:url';
 import { resolveClientDir } from '../../dist/shared.js';
 
+const baseOptions = {
+	mode: 'middleware' as const,
+	host: false as const,
+	port: 4321,
+	staticHeaders: false,
+	bodySizeLimit: 0,
+	portableOutput: false,
+};
+
 describe('resolveClientDir', () => {
-	it('throws a descriptive error when the server folder is not found in the path', () => {
-		// The adapter now bakes plain folder names (e.g., "client", "server")
-		// into the config, not absolute file:// URLs.
-		// When import.meta.url (of shared.js) does not contain a "server" segment,
-		// the while loop should terminate and throw instead of looping forever.
-		// This simulates what happens when the entry point is bundled with esbuild
-		// into a path that lacks the expected "server" directory segment.
+	it('throws a descriptive error with folder names (portableOutput)', () => {
 		assert.throws(
 			() =>
 				resolveClientDir({
+					...baseOptions,
+					portableOutput: true,
 					client: 'client',
 					server: 'server',
-					mode: 'middleware',
-					host: false,
-					port: 4321,
-					staticHeaders: false,
-					bodySizeLimit: 0,
+				}),
+			{
+				message: /Could not find the server directory "server".*bundled into a single file/,
+			},
+		);
+	});
+
+	it('throws a descriptive error with file:// URLs (default)', () => {
+		const root = new URL('project/dist/', pathToFileURL('/'));
+		assert.throws(
+			() =>
+				resolveClientDir({
+					...baseOptions,
+					client: new URL('client/', root).href,
+					server: new URL('server/', root).href,
 				}),
 			{
 				message: /Could not find the server directory "server".*bundled into a single file/,


### PR DESCRIPTION
## Changes
- Replaces absolute `file://` URLs in the SSR manifest with relative paths computed from `buildServerDir`. At runtime, `deserializeManifest` resolves them against `import.meta.url` of the server entry, producing correct absolute paths regardless of where `dist/` is deployed.
- Normalizes `componentMetadata`, `entryModules`, `inlinedScripts`, and `serverIslandNameMap` keys from absolute paths to root-relative paths during build. Compiled `.astro` and `.mdx` output is normalized to match.
- Keeps absolute paths for the prerender manifest (build-time only, discarded after static generation).
- Simplifies the Node adapter's baked-in config from absolute `file://` URLs to plain folder names. Session storage base path is resolved against `manifest.rootDir` at server startup.
- Dev mode is unchanged.
Ref: withastro/roadmap#1286
## Testing
- No new test files. Existing `serializeManifest`, SSR, server islands, and node adapter test suites cover the changed codepaths.
- End-to-end portability verified manually: built at `/tmp/hackernews/`, moved `dist/` + `node_modules/` to `/tmp/portable-app/`, ran from there. SSR pages, prerendered static pages, sharp image optimization, and fs-lite sessions all work.
## Docs
No docs update needed — internal change to the build output format.