### PR TITLE
fix(errors): correct param key in getStaticPaths error-doc examples (slug → id)

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -223,8 +223,8 @@ export const NoClientOnlyHint = {
  * ---
  * export async function getStaticPaths() {
  *	return [
- *		{ params: { slug: "blog" } },
- * 		{ params: { slug: "about" } }
+ *		{ params: { id: "blog" } },
+ * 		{ params: { id: "about" } }
  * 	];
  *}
  *---
@@ -247,8 +247,8 @@ export const InvalidGetStaticPathParam = {
  * ```ts title="pages/blog/[id].astro"
  * export async function getStaticPaths() {
  *	return [ // <-- Array
- *		{ params: { slug: "blog" } }, // <-- Object
- * 		{ params: { slug: "about" } }
+ *		{ params: { id: "blog" } }, // <-- Object
+ * 		{ params: { id: "about" } }
  * 	];
  *}
  * ```
@@ -271,8 +271,8 @@ export const InvalidGetStaticPathsEntry = {
  * ```ts title="pages/blog/[id].astro"
  * export async function getStaticPaths() {
  *	return [ // <-- Array
- *		{ params: { slug: "blog" } },
- * 		{ params: { slug: "about" } }
+ *		{ params: { id: "blog" } },
+ * 		{ params: { id: "about" } }
  * 	];
  *}
  * ```


### PR DESCRIPTION
## Summary

Three JSDoc example blocks in `errors-data.ts` — for `InvalidGetStaticPathParam`, `InvalidGetStaticPathsEntry`, and `InvalidGetStaticPathsReturn` — open with the route file `pages/blog/[id].astro` but then return params keyed on `slug`:

```astro title="pages/blog/[id].astro"
{ params: { slug: "blog" } },
{ params: { slug: "about" } }
```

For a dynamic route `[id].astro`, `getStaticPaths()` must return params keyed on the segment name `id`. A `slug` key would itself trigger a routing error, so these examples — whose whole purpose is to teach correct `getStaticPaths()` usage — are internally inconsistent.

These JSDoc blocks also generate the public Error Reference pages, so the mismatch is user-facing (e.g. `docs.astro.build/en/reference/errors/invalid-get-static-path-param/`).

## Change

Replace the `slug` param key with `id` in all six lines so each example matches its declared `[id].astro` route. This matches the neighboring blocks `GetStaticPathsExpectedParams` and `GetStaticPathsInvalidRouteParam`, which already use `{ params: { id: ... } }` for an `[id]` route.

Docs/comment example only — no runtime code changes.
