### PR TITLE
fix(docs): update InvalidRedirectDestination error message

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1059,6 +1059,9 @@ export const UnsupportedExternalRedirect = {
 
 /**
  * @docs
+ * @message
+ * **Example error message:**<br/>
+ * InvalidRedirectDestination: The redirect from "/posts" to "/blog" is invalid. The destination "/blog" does not match any existing route in your project.
  * @see
  * - [Configured redirects](https://docs.astro.build/en/guides/routing/#configured-redirects)
  * @description


### PR DESCRIPTION
## Changes

Updates `errors-data.ts` to fix a message not being correctly rendered in docs because of the conditional branches.

The message changed in #16831 but because we don't have `@message` in the JSDoc, this is not correctly rendered in docs (https://github.com/withastro/docs/pull/13924). See: https://deploy-preview-13924--astro-docs-2.netlify.app/en/reference/errors/invalid-redirect-destination/

## Testing

N/A

## Docs

This is docs.
I didn't add a changeset because #16831 is not yet released, and so I don't think this is necessary.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
