### PR TITLE
fix(core): include `mod` in SSR route-cache entry to silence false-positive warning

### DIFF
--- a/.changeset/ssr-route-cache-mod.md
+++ b/.changeset/ssr-route-cache-mod.md
@@ -2,8 +2,4 @@
 'astro': patch
 ---
 
-Fixes a regression introduced in 6.3.6 (#16776) where dynamic SSR routes logged `Internal Warning: route cache overwritten.` on every request after the first, per worker isolate.
-
-The SSR branch in `callGetStaticPaths` stored its empty static-paths entry without `mod`, so the new `cached.mod === mod` fast-path check always failed, control fell back into the SSR branch and `routeCache.set()` ran again. In production this triggered the warning at the top of `RouteCache.set()`.
-
-The SSR-branch entry now includes `mod`, so the fast-path hits cleanly on subsequent requests and no spurious warning is logged.
+Fixes a false-positive `Internal Warning: route cache overwritten` logged on every SSR request for dynamic routes

--- a/.changeset/ssr-route-cache-mod.md
+++ b/.changeset/ssr-route-cache-mod.md
@@ -1,0 +1,9 @@
+---
+'astro': patch
+---
+
+Fixes a regression introduced in 6.3.6 (#16776) where dynamic SSR routes logged `Internal Warning: route cache overwritten.` on every request after the first, per worker isolate.
+
+The SSR branch in `callGetStaticPaths` stored its empty static-paths entry without `mod`, so the new `cached.mod === mod` fast-path check always failed, control fell back into the SSR branch and `routeCache.set()` ran again. In production this triggered the warning at the top of `RouteCache.set()`.
+
+The SSR-branch entry now includes `mod`, so the fast-path hits cleanly on subsequent requests and no spurious warning is logged.

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -47,7 +47,11 @@ export async function callGetStaticPaths({
 	// No static paths in SSR mode. Return an empty RouteCacheEntry.
 	if (ssr && !route.prerender) {
 		const entry: GetStaticPathsResultKeyed = Object.assign([], { keyed: new Map() });
-		routeCache.set(route, { ...cached, staticPaths: entry });
+		// Store `mod` alongside the entry so the fast-path above hits on
+		// subsequent requests; otherwise `cached.mod === mod` is always false
+		// in SSR and we re-enter this branch, triggering the "route cache
+		// overwritten" warning on every request after the first.
+		routeCache.set(route, { ...cached, mod, staticPaths: entry });
 		return entry;
 	}
 

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -85,7 +85,7 @@ export async function callGetStaticPaths({
 }
 
 interface RouteCacheEntry {
-	mod?: ComponentInstance;
+	mod: ComponentInstance;
 	staticPaths: GetStaticPathsResultKeyed;
 }
 

--- a/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
+++ b/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
@@ -193,4 +193,46 @@ describe('getStaticPaths caching behavior', () => {
 		assert.equal(callCount, 2, 'new module should bypass cache');
 		assert.equal(result3.keyed.get('/one')?.props?.title, 'new');
 	});
+
+	it('does not log "route cache overwritten" on repeated SSR requests for the same module', async () => {
+		const messages: string[] = [];
+		const capturingDestination: AstroLoggerDestination<AstroLoggerMessage> = {
+			write: (msg) => {
+				messages.push(msg.message);
+				return true;
+			},
+		};
+		const warnLogger = new AstroLogger({ destination: capturingDestination, level: 'warn' });
+		const ssrCache = new RouteCache(warnLogger, 'production');
+
+		const route = makeRoute({
+			segments: [[dynamicPart('slug')]],
+			trailingSlash: 'never',
+			route: '/[slug]',
+			pathname: undefined,
+			type: 'page',
+			prerender: false,
+		});
+
+		const testMod = mod({ default: () => null });
+		const opts = {
+			mod: testMod,
+			route,
+			routeCache: ssrCache,
+			ssr: true,
+			base: '/' as const,
+			trailingSlash: 'never' as const,
+		};
+
+		await callGetStaticPaths(opts);
+		await callGetStaticPaths(opts);
+		await callGetStaticPaths(opts);
+
+		const overwriteWarnings = messages.filter((m) => m.includes('route cache overwritten'));
+		assert.equal(
+			overwriteWarnings.length,
+			0,
+			`SSR should not log "route cache overwritten" on repeated calls; got: ${overwriteWarnings.join(' | ')}`,
+		);
+	});
 });

--- a/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
+++ b/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, it, before, beforeEach } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import type { ComponentInstance } from '../../../dist/types/astro.js';
-import type { AstroLoggerMessage, AstroLoggerDestination } from '../../../dist/core/logger/core.js';
-import { AstroLogger } from '../../../dist/core/logger/core.js';
 import { RouteCache, callGetStaticPaths } from '../../../dist/core/render/route-cache.js';
+import { SpyLogger } from '../test-utils.ts';
 import { dynamicPart, makeRoute } from './test-helpers.ts';
 
 function mod(overrides: Partial<ComponentInstance>): ComponentInstance {
@@ -12,18 +11,11 @@ function mod(overrides: Partial<ComponentInstance>): ComponentInstance {
 
 describe('getStaticPaths caching behavior', () => {
 	let routeCache: RouteCache;
-	let logger: AstroLogger;
+	let logger: SpyLogger;
 	let callCount: number;
 
-	const destination: AstroLoggerDestination<AstroLoggerMessage> = {
-		write: () => true,
-	};
-
-	before(() => {
-		logger = new AstroLogger({ destination, level: 'error' });
-	});
-
 	beforeEach(() => {
+		logger = new SpyLogger();
 		routeCache = new RouteCache(logger, 'production');
 		callCount = 0;
 	});
@@ -195,15 +187,8 @@ describe('getStaticPaths caching behavior', () => {
 	});
 
 	it('does not log "route cache overwritten" on repeated SSR requests for the same module', async () => {
-		const messages: string[] = [];
-		const capturingDestination: AstroLoggerDestination<AstroLoggerMessage> = {
-			write: (msg) => {
-				messages.push(msg.message);
-				return true;
-			},
-		};
-		const warnLogger = new AstroLogger({ destination: capturingDestination, level: 'warn' });
-		const ssrCache = new RouteCache(warnLogger, 'production');
+		const spyLogger = new SpyLogger();
+		const ssrCache = new RouteCache(spyLogger, 'production');
 
 		const route = makeRoute({
 			segments: [[dynamicPart('slug')]],
@@ -228,11 +213,7 @@ describe('getStaticPaths caching behavior', () => {
 		await callGetStaticPaths(opts);
 		await callGetStaticPaths(opts);
 
-		const overwriteWarnings = messages.filter((m) => m.includes('route cache overwritten'));
-		assert.equal(
-			overwriteWarnings.length,
-			0,
-			`SSR should not log "route cache overwritten" on repeated calls; got: ${overwriteWarnings.join(' | ')}`,
-		);
+		const overwriteWarnings = spyLogger.logs.filter((l) => l.message.includes('route cache overwritten'));
+		assert.equal(overwriteWarnings.length, 0, 'SSR should not log "route cache overwritten" on repeated calls');
 	});
 });

--- a/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
+++ b/packages/astro/test/units/routing/getstaticpaths-cache.test.ts
@@ -214,7 +214,7 @@ describe('getStaticPaths caching behavior', () => {
 			prerender: false,
 		});
 
-		const testMod = mod({ default: () => null });
+		const testMod = mod({});
 		const opts = {
 			mod: testMod,
 			route,


### PR DESCRIPTION
## Changes

- Include `mod` in the SSR-branch cache entry in `callGetStaticPaths` so the new `cached.mod === mod` fast-path actually hits on subsequent SSR requests for the same component.

Before this patch, the SSR branch wrote `{ ...cached, staticPaths: entry }` without `mod`. The fast-path added in #16776 (`cached?.staticPaths && cached.mod === mod`) therefore always failed on the second request, control fell back into the SSR branch, `routeCache.set()` ran again, and `RouteCache.set()` emitted `Internal Warning: route cache overwritten` at the top of the function — once per dynamic-route component per worker isolate, on every request after the first, in production.

The static branch already stores `mod` so it was unaffected.

Closes #16863.

## Testing

Added a unit test in `packages/astro/test/units/routing/getstaticpaths-cache.test.ts`:

> `does not log "route cache overwritten" on repeated SSR requests for the same module`

It constructs a `RouteCache` in production mode with a capturing logger destination, calls `callGetStaticPaths` three times with `ssr: true`, `prerender: false`, the same `mod`, and asserts no `route cache overwritten` message was logged. The existing HMR and prerendered-route tests continue to pass.

## Docs

No docs changes — fixes an internal warning, no public API change.
