### PR TITLE
chore(renovate): bump max memory

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,9 @@
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "postUpdateOptions": ["pnpmDedupe"],
+  "toolSettings": {
+    "nodeMaxMemory": 3072
+  },
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
## Changes

- Renovate currently fails because of memory
- Per https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout-kernel-out-of-memory-limit-with-a-pnpmyarn-project and https://docs.renovatebot.com/mend-hosted/overview/#resources-and-scheduling, I updated the limit to 3GB
- If this doesn't work, we can ask for the better OSS plan and 6GB: https://github.com/renovatebot/renovate/discussions/new?category=mend-hosted-request

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
