### PR TITLE
refactor: use hex color in CSS test

### DIFF
--- a/packages/astro/test/css-path-case.test.ts
+++ b/packages/astro/test/css-path-case.test.ts
@@ -74,7 +74,7 @@ describe('CSS scoped styles with a case-mismatched project root', {
 	it('injects the scoped style into the page (issue #14013)', () => {
 		const injectedStyles = $('style').text().replace(/\s/g, '');
 		assert.equal(
-			injectedStyles.includes('color:rgb(255,165,0)'),
+			injectedStyles.includes('color:#123456'),
 			true,
 			'expected the scoped <style> to be injected even though the root case differs from disk',
 		);

--- a/packages/astro/test/fixtures/css-path-case/src/pages/index.astro
+++ b/packages/astro/test/fixtures/css-path-case/src/pages/index.astro
@@ -12,6 +12,12 @@
 
 <style>
 	h1 {
-		color: rgb(255, 165, 0);
+		/* 
+		A hex value already in its shortest canonical form: the Rust compiler
+		(@astrojs/compiler-rs) re-serializes CSS values when injecting scope
+		attributes, so a value with a shorter equivalent (e.g. `rgb(255, 165, 0)`
+		collapses to `orange`) would not survive verbatim for the assertion. 
+		*/
+		color: #123456;
 	}
 </style>

--- a/packages/astro/test/fixtures/css-path-case/src/pages/index.astro
+++ b/packages/astro/test/fixtures/css-path-case/src/pages/index.astro
@@ -12,12 +12,6 @@
 
 <style>
 	h1 {
-		/* 
-		A hex value already in its shortest canonical form: the Rust compiler
-		(@astrojs/compiler-rs) re-serializes CSS values when injecting scope
-		attributes, so a value with a shorter equivalent (e.g. `rgb(255, 165, 0)`
-		collapses to `orange`) would not survive verbatim for the assertion. 
-		*/
 		color: #123456;
 	}
 </style>


### PR DESCRIPTION
## Changes

Update a test so that it can pass in the `next` branch (with `@astrojs/compiler-rs`).

`@astrojs/compiler-rs` re-serializes CSS values from `rgb(255, 165, 0)` to `orange` to this test didn't pass in the `next` branch.

Unblock https://github.com/withastro/astro/pull/16962 

## Testing

`rgb(0, 255, 0)` CI.


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
