### PR TITLE
Partytown integration, README: fix outdated link

### DIFF
--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -1,6 +1,6 @@
 # @astrojs/partytown 🎉
 
-This **[Astro integration][astro-integration]** enables [Partytown](https://partytown.builder.io/) in your Astro project.
+This **[Astro integration][astro-integration]** enables [Partytown](https://partytown.qwik.dev/) in your Astro project.
 
 ## Documentation
 


### PR DESCRIPTION
### Changes

This PR fixes an outdated link in `README.md` of the Partytown integration.