### PR TITLE
Fix dangling pure CSS chunk imports when assetQueryParams is set

### DIFF
--- a/.changeset/bright-lilies-double.md
+++ b/.changeset/bright-lilies-double.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes 404s for dynamically imported JS chunks when using an adapter with `assetQueryParams` (e.g. Vercel skew protection)

--- a/packages/astro/src/core/build/plugins/plugin-chunk-imports.ts
+++ b/packages/astro/src/core/build/plugins/plugin-chunk-imports.ts
@@ -9,6 +9,12 @@ import type { StaticBuildOptions } from '../types.js';
  * bypass the HTML rendering pipeline and miss skew protection query params.
  *
  * Uses es-module-lexer to reliably parse both static and dynamic imports.
+ *
+ * This runs in `generateBundle` (not `renderChunk`) so that Vite's CSS plugin
+ * can first remove pure-CSS wrapper chunks and replace their imports with
+ * `/* empty css * /` comments. If we rewrote imports earlier (in `renderChunk`),
+ * the appended query params would break Vite's regex-based CSS chunk cleanup,
+ * leaving dangling imports to deleted chunks that 404 at runtime.
  */
 export function pluginChunkImports(options: StaticBuildOptions): VitePlugin | undefined {
 	const assetQueryParams = options.settings.adapter?.client?.assetQueryParams;
@@ -25,36 +31,36 @@ export function pluginChunkImports(options: StaticBuildOptions): VitePlugin | un
 			return environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.client;
 		},
 
-		async renderChunk(code, _chunk) {
-			if (!code.includes('./')) {
-				return null;
-			}
-
+		async generateBundle(_options, bundle) {
 			await init;
-			const [imports] = parse(code);
 
-			// Filter to relative JS imports only
-			const relativeImports = imports.filter(
-				(imp) => imp.n && /^\.\.?\//.test(imp.n) && /\.(?:js|mjs)$/.test(imp.n),
-			);
+			for (const [, chunk] of Object.entries(bundle)) {
+				if (chunk.type !== 'chunk') continue;
+				if (!chunk.code.includes('./')) continue;
 
-			if (relativeImports.length === 0) {
-				return null;
+				const [imports] = parse(chunk.code);
+
+				// Filter to relative JS imports only
+				const relativeImports = imports.filter(
+					(imp) => imp.n && /^\.\.?\//.test(imp.n) && /\.(?:js|mjs)$/.test(imp.n),
+				);
+
+				if (relativeImports.length === 0) continue;
+
+				// Build new code by replacing specifiers from end to start
+				// (reverse order preserves earlier offsets)
+				let rewritten = chunk.code;
+				for (let i = relativeImports.length - 1; i >= 0; i--) {
+					const imp = relativeImports[i];
+					// imp.s and imp.e are the start/end offsets of the module specifier.
+					// Static imports: e points after the specifier text, before the quote.
+					// Dynamic string imports: e points after the closing quote.
+					const insertAt = imp.d > -1 ? imp.e - 1 : imp.e;
+					rewritten = rewritten.slice(0, insertAt) + '?' + queryString + rewritten.slice(insertAt);
+				}
+
+				chunk.code = rewritten;
 			}
-
-			// Build new code by replacing specifiers from end to start
-			// (reverse order preserves earlier offsets)
-			let rewritten = code;
-			for (let i = relativeImports.length - 1; i >= 0; i--) {
-				const imp = relativeImports[i];
-				// imp.s and imp.e are the start/end offsets of the module specifier.
-				// Static imports: e points after the specifier text, before the quote.
-				// Dynamic string imports: e points after the closing quote.
-				const insertAt = imp.d > -1 ? imp.e - 1 : imp.e;
-				rewritten = rewritten.slice(0, insertAt) + '?' + queryString + rewritten.slice(insertAt);
-			}
-
-			return { code: rewritten, map: null };
 		},
 	};
 }

--- a/packages/astro/test/css-pure-chunk-query-params.test.ts
+++ b/packages/astro/test/css-pure-chunk-query-params.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.ts';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('CSS pure chunk cleanup with assetQueryParams', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/css-pure-chunk-query-params/',
+			output: 'server',
+			adapter: testAdapter({
+				extendAdapter: {
+					client: {
+						assetQueryParams: new URLSearchParams({ dpl: 'test-deploy-id' }),
+					},
+				},
+			}),
+			outDir: './dist/css-pure-chunk-query-params/',
+		});
+		await fixture.build();
+	});
+
+	it('does not leave dangling imports to deleted pure CSS chunks', async () => {
+		const allFiles = await fixture.glob('client/**/*');
+		const allFilenames = new Set(allFiles.map((f: string) => f.replace(/^client\//, '')));
+
+		const jsFiles = await fixture.glob('client/**/*.js');
+		assert.ok(jsFiles.length > 0, 'Should have at least one client JS file');
+
+		for (const file of jsFiles) {
+			const code = await fixture.readFile(`/${file}`);
+			const dir = file.includes('/') ? file.replace(/\/[^/]+$/, '/').replace(/^client\//, '') : '';
+
+			// Match static side-effect imports: import "./chunk.js" or import "./chunk.js?dpl=..."
+			// and value imports: import { x } from "./chunk.js" or from "./chunk.js?dpl=..."
+			const allImports = [
+				...code.matchAll(/(?:from|import)\s*["'](\.\.?\/[^"'?]+\.(?:js|mjs))(?:\?[^"']*)?["']/g),
+				...code.matchAll(/import\s*\(\s*["'](\.\.?\/[^"'?]+\.(?:js|mjs))(?:\?[^"']*)?["']\s*\)/g),
+			];
+
+			for (const match of allImports) {
+				const specifier = match[1];
+				// Resolve relative path
+				const resolved = new URL(specifier, `file:///client/${dir}placeholder`).pathname.replace(
+					/^\/client\//,
+					'',
+				);
+				assert.ok(
+					allFilenames.has(resolved),
+					`Chunk "${file}" imports "${specifier}" which resolves to "${resolved}" ` +
+						`but that file does not exist in the client output. ` +
+						`This indicates a dangling import to a deleted pure CSS chunk.`,
+				);
+			}
+		}
+	});
+
+	it('appends assetQueryParams to surviving JS imports', async () => {
+		const jsFiles = await fixture.glob('client/**/*.js');
+
+		let foundImportWithParams = false;
+		for (const file of jsFiles) {
+			const code = await fixture.readFile(`/${file}`);
+			// Match relative JS imports with query params
+			const imports = [
+				...code.matchAll(/(?:from|import)\s*["'](\.\.?\/[^"']+\.(?:js|mjs)\?[^"']*)["']/g),
+				...code.matchAll(/import\s*\(\s*["'](\.\.?\/[^"']+\.(?:js|mjs)\?[^"']*)["']\s*\)/g),
+			];
+			for (const match of imports) {
+				foundImportWithParams = true;
+				assert.match(
+					match[1],
+					/\?dpl=test-deploy-id/,
+					`Import should include assetQueryParams: ${match[0]}`,
+				);
+			}
+		}
+		assert.ok(foundImportWithParams, 'Should have at least one JS import with query params');
+	});
+});

--- a/packages/astro/test/fixtures/css-pure-chunk-query-params/astro.config.mjs
+++ b/packages/astro/test/fixtures/css-pure-chunk-query-params/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import vue from '@astrojs/vue';
+
+export default defineConfig({
+	integrations: [vue()],
+});

--- a/packages/astro/test/fixtures/css-pure-chunk-query-params/package.json
+++ b/packages/astro/test/fixtures/css-pure-chunk-query-params/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@test/css-pure-chunk-query-params",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"@astrojs/vue": "workspace:*",
+		"astro": "workspace:*",
+		"vue": "^3.5.30"
+	}
+}

--- a/packages/astro/test/fixtures/css-pure-chunk-query-params/src/components/Loader.vue
+++ b/packages/astro/test/fixtures/css-pure-chunk-query-params/src/components/Loader.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { defineAsyncComponent } from 'vue';
+
+// Two async components that both import the same CSS file.
+// This forces Rollup to create a shared pure CSS chunk for widget.css
+// which is then statically imported by both WidgetA and WidgetB chunks.
+const WidgetA = defineAsyncComponent(() => import('./WidgetA.vue'));
+const WidgetB = defineAsyncComponent(() => import('./WidgetB.vue'));
+</script>
+
+<template>
+	<WidgetA label="Hello from A" />
+	<WidgetB label="Hello from B" />
+</template>

--- a/packages/astro/test/fixtures/css-pure-chunk-query-params/src/components/WidgetA.vue
+++ b/packages/astro/test/fixtures/css-pure-chunk-query-params/src/components/WidgetA.vue
@@ -1,0 +1,8 @@
+<script setup>
+import '../styles/widget.css';
+defineProps({ label: String });
+</script>
+
+<template>
+	<div class="widget">A: {{ label }}</div>
+</template>

--- a/packages/astro/test/fixtures/css-pure-chunk-query-params/src/components/WidgetB.vue
+++ b/packages/astro/test/fixtures/css-pure-chunk-query-params/src/components/WidgetB.vue
@@ -1,0 +1,8 @@
+<script setup>
+import '../styles/widget.css';
+defineProps({ label: String });
+</script>
+
+<template>
+	<div class="widget">B: {{ label }}</div>
+</template>

--- a/packages/astro/test/fixtures/css-pure-chunk-query-params/src/pages/index.astro
+++ b/packages/astro/test/fixtures/css-pure-chunk-query-params/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import Loader from '../components/Loader.vue';
+---
+<html>
+	<head><title>CSS Pure Chunk + Query Params</title></head>
+	<body>
+		<Loader client:load />
+	</body>
+</html>

--- a/packages/astro/test/fixtures/css-pure-chunk-query-params/src/styles/widget.css
+++ b/packages/astro/test/fixtures/css-pure-chunk-query-params/src/styles/widget.css
@@ -1,0 +1,6 @@
+.widget {
+	display: flex;
+	align-items: center;
+	padding: 1rem;
+	background: #f0f0f0;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3040,6 +3040,18 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/css-pure-chunk-query-params:
+    dependencies:
+      '@astrojs/vue':
+        specifier: workspace:*
+        version: link:../../../../integrations/vue
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+      vue:
+        specifier: ^3.5.30
+        version: 3.5.30(typescript@6.0.3)
+
   packages/astro/test/fixtures/custom-404-injected-from-dep:
     dependencies:
       '@test/custom-404-pkg':


### PR DESCRIPTION
## Changes

- Moves `plugin-chunk-imports` from `renderChunk` to `generateBundle` so it runs **after** Vite's CSS plugin cleans up pure CSS wrapper chunks. Previously, appending `?dpl=...` query params during `renderChunk` broke Vite's regex-based `/* empty css */` replacement, leaving dangling imports to deleted chunks that 404 at runtime.

Fixes #16520

## Testing

- New `css-pure-chunk-query-params.test.ts` with a Vue fixture where two async components share the same CSS import, forcing Rollup to create a shared pure CSS chunk. Verifies no JS imports reference deleted files, and that query params are still appended to surviving imports.

## Docs

- No docs needed — internal build pipeline fix with no user-facing API change.