### PR TITLE
Preserve empty cookie values in Astro.cookies.get

### DIFF
--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -135,7 +135,7 @@ class AstroCookies implements AstroCookiesInterface {
 		const values = this.#ensureParsed();
 		if (key in values) {
 			const value = values[key];
-			if (value) {
+			if (value !== undefined) {
 				let decodedValue: string;
 				try {
 					decodedValue = decode(value);

--- a/packages/astro/test/units/cookies/get.test.ts
+++ b/packages/astro/test/units/cookies/get.test.ts
@@ -49,6 +49,18 @@ describe('astro/src/core/cookies', () => {
 			assert.equal(cookies.get('url')!.value, encode(url));
 		});
 
+		it('gets empty cookie values', () => {
+			const req = new Request('http://example.com/', {
+				headers: {
+					cookie: 'foo=',
+				},
+			});
+			const cookies = new AstroCookies(req);
+
+			assert.equal(cookies.has('foo'), true);
+			assert.equal(cookies.get('foo')!.value, '');
+		});
+
 		it("Returns undefined is the value doesn't exist", () => {
 			const req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);


### PR DESCRIPTION
## Summary

Preserve empty request cookie values in `Astro.cookies.get()`.

Related: #16983

## User-facing problem

A request with `Cookie: foo=` currently produces two conflicting results:

- `cookies.has('foo') === true`
- `cookies.get('foo') === undefined`

That collapses `present but empty` into the same result as `missing`.

## Expected behavior

For `Cookie: foo=`, `cookies.get('foo')?.value` should be `''`.

## Why this looks like a regression

I opened #16983 with a minimal reproduction and the full history.

Short version: `get()` used to preserve empty values, then started checking `if (value)` in `c69bf18a4e` on 2025-03-18. A later refactor in `018fbe90f4` on 2025-03-26 made the `has()` / `get()` mismatch more obvious.

## What changed

- treat `''` as a valid parsed cookie value in `Astro.cookies.get()`
- add a regression test for `cookie: 'foo='`

## Validation

- `npm exec --yes pnpm@11.5.0 -- exec astro-scripts test "test/units/cookies/*.test.ts" --strip-types --teardown ./test/units/teardown.ts`