### PR TITLE
fix(mdx): Restore MDX rehype plugin entrypoint

### DIFF
--- a/.changeset/public-ducks-wave.md
+++ b/.changeset/public-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-satteri': patch
+---
+
+Fixes missing provenance information on the publish

--- a/.changeset/restore-jsx-rehype.md
+++ b/.changeset/restore-jsx-rehype.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Restores the `astro/jsx/rehype.js` entry point so that older versions of `@astrojs/mdx` continue to work when used with Astro 6.x. This entry point will be removed in Astro 7.0.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -39,6 +39,7 @@
     "./astro-jsx": "./astro-jsx.d.ts",
     "./tsconfigs/*.json": "./tsconfigs/*",
     "./tsconfigs/*": "./tsconfigs/*.json",
+    "./jsx/rehype.js": "./dist/jsx/rehype.js",
     "./jsx-runtime": {
       "types": "./jsx-runtime.d.ts",
       "default": "./dist/jsx-runtime/index.js"
@@ -211,6 +212,8 @@
     "expect-type": "^1.3.0",
     "fs-fixture": "^2.13.0",
     "hono": "^4.12.14",
+    "mdast-util-mdx": "^3.0.0",
+    "mdast-util-mdx-jsx": "^3.2.0",
     "node-mocks-http": "^1.17.2",
     "parse-srcset": "^1.0.2",
     "rehype-autolink-headings": "^7.1.0",
@@ -240,6 +243,7 @@
       "./astro-jsx": "./astro-jsx.d.ts",
       "./tsconfigs/*.json": "./tsconfigs/*",
       "./tsconfigs/*": "./tsconfigs/*.json",
+      "./jsx/rehype.js": "./dist/jsx/rehype.js",
       "./jsx-runtime": {
         "types": "./jsx-runtime.d.ts",
         "default": "./dist/jsx-runtime/index.js"

--- a/packages/astro/src/jsx/rehype.ts
+++ b/packages/astro/src/jsx/rehype.ts
@@ -1,0 +1,377 @@
+// TODO: Remove this file in Astro 7.0. It now lives directly in the MDX integration at packages/integrations/mdx/src/rehype-analyze-astro-metadata.ts
+
+import type { RehypePlugin } from '@astrojs/internal-helpers/markdown';
+import type { RootContent } from 'hast';
+import type {} from 'mdast-util-mdx';
+import type {
+	MdxJsxAttribute,
+	MdxJsxFlowElementHast,
+	MdxJsxTextElementHast,
+} from 'mdast-util-mdx-jsx';
+import { visit } from 'unist-util-visit';
+import type { VFile } from 'vfile';
+import { AstroError } from '../core/errors/errors.js';
+import { AstroErrorData } from '../core/errors/index.js';
+import { resolvePath } from '../core/viteUtils.js';
+import { createDefaultAstroMetadata } from '../vite-plugin-astro/metadata.js';
+import type { PluginMetadata } from '../vite-plugin-astro/types.js';
+
+const ClientOnlyPlaceholder = 'astro-client-only';
+
+export const rehypeAnalyzeAstroMetadata: RehypePlugin = () => {
+	return (tree, file) => {
+		// Initial metadata for this MDX file, it will be mutated as we traverse the tree
+		const metadata = createDefaultAstroMetadata();
+
+		// Parse imports in this file. This is used to match components with their import source
+		const imports = parseImports(tree.children);
+
+		visit(tree, (node) => {
+			if (node.type !== 'mdxJsxFlowElement' && node.type !== 'mdxJsxTextElement') return;
+
+			const tagName = node.name;
+			if (
+				!tagName ||
+				!isComponent(tagName) ||
+				!(hasClientDirective(node) || hasServerDeferDirective(node))
+			)
+				return;
+
+			// From this point onwards, `node` is confirmed to be an island component
+
+			// Match this component with its import source
+			const matchedImport = findMatchingImport(tagName, imports);
+			if (!matchedImport) {
+				throw new AstroError({
+					...AstroErrorData.NoMatchingImport,
+					message: AstroErrorData.NoMatchingImport.message(node.name!),
+				});
+			}
+
+			// If this is an Astro component, that means the `client:` directive is misused as it doesn't
+			// work on Astro components as it's server-side only. Warn the user about this.
+			if (matchedImport.path.endsWith('.astro')) {
+				const clientAttribute = node.attributes.find(
+					(attr) => attr.type === 'mdxJsxAttribute' && attr.name.startsWith('client:'),
+				) as MdxJsxAttribute | undefined;
+				if (clientAttribute) {
+					console.warn(
+						`You are attempting to render <${node.name!} ${
+							clientAttribute.name
+						} />, but ${node.name!} is an Astro component. Astro components do not render in the client and should not have a hydration directive. Please use a framework component for client rendering.`,
+					);
+				}
+			}
+
+			const resolvedPath = resolvePath(matchedImport.path, file.path);
+
+			if (hasClientOnlyDirective(node)) {
+				// Add this component to the metadata
+				metadata.clientOnlyComponents.push({
+					exportName: matchedImport.name,
+					localName: '',
+					specifier: tagName,
+					resolvedPath,
+				});
+				// Mutate node with additional island attributes
+				addClientOnlyMetadata(node, matchedImport, resolvedPath);
+			} else if (hasClientDirective(node)) {
+				// Add this component to the metadata
+				metadata.hydratedComponents.push({
+					exportName: '*',
+					localName: '',
+					specifier: tagName,
+					resolvedPath,
+				});
+				// Mutate node with additional island attributes
+				addClientMetadata(node, matchedImport, resolvedPath);
+			} else if (hasServerDeferDirective(node)) {
+				metadata.serverComponents.push({
+					exportName: matchedImport.name,
+					localName: tagName,
+					specifier: matchedImport.path,
+					resolvedPath,
+				});
+				// Mutate node with additional island attributes
+				addServerDeferMetadata(node, matchedImport, resolvedPath);
+			}
+		});
+
+		// Attach final metadata here, which can later be retrieved by `getAstroMetadata`
+		file.data.__astroMetadata = metadata;
+	};
+};
+
+export function getAstroMetadata(file: VFile) {
+	return file.data.__astroMetadata as PluginMetadata['astro'] | undefined;
+}
+
+type ImportSpecifier = { local: string; imported: string };
+
+/**
+ * ```
+ * import Foo from './Foo.jsx'
+ * import { Bar } from './Bar.jsx'
+ * import { Baz as Wiz } from './Bar.jsx'
+ * import * as Waz from './BaWazz.jsx'
+ *
+ * // => Map {
+ * //   "./Foo.jsx" => Set { { local: "Foo", imported: "default" } },
+ * //   "./Bar.jsx" => Set {
+ * //     { local: "Bar", imported: "Bar" }
+ * //     { local: "Wiz", imported: "Baz" },
+ * //   },
+ * //   "./Waz.jsx" => Set { { local: "Waz", imported: "*" } },
+ * // }
+ * ```
+ */
+function parseImports(children: RootContent[]) {
+	// Map of import source to its imported specifiers
+	const imports = new Map<string, Set<ImportSpecifier>>();
+
+	for (const child of children) {
+		if (child.type !== 'mdxjsEsm') continue;
+
+		const body = child.data?.estree?.body;
+		if (!body) continue;
+
+		for (const ast of body) {
+			if (ast.type !== 'ImportDeclaration') continue;
+
+			const source = ast.source.value as string;
+			const specs: ImportSpecifier[] = ast.specifiers.map((spec) => {
+				switch (spec.type) {
+					case 'ImportDefaultSpecifier':
+						return { local: spec.local.name, imported: 'default' };
+					case 'ImportNamespaceSpecifier':
+						return { local: spec.local.name, imported: '*' };
+					case 'ImportSpecifier': {
+						return {
+							local: spec.local.name,
+							imported:
+								spec.imported.type === 'Identifier'
+									? spec.imported.name
+									: String(spec.imported.value),
+						};
+					}
+					default:
+						throw new Error('Unknown import declaration specifier: ' + spec);
+				}
+			});
+
+			// Get specifiers set from source or initialize a new one
+			let specSet = imports.get(source);
+			if (!specSet) {
+				specSet = new Set();
+				imports.set(source, specSet);
+			}
+
+			for (const spec of specs) {
+				specSet.add(spec);
+			}
+		}
+	}
+
+	return imports;
+}
+
+function isComponent(tagName: string) {
+	return (
+		(tagName[0] && tagName[0].toLowerCase() !== tagName[0]) ||
+		tagName.includes('.') ||
+		/[^a-zA-Z]/.test(tagName[0])
+	);
+}
+
+function hasClientDirective(node: MdxJsxFlowElementHast | MdxJsxTextElementHast) {
+	return node.attributes.some(
+		(attr) => attr.type === 'mdxJsxAttribute' && attr.name.startsWith('client:'),
+	);
+}
+
+function hasServerDeferDirective(node: MdxJsxFlowElementHast | MdxJsxTextElementHast) {
+	return node.attributes.some(
+		(attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'server:defer',
+	);
+}
+
+function hasClientOnlyDirective(node: MdxJsxFlowElementHast | MdxJsxTextElementHast) {
+	return node.attributes.some(
+		(attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'client:only',
+	);
+}
+
+type MatchedImport = { name: string; path: string };
+
+/**
+ * ```
+ * import Button from './Button.jsx'
+ * <Button />
+ * // => { name: "default", path: "./Button.jsx" }
+ *
+ * import { Button } from './Button.jsx'
+ * <Button />
+ * // => { name: "Button", path: "./Button.jsx" }
+ *
+ * import * as buttons from './Button.jsx'
+ * <buttons.Foo.Bar />
+ * // => { name: "Foo.Bar", path: "./Button.jsx" }
+ *
+ * import { buttons } from './Button.jsx'
+ * <buttons.Foo.Bar />
+ * // => { name: "buttons.Foo.Bar", path: "./Button.jsx" }
+ *
+ * import buttons from './Button.jsx'
+ * <buttons.Foo.Bar />
+ * // => { name: "default.Foo.Bar", path: "./Button.jsx" }
+ * ```
+ */
+function findMatchingImport(
+	tagName: string,
+	imports: Map<string, Set<ImportSpecifier>>,
+): MatchedImport | undefined {
+	const tagSpecifier = tagName.split('.')[0];
+	for (const [source, specs] of imports) {
+		for (const { imported, local } of specs) {
+			if (local === tagSpecifier) {
+				// If tagName access properties, we need to make sure the returned `name`
+				// properly access the properties from `path`
+				if (tagSpecifier !== tagName) {
+					switch (imported) {
+						// Namespace import: "<buttons.Foo.Bar />" => name: "Foo.Bar"
+						case '*': {
+							const accessPath = tagName.slice(tagSpecifier.length + 1);
+							return { name: accessPath, path: source };
+						}
+						// Default import: "<buttons.Foo.Bar />" => name: "default.Foo.Bar"
+						case 'default': {
+							// "buttons.Foo.Bar" => "Foo.Bar"
+							const accessPath = tagName.slice(tagSpecifier.length + 1);
+							return { name: `default.${accessPath}`, path: source };
+						}
+						// Named import: "<buttons.Foo.Bar />" => name: "buttons.Foo.Bar"
+						default: {
+							return { name: tagName, path: source };
+						}
+					}
+				}
+
+				return { name: imported, path: source };
+			}
+		}
+	}
+}
+
+function addClientMetadata(
+	node: MdxJsxFlowElementHast | MdxJsxTextElementHast,
+	meta: MatchedImport,
+	resolvedPath: string,
+) {
+	const attributeNames = node.attributes
+		.map((attr) => (attr.type === 'mdxJsxAttribute' ? attr.name : null))
+		.filter(Boolean);
+
+	if (!attributeNames.includes('client:component-path')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-path',
+			value: resolvedPath,
+		});
+	}
+	if (!attributeNames.includes('client:component-export')) {
+		if (meta.name === '*') {
+			meta.name = node.name!.split('.').slice(1).join('.')!;
+		}
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-export',
+			value: meta.name,
+		});
+	}
+	if (!attributeNames.includes('client:component-hydration')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-hydration',
+			value: null,
+		});
+	}
+}
+
+function addClientOnlyMetadata(
+	node: MdxJsxFlowElementHast | MdxJsxTextElementHast,
+	meta: { path: string; name: string },
+	resolvedPath: string,
+) {
+	const attributeNames = node.attributes
+		.map((attr) => (attr.type === 'mdxJsxAttribute' ? attr.name : null))
+		.filter(Boolean);
+
+	if (!attributeNames.includes('client:display-name')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:display-name',
+			value: node.name,
+		});
+	}
+	if (!attributeNames.includes('client:component-path')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-path',
+			value: resolvedPath,
+		});
+	}
+	if (!attributeNames.includes('client:component-export')) {
+		if (meta.name === '*') {
+			meta.name = node.name!.split('.').slice(1).join('.')!;
+		}
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-export',
+			value: meta.name,
+		});
+	}
+	if (!attributeNames.includes('client:component-hydration')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-hydration',
+			value: null,
+		});
+	}
+
+	node.name = ClientOnlyPlaceholder;
+}
+
+function addServerDeferMetadata(
+	node: MdxJsxFlowElementHast | MdxJsxTextElementHast,
+	meta: { path: string; name: string },
+	resolvedPath: string,
+) {
+	const attributeNames = node.attributes
+		.map((attr) => (attr.type === 'mdxJsxAttribute' ? attr.name : null))
+		.filter(Boolean);
+
+	if (!attributeNames.includes('server:component-directive')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'server:component-directive',
+			value: 'server:defer',
+		});
+	}
+	if (!attributeNames.includes('server:component-path')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'server:component-path',
+			value: resolvedPath,
+		});
+	}
+	if (!attributeNames.includes('server:component-export')) {
+		if (meta.name === '*') {
+			meta.name = node.name!.split('.').slice(1).join('.')!;
+		}
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'server:component-export',
+			value: meta.name,
+		});
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         version: 5.2.0(tinybench@2.9.0)(vite@7.3.2)(vitest@4.1.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2)
 
   benchmark/packages/adapter:
     dependencies:
@@ -249,7 +249,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2)
     devDependencies:
       '@types/react':
         specifier: ^18.3.28
@@ -523,7 +523,7 @@ importers:
         version: link:../../packages/astro
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2)
 
   packages/astro:
     dependencies:
@@ -747,6 +747,12 @@ importers:
       hono:
         specifier: ^4.12.14
         version: 4.12.16
+      mdast-util-mdx:
+        specifier: ^3.0.0
+        version: 3.0.0
+      mdast-util-mdx-jsx:
+        specifier: ^3.2.0
+        version: 3.2.0
       node-mocks-http:
         specifier: ^1.17.2
         version: 1.17.2(@types/express@5.0.6)(@types/node@22.19.19)
@@ -782,7 +788,7 @@ importers:
         version: 11.0.5
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2)
     optionalDependencies:
       sharp:
         specifier: ^0.34.0
@@ -4109,7 +4115,7 @@ importers:
         version: link:../../..
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2)
 
   packages/astro/test/fixtures/vue-component:
     dependencies:
@@ -16116,6 +16122,7 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -17686,7 +17693,7 @@ snapshots:
       '@codspeed/core': 5.2.0
       tinybench: 2.9.0
       vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2)
     transitivePeerDependencies:
       - debug
 
@@ -20315,7 +20322,7 @@ snapshots:
       svelte: 5.55.3
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2)
 
   '@textlint/ast-node-types@15.5.1': {}
 
@@ -27148,7 +27155,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.2)
@@ -27174,17 +27181,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.19
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:


### PR DESCRIPTION
## Changes

In https://github.com/withastro/astro/commit/f732f3cc716342a63e5b03815243ba10964b89dc I moved this rehype plugin from Astro to the MDX integration, but previous versions of MDX have no reasons to not work, I think, so restore it until Astro 7

## Testing

N/A

## Docs

N/A