### PR TITLE
chore: avoid an unwanted mdx major bump

### DIFF
--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -50,7 +50,7 @@
     "vfile": "^6.0.3"
   },
   "peerDependencies": {
-    "@astrojs/markdown-satteri": "workspace:*",
+    "@astrojs/markdown-satteri": "0.3.0",
     "astro": "^6.4.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Changes

Unblock https://github.com/withastro/astro/pull/16972#pullrequestreview-4427886135 

Before this PR, Changesets will make the following change in  https://github.com/withastro/astro/pull/16972:

```diff
  {
    "name": "@astrojs/markdown-satteri",
-   "version": "0.2.2",
+   "version": "0.3.0",
  }
```


```diff
  {
    "name": "@astrojs/mdx",
-   "version": "6.0.2",
+   "version": "7.0.0",
    "peerDependencies": {
-     "@astrojs/markdown-satteri": "0.2.2"
+     "@astrojs/markdown-satteri": "0.3.0"
    }
  }
```


After this PR, `changesets` will make the following change:


```diff
  {
    "name": "@astrojs/markdown-satteri",
-   "version": "0.2.2",
+   "version": "0.3.0",
  }
```


```diff
  {
    "name": "@astrojs/mdx",
-   "version": "6.0.2",
+   "version": "6.0.3",
    "peerDependencies": {
      "@astrojs/markdown-satteri": "0.3.0"
    }
  }
```


--- 

This is just a workaround. We can revert the change in this PR and reuse `workspace:*` once we have merged Changeset release and published new versions. 

 


## Testing

Tested locally with `./node_modules/.bin/changeset version` to ensure that Changeset won't crash and won't bump `@astrojs/mdx` to a major version after my change.

Green CI. In other words, tools like `pnpm` and `turbo` accept `"@astrojs/markdown-satteri": "0.3.0"` in the `peerDependencies`, even though `packages/markdown/satteri/package.json` only has `"version": "0.2.2"`.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
