### PR TITLE
fix(routing): preserve casing of dynamic param names in

### DIFF
--- a/.changeset/fix-route-pattern-casing.md
+++ b/.changeset/fix-route-pattern-casing.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.routePattern` to preserve original casing of dynamic parameter names from filenames. Previously, a file at `src/pages/blog/[postId].astro` would return `/blog/[postid]` for `Astro.routePattern` due to an internal `.toLowerCase()` call. It now correctly returns `/blog/[postId]`.

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -1002,7 +1002,7 @@ function joinSegments(segments: RoutePart[][]): string {
 		return segment.map((rp) => (rp.dynamic ? `[${rp.content}]` : rp.content)).join('');
 	});
 
-	return `/${arr.join('/')}`.toLowerCase();
+	return `/${arr.join('/')}`;
 }
 
 function replaceOrKeep(original: string, from: string, to: string): string {

--- a/packages/astro/src/core/routing/parse-route.ts
+++ b/packages/astro/src/core/routing/parse-route.ts
@@ -102,5 +102,5 @@ function joinSegments(segments: RoutePart[][]): string {
 		return segment.map((part) => (part.dynamic ? `[${part.content}]` : part.content)).join('');
 	});
 
-	return `/${arr.join('/')}`.toLowerCase();
+	return `/${arr.join('/')}`;
 }

--- a/packages/astro/test/units/routing/parse-route.test.ts
+++ b/packages/astro/test/units/routing/parse-route.test.ts
@@ -25,4 +25,30 @@ describe('parseRoute', () => {
 		assert.equal(pageRoute.route, '/blog/post');
 		assert.equal(pageRoute.isIndex, false);
 	});
+
+	it('preserves casing of dynamic param names in route pattern', () => {
+		const options: ParseRouteConfig = {
+			config: { base: '/', trailingSlash: 'ignore' } as AstroConfig,
+			pageExtensions: [],
+		};
+
+		const route = parseRoute('blog/[postId].astro', options, {
+			component: 'src/pages/blog/[postId].astro',
+		});
+		assert.equal(route.route, '/blog/[postId]');
+		assert.deepEqual(route.params, ['postId']);
+	});
+
+	it('preserves casing of multiple camelCase dynamic params', () => {
+		const options: ParseRouteConfig = {
+			config: { base: '/', trailingSlash: 'ignore' } as AstroConfig,
+			pageExtensions: [],
+		};
+
+		const route = parseRoute('users/[userId]/posts/[postSlug].astro', options, {
+			component: 'src/pages/users/[userId]/posts/[postSlug].astro',
+		});
+		assert.equal(route.route, '/users/[userId]/posts/[postSlug]');
+		assert.deepEqual(route.params, ['userId', 'postSlug']);
+	});
 });

--- a/packages/astro/test/units/routing/route-matching.test.ts
+++ b/packages/astro/test/units/routing/route-matching.test.ts
@@ -166,12 +166,12 @@ describe('Route matching', () => {
 			const sortedRouteNames = sortedMatches.map((match) => match.route);
 
 			assert.deepEqual(sortedRouteNames, [
-				'/[astaticdynamic]',
-				'/[xstaticdynamic]',
-				'/[serverdynamic]',
-				'/[...astaticrest]',
-				'/[...xstaticrest]',
-				'/[...serverrest]',
+				'/[aStaticDynamic]',
+				'/[xStaticDynamic]',
+				'/[serverDynamic]',
+				'/[...aStaticRest]',
+				'/[...xStaticRest]',
+				'/[...serverRest]',
 			]);
 		});
 	});


### PR DESCRIPTION
## Changes


Fixes an issue where `routePattern` was transformed into lower case

Closes https://github.com/withastro/astro/issues/16942

## Testing

Tests added by the bot. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
