### PR TITLE
chore(deps): update pnpm to v11.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "packageManager": "pnpm@11.0.9",
+  "packageManager": "pnpm@11.5.0",
   "dependencies": {
     "astro-benchmark": "workspace:*"
   },

--- a/packages/integrations/cloudflare/test/fixtures/user-optimize-deps/packages/fake-data-pkg/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/user-optimize-deps/packages/fake-data-pkg/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "fake-data-pkg",
+	"private": true,
 	"version": "1.0.0",
 	"type": "module",
 	"main": "./index.js"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,8 @@ publicHoistPattern:
 # Wait until three days after release to install new versions of packages
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
+  # 'fake-data-pkg' is a local package used for testing
+  - 'fake-data-pkg@1.0.0'
   # TODO: remove once more stable
   - '@flue/*'
   - '@astrojs/*'
@@ -71,6 +73,8 @@ trustPolicyExclude:
   # Old dependency of @types/node@22
   # TODO: Remove when dropping support for Node 22
   - undici-types@6.21.0
+  # 'fake-data-pkg' is a local package used for testing
+  - 'fake-data-pkg@1.0.0'
   # Dependencies in the docs repo that gets cloned for smoke tests
   - 'undici@5.29.0'
   - 'algoliasearch@4.27.0'


### PR DESCRIPTION
## Changes

Update pnpm from v11.0.9 to the latest version v11.5.0. 

There are two reasons that I want to update our pnpm:

1. Since pnpm [v11.1.3](https://github.com/pnpm/pnpm/releases/tag/v11.1.3), pnpm has a stricter verification against supply chain attacks. Now it will re-check all deps against `trustPolicy` and `minimumReleaseAge` when running `pnpm install`, if `pnpm-lock.yaml` has changed.

    ```
    $ pnpm i
    Scope: all 523 workspace projects
    ✓ Lockfile passes supply-chain policies (2227 entries in 32.6s)
    ```

2. It seems that pnpm v11 consumes more memory compared to pnpm v10, and this causes the Renovate bot to run OOM. As shown in the screenshot below: 
    
    <img width="2892" height="1782" alt="CleanShot 2026-05-30 at 13 03 49@2x" src="https://github.com/user-attachments/assets/6b36e106-8303-4d1e-b7b6-901f4ca21c53" />

 
    You can check [this link](https://github.com/renovatebot/renovate/discussions/43072) to see more discussion about the Renovate OOM issue after pnpm v11.
    
    pnpm [v11.3.0](https://github.com/pnpm/pnpm/releases/tag/v11.3.0) improved the memory footprint, and I want to see if this can bring back the Renovate bot for Astro.



## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
