### PR TITLE
Document compressHTML: "jsx" config is only available since Astro v6.2.0

### DIFF
--- a/.changeset/ready-cougars-march.md
+++ b/.changeset/ready-cougars-march.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Document compressHTML: "jsx" config is only available since Astro v6.2.0

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -480,7 +480,7 @@ export interface AstroUserConfig<
 	 *
 	 * By default, Astro removes whitespace from your HTML, including line breaks, in a lossless manner from `.astro` components. Some whitespace may be preserved as needed to maintain the visual rendering of your HTML.
 	 *
-	 * Setting this option to `"jsx"` instead applies the JSX whitespace stripping rules used by frameworks like React. Leading and trailing whitespace is only preserved when explicitly included in the source code through constructs such as `{" "}`, and is otherwise removed entirely.
+	 * Since 6.2.0, this option can also be set to `"jsx"`, Astro will apply the JSX whitespace stripping rules used by frameworks like React. Leading and trailing whitespace is only preserved when explicitly included in the source code through constructs such as `{" "}`, and is otherwise removed entirely.
 	 *
 	 * Setting this option to false disables HTML compression and preserves all whitespace.
 	 *


### PR DESCRIPTION
## Changes

Document on config reference page that `compressHTML: "jsx"` is only available starting Astro 6.2.0.

Without this reference, it looks like the option has always been available but users of older versions (e.g. 6.1.9) will see the following message that contradicts current documentation:
```
[config] Astro found issue(s) with your configuration:

! compressHTML: Expected type "boolean", received "string"
```

I tried to follow the writing style from [i18n.routing](https://github.com/withastro/astro/blob/ace96ba5024129cbeb9d8e75134f4f8bdf42a57a/packages/astro/src/types/public/config.ts#L2273) which also introduced a new option, by starting the sentence similarly.

From some past PRs I checked, doesn't seem like minor doc text change requires changeset, please correct me otherwise.

## Testing

Not tested since it's a doc text change.

## Docs

This is a doc change itself, which I previously mistakenly tried to do on the generated doc: https://github.com/withastro/docs/pull/13920