### PR TITLE
Add support for CSP Level 3 directives

### DIFF
--- a/.changeset/csp-level3-directives.md
+++ b/.changeset/csp-level3-directives.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds support for CSP Level 3 directives (`script-src-elem`, `script-src-attr`, `style-src-elem`, `style-src-attr`) in the `security.csp.directives` configuration. When these directives are specified, Astro will automatically mirror the generated script/style hashes into them, ensuring compatibility with granular CSP policies.

--- a/packages/astro/src/core/csp/config.ts
+++ b/packages/astro/src/core/csp/config.ts
@@ -59,6 +59,10 @@ const ALLOWED_DIRECTIVES = [
 	'report-uri',
 	'require-trusted-types-for',
 	'sandbox',
+	'script-src-attr',
+	'script-src-elem',
+	'style-src-attr',
+	'style-src-elem',
 	'trusted-types',
 	'upgrade-insecure-requests',
 	'worker-src',
@@ -73,7 +77,8 @@ export const allowedDirectivesSchema = z
 			return value.startsWith(allowedValue);
 		});
 		if (!isAllowed) {
-			if (value.startsWith('script-src') || value.startsWith('style-src')) {
+			const directiveName = value.split(/\s+/)[0];
+			if (directiveName === 'script-src' || directiveName === 'style-src') {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
 					message: `Directives \`script-src\` and \`style-src\` are not allowed in \`security.csp.directives\`. Please use \`security.csp.scriptDirective\` and \`security.csp.styleDirective\` instead.`,

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -22,7 +22,21 @@ export function renderCspContent(result: SSRResult): string {
 
 	let directives;
 	if (result.directives.length > 0) {
-		directives = result.directives.join(';') + ';';
+		directives =
+			result.directives
+				.map((d) => {
+					const name = d.split(/\s+/)[0];
+					if (name === 'script-src-elem' || name === 'script-src-attr') {
+						const hashes = Array.from(finalScriptHashes).join(' ');
+						return hashes ? `${d} ${hashes}` : d;
+					}
+					if (name === 'style-src-elem' || name === 'style-src-attr') {
+						const hashes = Array.from(finalStyleHashes).join(' ');
+						return hashes ? `${d} ${hashes}` : d;
+					}
+					return d;
+				})
+				.join(';') + ';';
 	}
 
 	let scriptResources = "'self'";

--- a/packages/astro/test/units/config/config-validate.test.ts
+++ b/packages/astro/test/units/config/config-validate.test.ts
@@ -618,6 +618,23 @@ describe('Config Validation', () => {
 				`[config] Astro found issue(s) with your configuration:\n\n! security.csp: Did not match union.\n  > Expected type boolean | Directives script-src and style-src are not allowed in security.csp.directives. Please use security.csp.scriptDirective and security.csp.styleDirective instead.\n  > Received { "directives": [ "script-src 'self'" ] }`,
 			);
 		});
+
+		it('should accept CSP Level 3 directives in security.csp.directives', async () => {
+			await assert.doesNotReject(() =>
+				validateConfig({
+					security: {
+						csp: {
+							directives: [
+								"script-src-elem 'self'",
+								"script-src-attr 'unsafe-inline'",
+								"style-src-elem 'self'",
+								"style-src-attr 'unsafe-inline'",
+							],
+						},
+					},
+				}),
+			);
+		});
 	});
 
 	describe('devToolbar', () => {

--- a/packages/astro/test/units/csp/rendering.test.ts
+++ b/packages/astro/test/units/csp/rendering.test.ts
@@ -222,6 +222,64 @@ describe('CSP Rendering', () => {
 				'Should include report-uri directive',
 			);
 		});
+
+		it('should include CSP Level 3 directives and mirror script hashes to script-src-elem', async () => {
+			const pipeline = createCspPipeline({
+				directives: ["script-src-elem 'self'"],
+				scriptHashes: ['sha256-abc123'],
+			});
+
+			const { html } = await renderPage(SimplePage, pipeline);
+			const $ = cheerio.load(html);
+
+			const meta = $('meta[http-equiv="Content-Security-Policy"]');
+			const content = meta.attr('content')!;
+
+			assert.ok(
+				content.includes("script-src-elem 'self' 'sha256-abc123'"),
+				'Should include script-src-elem with mirrored script hash',
+			);
+			assert.ok(content.includes('script-src'), 'Should still have script-src directive');
+		});
+
+		it('should mirror style hashes to style-src-elem and style-src-attr', async () => {
+			const pipeline = createCspPipeline({
+				directives: ["style-src-elem 'self'", "style-src-attr 'unsafe-inline'"],
+				styleHashes: ['sha256-def456'],
+			});
+
+			const { html } = await renderPage(SimplePage, pipeline);
+			const $ = cheerio.load(html);
+
+			const meta = $('meta[http-equiv="Content-Security-Policy"]');
+			const content = meta.attr('content')!;
+
+			assert.ok(
+				content.includes("style-src-elem 'self' 'sha256-def456'"),
+				'Should include style-src-elem with mirrored style hash',
+			);
+			assert.ok(
+				content.includes("style-src-attr 'unsafe-inline' 'sha256-def456'"),
+				'Should include style-src-attr with mirrored style hash',
+			);
+		});
+
+		it('should not append hashes to Level 3 directives when no hashes exist', async () => {
+			const pipeline = createCspPipeline({
+				directives: ["script-src-attr 'unsafe-inline'"],
+			});
+
+			const { html } = await renderPage(SimplePage, pipeline);
+			const $ = cheerio.load(html);
+
+			const meta = $('meta[http-equiv="Content-Security-Policy"]');
+			const content = meta.attr('content')!;
+
+			assert.ok(
+				content.includes("script-src-attr 'unsafe-inline'"),
+				'Should include script-src-attr without extra hashes',
+			);
+		});
 	});
 
 	describe('Custom Resources', () => {


### PR DESCRIPTION
## Changes

- Adds support for four CSP Level 3 directives (`script-src-elem`, `script-src-attr`, `style-src-elem`, `style-src-attr`) to the `ALLOWED_DIRECTIVES` list, allowing users to include them in their CSP config
- Fixes validation logic to use exact directive name matching instead of `startsWith`, preventing misleading error messages for Level 3 directives
- Auto-generates and mirrors script/style hashes to any Level 3 directives that users configure, ensuring they work correctly with Astro's built-in CSP system
- Maintains backward compatibility with existing CSP Level 2 configurations

## Testing

- Added unit tests in `test/units/config/config-validate.test.ts` to verify all four Level 3 directives pass config validation
- Added unit tests in `test/units/csp/rendering.test.ts` to verify hash mirroring works for `script-src-elem`, `style-src-elem`, and `style-src-attr`
- Verified existing CSP tests continue to pass with no regressions

## Docs

- No docs update needed, because this extends the existing CSP directive configuration without changing the API or requiring new documentation sections.

Closes #16233