### PR TITLE
docs: fix grammar in container API JSDoc comments

### DIFF
--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -96,7 +96,7 @@ export type ContainerRenderOptions = {
 	routeType?: RouteType;
 
 	/**
-	 * Allows to pass `Astro.props` to an Astro component:
+	 * Allows passing `Astro.props` to an Astro component:
 	 *
 	 * ```js
 	 * container.renderToString(Endpoint, { props: { "lorem": "ipsum" } });
@@ -105,9 +105,9 @@ export type ContainerRenderOptions = {
 	props?: Props;
 
 	/**
-	 * When `false`, it forces to render the component as it was a full-fledged page.
+	 * When `false`, it forces the component to render as if it were a full-fledged page.
 	 *
-	 * By default, the container API render components as [partials](https://docs.astro.build/en/basics/astro-pages/#page-partials).
+	 * By default, the container API renders components as [partials](https://docs.astro.build/en/basics/astro-pages/#page-partials).
 	 *
 	 */
 	partial?: boolean;


### PR DESCRIPTION
## Changes

Fixes three grammar errors in the `AstroContainer` options JSDoc (`packages/astro/src/container/index.ts`):

- `Allows to pass` -> `Allows passing`
- `it forces to render the component as it was a full-fledged page` -> `it forces the component to render as if it were a full-fledged page`
- `the container API render components` -> `the container API renders components`

## Testing

Comment-only change; no tests needed.

## Docs

No user-facing behavior change; internal JSDoc only.
