### PR TITLE
Fix glob loader watcher negation matching

### DIFF
--- a/.changeset/long-mugs-dig.md
+++ b/.changeset/long-mugs-dig.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix glob loader watcher negation matching

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -67,6 +67,24 @@ function checkPrefix(pattern: string | Array<string>, prefix: string) {
 	return pattern.startsWith(prefix);
 }
 
+function matchesPattern(entry: string, pattern: string | Array<string>) {
+	if (!Array.isArray(pattern)) {
+		return picomatch.isMatch(entry, pattern);
+	}
+
+	const positivePatterns = pattern.filter((p) => !p.startsWith('!'));
+	const negativePatterns = pattern.filter((p) => p.startsWith('!')).map((p) => p.slice(1));
+
+	if (positivePatterns.length === 0) {
+		return false;
+	}
+
+	return (
+		positivePatterns.some((p) => picomatch.isMatch(entry, p)) &&
+		!negativePatterns.some((p) => picomatch.isMatch(entry, p))
+	);
+}
+
 export const secretLegacyFlag = Symbol('astro.legacy-glob');
 
 /**
@@ -336,7 +354,7 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 			watcher.add(filePath);
 
 			const matchesGlob = (entry: string) =>
-				!entry.startsWith('../') && picomatch.isMatch(entry, globOptions.pattern);
+				!entry.startsWith('../') && matchesPattern(entry, globOptions.pattern);
 
 			const basePath = fileURLToPath(baseDir);
 

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 import { glob } from '../../../dist/content/loaders/glob.js';
 import { defineCollection } from '../../../dist/content/config.js';
@@ -13,6 +14,31 @@ import {
 
 describe('Glob Loader', () => {
 	const root = new URL('../../fixtures/content-layer/', import.meta.url);
+
+	function createWatcher() {
+		const listeners = new Map<string, Array<(path: string) => Promise<void> | void>>();
+
+		return {
+			add() {},
+			on(event: string, callback: (path: string) => Promise<void> | void) {
+				const callbacks = listeners.get(event) ?? [];
+				callbacks.push(callback);
+				listeners.set(event, callbacks);
+				return this;
+			},
+			off(event: string, callback: (path: string) => Promise<void> | void) {
+				const callbacks = listeners.get(event) ?? [];
+				listeners.set(
+					event,
+					callbacks.filter((listener) => listener !== callback),
+				);
+				return this;
+			},
+			async emit(event: string, path: string) {
+				await Promise.all((listeners.get(event) ?? []).map((callback) => callback(path)));
+			},
+		};
+	}
 
 	it('loads markdown files with glob pattern', async () => {
 		const store = new MutableDataStore();
@@ -84,6 +110,43 @@ describe('Glob Loader', () => {
 		// Check that other probes exist
 		const cassini = entries.find((e) => e.id === 'cassini');
 		assert.ok(cassini);
+	});
+
+	it('ignores watcher changes excluded by negated glob patterns', async () => {
+		const store = new MutableDataStore();
+		const watcher = createWatcher();
+		const settings = createMinimalSettings(root, {
+			contentEntryTypes: [createMarkdownEntryType()],
+		});
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'silent',
+		});
+
+		const collections = {
+			probes: defineCollection({
+				loader: glob({
+					pattern: ['src/data/space-probes/*.md', '!src/data/space-probes/voyager-*'],
+					base: '.',
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			watcher: watcher as any,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		const before = store.values('probes').map((entry) => entry.id);
+		await watcher.emit('change', fileURLToPath(new URL('src/content/space/columbia.md', root)));
+		const after = store.values('probes').map((entry) => entry.id);
+
+		assert.deepEqual(after, before);
 	});
 
 	it('retains body by default', async () => {


### PR DESCRIPTION
## Summary
- fix the content glob loader watcher so pattern arrays with `!` entries require a positive match and reject negated matches
- add a regression test that emits a watcher change for an unrelated Markdown file and verifies it is not added to the collection

Fixes #16851

## Tests
- `pnpm --dir packages/astro run build`
- `pnpm --dir packages/astro exec astro-scripts test "test/units/content-layer/**/*.test.ts" --strip-types --teardown ./test/units/teardown.ts`
- `pnpm exec prettier --check packages/astro/src/content/loaders/glob.ts packages/astro/test/units/content-layer/glob-loader.test.ts`
- `pnpm exec eslint packages/astro/src/content/loaders/glob.ts packages/astro/test/units/content-layer/glob-loader.test.ts`
