### PR TITLE
Emit hashchange events with view transitions

### DIFF
--- a/.changeset/frank-cloths-design.md
+++ b/.changeset/frank-cloths-design.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `hashchange` events not firing during same-page hash navigation with view transitions.

--- a/packages/astro/e2e/view-transitions.test.ts
+++ b/packages/astro/e2e/view-transitions.test.ts
@@ -4,6 +4,7 @@ import { type DevServer, testFactory, waitForHydrate } from './test-utils.ts';
 declare global {
 	interface Window {
 		preloads: string[];
+		hashchanges: HashChangeRecord[];
 		clientSideRouterForTestsParkedHere?: (
 			url: string,
 			options?: { history?: 'auto' | 'replace' | 'push' },
@@ -11,7 +12,10 @@ declare global {
 	}
 }
 
+type HashChangeRecord = { oldURL: string; newURL: string };
+
 const test = testFactory(import.meta.url, { root: './fixtures/view-transitions/' });
+const hashChangeStorageKey = 'astro:view-transition-hashchanges';
 
 let devServer: DevServer;
 
@@ -57,6 +61,37 @@ function collectPreloads(page: Page) {
 		});
 		observer.observe(document.head, { childList: true });
 	});
+}
+
+function collectHashChanges(page: Page) {
+	return page.evaluate((storageKey) => {
+		window.hashchanges = [];
+		sessionStorage.setItem(storageKey, JSON.stringify([]));
+		window.addEventListener('hashchange', (e) => {
+			const event = {
+				oldURL: e.oldURL,
+				newURL: e.newURL,
+			};
+			window.hashchanges.push(event);
+			const events = JSON.parse(sessionStorage.getItem(storageKey) ?? '[]') as HashChangeRecord[];
+			events.push(event);
+			sessionStorage.setItem(storageKey, JSON.stringify(events));
+		});
+	}, hashChangeStorageKey);
+}
+
+function getHashChanges(page: Page) {
+	return page.evaluate((storageKey) => {
+		return JSON.parse(sessionStorage.getItem(storageKey) ?? '[]') as HashChangeRecord[];
+	}, hashChangeStorageKey);
+}
+
+async function expectHashChangeCount(page: Page, count: number) {
+	await expect.poll(async () => (await getHashChanges(page)).length).toBe(count);
+	await page.waitForTimeout(200);
+	const events = await getHashChanges(page);
+	expect(events).toHaveLength(count);
+	return events;
 }
 
 async function nativeViewTransition(page: Page) {
@@ -376,6 +411,103 @@ test.describe('View Transitions', () => {
 		await expect(locator).toBeInViewport();
 	});
 
+	test('hashchange fires for same-page fragment navigation', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/long-page'));
+		await collectHashChanges(page);
+
+		await page.click('#click-scroll-down');
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page#click-one-again'));
+
+		const events = await expectHashChangeCount(page, 1);
+		expect(events[0]).toEqual({
+			oldURL: astro.resolveUrl('/long-page'),
+			newURL: astro.resolveUrl('/long-page#click-one-again'),
+		});
+	});
+
+	test('hashchange fires for same-page navigation between fragments', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/long-page#longpage'));
+		await collectHashChanges(page);
+
+		await page.click('#click-scroll-down');
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page#click-one-again'));
+
+		const events = await expectHashChangeCount(page, 1);
+		expect(events[0]).toEqual({
+			oldURL: astro.resolveUrl('/long-page#longpage'),
+			newURL: astro.resolveUrl('/long-page#click-one-again'),
+		});
+	});
+
+	test('hashchange uses native events for same-page fragment history traversal', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/long-page'));
+		await collectHashChanges(page);
+
+		await page.click('#click-scroll-down');
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page#click-one-again'));
+		await expectHashChangeCount(page, 1);
+
+		await page.goBack();
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page'));
+		let events = await expectHashChangeCount(page, 2);
+		expect(events[1]).toEqual({
+			oldURL: astro.resolveUrl('/long-page#click-one-again'),
+			newURL: astro.resolveUrl('/long-page'),
+		});
+
+		await page.goForward();
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page#click-one-again'));
+		events = await expectHashChangeCount(page, 3);
+		expect(events[2]).toEqual({
+			oldURL: astro.resolveUrl('/long-page'),
+			newURL: astro.resolveUrl('/long-page#click-one-again'),
+		});
+	});
+
+	test('hashchange does not fire when removing a fragment', async ({ page, astro }) => {
+		const expectLoads = collectLoads(page);
+
+		await page.goto(astro.resolveUrl('/long-page#click-one-again'));
+		await collectHashChanges(page);
+
+		await page.click('#click-self');
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page'));
+		await expectLoads(2);
+
+		await expectHashChangeCount(page, 0);
+	});
+
+	test('hashchange does not fire when going back after removing a fragment', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/long-page#click-one-again'));
+		await collectHashChanges(page);
+
+		await page.click('#click-self');
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page'));
+
+		await collectHashChanges(page);
+		await page.goBack();
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page#click-one-again'));
+
+		await expectHashChangeCount(page, 0);
+	});
+
+	test('hashchange does not fire for cross-page navigation', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/one'));
+		await collectHashChanges(page);
+
+		await page.click('#click-two');
+		const locator = page.locator('#two');
+		await expect(locator).toHaveText('Page 2');
+
+		await expectHashChangeCount(page, 0);
+	});
+
 	test('Scroll position restored when transitioning back to fragment', async ({ page, astro }) => {
 		// Go to the long page
 		await page.goto(astro.resolveUrl('/long-page'));
@@ -502,29 +634,26 @@ test.describe('View Transitions', () => {
 		await expect(locator).toBeInViewport();
 		expect(consoleCount).toEqual(1);
 
-		// click 'hash' to '' (transition)
-		consolePromise = page.waitForEvent('console');
+		// click 'hash' to '' (native navigation, no transition)
 		await page.click('#click-self');
-		await consolePromise;
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page'));
 		locator = page.locator('#longpage');
 		await expect(locator).toBeInViewport();
-		expect(consoleCount).toEqual(2);
+		expect(consoleCount).toEqual(1);
 
-		// back '' to 'hash' (transition)
-		consolePromise = page.waitForEvent('console');
-		await page.goBack();
-		await consolePromise;
+		// back '' to 'hash' (native traversal, no transition)
+		await page.goBack({ waitUntil: 'networkidle' });
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page#longpage'));
 		locator = page.locator('#longpage');
 		await expect(locator).toBeInViewport();
-		expect(consoleCount).toEqual(3);
+		expect(consoleCount).toEqual(1);
 
-		// forward 'hash' to '' (transition)
-		consolePromise = page.waitForEvent('console');
-		await page.goForward();
-		await consolePromise;
+		// forward 'hash' to '' (native traversal, no transition)
+		await page.goForward({ waitUntil: 'networkidle' });
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page'));
 		locator = page.locator('#longpage');
 		await expect(locator).toBeInViewport();
-		expect(consoleCount).toEqual(4);
+		expect(consoleCount).toEqual(1);
 	});
 
 	test('<Image /> component forwards transitions to the <img>', async ({ page, astro }) => {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -173,6 +173,7 @@ const moveToLocation = (
 	historyState?: State,
 ) => {
 	const intraPage = samePage(from, to);
+	const toHasFragment = to.href.includes('#');
 
 	const targetPageTitle = document.title;
 	document.title = pageTitleForBrowserHistory;
@@ -213,7 +214,7 @@ const moveToLocation = (
 	if (historyState) {
 		scrollTo(historyState.scrollX, historyState.scrollY);
 	} else {
-		if (to.hash) {
+		if (toHasFragment) {
 			// because we are already on the target page ...
 			// ... what comes next is an intra-page navigation
 			// that won't reload the page but instead scroll to the fragment
@@ -232,6 +233,16 @@ const moveToLocation = (
 			}
 		}
 		history.scrollRestoration = 'manual';
+	}
+	// pushState/replaceState above already set the URL to `to.href`, so assigning
+	// `location.href = to.href` for fragment scrolling was a same-URL no-op.
+	if (!historyState && intraPage && toHasFragment && from.href !== to.href) {
+		window.dispatchEvent(
+			new HashChangeEvent('hashchange', {
+				oldURL: from.href,
+				newURL: to.href,
+			}),
+		);
 	}
 };
 
@@ -365,7 +376,15 @@ async function transition(
 		updateScrollPosition({ scrollX, scrollY });
 	}
 	if (samePage(from, to) && !options.formData) {
-		if ((direction !== 'back' && to.hash) || (direction === 'back' && from.hash)) {
+		const fromHasFragment = from.href.includes('#');
+		const toHasFragment = to.href.includes('#');
+		if (!historyState && fromHasFragment && !toHasFragment) {
+			if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+			if (options.history === 'replace') location.replace(to.href);
+			else location.href = to.href;
+			return;
+		}
+		if ((direction !== 'back' && toHasFragment) || (direction === 'back' && fromHasFragment)) {
 			moveToLocation(to, from, options, document.title, historyState);
 			if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
 			return;


### PR DESCRIPTION
## Changes

- With View Transitions, `hashchange` events are now emitted when navigating between hash anchors on the same page, like clicking anchor links.
- The event includes `oldURL` and `newURL` properties matching standard browser behavior.
- This behaviour is useful for apps like documentation sites, where we want to sync the highlighted element in the sidebar to the hash.
- This follows up on #14746 and handles the browser-parity cases called out in review. Hash removal (`/long-page#section` to `/long-page`) is left to the browser so Astro does not emit `hashchange` for cases where native navigation would not.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- Added e2e tests in `view-transitions.test.ts`:
  - Test that `hashchange` fires for same-page hash navigation
  - Test that `hashchange` fires when navigating between hashes on the same page
  - Test that back/forward navigation with hashes does not double-fire events
  - Test that `hashchange` does NOT fire when removing a hash
  - Test that `hashchange` does NOT fire when going back after removing a hash
  - Test that `hashchange` does NOT fire for cross-page navigation
- Updated the existing `View Transitions Rule` test so hash removal and the later back/forward path assert native navigation without a ClientRouter transition.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs update needed. This fixes existing ClientRouter behavior to match how `hashchange` works during normal browser navigation.