### PR TITLE
feat: deprecate @astrojs/db

### DIFF
--- a/.changeset/light-impalas-wave.md
+++ b/.changeset/light-impalas-wave.md
@@ -2,4 +2,4 @@
 '@astrojs/db': patch
 ---
 
-Deprecate package
+Deprecates the `@astrojs/db` integration. We no longer have the bandwidth to maintain this package, and we recommend that users directly use the database client of their choice (Drizzle, Kysely, etc.) in their Astro projects instead.

--- a/.changeset/light-impalas-wave.md
+++ b/.changeset/light-impalas-wave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Deprecate package

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,14 +1,12 @@
-# @astrojs/db (experimental) 💿
+# @astrojs/db 💿
 
-This **[Astro integration][astro-integration]** enables the usage of [SQLite](https://www.sqlite.org/) in Astro Projects.
-
-## Documentation
-
-Read the [`@astrojs/db` docs][docs]
+> ⚠️ **This integration is deprecated**
+>
+> This integration is no longer maintained and will not receive updates. We recommend directly using the database client (Drizzle, Kysely, etc.) of your choice in your Astro project instead.
 
 ## Support
 
-- Get help in the [Astro Discord][discord]. Post questions in our `#support` forum, or visit our dedicated `#dev` channel to discuss current development and more!
+- Get help in the [Astro Discord][discord]. Post questions in our `#support` forum, or visit our dedicated `#framework` channel to discuss current development and more!
 
 - Check our [Astro Integration Documentation][astro-integration] for more on integrations.
 
@@ -29,10 +27,9 @@ MIT
 Copyright (c) 2023–present [Astro][astro]
 
 [astro]: https://astro.build/
-[docs]: https://docs.astro.build/en/guides/integrations-guide/db/
 [contributing]: https://github.com/withastro/astro/blob/main/CONTRIBUTING.md
 [coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
 [community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md
 [discord]: https://astro.build/chat/
 [issues]: https://github.com/withastro/astro/issues
-[astro-integration]: https://docs.astro.build/en/guides/integrations/
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/


### PR DESCRIPTION
## Changes

We no longer have the bandwidth to maintain this package and are generally not as interested as we once were regarding maintaining our own DB layer considering how much more mature tools like Drizzle and Prisma have become over time.

This package has also generally caused a lot of headaches for not much considering how little usage it has.

Close https://github.com/withastro/astro/issues/16738
Close https://github.com/withastro/astro/issues/15431

## Testing

N/A

## Docs

https://github.com/withastro/docs/pull/13985 (ish, probably also needs a main callout if we merge this now..)