### PR TITLE
Preserve slot attributes on children of custom elements in MDX

### DIFF
--- a/.changeset/fix-custom-element-slot-attribute.md
+++ b/.changeset/fix-custom-element-slot-attribute.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes custom elements in MDX having their children's `slot` attribute stripped by the JSX runtime
+
+When custom elements (tags with hyphens like `<my-element>`) are used in MDX files, the `slot` HTML attribute on their children is now correctly preserved. Previously, the shared JSX runtime would treat `slot` as an Astro slot assignment and remove it from the output, breaking Shadow DOM named slot distribution for web components.

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -123,6 +123,11 @@ Did you forget to import the component or is it possible there is a typo?`);
 			const _slots: Record<string, any> = {
 				default: [],
 			};
+			// For custom HTML elements (string type with hyphen), the `slot` attribute on children
+			// is a standard HTML attribute for web component Shadow DOM slot distribution, not an
+			// Astro slot assignment. Skip slot extraction to preserve it in the output.
+			const isCustomElement =
+				typeof vnode.type === 'string' && (vnode.type as string).includes('-');
 			function extractSlots(child: any): any {
 				if (Array.isArray(child)) {
 					return child.map((c) => extractSlots(c));
@@ -131,7 +136,7 @@ Did you forget to import the component or is it possible there is a typo?`);
 					_slots.default.push(child);
 					return;
 				}
-				if ('slot' in child.props) {
+				if ('slot' in child.props && !isCustomElement) {
 					_slots[child.props.slot] = [...(_slots[child.props.slot] ?? []), child];
 					delete child.props.slot;
 					return;

--- a/packages/astro/test/units/render/jsx-custom-elements.test.ts
+++ b/packages/astro/test/units/render/jsx-custom-elements.test.ts
@@ -102,6 +102,18 @@ describe('renderJSX custom elements', () => {
 		assert.ok(output.includes('</unknown-element>'), 'should have closing tag');
 	});
 
+	it('preserves slot attribute on children of custom elements', async () => {
+		const result = createMockResult();
+		const childVNode = createVNode('svg', { slot: 'icon', xmlns: 'http://www.w3.org/2000/svg' });
+		const vnode = createVNode('my-element', { children: [childVNode, 'text content'] });
+		const output = String(await renderJSX(result, vnode));
+
+		assert.ok(output.includes('slot="icon"'), 'should preserve slot attribute on child element');
+		assert.ok(output.includes('<svg'), 'should render the child svg element');
+		assert.ok(output.includes('<my-element'), 'should render the custom element');
+		assert.ok(output.includes('text content'), 'should render text children');
+	});
+
 	it('does not route standard elements through the renderer pipeline', async () => {
 		let rendererCheckCalled = false;
 


### PR DESCRIPTION
## Changes

- Fixes custom elements losing their `slot` HTML attributes when rendered through MDX, restoring proper Shadow DOM slot distribution
- Adds a guard in `extractSlots()` to skip slot extraction when the parent is a custom HTML element (contains hyphen)
- Custom elements still route through the renderer pipeline for SSR while preserving standard HTML slot attributes

## Testing

- Added `'preserves slot attribute on children of custom elements'` test case to `packages/astro/test/units/render/jsx-custom-elements.test.ts`
- Verified all existing custom element tests pass (renderer routing, fallback behavior)
- Confirmed MDX slots and children tests remain unaffected

## Docs

- No docs update needed, as this fixes broken behavior to match documented web component standards.

Closes #16891