### PR TITLE
fix(language-server): prevent stack overflow with project references containing non-TS files

### DIFF
--- a/.changeset/frank-ants-enter.md
+++ b/.changeset/frank-ants-enter.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixes a crash in the language server and `astro check` when using TypeScript project references with `.vue` or `.svelte` files

--- a/packages/language-tools/language-server/src/core/index.ts
+++ b/packages/language-tools/language-server/src/core/index.ts
@@ -21,6 +21,13 @@ import { extractScriptTags } from './parseJS.js';
 
 const decoratedHosts = new WeakSet<ts.LanguageServiceHost>();
 
+// File extensions that TypeScript cannot handle in project reference redirect maps.
+// When these appear in a referenced project's file list, TypeScript's
+// getOutputDeclarationFileName returns the input path unchanged (since changeExtension
+// doesn't recognize the extension), creating self-referencing redirect entries that
+// cause infinite recursion in findSourceFile.
+const nonTsExtensions = ['.vue', '.svelte', '.astro'];
+
 export function addAstroTypes(
 	astroInstall: PackageInfo | undefined,
 	ts: typeof import('typescript'),
@@ -89,6 +96,27 @@ export function addAstroTypes(
 					: baseCompilationSettings.moduleResolution,
 		};
 	};
+
+	// Provide getParsedCommandLine to filter non-TS files from referenced project
+	// configs. Without this, TypeScript builds redirect maps where non-TS files
+	// (like .vue) map to themselves, causing infinite recursion in findSourceFile.
+	if (host.getProjectReferences && !host.getParsedCommandLine) {
+		(host as any).getParsedCommandLine = (fileName: string) => {
+			const configFile = ts.readJsonConfigFile(fileName, ts.sys.readFile);
+			const basePath = path.dirname(fileName);
+			const parsed = ts.parseJsonSourceFileConfigFileContent(
+				configFile,
+				ts.sys,
+				basePath,
+				undefined,
+				fileName,
+			);
+			parsed.fileNames = parsed.fileNames.filter(
+				(f) => !nonTsExtensions.some((ext) => f.endsWith(ext)),
+			);
+			return parsed;
+		};
+	}
 }
 
 export function getAstroLanguagePlugin(): LanguagePlugin<URI, AstroVirtualCode> {

--- a/packages/language-tools/language-server/src/core/index.ts
+++ b/packages/language-tools/language-server/src/core/index.ts
@@ -21,11 +21,11 @@ import { extractScriptTags } from './parseJS.js';
 
 const decoratedHosts = new WeakSet<ts.LanguageServiceHost>();
 
-// File extensions that TypeScript cannot handle in project reference redirect maps.
-// When these appear in a referenced project's file list, TypeScript's
-// getOutputDeclarationFileName returns the input path unchanged (since changeExtension
-// doesn't recognize the extension), creating self-referencing redirect entries that
-// cause infinite recursion in findSourceFile.
+// Extensions that TypeScript doesn't recognize. When a referenced project contains
+// files with these extensions, TypeScript tries to compute a declaration output path
+// via changeExtension but doesn't know how to replace the extension, so it returns the
+// input path unchanged (e.g. Hello.vue → Hello.vue). This creates a self-referencing
+// entry in the redirect map, which causes infinite recursion in findSourceFile.
 const nonTsExtensions = ['.vue', '.svelte', '.astro'];
 
 export function addAstroTypes(
@@ -101,8 +101,9 @@ export function addAstroTypes(
 	// configs. Without this, TypeScript builds redirect maps where non-TS files
 	// (like .vue) map to themselves, causing infinite recursion in findSourceFile.
 	if (host.getProjectReferences && !host.getParsedCommandLine) {
-		(host as any).getParsedCommandLine = (fileName: string) => {
-			const configFile = ts.readJsonConfigFile(fileName, ts.sys.readFile);
+		host.getParsedCommandLine = (fileName: string) => {
+			const readFile = host.readFile?.bind(host) ?? ts.sys.readFile;
+			const configFile = ts.readJsonConfigFile(fileName, readFile);
 			const basePath = path.dirname(fileName);
 			const parsed = ts.parseJsonSourceFileConfigFileContent(
 				configFile,

--- a/packages/language-tools/language-server/test/units/utils.test.ts
+++ b/packages/language-tools/language-server/test/units/utils.test.ts
@@ -5,6 +5,7 @@ import ts from 'typescript';
 import type { Node } from 'vscode-html-languageservice';
 import * as html from 'vscode-html-languageservice';
 import { getTSXRangesAsLSPRanges, safeConvertToTSX } from '../../dist/core/astro2tsx.js';
+import { addAstroTypes } from '../../dist/core/index.js';
 import { getAstroMetadata } from '../../dist/core/parseAstro.js';
 import { patchTSX } from '../../dist/core/utils.js';
 import {
@@ -234,5 +235,28 @@ export default function Image__AstroComponent_(_props: Record<string, any>): any
 			patchTSX(input, 'file:///src/pages/[slug].astro'),
 			/export default function _slug_AstroComponent\(/,
 		);
+	});
+
+	it('addAstroTypes - adds getParsedCommandLine that filters non-TS files', () => {
+		const mockHost = {
+			getScriptFileNames: () => [],
+			getCompilationSettings: () => ({}),
+			getProjectReferences: () => [{ path: './tsconfig.app.json' }],
+		} as any;
+
+		addAstroTypes(undefined, ts, mockHost);
+
+		assert.ok(mockHost.getParsedCommandLine, 'getParsedCommandLine should be added to host');
+	});
+
+	it('addAstroTypes - does not add getParsedCommandLine without project references', () => {
+		const mockHost = {
+			getScriptFileNames: () => [],
+			getCompilationSettings: () => ({}),
+		} as any;
+
+		addAstroTypes(undefined, ts, mockHost);
+
+		assert.strictEqual(mockHost.getParsedCommandLine, undefined);
 	});
 });


### PR DESCRIPTION
Fixes #16817

When a tsconfig uses project references that include `.vue` or `.svelte` files, TypeScript's `getOutputDeclarationFileName` returns the input path unchanged (since `changeExtension` doesn't recognize these extensions). This creates self-referencing entries in the redirect maps (`Hello.vue` → `Hello.vue`), causing infinite recursion in `findSourceFile`.

The fix provides `getParsedCommandLine` on the language service host, which is TypeScript's official hook for customizing how referenced tsconfigs are parsed. Our implementation parses them normally but filters `.vue`/`.svelte`/`.astro` files from the file list, preventing the self-referencing redirect entries. Project references remain fully functional for all standard TS/JS files.