### PR TITLE
fix(config): Keep legacy plugins data on the config

### DIFF
--- a/.changeset/fix-legacy-markdown-plugins-iterable.md
+++ b/.changeset/fix-legacy-markdown-plugins-iterable.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a `plugins is not iterable` crash when using a pre-6.0 `@astrojs/mdx` alongside integrations (e.g. Starlight) that set `markdown.remarkPlugins`, `markdown.rehypePlugins`, or `markdown.remarkRehype`.

--- a/packages/astro/src/core/config/validate.ts
+++ b/packages/astro/src/core/config/validate.ts
@@ -51,11 +51,11 @@ function warnDeprecatedMarkdownOptions(
 let didWarnAboutLegacyMarkdownPlugins = false;
 let didWarnAboutProcessorMismatch = false;
 
+const migratedLegacyPluginCounts = new WeakMap<object, { remark: number; rehype: number }>();
 /**
  * Folds legacy `markdown.{remark,rehype}Plugins` / `remarkRehype` into the unified
- * processor and clears the legacy keys. Mutates `config` in place.
- * Runs on every validate pass so integration-added legacy plugins are picked up.
- * Without this they'd land in `config.markdown.*` and be silently dropped.
+ * processor (mutates `config`). Runs on every validate pass to catch integration-added
+ * legacy plugins.
  */
 async function coerceLegacyMarkdownPlugins(
 	config: Pick<AstroUserConfig, 'markdown'>,
@@ -80,23 +80,29 @@ async function coerceLegacyMarkdownPlugins(
 	if (!current || isUnifiedProcessor(current)) {
 		// `createRenderer` reads `.options.*` at render time, so in-place mutation propagates.
 		const target = (current ?? (md.processor = unified())) as ReturnType<typeof unified>;
-		target.options.remarkPlugins.push(...remarkPlugins);
-		target.options.rehypePlugins.push(...rehypePlugins);
+		const counts = migratedLegacyPluginCounts.get(target.options) ?? { remark: 0, rehype: 0 };
+		// Only push entries past what we've already folded; mergeConfig appends, so they sit at the tail.
+		if (remarkPlugins.length > counts.remark) {
+			target.options.remarkPlugins.push(...remarkPlugins.slice(counts.remark));
+		}
+		if (rehypePlugins.length > counts.rehype) {
+			target.options.rehypePlugins.push(...rehypePlugins.slice(counts.rehype));
+		}
+		// `remarkRehype` is an object, so Object.assign is idempotent for unchanged keys
+		// and absorbs any new keys integrations add.
 		Object.assign(target.options.remarkRehype, remarkRehype);
+		migratedLegacyPluginCounts.set(target.options, {
+			remark: remarkPlugins.length,
+			rehype: rehypePlugins.length,
+		});
 		if (!didWarnAboutLegacyMarkdownPlugins) {
 			didWarnAboutLegacyMarkdownPlugins = true;
 			console.warn(
 				'[astro] `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` are deprecated. Pass them to `unified({...})` from `@astrojs/markdown-remark` directly instead.',
 			);
 		}
-		delete md.remarkPlugins;
-		delete md.rehypePlugins;
-		delete md.remarkRehype;
 	} else if (!didWarnAboutProcessorMismatch) {
-		// Third-party processors can't run remark/rehype plugins. We *don't* swap the
-		// user's chosen processor — that would silently flip their Markdown engine.
-		// Instead, leave the legacy keys in place (so other tooling can still see them)
-		// and warn loudly: the plugins won't run until they move to `unified()`.
+		// Third-party processors can't run remark/rehype plugins. And if they can, they should be passed directly to the processor (like it is for unified) instead of the legacy keys, so we warn either way.
 		didWarnAboutProcessorMismatch = true;
 		console.warn(
 			`[astro] \`markdown.remarkPlugins\`/\`rehypePlugins\`/\`remarkRehype\` are set, but your ` +

--- a/packages/astro/test/units/config/config-validate.test.ts
+++ b/packages/astro/test/units/config/config-validate.test.ts
@@ -4,7 +4,10 @@ import { stripVTControlCharacters } from 'node:util';
 import * as z from 'zod/v4';
 import { fontProviders } from '../../../dist/assets/fonts/providers/index.js';
 import { LocalFontProvider } from '../../../dist/assets/fonts/providers/local.js';
-import { validateConfig as _validateConfig } from '../../../dist/core/config/validate.js';
+import {
+	validateConfig as _validateConfig,
+	validateConfigRefined,
+} from '../../../dist/core/config/validate.js';
 import { formatConfigErrorMessage } from '../../../dist/core/messages/runtime.js';
 import { envField } from '../../../dist/env/config.js';
 
@@ -617,6 +620,48 @@ describe('Config Validation', () => {
 				formattedError,
 				`[config] Astro found issue(s) with your configuration:\n\n! security.csp: Did not match union.\n  > Expected type boolean | Directives script-src and style-src are not allowed in security.csp.directives. Please use security.csp.scriptDirective and security.csp.styleDirective instead.\n  > Received { "directives": [ "script-src 'self'" ] }`,
 			);
+		});
+	});
+
+	describe('markdown legacy plugins', () => {
+		it('preserves legacy markdown.rehypePlugins on the validated config (pre-6.0 mdx compat)', async () => {
+			const plugin = () => (tree) => tree;
+			const result = await validateConfig({
+				markdown: { rehypePlugins: [plugin] },
+			});
+			// Pre-6.0 `@astrojs/mdx` reads `config.markdown.rehypePlugins` directly to feed
+			// its own MDX-side processor, so the legacy key must survive validation.
+			assert.deepEqual(result.markdown.rehypePlugins, [plugin]);
+			const options = result.markdown.processor.options;
+			assert.deepEqual(options.rehypePlugins, [plugin]);
+		});
+
+		it('does not duplicate legacy plugins across repeated validateConfigRefined passes', async () => {
+			const remark = () => (tree) => tree;
+			const rehype = () => (tree) => tree;
+			const validated = await validateConfig({
+				markdown: { remarkPlugins: [remark], rehypePlugins: [rehype] },
+			});
+			// The second pass runs after `astro:config:setup`; without the WeakMap guard
+			// it would re-fold the same plugins and double them up.
+			const again = await validateConfigRefined(validated);
+			const options = again.markdown.processor.options;
+			assert.deepEqual(options.remarkPlugins, [remark]);
+			assert.deepEqual(options.rehypePlugins, [rehype]);
+		});
+
+		it('folds integration-appended legacy plugins without re-folding the originals', async () => {
+			const userPlugin = () => (tree) => tree;
+			const integrationPlugin = () => (tree) => tree;
+			const validated = await validateConfig({
+				markdown: { rehypePlugins: [userPlugin] },
+			});
+			// Simulate `mergeConfig` appending an integration-added plugin to the legacy key
+			// (Starlight-style `updateConfig({ markdown: { rehypePlugins: [...] } })`).
+			validated.markdown.rehypePlugins.push(integrationPlugin);
+			const refined = await validateConfigRefined(validated);
+			const options = refined.markdown.processor.options;
+			assert.deepEqual(options.rehypePlugins, [userPlugin, integrationPlugin]);
 		});
 	});
 

--- a/packages/astro/test/units/config/config-validate.test.ts
+++ b/packages/astro/test/units/config/config-validate.test.ts
@@ -1,6 +1,11 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { stripVTControlCharacters } from 'node:util';
+import {
+	isUnifiedProcessor,
+	type RehypePlugin,
+	type RemarkPlugin,
+} from '@astrojs/markdown-remark';
 import * as z from 'zod/v4';
 import { fontProviders } from '../../../dist/assets/fonts/providers/index.js';
 import { LocalFontProvider } from '../../../dist/assets/fonts/providers/local.js';
@@ -625,34 +630,36 @@ describe('Config Validation', () => {
 
 	describe('markdown legacy plugins', () => {
 		it('preserves legacy markdown.rehypePlugins on the validated config (pre-6.0 mdx compat)', async () => {
-			const plugin = () => (tree) => tree;
+			const plugin: RehypePlugin = () => (tree) => tree;
 			const result = await validateConfig({
 				markdown: { rehypePlugins: [plugin] },
 			});
 			// Pre-6.0 `@astrojs/mdx` reads `config.markdown.rehypePlugins` directly to feed
 			// its own MDX-side processor, so the legacy key must survive validation.
 			assert.deepEqual(result.markdown.rehypePlugins, [plugin]);
-			const options = result.markdown.processor.options;
-			assert.deepEqual(options.rehypePlugins, [plugin]);
+			const { processor } = result.markdown;
+			assert.ok(isUnifiedProcessor(processor));
+			assert.deepEqual(processor.options.rehypePlugins, [plugin]);
 		});
 
 		it('does not duplicate legacy plugins across repeated validateConfigRefined passes', async () => {
-			const remark = () => (tree) => tree;
-			const rehype = () => (tree) => tree;
+			const remark: RemarkPlugin = () => (tree) => tree;
+			const rehype: RehypePlugin = () => (tree) => tree;
 			const validated = await validateConfig({
 				markdown: { remarkPlugins: [remark], rehypePlugins: [rehype] },
 			});
 			// The second pass runs after `astro:config:setup`; without the WeakMap guard
 			// it would re-fold the same plugins and double them up.
 			const again = await validateConfigRefined(validated);
-			const options = again.markdown.processor.options;
-			assert.deepEqual(options.remarkPlugins, [remark]);
-			assert.deepEqual(options.rehypePlugins, [rehype]);
+			const { processor } = again.markdown;
+			assert.ok(isUnifiedProcessor(processor));
+			assert.deepEqual(processor.options.remarkPlugins, [remark]);
+			assert.deepEqual(processor.options.rehypePlugins, [rehype]);
 		});
 
 		it('folds integration-appended legacy plugins without re-folding the originals', async () => {
-			const userPlugin = () => (tree) => tree;
-			const integrationPlugin = () => (tree) => tree;
+			const userPlugin: RehypePlugin = () => (tree) => tree;
+			const integrationPlugin: RehypePlugin = () => (tree) => tree;
 			const validated = await validateConfig({
 				markdown: { rehypePlugins: [userPlugin] },
 			});
@@ -660,8 +667,9 @@ describe('Config Validation', () => {
 			// (Starlight-style `updateConfig({ markdown: { rehypePlugins: [...] } })`).
 			validated.markdown.rehypePlugins.push(integrationPlugin);
 			const refined = await validateConfigRefined(validated);
-			const options = refined.markdown.processor.options;
-			assert.deepEqual(options.rehypePlugins, [userPlugin, integrationPlugin]);
+			const { processor } = refined.markdown;
+			assert.ok(isUnifiedProcessor(processor));
+			assert.deepEqual(processor.options.rehypePlugins, [userPlugin, integrationPlugin]);
 		});
 	});
 


### PR DESCRIPTION
## Changes

Integrations that are not updated yet for 6.4.0 still read the plugins from the legacy keys, so we need to keep them on the config. At worse, the plugins get dropped, at very bad, the integration doesn't expect the config to not be there anymore and crashes.

Caution, the fix is imo super goofy, but I couldn't find a better way that didn't break some other usages, hopefully anyway this code path gets hits less and less as we go forward

## Testing

Added unit tests for the config folding

## Docs

N/A