### PR TITLE
Fix i18n redirectToDefaultLocale not working with prefixDefaultLocale

### DIFF
--- a/.changeset/fix-i18n-redirect-header.md
+++ b/.changeset/fix-i18n-redirect-header.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes `redirectToDefaultLocale` not working after the Advanced Routing refactoring. The internal `ROUTE_TYPE_HEADER` was being deleted by middleware finalization before the i18n handler could read it, preventing locale redirects and other i18n post-processing from being applied.
+Fixes `redirectToDefaultLocale` not working after the Advanced Routing refactoring.

--- a/.changeset/fix-i18n-redirect-header.md
+++ b/.changeset/fix-i18n-redirect-header.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `redirectToDefaultLocale` not working after the Advanced Routing refactoring. The internal `ROUTE_TYPE_HEADER` was being deleted by middleware finalization before the i18n handler could read it, preventing locale redirects and other i18n post-processing from being applied.

--- a/packages/astro/src/core/i18n/handler.ts
+++ b/packages/astro/src/core/i18n/handler.ts
@@ -61,7 +61,9 @@ export class I18n {
 		const i18n = this.#i18n;
 		const typeHeader = response.headers.get(ROUTE_TYPE_HEADER);
 		// We don't need this header anymore, and we shouldn't pass downstream to users.
-		response.headers.delete(ROUTE_TYPE_HEADER);
+		if (typeHeader) {
+			response.headers.delete(ROUTE_TYPE_HEADER);
+		}
 
 		// This is a case where we are internally rendering a 404/500, so we
 		// need to bypass checks that were done already.

--- a/packages/astro/src/core/i18n/handler.ts
+++ b/packages/astro/src/core/i18n/handler.ts
@@ -60,6 +60,8 @@ export class I18n {
 		state.pipeline.usedFeatures |= PipelineFeatures.i18n;
 		const i18n = this.#i18n;
 		const typeHeader = response.headers.get(ROUTE_TYPE_HEADER);
+		// We don't need this header anymore, and we shouldn't pass downstream to users.
+		response.headers.delete(ROUTE_TYPE_HEADER);
 
 		// This is a case where we are internally rendering a 404/500, so we
 		// need to bypass checks that were done already.

--- a/packages/astro/src/core/middleware/astro-middleware.ts
+++ b/packages/astro/src/core/middleware/astro-middleware.ts
@@ -2,7 +2,6 @@ import type { FetchState } from '../fetch/fetch-state.js';
 import type { RewritePayload } from '../../types/public/common.js';
 import type { APIContext } from '../../types/public/context.js';
 import { type Pipeline, PipelineFeatures } from '../base-pipeline.js';
-import { ROUTE_TYPE_HEADER } from '../constants.js';
 import { attachCookiesToResponse } from '../cookies/index.js';
 import { applyRewriteToState } from '../rewrites/handler.js';
 import { callMiddleware } from './callMiddleware.js';
@@ -77,9 +76,6 @@ export class AstroMiddleware {
 	}
 
 	#finalize(state: FetchState, response: Response): Response {
-		if (response.headers.get(ROUTE_TYPE_HEADER)) {
-			response.headers.delete(ROUTE_TYPE_HEADER);
-		}
 		// LEGACY: we put cookies on the response object,
 		// where the adapter might be expecting to read it.
 		// New code should be using `app.render({ addCookieHeader: true })` instead.

--- a/packages/astro/test/units/i18n/i18n-app.test.ts
+++ b/packages/astro/test/units/i18n/i18n-app.test.ts
@@ -537,3 +537,40 @@ describe('i18n via App - domain with localhost and ports (#12385)', () => {
 		assert.equal($('#locale').text(), 'en');
 	});
 });
+
+describe('i18n via AstroHandler (no middleware) - prefix-always (#16800)', () => {
+	// This tests the handler-based i18n flow where I18n.finalize() runs
+	// as a post-processing step after AstroMiddleware, NOT as an internal
+	// middleware. This is the default code path for non-manual routing.
+	const i18n = makeI18nConfig({ strategy: 'pathname-prefix-always' });
+
+	function createHandlerApp() {
+		// Do NOT pass middleware — this forces i18n to be handled by
+		// AstroHandler's post-processing step (I18n.finalize), not by
+		// a middleware in the chain.
+		return createTestApp([localeCatchAll('en'), localeCatchAll('fr')], {
+			i18n,
+		});
+	}
+
+	it('redirects root / to /en/ via handler post-processing', async () => {
+		const app = createHandlerApp();
+		const res = await app.render(new Request('http://example.com/'));
+		assert.equal(res.status, 302);
+		assert.ok(res.headers.get('Location')?.includes('/en'));
+	});
+
+	it('renders locale-prefixed pages normally', async () => {
+		const app = createHandlerApp();
+		const res = await app.render(new Request('http://example.com/en/about'));
+		assert.equal(res.status, 200);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('#locale').text(), 'en');
+	});
+
+	it('returns 404 for paths without locale prefix', async () => {
+		const app = createHandlerApp();
+		const res = await app.render(new Request('http://example.com/about'));
+		assert.equal(res.status, 404);
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes `redirectToDefaultLocale` not working when `prefixDefaultLocale: true` by removing redundant `ROUTE_TYPE_HEADER` deletion from `AstroMiddleware.#finalize()`
- The header deletion was preventing `I18n.finalize()` from reading the route type needed to apply redirects
- Header is already properly stripped later in the pipeline by `prepareResponse()`, making the middleware deletion both redundant and harmful

## Testing

- Added 3 regression tests in `packages/astro/test/units/i18n/i18n-app.test.ts` that verify i18n redirects work through the `AstroHandler` code path
- All existing i18n, middleware, fetch, and routing unit tests continue to pass

## Docs

- No docs update needed, fixes documented functionality that regressed

Closes #16800