### PR TITLE
docs(astro): fix `allows to` grammar in two source comments

### DIFF
--- a/packages/astro/src/core/errors/dev/vite.ts
+++ b/packages/astro/src/core/errors/dev/vite.ts
@@ -166,7 +166,7 @@ export async function getViteErrorPayload(err: ErrorWithMetadata): Promise<Astro
 }
 
 /**
- * Transformer for `shiki`'s legacy `lineOptions`, allows to add classes to specific lines
+ * Transformer for `shiki`'s legacy `lineOptions`, allows adding classes to specific lines
  * FROM: https://github.com/shikijs/shiki/blob/4a58472070a9a359a4deafec23bb576a73e24c6a/packages/transformers/src/transformers/compact-line-options.ts
  * LICENSE: https://github.com/shikijs/shiki/blob/4a58472070a9a359a4deafec23bb576a73e24c6a/LICENSE
  */

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -164,7 +164,7 @@ export function copyRequest(
 			signal: oldRequest.signal,
 			keepalive: oldRequest.keepalive,
 			// https://fetch.spec.whatwg.org/#dom-request-duplex
-			// @ts-expect-error It isn't part of the types, but undici accepts it and it allows to carry over the body to a new request
+			// @ts-expect-error It isn't part of the types, but undici accepts it and it allows carrying over the body to a new request
 			duplex: 'half',
 		},
 	});


### PR DESCRIPTION
## Summary

Two source comments in `packages/astro` use the ungrammatical "allows to <verb>" construction (missing subject). Tightens the wording without changing any behavior.

## Changes

- `packages/astro/src/core/errors/dev/vite.ts` (transformerCompactLineOptions JSDoc):
  - `allows to add classes` -> `allows adding classes`
- `packages/astro/src/core/routing/rewrite.ts` (`@ts-expect-error` comment near `duplex: 'half'`):
  - `it allows to carry over the body` -> `it allows carrying over the body`

## Notes

- Comment-only change — no public API, behavior, or test impact.
- No changeset added since nothing user-facing changes (matches the precedent of #16818, a similar JSDoc-only fix).