### PR TITLE
fix: hmr refetch content api issue

### DIFF
--- a/.changeset/full-ties-add.md
+++ b/.changeset/full-ties-add.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an issue where the API fetch in the frontmatter was not triggered when modifying external CMS content while the development server was running.

--- a/packages/astro/src/vite-plugin-app/app.ts
+++ b/packages/astro/src/vite-plugin-app/app.ts
@@ -182,6 +182,11 @@ export class AstroServerApp extends BaseApp<RunnablePipeline> {
 
 		const self = this;
 		await self.#loadFetchHandler();
+		// Clear the route cache on every dev request so that getStaticPaths()
+		// re-runs when external data (e.g. a headless CMS) changes between requests.
+		// This mirrors the per-request behavior that existed before v6.3.0.
+		//self.clearRouteCache();
+		self.pipeline.clearRouteCache();
 
 		let handled = true;
 		await runWithErrorHandling({

--- a/packages/astro/src/vite-plugin-app/app.ts
+++ b/packages/astro/src/vite-plugin-app/app.ts
@@ -184,8 +184,6 @@ export class AstroServerApp extends BaseApp<RunnablePipeline> {
 		await self.#loadFetchHandler();
 		// Clear the route cache on every dev request so that getStaticPaths()
 		// re-runs when external data (e.g. a headless CMS) changes between requests.
-		// This mirrors the per-request behavior that existed before v6.3.0.
-		//self.clearRouteCache();
 		self.pipeline.clearRouteCache();
 
 		let handled = true;

--- a/packages/astro/test/dev-route-cache.test.ts
+++ b/packages/astro/test/dev-route-cache.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+
+// getStaticPaths() results were cached indefinitely during `astro dev`,
+// so external data changes (e.g. headless CMS) were never reflected without restarting the dev server.
+describe('dev: route cache is cleared between requests', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/hmr-route-cache/' });
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer?.stop();
+	});
+
+	it('re-runs getStaticPaths() on each request', async () => {
+		const res1 = await fixture.fetch('/test');
+		assert.equal(res1.status, 200);
+		const time1 = Number.parseInt(
+			cheerio
+				.load(await res1.text())('#time')
+				.text(),
+		);
+		await new Promise((r) => setTimeout(r, 10));
+		const res2 = await fixture.fetch('/test');
+		assert.equal(res2.status, 200);
+		const time2 = Number.parseInt(
+			cheerio
+				.load(await res2.text())('#time')
+				.text(),
+		);
+
+		assert.notEqual(time1, time2);
+	});
+});

--- a/packages/astro/test/fixtures/hmr-route-cache/package.json
+++ b/packages/astro/test/fixtures/hmr-route-cache/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@test/hmr-route-cache",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"astro": "workspace:*"
+	}
+}

--- a/packages/astro/test/fixtures/hmr-route-cache/src/pages/[id].astro
+++ b/packages/astro/test/fixtures/hmr-route-cache/src/pages/[id].astro
@@ -1,0 +1,7 @@
+---
+export async function getStaticPaths() {
+	return [{ params: { id: 'test' }, props: { callTime: Date.now() } }];
+}
+const { callTime } = Astro.props;
+---
+<p id="time">{callTime}</p>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3190,12 +3190,6 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
-  packages/astro/test/fixtures/hmr-content-api:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../..
-
   packages/astro/test/fixtures/hmr-markdown:
     dependencies:
       astro:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3190,6 +3190,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/hmr-content-api:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/hmr-markdown:
     dependencies:
       astro:
@@ -3197,6 +3203,12 @@ importers:
         version: link:../../..
 
   packages/astro/test/fixtures/hmr-new-page:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/astro/test/fixtures/hmr-route-cache:
     dependencies:
       astro:
         specifier: workspace:*


### PR DESCRIPTION
## Changes
Close #16744

During running astro dev server, `getStaticPaths()` results were cached indefinitely, so updates to the content collections API (or any external data source) were never reflected without restarting the dev server. This fix clears the route cache on every request in dev mode, ensuring `getStaticPaths()` always re-runs with the latest data.

## Testing

### Before implementation
<img width="924" height="500" alt="スクリーンショット 2026-05-29 20 29 26" src="https://github.com/user-attachments/assets/ea805e7b-ddb1-4437-9c00-fde3a1a77787" />

### After implementation
<img width="753" height="208" alt="スクリーンショット 2026-05-29 20 31 06" src="https://github.com/user-attachments/assets/1428bd81-cd30-43a0-8552-bb48dfd8f4ba" />


## Docs
