### PR TITLE
Skip Cloudflare runtime startup during type generation

### DIFF
--- a/.changeset/cloudflare-skip-sync-runtime.md
+++ b/.changeset/cloudflare-skip-sync-runtime.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/cloudflare": patch
+---
+
+Speeds up `astro sync` by no longer starting the Cloudflare runtime during type generation

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -174,7 +174,7 @@ export default function createIntegration({
 				const needsImagesBindingForDev = isCompile && command === 'dev';
 				const usesContentCollections = hasContentCollectionsConfig(config.srcDir);
 				const prebundleContentRuntime = command === 'dev' && usesContentCollections;
-				const isTypeGenOnly = command === 'build' || command === 'sync';
+				const isTypeGenPhase = command === 'build' || command === 'sync';
 
 				const adapterPluginConfig: Partial<PluginConfig> = {
 					config: cloudflareConfigCustomizer({
@@ -247,8 +247,11 @@ export default function createIntegration({
 					viteEnvironment: { name: 'ssr' },
 					assetsOnly: () => _buildOutput === 'static',
 				});
-				// Avoid starting the Cloudflare dev runtime during type generation. See #16332.
-				if (isTypeGenOnly) {
+				// `sync` and `build` both run type generation (build via its internal sync
+				// pass), which creates a temporary Vite server and fires `configureServer`
+				// the hook that boots the Cloudflare/workerd runtime. Drop it in both so
+				// type generation doesn't pay that startup cost. See #16332.
+				if (isTypeGenPhase) {
 					for (const plugin of cloudflareVitePlugins) {
 						plugin.configureServer = undefined;
 					}
@@ -280,8 +283,8 @@ export default function createIntegration({
 							{
 								name: '@astrojs/cloudflare:environment',
 								configEnvironment(environmentName, _options) {
-									// Avoid dependency optimization during type generation. See #16332.
-									if (isTypeGenOnly) {
+									// Skip dependency pre-bundling during type generation (see `isTypeGenPhase` above).
+									if (isTypeGenPhase) {
 										return { optimizeDeps: { noDiscovery: true, include: [] } };
 									}
 									const isServerEnvironment = ['astro', 'ssr', 'prerender'].includes(

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -174,6 +174,7 @@ export default function createIntegration({
 				const needsImagesBindingForDev = isCompile && command === 'dev';
 				const usesContentCollections = hasContentCollectionsConfig(config.srcDir);
 				const prebundleContentRuntime = command === 'dev' && usesContentCollections;
+				const isTypeGenOnly = command === 'build' || command === 'sync';
 
 				const adapterPluginConfig: Partial<PluginConfig> = {
 					config: cloudflareConfigCustomizer({
@@ -241,6 +242,18 @@ export default function createIntegration({
 				// include, and esbuildOptions (e.g. loader) entries are respected.
 				const userOptimizeDeps = config.vite?.optimizeDeps;
 
+				const cloudflareVitePlugins = cfVitePlugin({
+					...cfPluginConfig,
+					viteEnvironment: { name: 'ssr' },
+					assetsOnly: () => _buildOutput === 'static',
+				});
+				// Avoid starting the Cloudflare dev runtime during type generation. See #16332.
+				if (isTypeGenOnly) {
+					for (const plugin of cloudflareVitePlugins) {
+						plugin.configureServer = undefined;
+					}
+				}
+
 				updateConfig({
 					build: {
 						redirects: false,
@@ -251,11 +264,7 @@ export default function createIntegration({
 							...(prerenderEnvironment === 'node' && command === 'dev'
 								? [createNodePrerenderPlugin()]
 								: []),
-							cfVitePlugin({
-								...cfPluginConfig,
-								viteEnvironment: { name: 'ssr' },
-								assetsOnly: () => _buildOutput === 'static',
-							}),
+							cloudflareVitePlugins,
 							{
 								name: '@astrojs/cloudflare:cf-imports',
 								enforce: 'pre',
@@ -271,6 +280,10 @@ export default function createIntegration({
 							{
 								name: '@astrojs/cloudflare:environment',
 								configEnvironment(environmentName, _options) {
+									// Avoid dependency optimization during type generation. See #16332.
+									if (isTypeGenOnly) {
+										return { optimizeDeps: { noDiscovery: true, include: [] } };
+									}
 									const isServerEnvironment = ['astro', 'ssr', 'prerender'].includes(
 										environmentName,
 									);


### PR DESCRIPTION
## Changes

`astro sync` was much slower with `@astrojs/cloudflare` because type generation started the Cloudflare dev runtime even though no requests are served. During the invocation of the temporary type generation dev server, the adapter now:

- Clears `configureServer` from `@cloudflare/vite-plugin` plugins so the Cloudflare dev runtime never starts.
- Sets `optimizeDeps: { noDiscovery: true, include: [] }` on every environment so no dependencies are pre-bundled.
- `dev` and `preview` continue to start the Cloudflare runtime as expected.

## Testing

- Measured `astro sync` type generation with [the MRE](https://github.com/adamchal/astro-sync-perf):

| Adapter | `astro sync` |
|---|--:|
| none | 37 ms |
| `@astrojs/node` | 37 ms |
| `@astrojs/vercel` | 36 ms |
| `@astrojs/netlify` | 29 ms |
| `@astrojs/cloudflare` (before) | 1.16 s |
| `@astrojs/cloudflare` (after) | **56 ms** |

## Docs

- No docs needed. This is a build-time performance fix with no user-facing API change.

Closes #16332