### PR TITLE
Fix Node.js adapter static file serving with build format 'file' and 'preserve'

### DIFF
--- a/.changeset/fix-node-build-format-file.md
+++ b/.changeset/fix-node-build-format-file.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes prerendered pages returning 404 when using `build.format: 'file'` or `build.format: 'preserve'` with the Node adapter in standalone mode.
+
+Previously, clean URLs like `/about` would fail to resolve to `about.html` on disk, because the static file handler only supported the default `directory` format (`about/index.html`). Now the handler correctly resolves clean URLs to `.html` files when the build format produces them.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -123,6 +123,14 @@ export function createStaticHandler(
 			const stream = send(req, normalizedPathname, {
 				root: client,
 				dotfiles: normalizedPathname.startsWith('/.well-known/') ? 'allow' : 'deny',
+				// When build.format is 'file' or 'preserve', pages are output as
+				// `page.html` instead of `page/index.html`. Tell `send` to try
+				// appending `.html` so that clean URLs like `/about` resolve to
+				// `/about.html` on disk.
+				extensions:
+					app.manifest.buildFormat === 'file' || app.manifest.buildFormat === 'preserve'
+						? ['html']
+						: [],
 			});
 
 			let forwardError = false;

--- a/packages/integrations/node/test/build-format-file.test.ts
+++ b/packages/integrations/node/test/build-format-file.test.ts
@@ -1,0 +1,109 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import nodejs from '../dist/index.js';
+import {
+	type Fixture,
+	loadFixture,
+	waitServerListen,
+	type AdapterServer,
+} from './test-utils.ts';
+
+describe('build.format: file', () => {
+	let fixture: Fixture;
+	let server: AdapterServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/prerender/',
+			output: 'server',
+			outDir: './dist/build-format-file',
+			build: { format: 'file' },
+			adapter: nodejs({ mode: 'standalone' }),
+		});
+		await fixture.build();
+		const { startServer } = await fixture.loadAdapterEntryModule();
+		const res = startServer();
+		server = res.server;
+		await waitServerListen(server.server);
+	});
+
+	after(async () => {
+		await server.stop();
+		await fixture.clean();
+	});
+
+	it('Can render SSR route', async () => {
+		const res = await fetch(`http://${server.host}:${server.port}/one`);
+		const html = await res.text();
+		const $ = cheerio.load(html);
+
+		assert.equal(res.status, 200);
+		assert.equal($('h1').text(), 'One');
+	});
+
+	it('Can render prerendered route with clean URL', async () => {
+		const res = await fetch(`http://${server.host}:${server.port}/two`);
+		const html = await res.text();
+		const $ = cheerio.load(html);
+
+		assert.equal(res.status, 200);
+		assert.equal($('h1').text(), 'Two');
+	});
+
+	it('Can render prerendered route with explicit .html extension', async () => {
+		const res = await fetch(`http://${server.host}:${server.port}/two.html`);
+		const html = await res.text();
+		const $ = cheerio.load(html);
+
+		assert.equal(res.status, 200);
+		assert.equal($('h1').text(), 'Two');
+	});
+
+	it('Outputs pages as .html files, not directories', async () => {
+		assert.ok(fixture.pathExists('/client/two.html'));
+	});
+});
+
+describe('build.format: preserve', () => {
+	let fixture: Fixture;
+	let server: AdapterServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/prerender/',
+			output: 'server',
+			outDir: './dist/build-format-preserve',
+			build: { format: 'preserve' },
+			adapter: nodejs({ mode: 'standalone' }),
+		});
+		await fixture.build();
+		const { startServer } = await fixture.loadAdapterEntryModule();
+		const res = startServer();
+		server = res.server;
+		await waitServerListen(server.server);
+	});
+
+	after(async () => {
+		await server.stop();
+		await fixture.clean();
+	});
+
+	it('Can render SSR route', async () => {
+		const res = await fetch(`http://${server.host}:${server.port}/one`);
+		const html = await res.text();
+		const $ = cheerio.load(html);
+
+		assert.equal(res.status, 200);
+		assert.equal($('h1').text(), 'One');
+	});
+
+	it('Can render prerendered route with clean URL', async () => {
+		const res = await fetch(`http://${server.host}:${server.port}/two`);
+		const html = await res.text();
+		const $ = cheerio.load(html);
+
+		assert.equal(res.status, 200);
+		assert.equal($('h1').text(), 'Two');
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes clean URLs (e.g., `/about`) not resolving to static HTML files when using `build.format: 'file'` or `'preserve'` with the Node.js adapter
- Adds `extensions: ['html']` option to the `send()` call in `serve-static.ts` when `buildFormat` is `'file'` or `'preserve'`, enabling the `send` library to automatically append `.html` when resolving extensionless paths
- Resolves issue where only the index page worked while all other prerendered pages returned 404 despite the `.html` files existing on disk

## Testing

- Added `packages/integrations/node/test/build-format-file.test.ts` with 6 test cases covering both `'file'` and `'preserve'` formats
- Tests verify clean URL resolution, explicit `.html` extension handling, and correct file output structure
- Verified existing tests continue to pass with no regressions

## Docs

- No docs update needed — this fixes existing documented behavior that was broken

Closes #16570