### PR TITLE
Always provide session stub so Astro.session is never absent

### DIFF
--- a/.changeset/cozy-knives-buy.md
+++ b/.changeset/cozy-knives-buy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves the warning when accessing `Astro.session` without session storage configured. The `session` property is now always defined on the context object, and accessing it without configuration logs a helpful message instead of silently returning `undefined`.

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -780,13 +780,41 @@ export class FetchState implements AstroFetchState {
 	 * Used by context creation (APIContext, Astro global) so that
 	 * provider values like `session` and `cache` appear as properties
 	 * without hard-coding the keys.
+	 *
+	 * Always defines a `session` getter (returning `undefined` when no
+	 * provider is registered) so `ctx.session` / `Astro.session` is a
+	 * present property regardless of whether the sessions handler was
+	 * included in the pipeline.
 	 */
 	defineProviderGetters(target: Record<string, any>): void {
-		if (!this.#providers) return;
 		const state = this;
-		for (const key of this.#providers.keys()) {
-			Object.defineProperty(target, key, {
-				get: () => state.resolve(key),
+		if (this.#providers) {
+			for (const key of this.#providers.keys()) {
+				Object.defineProperty(target, key, {
+					get: () => state.resolve(key),
+					enumerable: true,
+					configurable: true,
+				});
+			}
+		}
+		// Ensure `session` is always a defined property even when the
+		// sessions handler is not part of the pipeline. Warns once on
+		// access so users know they need to configure session storage.
+		if (!this.#providers?.has('session')) {
+			let warned = false;
+			Object.defineProperty(target, 'session', {
+				get() {
+					if (!warned) {
+						warned = true;
+						state.pipeline.logger.warn(
+							'session',
+							'`Astro.session` was accessed but no session storage is configured. ' +
+								'Either configure the storage manually or use an adapter that provides session storage. ' +
+								'For more information, see https://docs.astro.build/en/guides/sessions/',
+						);
+					}
+					return undefined;
+				},
 				enumerable: true,
 				configurable: true,
 			});

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -13,8 +13,9 @@ import {
 } from '../../../dist/core/fetch/index.js';
 import { ALL_PIPELINE_FEATURES } from '../../../dist/core/base-pipeline.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
-import { createEndpoint, createPage, createRedirect, createTestApp } from '../mocks.ts';
+import { createEndpoint, createPage, createRedirect, createTestApp, createMockFetchState } from '../mocks.ts';
 import { dynamicPart, spreadPart } from '../routing/test-helpers.ts';
+import { SpyLogger } from '../test-utils.ts';
 
 /** A simple page component that renders `<h1>Hello</h1>`. */
 const simplePage = createComponent((_result: any, _props: any, _slots: any) => {
@@ -871,6 +872,41 @@ describe('FetchState X-Forwarded-* header resolution', () => {
 
 		const response = await astro(state);
 		assert.equal(response.status, 200);
+	});
+});
+
+// #endregion
+
+// #region session stub getter
+
+describe('session stub getter', () => {
+	it('session property is always defined on the context even without session config', () => {
+		const state = createMockFetchState();
+		const target: Record<string, any> = {};
+		state.defineProviderGetters(target);
+		assert.ok('session' in target, 'session should be a defined property');
+		assert.equal(target.session, undefined);
+	});
+
+	it('warns on first access when session is not configured', async () => {
+		const { createBasicPipeline } = await import('../test-utils.ts');
+		const logger = new SpyLogger();
+		const pipeline = createBasicPipeline({ logger });
+		const state = createMockFetchState({ pipeline });
+
+		const target: Record<string, any> = {};
+		state.defineProviderGetters(target);
+
+		// First access should warn
+		void target.session;
+		const warnings = logger.logs.filter((l) => l.level === 'warn' && l.label === 'session');
+		assert.equal(warnings.length, 1, 'should warn once on first access');
+		assert.ok(warnings[0].message.includes('no session storage is configured'));
+
+		// Second access should not warn again
+		void target.session;
+		const warningsAfter = logger.logs.filter((l) => l.level === 'warn' && l.label === 'session');
+		assert.equal(warningsAfter.length, 1, 'should not warn a second time');
 	});
 });
 


### PR DESCRIPTION
## Changes

- `defineProviderGetters` in `FetchState` now always defines a `session` getter on context objects, even when no session provider has been registered. This ensures `Astro.session` / `ctx.session` is always a present property regardless of whether the `sessions()` handler is included in the pipeline.
- Accessing `session` without storage configured logs a warning on first access: *"no session storage is configured. Either configure the storage manually or use an adapter that provides session storage."* This restores the helpful warning that existed in 6.2 before the advanced routing refactor moved session setup into the provider system.

## Testing

- Added two unit tests in `test/units/fetch/index.test.ts`: one verifying the property is always present (returning `undefined`), one verifying the warn-once behavior with `SpyLogger`.

## Docs

- No docs needed. No user-facing API change.