### PR TITLE
fix(node): resolve experimental logger before logging server startup …

### DIFF
--- a/.changeset/fix-node-logger-startup-message.md
+++ b/.changeset/fix-node-logger-startup-message.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes the `experimental.logger` destination not being used for the "Server listening on..." startup message. The custom logger is now resolved before the server starts listening, so the startup message uses the correct destination.

--- a/.changeset/fix-node-logger-startup-message.md
+++ b/.changeset/fix-node-logger-startup-message.md
@@ -1,5 +1,6 @@
 ---
 '@astrojs/node': patch
+'astro': patch
 ---
 
-Fixes the `experimental.logger` destination not being used for the "Server listening on..." startup message. The custom logger is now resolved before the server starts listening, so the startup message uses the correct destination.
+Fixes the `experimental.logger` destination not being used for the "Server listening on..." startup message. The logger is now resolved before the server starts listening, and `adapterLogger` re-creates itself when the underlying logger changes so the startup message uses the correct destination.

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -154,9 +154,10 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 	}
 
 	get adapterLogger(): AstroIntegrationLogger {
-		if (!this.#adapterLogger) {
+		const currentOptions = this.logger.options;
+		if (!this.#adapterLogger || this.#adapterLogger.options !== currentOptions) {
 			this.#adapterLogger = new AstroIntegrationLogger(
-				this.logger.options,
+				currentOptions,
 				this.manifest.adapterName,
 			);
 		}

--- a/packages/astro/test/units/app/logger.test.ts
+++ b/packages/astro/test/units/app/logger.test.ts
@@ -43,6 +43,23 @@ function createAppWithLogger(experimentalLogger?: LoggerHandlerConfig) {
 }
 
 describe('SSR Logger', () => {
+	it('adapterLogger re-creates itself after the pipeline logger is replaced', async () => {
+		const app = createAppWithLogger({ entrypoint: 'astro/logger/json' });
+
+		// Access adapterLogger before getLogger() — caches it with the default options
+		const beforeOptions = app.adapterLogger.options;
+
+		await app.pipeline.getLogger();
+
+		// After getLogger() replaces pipeline.logger, adapterLogger should re-create
+		const afterOptions = app.adapterLogger.options;
+		assert.notEqual(
+			beforeOptions,
+			afterOptions,
+			'adapterLogger should re-create when the pipeline logger is replaced',
+		);
+	});
+
 	it('resolves a custom logger destination from the manifest on first request', async () => {
 		const app = createAppWithLogger({ entrypoint: 'astro/logger/json' });
 

--- a/packages/astro/test/units/app/logger.test.ts
+++ b/packages/astro/test/units/app/logger.test.ts
@@ -46,7 +46,7 @@ describe('SSR Logger', () => {
 	it('adapterLogger re-creates itself after the pipeline logger is replaced', async () => {
 		const app = createAppWithLogger({ entrypoint: 'astro/logger/json' });
 
-		// Access adapterLogger before getLogger() — caches it with the default options
+		// Access adapterLogger before getLogger(), caches it with the default options
 		const beforeOptions = app.adapterLogger.options;
 
 		await app.pipeline.getLogger();

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -17,7 +17,7 @@ export const hostOptions = (host: Options['host']): string => {
 	return host;
 };
 
-export default async function standalone(
+export default function standalone(
 	app: BaseApp,
 	options: Options,
 	headersMap: NodeAppHeadersJson | undefined,
@@ -30,13 +30,14 @@ export default async function standalone(
 	const resolvedOptions = { ...options, port };
 	const handler = createStandaloneHandler(app, resolvedOptions, headersMap);
 	const server = createServer(handler, host, port);
-	// Resolve the user-configured logger before starting the server so that
-	// the startup message uses the correct destination and adapterLogger is
-	// created from the already-replaced pipeline.logger.
-	await app.pipeline.getLogger();
 	server.server.listen(port, host);
 	if (process.env.ASTRO_NODE_LOGGING !== 'disabled') {
-		logListeningOn(app.adapterLogger, server.server, host);
+		// Resolve the user-configured logger before logging the startup message.
+		// getLogger() resolves before the OS finishes binding the port (and emitting
+		// 'listening'), so logListeningOn's once('listening') handler is registered
+		// in time. standalone() stays synchronous so callers receive the server object
+		// immediately, as they did before.
+		app.pipeline.getLogger().then(() => logListeningOn(app.adapterLogger, server.server, host));
 	}
 	server.server.on('close', () => {
 		app.logger.close();

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -17,7 +17,7 @@ export const hostOptions = (host: Options['host']): string => {
 	return host;
 };
 
-export default function standalone(
+export default async function standalone(
 	app: BaseApp,
 	options: Options,
 	headersMap: NodeAppHeadersJson | undefined,
@@ -30,6 +30,10 @@ export default function standalone(
 	const resolvedOptions = { ...options, port };
 	const handler = createStandaloneHandler(app, resolvedOptions, headersMap);
 	const server = createServer(handler, host, port);
+	// Resolve the user-configured logger before starting the server so that
+	// the startup message uses the correct destination and adapterLogger is
+	// created from the already-replaced pipeline.logger.
+	await app.pipeline.getLogger();
 	server.server.listen(port, host);
 	if (process.env.ASTRO_NODE_LOGGING !== 'disabled') {
 		logListeningOn(app.adapterLogger, server.server, host);

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -32,11 +32,9 @@ export default function standalone(
 	const server = createServer(handler, host, port);
 	server.server.listen(port, host);
 	if (process.env.ASTRO_NODE_LOGGING !== 'disabled') {
-		// Resolve the user-configured logger before logging the startup message.
-		// getLogger() resolves before the OS finishes binding the port (and emitting
-		// 'listening'), so logListeningOn's once('listening') handler is registered
-		// in time. standalone() stays synchronous so callers receive the server object
-		// immediately, as they did before.
+		// Resolve the logger before the 'listening' event fires so the startup message
+		// uses the correct destination. standalone() stays synchronous so callers get
+		// the server object immediately.
 		app.pipeline.getLogger().then(() => logListeningOn(app.adapterLogger, server.server, host));
 	}
 	server.server.on('close', () => {


### PR DESCRIPTION
Fixes #16974  so startup message shows on `experimental.logger` destination, not default terminal.

Currently it fires before any request arrives, always missing the user-configured destination.

## Changes
- Adds `getLogger().then()` before logListeningOn to correct destination.
- Makes `adapterLogger` re-create itself when the underlying logger instance changes, so it always reflects the resolved logger regardless of first access

## Testing
### Before Implementation
<img width="943" height="445" alt="Screenshot 2026-06-08 at 3 07 04 AM" src="https://github.com/user-attachments/assets/0929f855-8446-4ad1-ba07-b06ad227e87c" />

### After Implementation
<img width="643" height="274" alt="Screenshot 2026-06-08 at 3 11 34 AM" src="https://github.com/user-attachments/assets/013f235b-c45e-4c57-bcea-ed0073661249" />

Confirmed the first line of stdout is` {"message":"Server listening on ...","label":"@astrojs/node","level":"info"}` when manually building standalone server.

Added unit test verifying that `adapterLogger` re-creates itself when `pipeline.getLogger()` replaces the underlying logger instance. Both packages build without errors.

## Docs
No update needed.



<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
