### PR TITLE
fix: handle negation patterns correctly in glob-loader watcher

### DIFF
--- a/.changeset/fix-glob-negation-pattern.md
+++ b/.changeset/fix-glob-negation-pattern.md
@@ -1,0 +1,5 @@
+---
+astro: patch
+---
+
+Fix glob-loader watcher to correctly handle negation patterns in file watching

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -335,8 +335,14 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 
 			watcher.add(filePath);
 
+			// Use picomatch() to compile patterns into a matcher function.
+			// picomatch.isMatch() with array patterns containing negation entries (!pattern)
+			// incorrectly treats each array element independently, causing negation patterns
+			// to match everything. A compiled matcher correctly handles negation patterns.
+			// See https://github.com/withastro/astro/issues/16851
+			const matchGlob = picomatch(globOptions.pattern);
 			const matchesGlob = (entry: string) =>
-				!entry.startsWith('../') && picomatch.isMatch(entry, globOptions.pattern);
+				!entry.startsWith('../') && matchGlob(entry);
 
 			const basePath = fileURLToPath(baseDir);
 


### PR DESCRIPTION
## Problem

In , the dev-mode file watcher uses  to decide whether a changed file belongs to the collection.

When  is an array containing negation entries (e.g. ),  treats each array element independently and returns  if ANY pattern matches, including the negation entry itself.

This causes every changed file to be treated as a collection entry, producing schema errors for unrelated files like .

### Repro from issue



## Solution

Replace  with a compiled matcher created by . The compiled matcher function correctly handles negation patterns within arrays.

### After fix



Fixes #16851