### PR TITLE
Fix flue skill calls for runtime 0.8 compatibility

### DIFF
--- a/.agents/skills/merge/SKILL.md
+++ b/.agents/skills/merge/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: merge
+description: Handle main-to-next merge tasks including conflict resolution, changeset cleanup, and CI fix-ups. Use when merging main into next.
+---
+
+# Merge
+
+Handle the main-to-next merge process. This skill has sub-skills for each stage:
+
+- [resolve-conflicts.md](resolve-conflicts.md) — Resolve git merge conflicts
+- [fix-ci.md](fix-ci.md) — Fix build errors, type errors, and test failures
+- [clean-changesets.md](clean-changesets.md) — Remove stale changeset files
+
+When invoked, check the `step` argument to determine which sub-skill to run, then read and follow that file's instructions.

--- a/.flue/workflows/fix-verification.ts
+++ b/.flue/workflows/fix-verification.ts
@@ -117,7 +117,7 @@ Return your classification.`,
 	}
 
 	// Use the astro-pr-writer skill to generate a good PR title and body.
-	const { data: prContent } = await session.skill('astro-pr-writer/SKILL.md', {
+	const { data: prContent } = await session.skill('astro-pr-writer', {
 		args: {
 			issueNumber,
 			issueDetails,

--- a/.flue/workflows/issue-triage.ts
+++ b/.flue/workflows/issue-triage.ts
@@ -178,8 +178,14 @@ async function runTriagePipeline(
 	fixed: boolean;
 	commitMessage: string | null;
 }> {
-	const { data: reproduceResult } = await session.skill('triage/reproduce.md', {
-		args: { issueNumber, issueDetails },
+	const { data: reproduceResult } = await session.skill('triage', {
+		args: {
+			issueNumber,
+			issueDetails,
+			step: 'reproduce',
+			instructions:
+				'Run only the "reproduce" sub-skill from reproduce.md. Do not continue to diagnose, verify, or fix steps.',
+		},
 		result: v.object({
 			reproducible: v.pipe(
 				v.boolean(),
@@ -206,8 +212,13 @@ async function runTriagePipeline(
 		};
 	}
 
-	const { data: diagnoseResult } = await session.skill('triage/diagnose.md', {
-		args: { issueDetails },
+	const { data: diagnoseResult } = await session.skill('triage', {
+		args: {
+			issueDetails,
+			step: 'diagnose',
+			instructions:
+				'Run only the "diagnose" sub-skill from diagnose.md. Do not continue to verify or fix steps.',
+		},
 		result: v.object({
 			confidence: v.pipe(
 				v.nullable(v.picklist(['high', 'medium', 'low'])),
@@ -215,8 +226,12 @@ async function runTriagePipeline(
 			),
 		}),
 	});
-	const { data: verifyResult } = await session.skill('triage/verify.md', {
-		args: { issueDetails },
+	const { data: verifyResult } = await session.skill('triage', {
+		args: {
+			issueDetails,
+			step: 'verify',
+			instructions: 'Run only the "verify" sub-skill from verify.md. Do not continue to fix step.',
+		},
 		result: v.object({
 			verdict: v.pipe(
 				v.picklist(['bug', 'intended-behavior', 'unclear']),
@@ -241,8 +256,8 @@ async function runTriagePipeline(
 		};
 	}
 
-	const { data: fixResult } = await session.skill('triage/fix.md', {
-		args: { issueDetails },
+	const { data: fixResult } = await session.skill('triage', {
+		args: { issueDetails, step: 'fix', instructions: 'Run only the "fix" sub-skill from fix.md.' },
 		result: v.object({
 			fixed: v.pipe(
 				v.boolean(),
@@ -334,8 +349,16 @@ export async function run({ init, payload }: FlueContext) {
 	assert(packageLabels.length > 0, 'no package labels found');
 
 	const branchName = isPushed ? branch : null;
-	const { data: comment } = await session.skill('triage/comment.md', {
-		args: { branchName, priorityLabels, issueDetails, previewRelease },
+	const { data: comment } = await session.skill('triage', {
+		args: {
+			branchName,
+			priorityLabels,
+			issueDetails,
+			previewRelease,
+			step: 'comment',
+			instructions:
+				'Run only the "comment" sub-skill from comment.md. Generate the GitHub comment from triage findings.',
+		},
 		result: v.pipe(
 			v.string(),
 			v.description(

--- a/.flue/workflows/merge-fix/WORKFLOW.ts
+++ b/.flue/workflows/merge-fix/WORKFLOW.ts
@@ -35,8 +35,13 @@ export async function run({ init, payload }: FlueContext) {
 	// Conflicts have already been resolved by the merge-resolve workflow.
 	// Dependencies are installed but packages may NOT be built yet — the skill
 	// handles building and fixing any errors that come up.
-	const { data: fixResult } = await session.skill('merge/fix-ci.md', {
-		args: { prNumber, ciLogs },
+	const { data: fixResult } = await session.skill('merge', {
+		args: {
+			prNumber,
+			ciLogs,
+			step: 'fix-ci',
+			instructions: 'Run only the "fix-ci" sub-skill from fix-ci.md.',
+		},
 		result: v.object({
 			ciPass: v.pipe(v.boolean(), v.description('true if build + tests pass after fixes')),
 			fixedFiles: v.pipe(

--- a/.flue/workflows/merge-resolve/WORKFLOW.ts
+++ b/.flue/workflows/merge-resolve/WORKFLOW.ts
@@ -31,8 +31,13 @@ export async function run({ init, payload }: FlueContext) {
 	// conflicts, the working tree has conflict markers in all affected files.
 	// This skill resolves them intelligently — keeping next-side versions but
 	// preserving important changes from main (new deps, bug fixes, etc.)
-	const { data: resolveResult } = await session.skill('merge/resolve-conflicts.md', {
-		args: { branch, hasConflicts },
+	const { data: resolveResult } = await session.skill('merge', {
+		args: {
+			branch,
+			hasConflicts,
+			step: 'resolve-conflicts',
+			instructions: 'Run only the "resolve-conflicts" sub-skill from resolve-conflicts.md.',
+		},
 		result: v.object({
 			resolvedFiles: v.pipe(
 				v.array(v.string()),
@@ -42,8 +47,11 @@ export async function run({ init, payload }: FlueContext) {
 	});
 
 	// Step 2: Remove stale changesets that were already released on main
-	const { data: changesetResult } = await session.skill('merge/clean-changesets.md', {
-		args: {},
+	const { data: changesetResult } = await session.skill('merge', {
+		args: {
+			step: 'clean-changesets',
+			instructions: 'Run only the "clean-changesets" sub-skill from clean-changesets.md.',
+		},
 		result: v.object({
 			removedChangesets: v.pipe(
 				v.array(v.string()),


### PR DESCRIPTION
## Changes

- Update all `session.skill()` calls to use registered skill names instead of file paths (e.g. `triage/reproduce.md` -> `triage`). Flue runtime 0.8 removed support for addressing sub-files within a skill; the old runtime was lax about this.
- Pass `step` and `instructions` via args to direct the agent to the correct sub-skill file within each skill.
- Add `.agents/skills/merge/SKILL.md` so the merge skill gets discovered by the runtime (it had no `SKILL.md` and was invisible).

## Testing

- No test changes. This is a CI workflow fix — validation is the next issue triage run succeeding instead of failing with `Skill "triage/reproduce.md" not registered`.

## Docs

- No docs needed. Internal CI workflow change only.