### PR TITLE
fix: remove dead else branch in csp insertDirective

### DIFF
--- a/.changeset/fix-csp-insert-directive.md
+++ b/.changeset/fix-csp-insert-directive.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Simplifies `context.csp.insertDirective` to remove an unreachable `else` branch that would have thrown a `TypeError` if its precondition ever held. The implementation now matches the pattern used by the sibling `insertScriptResource` / `insertStyleResource` methods.

--- a/.changeset/fix-csp-insert-directive.md
+++ b/.changeset/fix-csp-insert-directive.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Simplifies `context.csp.insertDirective` to remove an unreachable `else` branch that would have thrown a `TypeError` if its precondition ever held. The implementation now matches the pattern used by the sibling `insertScriptResource` / `insertStyleResource` methods.

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -579,10 +579,8 @@ export class FetchState implements AstroFetchState {
 		}
 		return {
 			insertDirective(payload) {
-				if (state?.result?.directives) {
+				if (state.result) {
 					state.result.directives = pushDirective(state.result.directives, payload);
-				} else {
-					state?.result?.directives.push(payload);
 				}
 			},
 			insertScriptResource(resource) {


### PR DESCRIPTION
### Description

Simplifies the `insertDirective` method returned by `context.csp` (in `packages/astro/src/core/fetch/fetch-state.ts`).

The previous implementation had a misleading `else` branch:

```ts
insertDirective(payload) {
  if (state?.result?.directives) {
    state.result.directives = pushDirective(state.result.directives, payload);
  } else {
    state?.result?.directives.push(payload);
  }
},
```

Two problems:

1. **Dead code.** `state.result.directives` is always initialized to an array (see `fetch-state.ts:407` — `directives: manifest.csp?.directives ? [...manifest.csp.directives] : []`). Because empty arrays are truthy in JS, the `if` branch fires whenever `state.result` exists. The `else` is unreachable in practice.
2. **The `else` would crash if reached.** Calling `.push` on the value that the `if`-condition just established is nullish would throw a `TypeError`. The optional-chaining `?.` doesn't help — it only short-circuits up through `state?.result?`, not the final `.push` call.

This PR replaces both branches with the same single-statement pattern used by the sibling `insertScriptResource` / `insertStyleResource` methods directly below it.

### Testing

Pure refactor of unreachable code; behavior under all currently-reachable inputs (i.e. whenever `state.result` exists, which is the only state the existing if-branch matches) is unchanged.

### Docs

Not user-visible; no docs changes needed.

### Changeset

Included.