### PR TITLE
Fix misleading error when redirect has more dynamic params than destination

### DIFF
--- a/.changeset/clear-redirect-params.md
+++ b/.changeset/clear-redirect-params.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a misleading `GetStaticPathsRequired` error when a redirect is configured from a dynamic route to a static (or less-dynamic) destination. For example, `'/project/[slug]': '/'` previously produced a confusing error pointing at `index.astro`. Astro now detects the parameter mismatch at config validation time and throws a clear `InvalidRedirectDestination` error naming the missing parameters.

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1071,7 +1071,7 @@ export const UnsupportedExternalRedirect = {
 export const InvalidRedirectDestination = {
 	name: 'InvalidRedirectDestination',
 	title: 'Invalid redirect destination.',
-	message: (from: string, to: string, missingParams?: string[]) => {
+	message(from: string, to: string, missingParams?: string[]) {
 		if (missingParams && missingParams.length > 0) {
 			const formatted = missingParams.map((p) => `[${p}]`).join(', ');
 			return `The redirect from "${from}" to "${to}" is invalid. The destination route is missing dynamic parameter(s) ${formatted} required by the source route "${from}".`;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1062,16 +1062,23 @@ export const UnsupportedExternalRedirect = {
  * @see
  * - [Configured redirects](https://docs.astro.build/en/guides/routing/#configured-redirects)
  * @description
- * A dynamic redirect destination must match an existing route pattern.
+ * A dynamic redirect destination must match an existing route pattern and include
+ * all dynamic parameters from the source route.
  * This error occurs when a redirect with dynamic parameters points to a destination
- * that doesn't correspond to any page in your project.
+ * that doesn't correspond to any page in your project, or when the destination route
+ * has fewer dynamic parameters than the source route.
  */
 export const InvalidRedirectDestination = {
 	name: 'InvalidRedirectDestination',
 	title: 'Invalid redirect destination.',
-	message: (from: string, to: string) =>
-		`The redirect from "${from}" to "${to}" is invalid. The destination "${to}" does not match any existing route in your project.`,
-	hint: 'If you are redirecting to a specific page of a dynamic route (e.g., "/posts/[slug]/1"), this is not supported. The destination must be either a static path or a route pattern that matches an existing page (e.g., "/posts/[slug]/[page]").',
+	message: (from: string, to: string, missingParams?: string[]) => {
+		if (missingParams && missingParams.length > 0) {
+			const formatted = missingParams.map((p) => `[${p}]`).join(', ');
+			return `The redirect from "${from}" to "${to}" is invalid. The destination route is missing dynamic parameter(s) ${formatted} required by the source route "${from}".`;
+		}
+		return `The redirect from "${from}" to "${to}" is invalid. The destination "${to}" does not match any existing route in your project.`;
+	},
+	hint: 'The destination of a dynamic redirect must include all dynamic parameters from the source route. For example, a redirect from "/old/[slug]" must go to a route that also has a [slug] parameter, like "/new/[slug]".',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -559,6 +559,25 @@ function createRedirectRoutes(
 			});
 		}
 
+		// If the source has dynamic params and the destination route exists but has
+		// fewer params, the build will fail later with a misleading error (e.g.,
+		// "getStaticPaths required" pointing at the wrong file). Catch this early.
+		if (
+			params.length > 0 &&
+			redirectRoute &&
+			!URL.canParse(destination) &&
+			getPrerenderDefault(config)
+		) {
+			const destParams = redirectRoute.params ?? [];
+			const missingParams = params.filter((p) => !destParams.includes(p));
+			if (missingParams.length > 0) {
+				throw new AstroError({
+					...InvalidRedirectDestination,
+					message: InvalidRedirectDestination.message(from, destination, missingParams),
+				});
+			}
+		}
+
 		routes.push({
 			type: 'redirect',
 			// For backwards compatibility, a redirect is never considered an index route.

--- a/packages/astro/test/units/redirects/static-build.test.ts
+++ b/packages/astro/test/units/redirects/static-build.test.ts
@@ -307,6 +307,65 @@ describe('static redirects — invalid redirect destination throws', () => {
 			},
 		);
 	});
+
+	it('throws InvalidRedirectDestination when dynamic origin redirects to static destination', async () => {
+		// Regression test for https://github.com/withastro/astro/issues/16482
+		// where a redirect like /project/[slug] -> / produced a misleading
+		// "getStaticPaths required" error pointing at index.astro instead of
+		// a clear error about the param mismatch in the redirect config.
+		await assert.rejects(
+			() =>
+				createStaticBuildOptions({
+					pages: {
+						'src/pages/index.astro': '---\n---\n<p>Home</p>',
+					},
+					inlineConfig: {
+						redirects: {
+							'/project/[slug]': '/',
+						},
+					},
+				}),
+			(err: Error & { name: string }) => {
+				// Should NOT be the misleading getStaticPaths error
+				assert.ok(!err.message.includes('getStaticPaths()'));
+				// Should mention the missing param
+				assert.ok(err.message.includes('[slug]'));
+				assert.equal(err.name, 'InvalidRedirectDestination');
+				return true;
+			},
+		);
+	});
+
+	it('throws InvalidRedirectDestination when destination has fewer params than origin', async () => {
+		// Regression test for https://github.com/withastro/astro/issues/16482
+		// where a redirect from a route with more params to one with fewer params
+		// produced a misleading error at build time.
+		await assert.rejects(
+			() =>
+				createStaticBuildOptions({
+					pages: {
+						'src/pages/posts/[id].astro':
+							'---\nexport function getStaticPaths() { return [{ params: { id: "1" } }]; }\n---\n<p>Post</p>',
+					},
+					inlineConfig: {
+						redirects: {
+							'/old/[id]/[page]': '/posts/[id]',
+						},
+					},
+				}),
+			(err: Error & { name: string }) => {
+				// Should NOT be the misleading getStaticPaths error
+				assert.ok(!err.message.includes('getStaticPaths()'));
+				// Should mention [page] as a missing param
+				assert.ok(err.message.includes('[page]'));
+				// The "missing dynamic parameter(s)" portion should only list [page],
+				// not [id] which is present in both source and destination
+				assert.ok(err.message.includes('missing dynamic parameter(s) [page]'));
+				assert.equal(err.name, 'InvalidRedirectDestination');
+				return true;
+			},
+		);
+	});
 });
 
 describe('Astro.redirect() in a page component — build.redirects = false', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6979,6 +6979,12 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  triage/gh-16482:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+
 packages:
 
   '@anthropic-ai/sdk@0.91.1':


### PR DESCRIPTION
## Changes

- Fixes misleading `GetStaticPathsRequired` error when redirects from dynamic routes to static destinations are configured (e.g., `'/project/[slug]': '/'`)
- Adds parameter validation in `createRedirectRoutes()` to check that destination routes have all required parameters from source routes
- Extends `InvalidRedirectDestination` error message to clearly identify missing parameters, preventing confusion about which file is causing the issue

## Testing

- Added unit test for dynamic origin redirecting to static destination (`/project/[slug]` → `/`)
- Added unit test for dynamic origin with more params than destination (`/old/[id]/[page]` → `/posts/[id]`)
- Both tests verify the error is `InvalidRedirectDestination` with clear parameter information, not the misleading `GetStaticPathsRequired`

## Docs

- No docs update needed, as this fixes an existing error case to be clearer rather than introducing new functionality.

Closes #16482