### PR TITLE
Mark context provider APIs as internal

### DIFF
--- a/.changeset/beige-doodles-bow.md
+++ b/.changeset/beige-doodles-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes `state.provide()`, `state.resolve()`, `state.finalizeAll()`, and `App.Providers` from the public advanced routing API. These context provider extension points are now internal-only. If you were using them in an integration, use `locals` to share per-request state instead.

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -45,6 +45,8 @@ import { getFirstForwardedValue, validateForwardedHeaders } from '../app/validat
  * Describes a lazily-created value that handlers can contribute to the
  * request context. `create` is called at most once (on first `resolve`);
  * `finalize` runs during `finalizeAll` to clean up / persist.
+ *
+ * @internal Not for use by 3rd-party code. May change without notice.
  */
 export interface ContextProvider<T> {
 	/** Factory called lazily on the first `resolve(key)`. */
@@ -91,24 +93,6 @@ export interface AstroFetchState {
 	 * [Astro reference](https://docs.astro.build/en/guides/routing/#rewrites)
 	 */
 	rewrite(payload: RewritePayload): Promise<Response>;
-
-	/**
-	 * Registers a context provider under the given key. The `create`
-	 * factory is called lazily on the first `resolve(key)`.
-	 */
-	provide<T>(key: string, provider: ContextProvider<T>): void;
-
-	/**
-	 * Lazily resolves a provider registered under `key`. Returns
-	 * `undefined` if no provider was registered for the key.
-	 */
-	resolve<T>(key: string): T | undefined;
-
-	/**
-	 * Runs all registered provider `finalize` callbacks. Call this after
-	 * the response is produced, typically in a `finally` block.
-	 */
-	finalizeAll(): Promise<void> | void;
 }
 
 /**

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -138,7 +138,7 @@ export interface AstroGlobal<
 export interface APIContext<
 	Props extends Record<string, any> = Record<string, any>,
 	Params extends Record<string, string | undefined> = Record<string, string | undefined>,
-> extends App.Providers {
+> {
 	/**
 	 * The site provided in the astro config, parsed as an instance of `URL`, without base.
 	 * `undefined` if the site is not provided in the config.

--- a/packages/astro/src/types/public/extendables.ts
+++ b/packages/astro/src/types/public/extendables.ts
@@ -15,25 +15,6 @@ declare global {
 		 * Optionally type the data stored in the session
 		 */
 		export interface SessionData {}
-
-		/**
-		 * Declare custom context providers to get typed access on `Astro` and `ctx`.
-		 * Libraries and users register providers via `state.provide(key, { create, finalize? })`,
-		 * and the corresponding types are declared here using module augmentation.
-		 *
-		 * Built-in providers like `session` are already typed by Astro and don't
-		 * need to be declared here.
-		 *
-		 * @example
-		 * ```ts
-		 * declare namespace App {
-		 *   interface Providers {
-		 *     oauth: import('./lib/oauth').OAuthSession;
-		 *   }
-		 * }
-		 * ```
-		 */
-		export interface Providers {}
 	}
 
 	namespace Astro {


### PR DESCRIPTION
## Changes

- Removes `provide`, `resolve`, and `finalizeAll` from the public `AstroFetchState` interface. The concrete `FetchState` class retains them for internal use (session, cache).
- Removes `App.Providers` module augmentation interface — nothing depends on it since built-in providers are already explicitly typed on `APIContext`.
- Removes `extends App.Providers` from `APIContext`.
- Marks `ContextProvider<T>` as `@internal`.

Per the [discussion on #16877](https://github.com/withastro/astro/pull/16877#discussion_r2124362137), we do not want 3rd-party handlers extending the Astro global via `FetchState#provide` yet. This keeps the machinery working internally while removing it from the public API surface.

## Testing

No test changes — existing context provider tests continue to pass since the internal class is unchanged.

## Docs

- https://github.com/withastro/docs/pull/13993