### PR TITLE
Revert isNode workerd detection that caused Cloudflare build regression

### DIFF
--- a/.changeset/spicy-pandas-retire.md
+++ b/.changeset/spicy-pandas-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Reverts a change to `isNode` runtime detection that caused a significant build time regression for Cloudflare adapter users with large prerendered sites

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -275,9 +275,7 @@ export interface RendererFlusher {
 }
 
 export const isNode =
-	typeof process !== 'undefined' &&
-	Object.prototype.toString.call(process) === '[object process]' &&
-	!(typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers');
+	typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]';
 // @ts-expect-error: Deno is not part of the types.
 export const isDeno = typeof Deno !== 'undefined';
 


### PR DESCRIPTION
## Changes

- Reverts #16720, which added a `Cloudflare-Workers` navigator check to the `isNode` variable in `packages/astro/src/runtime/server/render/util.ts`. This change caused `isNode` to return `false` inside workerd, forcing the rendering pipeline onto `renderToReadableStream` instead of `renderToAsyncIterable`. For large prerendered sites on Cloudflare (~14k pages), this caused a ~6x build time regression (6-7 min to 40 min).

## Testing

- No new tests. The regression is workerd-specific and only manifests at scale with the Cloudflare adapter. A preview release should be created so the reporter on #16973 can verify the fix.

## Docs

- No docs needed — this restores previous behavior.