### PR TITLE
fix(routing): preserve .html in pathname for endpoint routes with dynamic params and solve conflicts

### DIFF
--- a/.changeset/fix-endpoint-html-params.md
+++ b/.changeset/fix-endpoint-html-params.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where static file endpoints using `getStaticPaths` with `.html` in dynamic param values (e.g. `{ path: 'file.html' }`) would fail with a `NoMatchingStaticPathFound` error during build. The `.html` suffix is no longer incorrectly stripped from endpoint route pathnames.

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -773,11 +773,14 @@ export class FetchState implements AstroFetchState {
 	 */
 	/**
 	 * Strip `.html` / `/index.html` suffixes from the pathname so the
-	 * rendering pipeline sees the canonical route path. Skipped when the
-	 * matched route itself has an `.html` extension in its definition.
+	 * rendering pipeline sees the canonical route path. Only applies to
+	 * page routes where `.html` is framework-injected. Endpoint routes
+	 * preserve `.html` because any such suffix is user-provided (e.g.
+	 * from `getStaticPaths` params). Skipped when the matched route
+	 * itself has an `.html` extension in its definition.
 	 */
 	#stripHtmlExtension(): void {
-		if (this.routeData && !routeHasHtmlExtension(this.routeData)) {
+		if (this.routeData && this.routeData.type === 'page' && !routeHasHtmlExtension(this.routeData)) {
 			this.pathname = this.pathname.replace(/\/index\.html$/, '/').replace(/\.html$/, '');
 		}
 	}

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -14,7 +14,7 @@ import {
 import { ALL_PIPELINE_FEATURES } from '../../../dist/core/base-pipeline.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import { createEndpoint, createPage, createRedirect, createTestApp } from '../mocks.ts';
-import { dynamicPart } from '../routing/test-helpers.ts';
+import { dynamicPart, spreadPart } from '../routing/test-helpers.ts';
 
 /** A simple page component that renders `<h1>Hello</h1>`. */
 const simplePage = createComponent((_result: any, _props: any, _slots: any) => {
@@ -89,6 +89,28 @@ describe('FetchState (astro/fetch)', () => {
 
 		assert.ok(state.routeData, 'routeData should fall back to the 404 route');
 		assert.equal(state.routeData!.route, '/404');
+	});
+
+	it('preserves .html in pathname for endpoint routes with dynamic params', () => {
+		// Regression test for #16941: when a dynamic endpoint returns a param
+		// value like `file.html`, the `.html` suffix must not be stripped from
+		// the pathname. Only page routes should have `.html` stripped (it is
+		// framework-injected there), but for endpoints the suffix is user-provided.
+		const endpoint = createEndpoint(
+			{ GET: () => new Response('ok') },
+			{
+				route: '/[...path]',
+				pathname: undefined,
+				segments: [[spreadPart('path')]],
+			},
+		);
+		const app = createTestApp([endpoint]);
+		const request = stampApp(new Request('http://example.com/file.html'), app);
+		const state = new FetchState(request);
+
+		assert.ok(state.routeData, 'routeData should be set');
+		assert.equal(state.routeData!.type, 'endpoint');
+		assert.equal(state.pathname, '/file.html', '.html should be preserved for endpoint routes');
 	});
 });
 


### PR DESCRIPTION
## Changes
- Fixes static file endpoints using dynamic routing where .html extensions in getStaticPaths params caused NoMatchingStaticPathFound build errors
- Modifies FetchState.#stripHtmlExtension() to only strip .html from page routes, not endpoint routes, by adding this.routeData.type === 'page' guard
- Resolves v5-to-v6 regression where endpoint routes with .html in param values would fail to build
## Testing
- Added regression test preserves .html in pathname for endpoint routes with dynamic params in packages/astro/test/units/fetch/index.test.ts
- Verified fix resolves the reproduction case and produces correct dist/file.html output
## Docs
- No docs update needed, this restores expected behavior from v5.

Closes https://github.com/withastro/astro/issues/16941