### PR TITLE
feat: make jsx whitespace handling the default

### DIFF
--- a/.changeset/compress-html-jsx-default.md
+++ b/.changeset/compress-html-jsx-default.md
@@ -1,0 +1,9 @@
+---
+'astro': major
+---
+
+Makes `'jsx'` the default value for `compressHTML`
+
+Astro now strips whitespace from your HTML using JSX rules by default, the same way frameworks like React do. Whitespace and line breaks between elements are removed unless you explicitly write them in your source, for example with `{" "}`.
+
+This can change rendered output where whitespace between inline elements was previously meaningful. To keep Astro's earlier behavior, set `compressHTML: true` for HTML-aware compression, or `compressHTML: false` to preserve all whitespace.

--- a/.changeset/compress-html-jsx-default.md
+++ b/.changeset/compress-html-jsx-default.md
@@ -4,6 +4,6 @@
 
 Makes `'jsx'` the default value for `compressHTML`
 
-Astro now strips whitespace from your HTML using JSX rules by default, the same way frameworks like React do. Whitespace and line breaks between elements are removed unless you explicitly write them in your source, for example with `{" "}`.
+Astro now strips whitespace from your HTML using JSX rules by default, the same way frameworks like React do. Whitespace and line breaks around elements are removed, but meaningful whitespace within a single line — like a space between two inline elements — is preserved. To keep a space that would otherwise be removed, write it explicitly in your source, for example with `{" "}`.
 
 This can change rendered output where whitespace between inline elements was previously meaningful. To keep Astro's earlier behavior, set `compressHTML: true` for HTML-aware compression, or `compressHTML: false` to preserve all whitespace.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -133,7 +133,7 @@
     "test:integration": "astro-scripts test \"test/*.test.ts\" --parallel --strip-types"
   },
   "dependencies": {
-    "@astrojs/compiler-rs": "^0.1.10",
+    "@astrojs/compiler-rs": "^0.2.2",
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/markdown-satteri": "workspace:*",
     "@astrojs/telemetry": "workspace:*",

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -470,7 +470,7 @@ export async function renderPath({
 			relativeLocation: locationSite,
 			from: fromPath,
 		});
-		if (config.compressHTML === true) {
+		if (config.compressHTML) {
 			body = body.replaceAll('\n', '');
 		}
 		if (route.type !== 'redirect') {

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -85,7 +85,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 	devToolbar: {
 		enabled: true,
 	},
-	compressHTML: true,
+	compressHTML: 'jsx',
 	server: {
 		host: false,
 		port: 4321,

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -474,22 +474,22 @@ export interface AstroUserConfig<
 	 * @docs
 	 * @name compressHTML
 	 * @type {boolean | "jsx"}
-	 * @default `true`
+	 * @default `'jsx'`
 	 * @description
 	 *
 	 * Controls how Astro handles whitespace in your HTML. This affects both development mode and the final build output.
 	 *
-	 * By default, Astro removes whitespace from your HTML, including line breaks, in a lossless manner from `.astro` components. Some whitespace may be preserved as needed to maintain the visual rendering of your HTML.
+	 * By default (`'jsx'`), Astro applies the JSX whitespace stripping rules used by frameworks like React. Leading and trailing whitespace is only preserved when explicitly included in the source code through constructs such as `{" "}`, and is otherwise removed entirely.
 	 *
-	 * Since 6.2.0, this option can also be set to `"jsx"`, Astro will apply the JSX whitespace stripping rules used by frameworks like React. Leading and trailing whitespace is only preserved when explicitly included in the source code through constructs such as `{" "}`, and is otherwise removed entirely.
+	 * Setting this option to `true` instead removes whitespace, including line breaks, in a lossless manner from `.astro` components. Some whitespace may be preserved as needed to maintain the visual rendering of your HTML.
 	 *
-	 * Setting this option to false disables HTML compression and preserves all whitespace.
+	 * Setting this option to `false` disables HTML compression and preserves all whitespace.
 	 *
 	 * ```js
 	 * {
-	 *   compressHTML: false
+	 *   compressHTML: true
 	 *   // or:
-	 *   // compressHTML: 'jsx'
+	 *   // compressHTML: false
 	 * }
 	 * ```
 	 */

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -479,7 +479,7 @@ export interface AstroUserConfig<
 	 *
 	 * Controls how Astro handles whitespace in your HTML. This affects both development mode and the final build output.
 	 *
-	 * By default (`'jsx'`), Astro applies the JSX whitespace stripping rules used by frameworks like React. Leading and trailing whitespace is only preserved when explicitly included in the source code through constructs such as `{" "}`, and is otherwise removed entirely.
+	 * By default (`'jsx'`), Astro applies the JSX whitespace rules used by frameworks like React. Whitespace and line breaks around elements are removed and multi-line text is collapsed onto a single line, but whitespace within a single line — such as a space between two inline elements — is preserved. To keep a space that would otherwise be removed, include it explicitly in the source through constructs such as `{" "}`.
 	 *
 	 * Setting this option to `true` instead removes whitespace, including line breaks, in a lossless manner from `.astro` components. Some whitespace may be preserved as needed to maintain the visual rendering of your HTML.
 	 *

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -479,7 +479,7 @@ export interface AstroUserConfig<
 	 *
 	 * Controls how Astro handles whitespace in your HTML. This affects both development mode and the final build output.
 	 *
-	 * By default (`'jsx'`), Astro applies the JSX whitespace rules used by frameworks like React. Whitespace and line breaks around elements are removed and multi-line text is collapsed onto a single line, but whitespace within a single line — such as a space between two inline elements — is preserved. To keep a space that would otherwise be removed, include it explicitly in the source through constructs such as `{" "}`.
+	 * Since v7.0,  Astro applies by default the JSX whitespace rules used by frameworks like React. This removes whitespace and line breaks around elements, collapses multi-line text onto a single line, and preserves whitespace within a single line (e.g. a space between two inline elements). To keep a space that would otherwise be removed, include it explicitly in the source through constructs such as `{" "}`.
 	 *
 	 * Setting this option to `true` instead removes whitespace, including line breaks, in a lossless manner from `.astro` components. Some whitespace may be preserved as needed to maintain the visual rendering of your HTML.
 	 *

--- a/packages/astro/test/astro-script-template-dedup.test.ts
+++ b/packages/astro/test/astro-script-template-dedup.test.ts
@@ -29,8 +29,8 @@ describe('Scripts inside template elements', () => {
 		const $ = cheerio.load(html);
 
 		// One script inside the <template> (inert), one outside (executes)
-		assert.equal($('script').length, 1);
-		assert.equal(countSubstring(html, '<script type="module">'), 1);
+		assert.equal($('script').length, 2);
+		assert.equal(countSubstring(html, '<script type="module">'), 2);
 	});
 
 	it('renders script outside template when component is used outside first, then in template', async () => {
@@ -38,8 +38,8 @@ describe('Scripts inside template elements', () => {
 		const $ = cheerio.load(html);
 
 		// One script outside (executes, deduplicated normally), one inside the template
-		assert.equal($('script').length, 1);
-		assert.equal(countSubstring(html, '<script type="module">'), 1);
+		assert.equal($('script').length, 2);
+		assert.equal(countSubstring(html, '<script type="module">'), 2);
 	});
 
 	it('renders script outside nested templates', async () => {
@@ -47,8 +47,8 @@ describe('Scripts inside template elements', () => {
 		const $ = cheerio.load(html);
 
 		// One script outside (executes), one inside the nested templates
-		assert.equal($('script').length, 1);
-		assert.equal(countSubstring(html, '<script type="module">'), 1);
+		assert.equal($('script').length, 2);
+		assert.equal(countSubstring(html, '<script type="module">'), 2);
 	});
 
 	it('deduplicates scripts outside template while keeping one inside', async () => {
@@ -57,7 +57,7 @@ describe('Scripts inside template elements', () => {
 
 		// Two components outside the template should still deduplicate to one script.
 		// The template gets its own (inert) copy. Total: 2 scripts.
-		assert.equal($('script').length, 1);
-		assert.equal(countSubstring(html, '<script type="module">'), 1);
+		assert.equal($('script').length, 2);
+		assert.equal(countSubstring(html, '<script type="module">'), 2);
 	});
 });

--- a/packages/astro/test/fixtures/minification-html-default/astro.config.mjs
+++ b/packages/astro/test/fixtures/minification-html-default/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+// Intentionally does not set `compressHTML` so the default value is exercised.
+export default defineConfig({});

--- a/packages/astro/test/fixtures/minification-html-default/package.json
+++ b/packages/astro/test/fixtures/minification-html-default/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/minification-html-default",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/minification-html-default/src/pages/index.astro
+++ b/packages/astro/test/fixtures/minification-html-default/src/pages/index.astro
@@ -1,0 +1,23 @@
+---
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>default minification</title>
+  </head>
+  <body>
+    <p id="multi-line">
+      Hello
+      world
+    </p>
+    <div id="inline">
+      <span>hello</span>
+      <em>world</em>
+    </div>
+    <pre id="preserved">
+  keep
+    this
+      whitespace
+    </pre>
+  </body>
+</html>

--- a/packages/astro/test/minification-html.test.ts
+++ b/packages/astro/test/minification-html.test.ts
@@ -122,3 +122,56 @@ describe('HTML minification (JSX mode)', () => {
 		});
 	});
 });
+
+describe('HTML minification (default)', () => {
+	let html: string;
+	before(async () => {
+		// This fixture intentionally leaves `compressHTML` unset to exercise the default.
+		const fixture = await loadFixture({
+			root: './fixtures/minification-html-default/',
+			build: { inlineStylesheets: 'never' },
+			outDir: './dist/minification-html-default/',
+		});
+		await fixture.build();
+		html = await fixture.readFile('/index.html');
+	});
+
+	it('strips whitespace between inline elements, following JSX rules', () => {
+		// The discriminator: HTML-aware compression (`true`) keeps a single space
+		// here, while the default JSX rules remove it entirely.
+		assert.ok(
+			html.includes('<span>hello</span><em>world</em>'),
+			'whitespace between inline elements should be removed',
+		);
+	});
+
+	it('collapses multi-line text into a single line', () => {
+		assert.ok(html.includes('<p id="multi-line">Hello world</p>'));
+	});
+
+	it('preserves whitespace inside <pre> tags', () => {
+		assert.match(html, /<pre id="preserved">\n\s+keep\n\s+this\n\s+whitespace/);
+	});
+
+	it('removes every newline outside of <pre>', () => {
+		const withoutPre = html.replace(/<pre[\s\S]*?<\/pre>/g, '');
+		assert.equal(NEW_LINES.test(withoutPre), false);
+	});
+});
+
+describe('HTML minification (compressHTML: true differs from the default)', () => {
+	it('keeps a single space between inline elements', async () => {
+		const fixture = await loadFixture({
+			root: './fixtures/minification-html-default/',
+			build: { inlineStylesheets: 'never' },
+			outDir: './dist/minification-html-true/',
+			compressHTML: true,
+		});
+		await fixture.build();
+		const html = await fixture.readFile('/index.html');
+		assert.ok(
+			html.includes('<span>hello</span> <em>world</em>'),
+			'HTML-aware compression should preserve inline whitespace as a single space',
+		);
+	});
+});

--- a/packages/astro/test/minification-html.test.ts
+++ b/packages/astro/test/minification-html.test.ts
@@ -116,7 +116,7 @@ describe('HTML minification (JSX mode)', () => {
 
 		it('should preserve inline text and elements on the same line', () => {
 			assert.ok(
-				html.includes('<span>hello</span><em>world</em>'),
+				html.includes('<span>hello</span> <em>world</em>'),
 				'inline elements should preserve spacing',
 			);
 		});

--- a/packages/astro/test/serializeManifest.test.ts
+++ b/packages/astro/test/serializeManifest.test.ts
@@ -39,7 +39,7 @@ describe('astro:config/client', () => {
 						format: 'directory',
 					},
 					trailingSlash: 'always',
-					compressHTML: true,
+					compressHTML: 'jsx',
 					site: 'https://example.com',
 				}),
 			);

--- a/packages/astro/test/units/manifest/serialized.test.ts
+++ b/packages/astro/test/units/manifest/serialized.test.ts
@@ -165,10 +165,10 @@ describe('serializedManifestPlugin - dev mode', () => {
 	});
 
 	describe('compressHTML', () => {
-		it('is true by default', async () => {
+		it("is 'jsx' by default", async () => {
 			const settings = await createBasicSettings({});
 			const manifest = await getManifest(settings);
-			assert.equal(manifest.compressHTML, true);
+			assert.equal(manifest.compressHTML, 'jsx');
 		});
 
 		it('is false when explicitly disabled', async () => {

--- a/packages/astro/test/units/test-utils.ts
+++ b/packages/astro/test/units/test-utils.ts
@@ -162,7 +162,7 @@ export function createBasicPipeline(
 		adapterName?: string;
 		clientDirectives?: Map<string, string>;
 		inlinedScripts?: Map<string, string>;
-		compressHTML?: boolean;
+		compressHTML?: boolean | 'jsx';
 		i18n?: SSRManifest['i18n'];
 		middleware?: SSRManifest['middleware'];
 		routeCache?: RouteCache;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3434,6 +3434,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/minification-html-default:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/minification-html-jsx:
     dependencies:
       '@astrojs/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,8 +528,8 @@ importers:
   packages/astro:
     dependencies:
       '@astrojs/compiler-rs':
-        specifier: ^0.1.10
-        version: 0.1.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.2.2
+        version: 0.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@astrojs/internal-helpers':
         specifier: workspace:*
         version: link:../internal-helpers
@@ -6770,69 +6770,69 @@ packages:
     resolution: {integrity: sha512-bVzyKzEpIwqjihBU/aUzt1LQckJuHK0agd3/ITdXhPUYculrc6K1/K7H+XG4rwjXtg+ikT3PM05V1MVYWiIvQw==}
     engines: {node: '>=18.14.1'}
 
-  '@astrojs/compiler-binding-darwin-arm64@0.1.10':
-    resolution: {integrity: sha512-zDYwHvXVCm91XUm5xBRPbZK6yx9foM+Ut2qHiL0L37r1daF1bGLhnYjNV/VP35OLH5o/A1j+9uvl1xEX2a3ftw==}
+  '@astrojs/compiler-binding-darwin-arm64@0.2.2':
+    resolution: {integrity: sha512-1WxpECx3izz5X4Ha3l6ex79HZlUHpKBTElGJsfOosnhVvXhccfcXAsBlrYPNmUOKJWiG7mcrje0ELSr1KPE69Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@astrojs/compiler-binding-darwin-x64@0.1.10':
-    resolution: {integrity: sha512-EqugPJFuQdG11sG6TtO8uq0njcEyv9y/5gdpBRZJE6aSoM3yWFmTQ/aNU8PWIiz1upZFjdNQ/UUnVNzYd7N7Uw==}
+  '@astrojs/compiler-binding-darwin-x64@0.2.2':
+    resolution: {integrity: sha512-PdIQidwQ4nUX/qNL0JXzSwNYadr+yX/Yoo+kZSCxBZqlAqug9SlKR/1H5EG5jSEpkEDRo2d1JdrO1W4kU6uNHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@astrojs/compiler-binding-linux-arm64-gnu@0.1.10':
-    resolution: {integrity: sha512-h1UN8yx2vO/0uwnExN/8MNfsDr7OFADVM3Vv0JWeSpmUO6sFOvTsGVAeBBl29up6c4sdT3QJ5rf6sczQsc25dA==}
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.2.2':
+    resolution: {integrity: sha512-5sZicPkJCoyxTEOW2he+u6UV97pTXY4c7fbHOZ/aslu9ewsunD0231QUBSvnjBB9hRFzzP2JRfNCLY+IvWfw0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@astrojs/compiler-binding-linux-arm64-musl@0.1.10':
-    resolution: {integrity: sha512-ot1Lksml0FqrrlYa89wGXQM+n290ncj65PZAq8siEWmXsmwoNCYCbqRSwRO6I/cT+PDlmmV0AcFTrp1DEO3PUA==}
+  '@astrojs/compiler-binding-linux-arm64-musl@0.2.2':
+    resolution: {integrity: sha512-Vto5fqRzMepQNJPeEhQLOIkmAoNbSBQNlpMe64OHTjEbAtQpJYVHEwe+8WJLaEGLA9qBksLv7ctiYPLLxgVVYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@astrojs/compiler-binding-linux-x64-gnu@0.1.10':
-    resolution: {integrity: sha512-RGKGCbCvDat+DppnQbiWIhif6ptvkyXMdqOa7NjES4UoqIIUjE3YZfRn8gp3bXUe4ReWv4hGO1TQd2eitONt1g==}
+  '@astrojs/compiler-binding-linux-x64-gnu@0.2.2':
+    resolution: {integrity: sha512-NJTTaUDU49WEJT+ImS9evlv3i3x42HN8PbcqdyydI9picnKtuf5TxRL94naoW09YDMYWpkrwVeVqaG7GTSIepQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@astrojs/compiler-binding-linux-x64-musl@0.1.10':
-    resolution: {integrity: sha512-UemMv5Xq9c7trG9Cel4MHAo2wYiCxZ6qIKUnI4NJqBXDtOBqAjcMoqMbw78KYkb9vg2OIewVaJ+YvQrFZs5VBg==}
+  '@astrojs/compiler-binding-linux-x64-musl@0.2.2':
+    resolution: {integrity: sha512-9nFdNDkWaU35bhWUIciDmi439W0fq2ZNgv1GCi2A/LSb+8vTw9l9z+fVW4YEn7Tlvbs8gyQkJvbc62ZD1H76xA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.1.10':
-    resolution: {integrity: sha512-SwawjgiYnm7s5neVKRoHIsnGG06vhuFhKg0iMBO6EsnL19xVbUp61V50gVtdgFlsfXalfH6SHuv2wQw8FhFSNg==}
+  '@astrojs/compiler-binding-wasm32-wasi@0.2.2':
+    resolution: {integrity: sha512-3NWaxRc3KSwr9zHBEGcQ147rMgAhi/HzZWZJPRN2YLbtuLhoeBPruhdX1MIlOYAg3FvJPYdzGCAKvvWWU6pF0A==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@astrojs/compiler-binding-win32-arm64-msvc@0.1.10':
-    resolution: {integrity: sha512-DKGOtbS8AZztvKUUdzvf+bOp7QLudmQiMHSYobSZKFanryQH5SllOMrZsL2pbDAcfBBrf0WsYWp9R+/ga7gGhQ==}
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.2.2':
+    resolution: {integrity: sha512-QsyOgocLGOwDm8zAyuAiziALMzbTTevaqBLv5lvdhyhj2JC5yjp0H3yeEBtE0owRLr1gDQdX0+1qBSc5tTwp4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@astrojs/compiler-binding-win32-x64-msvc@0.1.10':
-    resolution: {integrity: sha512-de9Y0GPm19G6SPgUk86ycZNuWEw7AA7vLZvsi/+cNR7tr/vOabU931O22L4bjjS138PFWmBz+qYOH9CT6h6BDA==}
+  '@astrojs/compiler-binding-win32-x64-msvc@0.2.2':
+    resolution: {integrity: sha512-+/C8Oh9YS8C0fwtaqDtUSPniKwlJqgiQbxp7XuzxCP0RI/Jf7yOlz9ZHNr6jD3ZJa4CHdq0mYq7pd8QFiNGIZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@astrojs/compiler-binding@0.1.10':
-    resolution: {integrity: sha512-XvsWOM1JTjTDETD4qK2rIIHyPSMtBP+t7+Hmgk1kd4/iiUxLPnyLjnwLKX7N5t1MBHNmGiEA39DOslSMtlnfeg==}
+  '@astrojs/compiler-binding@0.2.2':
+    resolution: {integrity: sha512-PkCo+UcSxMt9pufjv28kRy8YU88O/XNgm7apwkyhkrCecLY62QCj5UA3nOTMO88PPyVKnUh/6FZbPefBhDD5IA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@astrojs/compiler-rs@0.1.10':
-    resolution: {integrity: sha512-Mul2veNSpEzwd1Zk6coIAu9TKyk6RjBJMWaOOrelBBA+ZmcGXhj7MabjowNTOMgvRUU8YHXAHadzoKD0y49uxw==}
+  '@astrojs/compiler-rs@0.2.2':
+    resolution: {integrity: sha512-C0qoz7Hxa2krlwMYfzQ1ZxOjR6cGmO+iskjRXXCdUM85W/cAPGTi/MSQlLkv0ADMz+Go1/lqeRBjL8AZwsFffQ==}
 
   '@astrojs/compiler@2.13.1':
     resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
@@ -8636,6 +8636,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@netlify/ai@0.4.1':
     resolution: {integrity: sha512-ETLtV/9taYrcGhszwO+BLFgFJJ2MCnJp8BwxfwV6Z/+z3SsaUG4ExC8x4xzNCdB2GPWxXrXkvR2LFNsPFSLcRA==}
     engines: {node: '>=20.6.1'}
@@ -9692,6 +9698,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/alpinejs@3.13.11':
     resolution: {integrity: sha512-3KhGkDixCPiLdL3Z/ok1GxHwLxEWqQOKJccgaQL01wc0EVM2tCTaqlC3NIedmxAXkVzt/V6VTM8qPgnOHKJ1MA==}
@@ -15772,56 +15781,56 @@ snapshots:
       log-update: 5.0.1
       sisteransi: 1.0.5
 
-  '@astrojs/compiler-binding-darwin-arm64@0.1.10':
+  '@astrojs/compiler-binding-darwin-arm64@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding-darwin-x64@0.1.10':
+  '@astrojs/compiler-binding-darwin-x64@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-arm64-gnu@0.1.10':
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-arm64-musl@0.1.10':
+  '@astrojs/compiler-binding-linux-arm64-musl@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-x64-gnu@0.1.10':
+  '@astrojs/compiler-binding-linux-x64-gnu@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-x64-musl@0.1.10':
+  '@astrojs/compiler-binding-linux-x64-musl@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.1.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@astrojs/compiler-binding-wasm32-wasi@0.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
     optional: true
 
-  '@astrojs/compiler-binding-win32-arm64-msvc@0.1.10':
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding-win32-x64-msvc@0.1.10':
+  '@astrojs/compiler-binding-win32-x64-msvc@0.2.2':
     optional: true
 
-  '@astrojs/compiler-binding@0.1.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@astrojs/compiler-binding@0.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     optionalDependencies:
-      '@astrojs/compiler-binding-darwin-arm64': 0.1.10
-      '@astrojs/compiler-binding-darwin-x64': 0.1.10
-      '@astrojs/compiler-binding-linux-arm64-gnu': 0.1.10
-      '@astrojs/compiler-binding-linux-arm64-musl': 0.1.10
-      '@astrojs/compiler-binding-linux-x64-gnu': 0.1.10
-      '@astrojs/compiler-binding-linux-x64-musl': 0.1.10
-      '@astrojs/compiler-binding-wasm32-wasi': 0.1.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@astrojs/compiler-binding-win32-arm64-msvc': 0.1.10
-      '@astrojs/compiler-binding-win32-x64-msvc': 0.1.10
+      '@astrojs/compiler-binding-darwin-arm64': 0.2.2
+      '@astrojs/compiler-binding-darwin-x64': 0.2.2
+      '@astrojs/compiler-binding-linux-arm64-gnu': 0.2.2
+      '@astrojs/compiler-binding-linux-arm64-musl': 0.2.2
+      '@astrojs/compiler-binding-linux-x64-gnu': 0.2.2
+      '@astrojs/compiler-binding-linux-x64-musl': 0.2.2
+      '@astrojs/compiler-binding-wasm32-wasi': 0.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@astrojs/compiler-binding-win32-arm64-msvc': 0.2.2
+      '@astrojs/compiler-binding-win32-x64-msvc': 0.2.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@astrojs/compiler-rs@0.1.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@astrojs/compiler-rs@0.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@astrojs/compiler-binding': 0.1.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@astrojs/compiler-binding': 0.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -17819,6 +17828,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@netlify/ai@0.4.1':
     dependencies:
       '@netlify/api': 14.0.18
@@ -18951,6 +18967,11 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true


### PR DESCRIPTION
## Changes

The newly introduced `compressHTML: 'jsx'` is now the default option in V7, requested by our steward. The Rust compiler always had support for this unlike the Go one, so it's really just switching up the default.

## Testing

Tests should pass, added tests for this specific behavior

## Docs

https://github.com/withastro/docs/pull/14076
