### PR TITLE
Fix dynamic route parameters in domain-based i18n routing

### DIFF
--- a/.changeset/fix-i18n-domain-dynamic-params.md
+++ b/.changeset/fix-i18n-domain-dynamic-params.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes dynamic routes returning 500 "TypeError: Missing parameter" when using domain-based i18n routing (`domains-prefix-other-locales`, `domains-prefix-always`, or `domains-prefix-always-no-redirect`) in SSR.
+
+When a non-default locale was mapped to a separate domain via `i18n.domains`, the locale-prefixed pathname computed during route matching was not passed through to the rendering context. This caused param extraction to fail for dynamic routes (e.g. `/boats/[id]/[slug]`) because the route pattern expected the locale prefix but the pathname used for matching did not include it.

--- a/.changeset/fix-i18n-domain-dynamic-params.md
+++ b/.changeset/fix-i18n-domain-dynamic-params.md
@@ -2,6 +2,4 @@
 'astro': patch
 ---
 
-Fixes dynamic routes returning 500 "TypeError: Missing parameter" when using domain-based i18n routing (`domains-prefix-other-locales`, `domains-prefix-always`, or `domains-prefix-always-no-redirect`) in SSR.
-
-When a non-default locale was mapped to a separate domain via `i18n.domains`, the locale-prefixed pathname computed during route matching was not passed through to the rendering context. This caused param extraction to fail for dynamic routes (e.g. `/boats/[id]/[slug]`) because the route pattern expected the locale prefix but the pathname used for matching did not include it.
+Fixes dynamic routes returning 500 "TypeError: Missing parameter" when using domain-based i18n routing in SSR.

--- a/.changeset/rare-bikes-open.md
+++ b/.changeset/rare-bikes-open.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.currentLocale` returning the default locale instead of the domain's locale on dynamic routes served from a mapped domain.

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -1,12 +1,10 @@
 import {
-	appendForwardSlash,
 	collapseDuplicateLeadingSlashes,
-	joinPaths,
 	prependForwardSlash,
 	removeTrailingForwardSlash,
 } from '@astrojs/internal-helpers/path';
 import { matchPattern } from '@astrojs/internal-helpers/remote';
-import { normalizeTheLocale } from '../../i18n/index.js';
+import { computePathnameFromDomain } from '../i18n/domain.js';
 import type { RoutesList } from '../../types/astro.js';
 import type { RemotePattern, RouteData } from '../../types/public/index.js';
 import { type Pipeline, PipelineFeatures } from '../base-pipeline.js';
@@ -95,13 +93,6 @@ export interface ResolvedRenderOptions {
 	locals: RequiredRenderOptions['locals'] | undefined;
 	routeData: RequiredRenderOptions['routeData'] | undefined;
 	waitUntil: RequiredRenderOptions['waitUntil'] | undefined;
-	/**
-	 * Locale-prefixed pathname computed from domain-based i18n routing.
-	 * When set, overrides the URL-derived pathname in FetchState so that
-	 * param extraction matches the route pattern.
-	 * @internal
-	 */
-	domainPathname?: string;
 }
 
 export interface RenderErrorOptions extends ResolvedRenderOptions {
@@ -346,76 +337,14 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 	}
 
 	private computePathnameFromDomain(request: Request): string | undefined {
-		let pathname: string | undefined = undefined;
-		const url = new URL(request.url);
-
-		if (
-			this.manifest.i18n &&
-			(this.manifest.i18n.strategy === 'domains-prefix-always' ||
-				this.manifest.i18n.strategy === 'domains-prefix-other-locales' ||
-				this.manifest.i18n.strategy === 'domains-prefix-always-no-redirect')
-		) {
-			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
-			let host = request.headers.get('X-Forwarded-Host');
-			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
-			let protocol = request.headers.get('X-Forwarded-Proto');
-			if (protocol) {
-				// this header doesn't have a colon at the end, so we add to be in line with URL#protocol, which does have it
-				protocol = protocol + ':';
-			} else {
-				// we fall back to the protocol of the request
-				protocol = url.protocol;
-			}
-			if (!host) {
-				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-				host = request.headers.get('Host');
-			}
-			// If we don't have a host and a protocol, it's impossible to proceed
-			if (host && protocol) {
-				// The header might have a port in their name, so we remove it
-				host = host.split(':')[0];
-				try {
-					let locale;
-					const hostAsUrl = new URL(`${protocol}//${host}`);
-					for (const [domainKey, localeValue] of Object.entries(
-						this.manifest.i18n.domainLookupTable,
-					)) {
-						// This operation should be safe because we force the protocol via zod inside the configuration
-						// If not, then it means that the manifest was tampered
-						const domainKeyAsUrl = new URL(domainKey);
-
-						if (
-							hostAsUrl.host === domainKeyAsUrl.host &&
-							hostAsUrl.protocol === domainKeyAsUrl.protocol
-						) {
-							locale = localeValue;
-							break;
-						}
-					}
-
-					if (locale) {
-						pathname = prependForwardSlash(
-							joinPaths(normalizeTheLocale(locale), this.removeBase(url.pathname)),
-						);
-						if (this.manifest.trailingSlash === 'always') {
-							pathname = appendForwardSlash(pathname);
-						} else if (this.manifest.trailingSlash === 'never') {
-							pathname = removeTrailingForwardSlash(pathname);
-						} else if (url.pathname.endsWith('/')) {
-							// trailingSlash === 'ignore': preserve the original trailing slash
-							pathname = appendForwardSlash(pathname);
-						}
-					}
-				} catch (e: any) {
-					this.logger.error(
-						'router',
-						`Astro tried to parse ${protocol}//${host} as an URL, but it threw a parsing error. Check the X-Forwarded-Host and X-Forwarded-Proto headers.`,
-					);
-					this.logger.error('router', `Error: ${e}`);
-				}
-			}
-		}
-		return pathname;
+		return computePathnameFromDomain(
+			request,
+			new URL(request.url),
+			this.manifest.i18n,
+			this.manifest.base,
+			this.manifest.trailingSlash,
+			this.logger,
+		);
 	}
 
 	public async render(
@@ -461,11 +390,14 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 				});
 			}
 		}
-		// For domain-based i18n, compute the locale-prefixed pathname from
-		// the Host header and pass it so FetchState can match correctly.
-		const domainPathname = this.computePathnameFromDomain(request);
-		if (!routeData && domainPathname) {
-			routeData = this.pipeline.matchRoute(this.safeDecodeURI(domainPathname));
+		// For domain-based i18n, match against the locale-prefixed pathname
+		// derived from the Host header. FetchState recomputes this pathname
+		// itself for param/locale resolution, so it isn't threaded through here.
+		if (!routeData) {
+			const domainPathname = this.computePathnameFromDomain(request);
+			if (domainPathname) {
+				routeData = this.pipeline.matchRoute(this.safeDecodeURI(domainPathname));
+			}
 		}
 		const resolvedOptions: ResolvedRenderOptions = {
 			addCookieHeader,
@@ -474,7 +406,6 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 			locals,
 			routeData,
 			waitUntil,
-			domainPathname,
 		};
 
 		let response: Response;

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -95,6 +95,13 @@ export interface ResolvedRenderOptions {
 	locals: RequiredRenderOptions['locals'] | undefined;
 	routeData: RequiredRenderOptions['routeData'] | undefined;
 	waitUntil: RequiredRenderOptions['waitUntil'] | undefined;
+	/**
+	 * Locale-prefixed pathname computed from domain-based i18n routing.
+	 * When set, overrides the URL-derived pathname in FetchState so that
+	 * param extraction matches the route pattern.
+	 * @internal
+	 */
+	domainPathname?: string;
 }
 
 export interface RenderErrorOptions extends ResolvedRenderOptions {
@@ -456,11 +463,9 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		}
 		// For domain-based i18n, compute the locale-prefixed pathname from
 		// the Host header and pass it so FetchState can match correctly.
-		if (!routeData) {
-			const domainPathname = this.computePathnameFromDomain(request);
-			if (domainPathname) {
-				routeData = this.pipeline.matchRoute(this.safeDecodeURI(domainPathname));
-			}
+		const domainPathname = this.computePathnameFromDomain(request);
+		if (!routeData && domainPathname) {
+			routeData = this.pipeline.matchRoute(this.safeDecodeURI(domainPathname));
 		}
 		const resolvedOptions: ResolvedRenderOptions = {
 			addCookieHeader,
@@ -469,6 +474,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 			locals,
 			routeData,
 			waitUntil,
+			domainPathname,
 		};
 
 		let response: Response;

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -263,7 +263,19 @@ export class FetchState implements AstroFetchState {
 		this.slots = undefined;
 		// Parse the URL once and derive both pathname and url from it.
 		const url = new URL(request.url);
-		this.pathname = this.#computePathname(url);
+		// When domain-based i18n routing detected a locale from the Host header,
+		// the domain pathname includes the locale prefix (e.g. /en/boats/1/foo)
+		// that the matched route pattern expects. Use it instead of the raw URL
+		// pathname so that param extraction produces correct values.
+		if (this.renderOptions.domainPathname) {
+			try {
+				this.pathname = decodeURI(this.renderOptions.domainPathname);
+			} catch {
+				this.pathname = this.renderOptions.domainPathname;
+			}
+		} else {
+			this.pathname = this.#computePathname(url);
+		}
 		this.timeStart = performance.now();
 		this.clientAddress = options?.clientAddress;
 		this.locals = (options?.locals ?? {}) as App.Locals;

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -35,6 +35,7 @@ import { Rewrites } from '../rewrites/handler.js';
 import { isRoute404or500, isRouteServerIsland } from '../routing/match.js';
 import { normalizeUrl } from '../util/normalized-url.js';
 import { getOriginPathname, setOriginPathname } from '../routing/rewrite.js';
+import { computePathnameFromDomain } from '../i18n/domain.js';
 import { getCustom404Route, routeHasHtmlExtension } from '../routing/helpers.js';
 import type { ResolvedRenderOptions } from '../app/base.js';
 import { getRenderOptions } from '../app/render-options.js';
@@ -236,6 +237,13 @@ export class FetchState implements AstroFetchState {
 	#rewrites: Rewrites | undefined;
 	/** Memoized Astro page partial. */
 	#astroPagePartial?: Omit<AstroGlobal, 'props' | 'self' | 'slots'>;
+	/**
+	 * Locale-prefixed pathname derived from the Host header for domain-based
+	 * i18n routing (e.g. `/en/boats/1/foo`), or `undefined` when the request
+	 * isn't served from a locale-mapped domain. When set, `this.pathname` is
+	 * derived from it so locale/param resolution match the route pattern.
+	 */
+	#domainPathname: string | undefined;
 	/** Memoized current locale. */
 	#currentLocale: APIContext['currentLocale'];
 	/** Memoized preferred locale. */
@@ -263,15 +271,25 @@ export class FetchState implements AstroFetchState {
 		this.slots = undefined;
 		// Parse the URL once and derive both pathname and url from it.
 		const url = new URL(request.url);
-		// When domain-based i18n routing detected a locale from the Host header,
-		// the domain pathname includes the locale prefix (e.g. /en/boats/1/foo)
-		// that the matched route pattern expects. Use it instead of the raw URL
-		// pathname so that param extraction produces correct values.
-		if (this.renderOptions.domainPathname) {
+		// For domain-based i18n routing, the locale prefix is derived from the
+		// request's Host header rather than its URL. When a locale is detected,
+		// the resulting pathname includes the prefix (e.g. /en/boats/1/foo) that
+		// the matched route pattern expects — use it instead of the raw URL
+		// pathname so param and locale resolution produce correct values.
+		const domainPathname = computePathnameFromDomain(
+			request,
+			url,
+			pipeline.manifest.i18n,
+			pipeline.manifest.base,
+			pipeline.manifest.trailingSlash,
+			pipeline.logger,
+		);
+		if (domainPathname) {
+			this.#domainPathname = domainPathname;
 			try {
-				this.pathname = decodeURI(this.renderOptions.domainPathname);
+				this.pathname = decodeURI(domainPathname);
 			} catch {
-				this.pathname = this.renderOptions.domainPathname;
+				this.pathname = domainPathname;
 			}
 		} else {
 			this.pathname = this.#computePathname(url);
@@ -644,7 +662,7 @@ export class FetchState implements AstroFetchState {
 			// route matched against (e.g. `/en/boats/1/foo`), whereas `url.pathname`
 			// does not. This matters for dynamic routes, which have no static
 			// `routeData.pathname` to fall back to. See #16854.
-			if (this.renderOptions.domainPathname) {
+			if (this.#domainPathname) {
 				pathname = this.pathname;
 			} else if (url && !routeData.pattern.test(url.pathname)) {
 				for (const fallbackRoute of routeData.fallbackRoutes) {

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -639,7 +639,14 @@ export class FetchState implements AstroFetchState {
 			}
 		} else {
 			let pathname = routeData.pathname;
-			if (url && !routeData.pattern.test(url.pathname)) {
+			// For domain-based i18n the locale prefix comes from the Host header,
+			// not the URL. `this.pathname` carries the locale-prefixed path the
+			// route matched against (e.g. `/en/boats/1/foo`), whereas `url.pathname`
+			// does not. This matters for dynamic routes, which have no static
+			// `routeData.pathname` to fall back to. See #16854.
+			if (this.renderOptions.domainPathname) {
+				pathname = this.pathname;
+			} else if (url && !routeData.pattern.test(url.pathname)) {
 				for (const fallbackRoute of routeData.fallbackRoutes) {
 					if (fallbackRoute.pattern.test(url.pathname)) {
 						pathname = fallbackRoute.pathname;

--- a/packages/astro/src/core/i18n/domain.ts
+++ b/packages/astro/src/core/i18n/domain.ts
@@ -1,0 +1,109 @@
+import {
+	appendForwardSlash,
+	collapseDuplicateLeadingSlashes,
+	joinPaths,
+	prependForwardSlash,
+	removeTrailingForwardSlash,
+} from '@astrojs/internal-helpers/path';
+import { normalizeTheLocale } from '../../i18n/index.js';
+import type { SSRManifest } from '../app/types.js';
+import type { AstroLogger } from '../logger/core.js';
+
+/**
+ * For domain-based i18n routing strategies, derives the locale-prefixed
+ * pathname from the request's `Host` header rather than its URL. For example,
+ * a request for `/foo` served from `https://example.fr` resolves to `/fr/foo`.
+ *
+ * Returns `undefined` when the strategy isn't domain-based or the host isn't
+ * mapped to a locale — in which case normal pathname routing applies.
+ *
+ */
+export function computePathnameFromDomain(
+	request: Request,
+	url: URL,
+	i18n: SSRManifest['i18n'],
+	base: SSRManifest['base'],
+	trailingSlash: SSRManifest['trailingSlash'],
+	logger: AstroLogger,
+): string | undefined {
+	let pathname: string | undefined = undefined;
+
+	if (
+		i18n &&
+		(i18n.strategy === 'domains-prefix-always' ||
+			i18n.strategy === 'domains-prefix-other-locales' ||
+			i18n.strategy === 'domains-prefix-always-no-redirect')
+	) {
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+		let host = request.headers.get('X-Forwarded-Host');
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+		let protocol = request.headers.get('X-Forwarded-Proto');
+		if (protocol) {
+			// this header doesn't have a colon at the end, so we add to be in line with URL#protocol, which does have it
+			protocol = protocol + ':';
+		} else {
+			// we fall back to the protocol of the request
+			protocol = url.protocol;
+		}
+		if (!host) {
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+			host = request.headers.get('Host');
+		}
+		// If we don't have a host and a protocol, it's impossible to proceed
+		if (host && protocol) {
+			// The header might have a port in their name, so we remove it
+			host = host.split(':')[0];
+			try {
+				let locale;
+				const hostAsUrl = new URL(`${protocol}//${host}`);
+				for (const [domainKey, localeValue] of Object.entries(i18n.domainLookupTable)) {
+					// This operation should be safe because we force the protocol via zod inside the configuration
+					// If not, then it means that the manifest was tampered
+					const domainKeyAsUrl = new URL(domainKey);
+
+					if (
+						hostAsUrl.host === domainKeyAsUrl.host &&
+						hostAsUrl.protocol === domainKeyAsUrl.protocol
+					) {
+						locale = localeValue;
+						break;
+					}
+				}
+
+				if (locale) {
+					pathname = prependForwardSlash(
+						joinPaths(normalizeTheLocale(locale), removeBase(url.pathname, base)),
+					);
+					if (trailingSlash === 'always') {
+						pathname = appendForwardSlash(pathname);
+					} else if (trailingSlash === 'never') {
+						pathname = removeTrailingForwardSlash(pathname);
+					} else if (url.pathname.endsWith('/')) {
+						// trailingSlash === 'ignore': preserve the original trailing slash
+						pathname = appendForwardSlash(pathname);
+					}
+				}
+			} catch (e: any) {
+				logger.error(
+					'router',
+					`Astro tried to parse ${protocol}//${host} as an URL, but it threw a parsing error. Check the X-Forwarded-Host and X-Forwarded-Proto headers.`,
+				);
+				logger.error('router', `Error: ${e}`);
+			}
+		}
+	}
+	return pathname;
+}
+
+/**
+ * Mirror of `BaseApp.removeBase`, including the
+ * `collapseDuplicateLeadingSlashes` fix that prevents middleware
+ * authorization bypass when the URL starts with `//`.
+ */
+function removeBase(pathname: string, base: string): string {
+	pathname = collapseDuplicateLeadingSlashes(pathname);
+	if (pathname.startsWith(base)) {
+		return pathname.slice(removeTrailingForwardSlash(base).length + 1);
+	}
+	return pathname;
+}

--- a/packages/astro/test/units/i18n/domain.test.ts
+++ b/packages/astro/test/units/i18n/domain.test.ts
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { computePathnameFromDomain } from '../../../dist/core/i18n/domain.js';
+import type { SSRManifestI18n } from '../../../dist/core/app/types.js';
+import type { RoutingStrategies } from '../../../dist/core/app/common.js';
+import type { Locales } from '../../../dist/types/public/config.js';
+import { defaultLogger, SpyLogger } from '../test-utils.ts';
+
+interface I18nOverrides {
+	strategy?: RoutingStrategies;
+	locales?: Locales;
+	defaultLocale?: string;
+	domainLookupTable?: Record<string, string>;
+}
+
+function makeI18n(overrides: I18nOverrides = {}): SSRManifestI18n {
+	return {
+		fallback: undefined,
+		fallbackType: 'rewrite',
+		strategy: overrides.strategy ?? 'domains-prefix-other-locales',
+		locales: overrides.locales ?? (['en', 'fr'] as Locales),
+		defaultLocale: overrides.defaultLocale ?? 'en',
+		domainLookupTable: overrides.domainLookupTable ?? { 'https://example.fr': 'fr' },
+		domains: undefined,
+	};
+}
+
+/** Builds a request + parsed URL pair, the two positional args the fn takes. */
+function reqAndUrl(url: string, headers: Record<string, string> = {}) {
+	const request = new Request(url, { headers });
+	return [request, new URL(request.url)] as const;
+}
+
+function run(
+	url: string,
+	headers: Record<string, string>,
+	opts: {
+		i18n?: SSRManifestI18n | undefined;
+		base?: string;
+		trailingSlash?: 'always' | 'never' | 'ignore';
+		logger?: typeof defaultLogger;
+	} = {},
+) {
+	// Resolve i18n via key presence so an explicit `i18n: undefined` is honored
+	// (a destructuring default would replace it with the configured fallback).
+	const i18n = 'i18n' in opts ? opts.i18n : makeI18n();
+	const base = opts.base ?? '/';
+	const trailingSlash = opts.trailingSlash ?? 'ignore';
+	const logger = opts.logger ?? defaultLogger;
+	const [request, parsedUrl] = reqAndUrl(url, headers);
+	return computePathnameFromDomain(request, parsedUrl, i18n, base, trailingSlash, logger);
+}
+
+describe('computePathnameFromDomain', () => {
+	it('returns undefined when i18n is not configured', () => {
+		assert.equal(
+			run('https://example.fr/about', { 'X-Forwarded-Host': 'example.fr' }, { i18n: undefined }),
+			undefined,
+		);
+	});
+
+	it('returns undefined for non domain-based strategies', () => {
+		const i18n = makeI18n({ strategy: 'pathname-prefix-other-locales' });
+		assert.equal(
+			run('https://example.fr/about', { 'X-Forwarded-Host': 'example.fr' }, { i18n }),
+			undefined,
+		);
+	});
+
+	it('returns undefined when the host is not mapped to a locale', () => {
+		assert.equal(
+			run('https://example.com/about', { 'X-Forwarded-Host': 'example.com' }),
+			undefined,
+		);
+	});
+
+	it('returns undefined when neither Host nor X-Forwarded-Host is present', () => {
+		// `new Request` always derives a Host from the URL, so build a request
+		// whose URL host is unmapped and pass no forwarding headers.
+		assert.equal(run('https://example.com/about', {}), undefined);
+	});
+
+	it('prepends the locale prefix derived from X-Forwarded-Host', () => {
+		assert.equal(
+			run('https://example.fr/about', {
+				'X-Forwarded-Host': 'example.fr',
+				'X-Forwarded-Proto': 'https',
+			}),
+			'/fr/about',
+		);
+	});
+
+	it('falls back to the Host header when X-Forwarded-Host is absent', () => {
+		assert.equal(run('https://example.fr/about', { Host: 'example.fr' }), '/fr/about');
+	});
+
+	it('strips a port from the forwarded host before matching', () => {
+		assert.equal(
+			run('https://example.fr/about', {
+				'X-Forwarded-Host': 'example.fr:8443',
+				'X-Forwarded-Proto': 'https',
+			}),
+			'/fr/about',
+		);
+	});
+
+	it('returns undefined on protocol mismatch with the mapped domain', () => {
+		// domainLookupTable maps https://example.fr; an http request must not match.
+		assert.equal(
+			run('http://example.fr/about', {
+				'X-Forwarded-Host': 'example.fr',
+				'X-Forwarded-Proto': 'http',
+			}),
+			undefined,
+		);
+	});
+
+	it('appends a trailing slash when trailingSlash is "always"', () => {
+		assert.equal(
+			run(
+				'https://example.fr/about',
+				{ 'X-Forwarded-Host': 'example.fr' },
+				{ trailingSlash: 'always' },
+			),
+			'/fr/about/',
+		);
+	});
+
+	it('removes the trailing slash when trailingSlash is "never"', () => {
+		assert.equal(
+			run(
+				'https://example.fr/about/',
+				{ 'X-Forwarded-Host': 'example.fr' },
+				{ trailingSlash: 'never' },
+			),
+			'/fr/about',
+		);
+	});
+
+	it('preserves the request trailing slash when trailingSlash is "ignore"', () => {
+		assert.equal(
+			run(
+				'https://example.fr/about/',
+				{ 'X-Forwarded-Host': 'example.fr' },
+				{ trailingSlash: 'ignore' },
+			),
+			'/fr/about/',
+		);
+		assert.equal(
+			run(
+				'https://example.fr/about',
+				{ 'X-Forwarded-Host': 'example.fr' },
+				{ trailingSlash: 'ignore' },
+			),
+			'/fr/about',
+		);
+	});
+
+	it('strips the configured base before prepending the locale', () => {
+		assert.equal(
+			run('https://example.fr/shop/about', { 'X-Forwarded-Host': 'example.fr' }, { base: '/shop' }),
+			'/fr/about',
+		);
+	});
+
+	it('returns the locale-prefixed pathname without decoding (encoding preserved)', () => {
+		assert.equal(
+			run('https://example.fr/caf%C3%A9', { 'X-Forwarded-Host': 'example.fr' }),
+			'/fr/caf%C3%A9',
+		);
+	});
+
+	it('works for the domains-prefix-always strategy', () => {
+		const i18n = makeI18n({ strategy: 'domains-prefix-always' });
+		assert.equal(
+			run('https://example.fr/about', { 'X-Forwarded-Host': 'example.fr' }, { i18n }),
+			'/fr/about',
+		);
+	});
+
+	it('works for the domains-prefix-always-no-redirect strategy', () => {
+		const i18n = makeI18n({ strategy: 'domains-prefix-always-no-redirect' });
+		assert.equal(
+			run('https://example.fr/about', { 'X-Forwarded-Host': 'example.fr' }, { i18n }),
+			'/fr/about',
+		);
+	});
+
+	it('logs an error and returns undefined when the host cannot be parsed as a URL', () => {
+		const logger = new SpyLogger();
+		const result = run('https://example.fr/about', { 'X-Forwarded-Host': '[' }, { logger });
+		assert.equal(result, undefined);
+		assert.ok(
+			logger.logs.some((entry) => entry.level === 'error' && entry.label === 'router'),
+			'expected a router error to be logged',
+		);
+	});
+});

--- a/packages/astro/test/units/i18n/i18n-app.test.ts
+++ b/packages/astro/test/units/i18n/i18n-app.test.ts
@@ -35,6 +35,11 @@ const localePage = createComponent((result, props, slots) => {
 	return render`<h1 id="locale">${Astro.currentLocale}</h1><h2 id="path">${Astro.url.pathname}</h2>`;
 });
 
+const paramsPage = createComponent((result, props, slots) => {
+	const Astro = result.createAstro(props, slots);
+	return render`<h1 id="locale">${Astro.currentLocale}</h1><span id="id">${Astro.params.id}</span><span id="slug">${Astro.params.slug}</span>`;
+});
+
 const notFoundPage = createComponent(() => {
 	return render`<h1 id="not-found">404 Not Found</h1>`;
 });
@@ -409,6 +414,64 @@ describe('i18n via App - domains-prefix-other-locales', () => {
 		assert.equal(res.status, 200);
 		const $ = cheerio.load(await res.text());
 		assert.equal($('#locale').text(), 'en');
+	});
+});
+
+// #16854: Dynamic routes with non-spread params should work with domain-based i18n
+describe('i18n via App - domains-prefix-other-locales with dynamic params (#16854)', () => {
+	const i18n = makeI18nConfig({
+		strategy: 'domains-prefix-other-locales',
+		locales: ['fi', 'en'],
+		defaultLocale: 'fi',
+	});
+	i18n.domainLookupTable = { 'https://en.example.com': 'en' };
+	i18n.domains = { en: 'https://en.example.com' };
+
+	const middleware = createI18nMiddleware(i18n, '/', 'ignore', 'directory');
+
+	function createDomainApp() {
+		return createTestApp(
+			[
+				createPage(paramsPage, {
+					route: '/boats/[id]/[slug]',
+					segments: [[staticPart('boats')], [dynamicPart('id')], [dynamicPart('slug')]],
+					pathname: undefined,
+				}),
+				createPage(paramsPage, {
+					route: '/en/boats/[id]/[slug]',
+					segments: [
+						[staticPart('en')],
+						[staticPart('boats')],
+						[dynamicPart('id')],
+						[dynamicPart('slug')],
+					],
+					pathname: undefined,
+				}),
+			],
+			{ i18n, middleware: () => ({ onRequest: middleware }) },
+		);
+	}
+
+	it('resolves params for dynamic route on non-default locale domain', async () => {
+		const app = createDomainApp();
+		const res = await app.render(
+			new Request('https://en.example.com/boats/1/sunset-cruiser', {
+				headers: { 'X-Forwarded-Host': 'en.example.com', 'X-Forwarded-Proto': 'https' },
+			}),
+		);
+		assert.equal(res.status, 200);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('#id').text(), '1');
+		assert.equal($('#slug').text(), 'sunset-cruiser');
+	});
+
+	it('resolves params for dynamic route on default locale domain', async () => {
+		const app = createDomainApp();
+		const res = await app.render(new Request('http://example.com/boats/2/blue-wave'));
+		assert.equal(res.status, 200);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('#id').text(), '2');
+		assert.equal($('#slug').text(), 'blue-wave');
 	});
 });
 

--- a/packages/astro/test/units/i18n/i18n-app.test.ts
+++ b/packages/astro/test/units/i18n/i18n-app.test.ts
@@ -430,29 +430,33 @@ describe('i18n via App - domains-prefix-other-locales with dynamic params (#1685
 	const middleware = createI18nMiddleware(i18n, '/', 'ignore', 'directory');
 
 	function createDomainApp() {
-		return createTestApp(
-			[
-				createPage(paramsPage, {
-					route: '/boats/[id]/[slug]',
-					segments: [[staticPart('boats')], [dynamicPart('id')], [dynamicPart('slug')]],
-					pathname: undefined,
-				}),
-				createPage(paramsPage, {
-					route: '/en/boats/[id]/[slug]',
-					segments: [
-						[staticPart('en')],
-						[staticPart('boats')],
-						[dynamicPart('id')],
-						[dynamicPart('slug')],
-					],
-					pathname: undefined,
-				}),
+		const fiPage = createPage(paramsPage, {
+			route: '/boats/[id]/[slug]',
+			segments: [[staticPart('boats')], [dynamicPart('id')], [dynamicPart('slug')]],
+		});
+		const enPage = createPage(paramsPage, {
+			route: '/en/boats/[id]/[slug]',
+			segments: [
+				[staticPart('en')],
+				[staticPart('boats')],
+				[dynamicPart('id')],
+				[dynamicPart('slug')],
 			],
-			{ i18n, middleware: () => ({ onRequest: middleware }) },
-		);
+		});
+		// Real Astro leaves `pathname` undefined for dynamic routes, but the mock
+		// defaults it to the route string (which contains the `/en/` prefix). That
+		// would mask the `Astro.currentLocale` bug, since locale detection would
+		// find the prefix in routeData.pathname instead of relying on the
+		// domain-derived pathname. Null it out so the test reproduces #16854.
+		fiPage.routeData.pathname = undefined;
+		enPage.routeData.pathname = undefined;
+		return createTestApp([fiPage, enPage], {
+			i18n,
+			middleware: () => ({ onRequest: middleware }),
+		});
 	}
 
-	it('resolves params for dynamic route on non-default locale domain', async () => {
+	it('resolves params and currentLocale for dynamic route on non-default locale domain', async () => {
 		const app = createDomainApp();
 		const res = await app.render(
 			new Request('https://en.example.com/boats/1/sunset-cruiser', {
@@ -463,15 +467,17 @@ describe('i18n via App - domains-prefix-other-locales with dynamic params (#1685
 		const $ = cheerio.load(await res.text());
 		assert.equal($('#id').text(), '1');
 		assert.equal($('#slug').text(), 'sunset-cruiser');
+		assert.equal($('#locale').text(), 'en');
 	});
 
-	it('resolves params for dynamic route on default locale domain', async () => {
+	it('resolves params and currentLocale for dynamic route on default locale domain', async () => {
 		const app = createDomainApp();
 		const res = await app.render(new Request('http://example.com/boats/2/blue-wave'));
 		assert.equal(res.status, 200);
 		const $ = cheerio.load(await res.text());
 		assert.equal($('#id').text(), '2');
 		assert.equal($('#slug').text(), 'blue-wave');
+		assert.equal($('#locale').text(), 'fi');
 	});
 });
 


### PR DESCRIPTION
## Changes

This PR fixes two bugs:
- `TypeError: Missing parameter` triggered in some cases, as reported in the issue.
- It also fixes a bug where `Astro.currentLocale` was incorrect when rendering a domain pathname. That was caused by the fact that the `i18n` didn't have visibility of the domain pathname. The logic that computes the domain pathname is now extracted in a pure function. 

## Testing

- Adds test suite in `packages/astro/test/units/i18n/i18n-app.test.ts` with two tests verifying params are correctly resolved for dynamic routes on both non-default and default locale domains
- Tests cover the specific case of non-spread dynamic params (e.g. `[id]`, `[slug]`) that trigger `TypeError: Missing parameter` when missing, unlike catch-all `[...slug]` routes which return empty strings
- Added unit tests for the function that computes the domain pathname

## Docs

- No docs update needed as this fixes existing documented functionality that was broken

Closes #16854