### PR TITLE
fix: improve error message with debugging context

### DIFF
--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -59,7 +59,11 @@ export async function callGetStaticPaths({
 	// Add a check here to make TypeScript happy.
 	// This is already checked in validateDynamicRouteModule().
 	if (!mod.getStaticPaths) {
-		throw new Error('Unexpected Error.');
+		throw new Error(
+			`Unexpected error: the module for route "${route.route}" (component: ${route.component}) does not export a getStaticPaths function. ` +
+			`This route expects static paths but the module has no getStaticPaths() export. ` +
+			`Ensure ${route.component} defines and exports a getStaticPaths() function.`
+		);
 	}
 
 	// Calculate your static paths.


### PR DESCRIPTION
## What
Improves an error message in `callGetStaticPaths()` to include more debugging context.

The previous message was a bare `Unexpected Error.` with no indication of which route or component triggered it. The new message includes:
- The route pattern (`route.route`)
- The source component path (`route.component`)
- A hint about what is expected (exporting `getStaticPaths()`)

## Why
Better error messages help developers fix issues faster. When a dynamic route module fails to export `getStaticPaths`, the developer now sees exactly which component file to inspect instead of a generic error with no context.

NO EM DASHES.