### PR TITLE
Add retries for remote image dimension inference

### DIFF
--- a/.changeset/floppy-regions-kiss.md
+++ b/.changeset/floppy-regions-kiss.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Improves remote image dimension inference by retrying transient network failures for `inferSize` and `inferRemoteSize`.

--- a/packages/astro/src/assets/utils/remoteProbe.ts
+++ b/packages/astro/src/assets/utils/remoteProbe.ts
@@ -1,11 +1,25 @@
 import { isRemoteAllowed } from '@astrojs/internal-helpers/remote';
 import { AstroError, AstroErrorData } from '../../core/errors/index.js';
+import { debug } from '../../core/logger/core.js';
 import type { AstroConfig } from '../../types/public/config.js';
 import type { ImageMetadata } from '../types.js';
 import { imageMetadata } from './metadata.js';
 import { fetchWithRedirects } from './redirectValidation.js';
 
 type RemoteImageConfig = Pick<AstroConfig['image'], 'domains' | 'remotePatterns'>;
+
+const REMOTE_IMAGE_DIMENSION_RETRY_DELAYS = [500, 1500];
+const NETWORK_ERROR_CODES = new Set([
+	'ECONNABORTED',
+	'ECONNREFUSED',
+	'ECONNRESET',
+	'EHOSTUNREACH',
+	'ENETDOWN',
+	'ENETUNREACH',
+	'ENOTFOUND',
+	'ETIMEDOUT',
+	'EAI_AGAIN',
+]);
 
 /**
  * Infers the dimensions of a remote image by streaming its data and analyzing it progressively until sufficient metadata is available.
@@ -50,87 +64,161 @@ export async function inferRemoteSize(
 		});
 	}
 
-	// Start fetching the image with redirect validation
-	let response: Response;
-	try {
-		response = await fetchWithRedirects({
-			url,
-			onMaxRedirectsExceeded: (u) =>
-				new AstroError({
-					...AstroErrorData.FailedToFetchRemoteImageDimensions,
-					message: AstroErrorData.FailedToFetchRemoteImageDimensions.message(u),
-				}),
-			onMissingLocationHeader: (_status, u) =>
-				new AstroError({
-					...AstroErrorData.FailedToFetchRemoteImageDimensions,
-					message: AstroErrorData.FailedToFetchRemoteImageDimensions.message(u),
-				}),
-			imageConfig: imageConfig ?? {
-				remotePatterns: [],
-				domains: [],
-			},
-		});
-	} catch (_err) {
-		throw new AstroError({
-			...AstroErrorData.FailedToFetchRemoteImageDimensions,
-			message: AstroErrorData.FailedToFetchRemoteImageDimensions.message(url),
-		});
-	}
+	const totalAttempts = REMOTE_IMAGE_DIMENSION_RETRY_DELAYS.length + 1;
 
-	// Validate that the final URL (after redirects) is allowed
-	if (allowlistConfig && !isRemoteAllowed(response.url, allowlistConfig)) {
-		throw new AstroError({
-			...AstroErrorData.RemoteImageNotAllowed,
-			message: AstroErrorData.RemoteImageNotAllowed.message(url),
-		});
-	}
+	for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+		try {
+			// Retry the original probe itself, so fetch-level failures during redirects or
+			// body reads are classified before being collapsed into Astro errors
+			const response = await fetchWithRedirects({
+				url,
+				onMaxRedirectsExceeded: (u) => createFailedToFetchRemoteImageDimensionsError(u),
+				onMissingLocationHeader: (_status, u) => createFailedToFetchRemoteImageDimensionsError(u),
+				onDisallowedRedirect: (_current, target) =>
+					new AstroError({
+						...AstroErrorData.RemoteImageNotAllowed,
+						message: AstroErrorData.RemoteImageNotAllowed.message(target),
+					}),
+				imageConfig: imageConfig ?? {
+					remotePatterns: [],
+					domains: [],
+				},
+			});
 
-	if (!response.body || !response.ok) {
-		throw new AstroError({
-			...AstroErrorData.FailedToFetchRemoteImageDimensions,
-			message: AstroErrorData.FailedToFetchRemoteImageDimensions.message(url),
-		});
-	}
-
-	const reader = response.body.getReader();
-
-	let done: boolean | undefined, value: Uint8Array;
-	let accumulatedChunks = new Uint8Array();
-
-	// Process the stream chunk by chunk
-	while (!done) {
-		const readResult = await reader.read();
-		done = readResult.done;
-
-		if (done) break;
-
-		if (readResult.value) {
-			value = readResult.value;
-
-			// Accumulate chunks
-			let tmp = new Uint8Array(accumulatedChunks.length + value.length);
-			tmp.set(accumulatedChunks, 0);
-			tmp.set(value, accumulatedChunks.length);
-			accumulatedChunks = tmp;
-
-			try {
-				// Attempt to determine the size with each new chunk
-				const dimensions = await imageMetadata(accumulatedChunks, url);
-
-				if (dimensions) {
-					await reader.cancel(); // stop stream as we have size now
-
-					return dimensions;
-				}
-			} catch {
-				// This catch block is specifically for `imageMetadata` errors
-				// which might occur if the accumulated data isn't yet sufficient.
+			// Validate that the final URL (after redirects) is allowed
+			if (allowlistConfig && !isRemoteAllowed(response.url, allowlistConfig)) {
+				throw new AstroError({
+					...AstroErrorData.RemoteImageNotAllowed,
+					message: AstroErrorData.RemoteImageNotAllowed.message(url),
+				});
 			}
+
+			if (!response.body || !response.ok) {
+				throw createFailedToFetchRemoteImageDimensionsError(url);
+			}
+
+			const reader = response.body.getReader();
+
+			let done: boolean | undefined;
+			let accumulatedChunks = new Uint8Array();
+
+			// Process the stream chunk by chunk
+			while (!done) {
+				const readResult = await reader.read();
+				done = readResult.done;
+
+				if (done) break;
+				if (!readResult.value) continue;
+
+				// Accumulate chunks
+				const tmp = new Uint8Array(accumulatedChunks.length + readResult.value.length);
+				tmp.set(accumulatedChunks, 0);
+				tmp.set(readResult.value, accumulatedChunks.length);
+				accumulatedChunks = tmp;
+
+				try {
+					// Attempt to determine the size with each new chunk
+					const dimensions = await imageMetadata(accumulatedChunks, url);
+
+					if (dimensions) {
+						await reader.cancel(); // stop stream as we have size now
+
+						return dimensions;
+					}
+				} catch {
+					// This catch block is specifically for `imageMetadata` errors
+					// which might occur if the accumulated data isn't yet sufficient.
+				}
+			}
+
+			throw new AstroError({
+				...AstroErrorData.NoImageMetadata,
+				message: AstroErrorData.NoImageMetadata.message(url),
+			});
+		} catch (err) {
+			// Only thrown network failures consume retry slots. Astro validation,
+			// redirect, HTTP response, and metadata errors keep their original behavior.
+			if (!isNetworkError(err)) {
+				throw err;
+			}
+
+			const delay = REMOTE_IMAGE_DIMENSION_RETRY_DELAYS[attempt - 1];
+			if (delay == null) {
+				throw createFailedToFetchRemoteImageDimensionsError(url, {
+					cause: err,
+					totalAttempts,
+				});
+			}
+
+			debug(
+				'assets',
+				`Retrying remote image dimension fetch for ${url}: attempt ${attempt + 1}/${totalAttempts} after ${summarizeError(err)}; waiting ${delay}ms.`,
+			);
+
+			await new Promise<void>((resolve) => setTimeout(resolve, delay));
 		}
 	}
 
-	throw new AstroError({
-		...AstroErrorData.NoImageMetadata,
-		message: AstroErrorData.NoImageMetadata.message(url),
-	});
+	throw createFailedToFetchRemoteImageDimensionsError(url);
+}
+
+function createFailedToFetchRemoteImageDimensionsError(
+	url: string,
+	retryExhaustion?: { cause: unknown; totalAttempts: number },
+) {
+	const message = retryExhaustion
+		? `${AstroErrorData.FailedToFetchRemoteImageDimensions.message(url)} The request failed after ${retryExhaustion.totalAttempts} attempts due to a network error.`
+		: AstroErrorData.FailedToFetchRemoteImageDimensions.message(url);
+	const hint = retryExhaustion
+		? `${AstroErrorData.FailedToFetchRemoteImageDimensions.hint} If the URL is correct, check the remote server or network availability, or provide explicit width and height values.`
+		: AstroErrorData.FailedToFetchRemoteImageDimensions.hint;
+
+	return new AstroError(
+		{
+			...AstroErrorData.FailedToFetchRemoteImageDimensions,
+			message,
+			hint,
+		},
+		retryExhaustion ? { cause: retryExhaustion.cause } : undefined,
+	);
+}
+
+function isNetworkError(error: unknown): boolean {
+	if (!error || typeof error !== 'object') return false;
+
+	const { name, code, cause } = error as {
+		name?: unknown;
+		code?: unknown;
+		cause?: unknown;
+	};
+
+	if (name === 'TypeError' || name === 'AbortError' || name === 'TimeoutError') {
+		return true;
+	}
+
+	if (typeof code === 'string' && (NETWORK_ERROR_CODES.has(code) || code.startsWith('UND_ERR_'))) {
+		return true;
+	}
+
+	// Undici often stores the actual network failure on `cause`
+	return cause ? isNetworkError(cause) : false;
+}
+
+function summarizeError(error: unknown) {
+	if (!error || typeof error !== 'object') return String(error);
+
+	const { name, message, code, cause } = error as {
+		name?: unknown;
+		message?: unknown;
+		code?: unknown;
+		cause?: { code?: unknown };
+	};
+
+	const errorName = typeof name === 'string' ? name : 'Error';
+	const errorMessage = typeof message === 'string' ? message : String(error);
+	const errorCode = typeof code === 'string' ? code : cause?.code;
+
+	return typeof errorCode === 'string'
+		? `${errorName}: ${errorMessage} (${errorCode})`
+		: `${errorName}: ${errorMessage}`;
 }

--- a/packages/astro/test/core-image-infersize.test.ts
+++ b/packages/astro/test/core-image-infersize.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
 import { Writable } from 'node:stream';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
@@ -88,6 +89,74 @@ describe('astro:image:infersize', () => {
 				(log) => log.message.includes('Remote image') && log.message.includes('not allowed'),
 			);
 			assert.equal(hasDisallowedLog, true);
+		});
+	});
+
+	describe('dev inferSize retry', () => {
+		// Enough PNG header metadata for dimension inference.
+		const TINY_PNG_HEADER = new Uint8Array([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+			0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		]);
+
+		let retryFixture: Fixture;
+		let retryDevServer: DevServer | undefined;
+		let remoteServer: Server | undefined;
+		let remoteRequests = 0;
+
+		before(async () => {
+			remoteServer = createServer((req, res) => {
+				remoteRequests++;
+				if (remoteRequests <= 2) {
+					req.socket.destroy();
+					return;
+				}
+
+				res.writeHead(200, { 'Content-Type': 'image/png' });
+				res.end(TINY_PNG_HEADER);
+			});
+
+			await new Promise<void>((resolve) => remoteServer!.listen(0, '127.0.0.1', resolve));
+
+			const address = remoteServer.address();
+			assert.ok(address && typeof address === 'object');
+
+			process.env.ASTRO_REMOTE_IMAGE_RETRY_URL = `http://127.0.0.1:${address.port}/image.png`;
+			retryFixture = await loadFixture({
+				root: './fixtures/core-image-infersize/',
+				image: {
+					remotePatterns: [
+						{
+							protocol: 'http',
+							hostname: '127.0.0.1',
+							port: String(address.port),
+						},
+					],
+				},
+				outDir: './dist/core-image-infersize-dev-retry/',
+			});
+
+			retryDevServer = await retryFixture.startDevServer({});
+		});
+
+		after(async () => {
+			delete process.env.ASTRO_REMOTE_IMAGE_RETRY_URL;
+			await retryDevServer?.stop();
+
+			if (remoteServer) {
+				await new Promise<void>((resolve) => remoteServer!.close(() => resolve()));
+			}
+		});
+
+		it('retries network errors when remote inferSize fetches dimensions', async () => {
+			const res = await retryFixture.fetch('/retry');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			const $img = $('#retry-image');
+
+			assert.equal(remoteRequests, 3);
+			assert.equal($img.attr('width'), '1');
+			assert.equal($img.attr('height'), '1');
 		});
 	});
 

--- a/packages/astro/test/fixtures/core-image-infersize/src/pages/retry.astro
+++ b/packages/astro/test/fixtures/core-image-infersize/src/pages/retry.astro
@@ -1,0 +1,10 @@
+---
+import { Image } from 'astro:assets';
+
+const remoteImageUrl = process.env.ASTRO_REMOTE_IMAGE_RETRY_URL;
+if (!remoteImageUrl) {
+	throw new Error('ASTRO_REMOTE_IMAGE_RETRY_URL is required for this test page.');
+}
+---
+
+<Image src={remoteImageUrl} inferSize={true} alt="" id="retry-image" />

--- a/packages/astro/test/units/assets/remote-probe.test.ts
+++ b/packages/astro/test/units/assets/remote-probe.test.ts
@@ -1,0 +1,345 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { describe, it } from 'node:test';
+import { inferRemoteSize } from '../../../dist/assets/utils/index.js';
+
+describe('inferRemoteSize', () => {
+	// Enough PNG header metadata for dimension inference.
+	const TINY_PNG_HEADER = new Uint8Array([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	]);
+
+	it('retries network errors and returns dimensions when a later attempt succeeds', async () => {
+		let requests = 0;
+
+		const server = createServer((req, res) => {
+			requests++;
+			if (requests <= 2) {
+				req.socket.destroy();
+				return;
+			}
+
+			res.writeHead(200, { 'Content-Type': 'image/png' });
+			res.end(TINY_PNG_HEADER);
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			const result = await inferRemoteSize(`${origin}/image.png`, {
+				domains: [],
+				remotePatterns: [{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) }],
+			});
+
+			assert.equal(requests, 3);
+			assert.equal(result.width, 1);
+			assert.equal(result.height, 1);
+			assert.equal(result.format, 'png');
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('does not retry a final 404 response', async () => {
+		let requests = 0;
+
+		const server = createServer((_req, res) => {
+			requests++;
+			res.writeHead(404);
+			res.end();
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await assert.rejects(
+				() =>
+					inferRemoteSize(`${origin}/missing.png`, {
+						domains: [],
+						remotePatterns: [
+							{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) },
+						],
+					}),
+				{ name: 'FailedToFetchRemoteImageDimensions' },
+			);
+
+			assert.equal(requests, 1);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('does not retry a final 5xx response', async () => {
+		let requests = 0;
+
+		const server = createServer((_req, res) => {
+			requests++;
+			res.writeHead(503);
+			res.end();
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await assert.rejects(
+				() =>
+					inferRemoteSize(`${origin}/unavailable.png`, {
+						domains: [],
+						remotePatterns: [
+							{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) },
+						],
+					}),
+				{ name: 'FailedToFetchRemoteImageDimensions' },
+			);
+
+			assert.equal(requests, 1);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('does not retry directly disallowed remote URLs', async () => {
+		await assert.rejects(
+			() =>
+				inferRemoteSize('https://not-allowed.example/image.png', {
+					domains: ['example.com'],
+					remotePatterns: [],
+				}),
+			{ name: 'RemoteImageNotAllowed' },
+		);
+	});
+
+	it('does not retry or mask disallowed redirects', async () => {
+		let requests = 0;
+
+		const server = createServer((_req, res) => {
+			requests++;
+			res.writeHead(302, { Location: 'https://not-allowed.example/image.png' });
+			res.end();
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await assert.rejects(
+				() =>
+					inferRemoteSize(`${origin}/redirect.png`, {
+						domains: [],
+						remotePatterns: [
+							{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) },
+						],
+					}),
+				{ name: 'RemoteImageNotAllowed' },
+			);
+
+			assert.equal(requests, 1);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('does not retry redirects with missing Location headers', async () => {
+		let requests = 0;
+
+		const server = createServer((_req, res) => {
+			requests++;
+			res.writeHead(302);
+			res.end();
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await assert.rejects(
+				() =>
+					inferRemoteSize(`${origin}/redirect.png`, {
+						domains: [],
+						remotePatterns: [
+							{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) },
+						],
+					}),
+				{ name: 'FailedToFetchRemoteImageDimensions' },
+			);
+
+			assert.equal(requests, 1);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('does not retry after max redirect depth is reached', async () => {
+		let requests = 0;
+
+		const server = createServer((_req, res) => {
+			requests++;
+			res.writeHead(302, { Location: `/redirect-${requests}.png` });
+			res.end();
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await assert.rejects(
+				() =>
+					inferRemoteSize(`${origin}/redirect.png`, {
+						domains: [],
+						remotePatterns: [
+							{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) },
+						],
+					}),
+				{ name: 'FailedToFetchRemoteImageDimensions' },
+			);
+
+			assert.equal(requests, 10);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('retries network errors after allowed redirects', async () => {
+		let redirectRequests = 0;
+		let imageRequests = 0;
+
+		const server = createServer((req, res) => {
+			if (req.url === '/redirect.png') {
+				redirectRequests++;
+				res.writeHead(302, { Location: '/image.png' });
+				res.end();
+				return;
+			}
+
+			imageRequests++;
+			if (imageRequests === 1) {
+				req.socket.destroy();
+				return;
+			}
+
+			res.writeHead(200, { 'Content-Type': 'image/png' });
+			res.end(TINY_PNG_HEADER);
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			const result = await inferRemoteSize(`${origin}/redirect.png`, {
+				domains: [],
+				remotePatterns: [{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) }],
+			});
+
+			assert.equal(redirectRequests, 2);
+			assert.equal(imageRequests, 2);
+			assert.equal(result.width, 1);
+			assert.equal(result.height, 1);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('does not retry responses without image metadata', async () => {
+		let requests = 0;
+
+		const server = createServer((_req, res) => {
+			requests++;
+			res.writeHead(200, { 'Content-Type': 'text/plain' });
+			res.end('not image metadata');
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await assert.rejects(
+				() =>
+					inferRemoteSize(`${origin}/not-image.txt`, {
+						domains: [],
+						remotePatterns: [
+							{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) },
+						],
+					}),
+				{ name: 'NoImageMetadata' },
+			);
+
+			assert.equal(requests, 1);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+
+	it('stops after the final retry attempt is exhausted', async () => {
+		let requests = 0;
+
+		const server = createServer((req) => {
+			requests++;
+			req.socket.destroy();
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+		const address = server.address();
+		assert.ok(address && typeof address === 'object');
+
+		const origin = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await assert.rejects(
+				() =>
+					inferRemoteSize(`${origin}/image.png`, {
+						domains: [],
+						remotePatterns: [
+							{ protocol: 'http', hostname: '127.0.0.1', port: String(address.port) },
+						],
+					}),
+				(err: unknown) => {
+					assert.ok(err instanceof Error);
+					assert.equal(err.name, 'FailedToFetchRemoteImageDimensions');
+					assert.match(err.message, /after 3 attempts/);
+					assert.ok((err as Error & { cause?: unknown }).cause);
+					return true;
+				},
+			);
+
+			assert.equal(requests, 3);
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+	});
+});


### PR DESCRIPTION
## Changes

This pull request adds retries for remote image dimension inference in Astro's image service. Currently, if a transient network error happens during build, the entire build fails, which can lead to several builds failing till it succeeds in some environments, making this a QoL improvement.

I am not sure if this counts as a patch or minor change? It doesn't add new API but kinda changes how builds behave regarding images, so I defaulted to minor for the moment.

## Testing

I added new unit tests in `remote-probe.test.ts` + integration tests in `core-image-infersize.test.ts` to test this plus a combination of scenarios like redirects, not allowed remote sources, 5xx errors, etc.

## Docs

Docs PR: https://github.com/withastro/docs/pull/14580 

/cc @withastro/maintainers-docs 
