### PR TITLE
chore: eliminate duplicate pnpm configurations

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,14 +51,6 @@ peerDependencyRules:
   allowAny:
     - 'astro'
     - 'vite'
-onlyBuiltDependencies:
-  - 'esbuild'
-  - 'workerd'
-  - '@biomejs/biome'
-  - 'sharp'
-  - '@parcel/watcher'
-  - 'keytar'
-  - '@vscode/vsce-sign'
 
 patchedDependencies:
   '@changesets/get-github-info@0.7.0': patches/@changesets__get-github-info@0.7.0.patch


### PR DESCRIPTION
## Changes

https://pnpm.io/settings#allowbuilds

`allowBuilds` includes the configuration for `onlyBuiltDependencies`, so the configuration related to `onlyBuiltDependencies` can be removed.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
