### PR TITLE
Set GH_TOKEN for preview release label removal step

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Remove Preview Label
         run: gh pr edit ${{ github.event.number }} --remove-label "pr preview"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Publish packages
         run: |

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -94,6 +94,8 @@ jobs:
       # This step doesn't work for forks
       - name: Remove Preview Label
         run: gh pr edit ${{ github.event.number }} --remove-label "pr preview"
+        env:
+          GH_TOKEN: ${{ github.token }}
         
       - name: Publish packages
         run: |


### PR DESCRIPTION
## Changes

- Adds `GH_TOKEN` to the "Remove Preview Label" step in the preview release workflow. PR #16810 replaced the `actions-ecosystem/action-remove-labels` action with a `gh` CLI call but did not set the token — `gh` requires `GH_TOKEN` explicitly, unlike GitHub Actions which inject auth automatically for actions.

## Testing

- No test changes. This is a CI-only fix — the step was failing with exit code 4 on every preview release since #16810 merged.

## Docs

- No docs needed — internal CI fix.