### PR TITLE
docs: fix example README links and add missing READMEs

### DIFF
--- a/examples/advanced-routing/README.md
+++ b/examples/advanced-routing/README.md
@@ -1,0 +1,53 @@
+# Astro Advanced Routing Example
+
+```sh
+npm create astro@latest -- --template advanced-routing
+```
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/advanced-routing)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/advanced-routing)
+
+This example showcases Astro's experimental advanced routing with `src/app.ts`, using [Hono](https://hono.dev/) middleware to control the request pipeline.
+
+## 🚀 Project Structure
+
+Inside of your Astro project, you'll see the following folders and files:
+
+```text
+/
+├── src/
+│   ├── actions/
+│   ├── layouts/
+│   ├── pages/
+│   │   ├── dashboard/
+│   │   └── es/
+│   └── app.ts
+├── astro.config.mjs
+├── package.json
+└── tsconfig.json
+```
+
+Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+
+The `src/app.ts` file controls the request pipeline. This example composes Astro's middleware with custom Hono middleware to handle routing behavior like authentication, redirects, and locale-specific pages.
+
+## Server-side rendering (SSR)
+
+This project uses the [`@astrojs/node`](https://docs.astro.build/en/guides/integrations-guide/node/) adapter with `output: "server"` and enables Astro's experimental `advancedRouting` option.
+
+## 🧞 Commands
+
+All commands are run from the root of the project, from a terminal:
+
+| Command                   | Action                                           |
+| :------------------------ | :----------------------------------------------- |
+| `npm install`             | Installs dependencies                            |
+| `npm run dev`             | Starts local dev server at `localhost:4321`      |
+| `npm run build`           | Build your production site to `./dist/`          |
+| `npm run preview`         | Preview your build locally, before deploying     |
+| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
+| `npm run astro -- --help` | Get help using the Astro CLI                     |
+
+## 👀 Want to learn more?
+
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -6,8 +6,8 @@ This is a template for an Astro component library. Use this template for writing
 npm create astro@latest -- --template component
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/non-html-pages)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/component)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/component)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/component/devcontainer.json)
 
 ## 🚀 Project Structure

--- a/examples/container-with-vitest/README.md
+++ b/examples/container-with-vitest/README.md
@@ -4,8 +4,8 @@
 npm create astro@latest -- --template container-with-vitest
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vitest)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/with-vitest)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/container-with-vitest)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/container-with-vitest)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/with-vitest/devcontainer.json)
 
 This example showcases Astro working with [Vitest](https://vitest.dev/) and how to test components using the Container API.

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -1,0 +1,62 @@
+# Astro SSR Example
+
+```sh
+npm create astro@latest -- --template ssr
+```
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/ssr)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/ssr)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/ssr/devcontainer.json)
+
+This example showcases server-side rendering with Astro using the [`@astrojs/node`](https://docs.astro.build/en/guides/integrations-guide/node/) adapter and [`@astrojs/svelte`](https://docs.astro.build/en/guides/integrations-guide/svelte/) integration.
+
+## 🚀 Project Structure
+
+Inside of your Astro project, you'll see the following folders and files:
+
+```text
+/
+├── public/
+│   ├── favicon.ico
+│   ├── favicon.svg
+│   └── images/
+├── src/
+│   ├── components/
+│   ├── models/
+│   ├── pages/
+│   │   ├── api/
+│   │   └── products/
+│   ├── styles/
+│   └── api.ts
+├── astro.config.mjs
+├── package.json
+└── tsconfig.json
+```
+
+Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name. Dynamic routes like `products/[id].astro` are used to render individual product pages.
+
+There's nothing special about `src/components/`, but that's where we like to put any Astro or framework components.
+
+Any static assets, like images, can be placed in the `public/` directory.
+
+## Server-side rendering (SSR)
+
+This project uses the [`@astrojs/node`](https://docs.astro.build/en/guides/integrations-guide/node/) adapter with `output: "server"` to render pages on demand and expose API routes from `src/pages/api/`.
+
+## 🧞 Commands
+
+All commands are run from the root of the project, from a terminal:
+
+| Command                   | Action                                           |
+| :------------------------ | :----------------------------------------------- |
+| `npm install`             | Installs dependencies                            |
+| `npm run dev`             | Starts local dev server at `localhost:4321`      |
+| `npm run build`           | Build your production site to `./dist/`          |
+| `npm run preview`         | Preview your build locally, before deploying     |
+| `npm run server`          | Run the built Node server from `./dist/server/`  |
+| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
+| `npm run astro -- --help` | Get help using the Astro CLI                     |
+
+## 👀 Want to learn more?
+
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).


### PR DESCRIPTION
## Changes

- Fixes the StackBlitz and CodeSandbox links in the `component` and `container-with-vitest` example READMEs so they point to the correct example folders.
- Adds missing READMEs for the `ssr` and `advanced-routing` examples using the same structure as the other example templates, with commands and project details that match each example's actual setup.

## Testing

- No test code was added or changed. This PR only updates example README content and link targets.
- Verified the updated sandbox links now match their example directory names and checked the new README content against each example's `package.json`, `astro.config.mjs`, and `src/` structure.

## Docs

- No separate docs repo update is needed because this change only fixes and adds in-repo example READMEs.