### PR TITLE
Fix unnecessary backend reloads when editing client-side components

### DIFF
--- a/.changeset/fix-client-hmr-program-reload.md
+++ b/.changeset/fix-client-hmr-program-reload.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where editing a client-side component (e.g. with `client:idle`, `client:load`, etc.) caused an unnecessary full program reload of the backend during development. The `astro:hmr-reload` plugin now correctly returns an empty array when all changed modules are found in the client module graph, preventing Vite's default SSR HMR propagation from triggering a full reload. This was a regression from Astro v5 where client-side component edits only triggered client-side HMR without affecting the server.

--- a/.changeset/fix-client-hmr-program-reload.md
+++ b/.changeset/fix-client-hmr-program-reload.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue where editing a client-side component (e.g. with `client:idle`, `client:load`, etc.) caused an unnecessary full program reload of the backend during development. The `astro:hmr-reload` plugin now correctly returns an empty array when all changed modules are found in the client module graph, preventing Vite's default SSR HMR propagation from triggering a full reload. This was a regression from Astro v5 where client-side component edits only triggered client-side HMR without affecting the server.
+Fixes an issue where editing a client-side component (e.g. with `client:idle`, `client:load`, etc.) caused an unnecessary full program reload of the backend during development.

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -99,6 +99,16 @@ export default function hmrReload(): Plugin {
 				if (hasSkippedStyleModules) {
 					return [];
 				}
+
+				// If we processed modules but none were SSR-only (all were found in the
+				// client module graph), return an empty array to prevent Vite's default
+				// HMR propagation. Without this, Vite would propagate through the SSR
+				// module graph, find no HMR boundary (e.g. .astro files), and trigger
+				// a full-reload that causes unnecessary program reloads for the module
+				// runner. The client environment handles HMR for these modules natively.
+				if (modules.length > 0) {
+					return [];
+				}
 			},
 		},
 	};

--- a/packages/astro/test/units/vite-plugin-hmr-reload/hmr-reload.test.ts
+++ b/packages/astro/test/units/vite-plugin-hmr-reload/hmr-reload.test.ts
@@ -168,6 +168,7 @@ describe('astro:hmr-reload', () => {
 		const result = ctx.call();
 		assert.ok(Array.isArray(result), 'should return an array');
 		assert.equal(result.length, 0, 'should return empty array for styles');
+		assert.equal(ctx.wsSent.length, 0, 'should NOT send full-reload for style modules');
 	});
 
 	it('invalidates importers in the module graph for dynamic import chains', () => {
@@ -208,5 +209,41 @@ describe('astro:hmr-reload', () => {
 		// Only the SSR-only module should be invalidated in the module graph
 		assert.equal(ctx.invalidated.length, 1, 'should only invalidate SSR-only module');
 		assert.equal(ctx.invalidated[0], ssrMod);
+	});
+
+	it('returns [] for modules that exist in the client module graph (prevents unnecessary program reload)', () => {
+		const mod = createMockModule('/src/components/Foo.tsx');
+		const ctx = createMockContext({
+			environmentName: 'ssr',
+			modules: [mod],
+			clientModuleIds: ['/src/components/Foo.tsx'], // module IS in client graph
+		});
+
+		const result = ctx.call();
+
+		assert.deepEqual(
+			result,
+			[],
+			'Should return empty array to prevent Vite default HMR propagation',
+		);
+		assert.equal(ctx.wsSent.length, 0, 'Should NOT send full-reload via WebSocket');
+		assert.equal(ctx.hotSent.length, 0, 'Should NOT send full-reload via hot channel');
+		assert.equal(ctx.invalidated.length, 0, 'Should NOT invalidate client-graph modules');
+	});
+
+	it('sends full-reload when mix of client and SSR-only modules', () => {
+		const clientMod = createMockModule('/src/components/Foo.tsx');
+		const ssrOnlyMod = createMockModule('/src/backend/db.ts');
+		const ctx = createMockContext({
+			environmentName: 'ssr',
+			modules: [clientMod, ssrOnlyMod],
+			clientModuleIds: ['/src/components/Foo.tsx'], // only Foo.tsx in client graph
+		});
+
+		const result = ctx.call();
+
+		assert.deepEqual(result, [], 'Should return empty array');
+		assert.equal(ctx.wsSent.length, 1, 'Should send full-reload because of SSR-only module');
+		assert.equal(ctx.wsSent[0].type, 'full-reload');
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes a v6 regression where editing client-side components (`client:idle`, `client:load`, `client:visible`, etc.) causes a full backend program reload during development
- Returns empty array from `astro:hmr-reload` plugin when all processed modules exist only in the client module graph, preventing Vite's default SSR HMR propagation
- Matches the existing pattern used for style modules (CSS/SCSS) that was fixed in PR #14924

## Testing

- Added unit test `returns empty array for client-only modules to prevent unnecessary backend reloads` covering the specific case where all modules are client-side
- Verified fix prevents `[vite] program reload` and server-side module re-execution when editing client components
- Confirmed no regression for SSR-only module invalidation

## Docs

- No docs update needed - this fixes a bug to restore expected v5 behavior

Closes #15951