### PR TITLE
fix: file endpoints should not require trailing slash in dev mode

### DIFF
--- a/.changeset/fix-file-endpoint-trailing-slash.md
+++ b/.changeset/fix-file-endpoint-trailing-slash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix file-extension routes (like `/api/data.json`) requiring a trailing slash when `trailingSlash` is set to `'always'`.

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -241,11 +241,7 @@ function createFileBasedRoutes(
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
 					: null;
-				const trailingSlash = trailingSlashForPath(
-					pathname,
-					settings.config,
-					item.isPage ? 'page' : 'endpoint',
-				);
+				const trailingSlash = trailingSlashForPath(pathname, settings.config);
 				const pattern = getPattern(segments, settings.config.base, trailingSlash);
 				const route = joinSegments(segments);
 				routes.push({
@@ -386,11 +382,7 @@ function createRoutesFromEntriesByDir(
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
 					: null;
-				const trailingSlash = trailingSlashForPath(
-					pathname,
-					settings.config,
-					item.isPage ? 'page' : 'endpoint',
-				);
+				const trailingSlash = trailingSlashForPath(pathname, settings.config);
 				const pattern = getPattern(segments, settings.config.base, trailingSlash);
 				const route = joinSegments(segments);
 				routes.push({
@@ -435,15 +427,11 @@ function groupEntriesByDir(entries: RouteEntry[]): Map<string, RouteEntry[]> {
 	return entriesByDir;
 }
 
-// Get trailing slash rule for a path, based on the config and whether the path has an extension.
-// Routes with file extensions (like /feed.xml or /api/data.json) should force 'never' for
-// trailing slashes so they are accessible without a trailing slash, regardless of the global
-// trailingSlash config. This matches the production build behavior in generate.ts which also
-// skips trailing-slash appending for file-extension paths.
+// File-extension routes (e.g. /feed.xml, /api/data.json) always use trailingSlash: 'never',
+// matching the production build behavior in generate.ts.
 const trailingSlashForPath = (
 	pathname: string | null,
 	config: AstroConfig,
-	_type: 'page' | 'endpoint',
 ): AstroConfig['trailingSlash'] =>
 	pathname && hasFileExtension(pathname) ? 'never' : config.trailingSlash;
 
@@ -470,7 +458,7 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Rou
 			? `/${segments.map((segment) => segment[0].content).join('/')}`
 			: null;
 
-		const trailingSlash = trailingSlashForPath(pathname, config, type);
+		const trailingSlash = trailingSlashForPath(pathname, config);
 		const pattern = getPattern(segments, settings.config.base, trailingSlash);
 		const params = segments
 			.flat()

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -241,7 +241,11 @@ function createFileBasedRoutes(
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
 					: null;
-				const trailingSlash = trailingSlashForPath(pathname, settings.config);
+				const trailingSlash = trailingSlashForPath(
+					pathname,
+					settings.config,
+					item.isPage ? 'page' : 'endpoint',
+				);
 				const pattern = getPattern(segments, settings.config.base, trailingSlash);
 				const route = joinSegments(segments);
 				routes.push({
@@ -382,7 +386,11 @@ function createRoutesFromEntriesByDir(
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
 					: null;
-				const trailingSlash = trailingSlashForPath(pathname, settings.config);
+				const trailingSlash = trailingSlashForPath(
+					pathname,
+					settings.config,
+					item.isPage ? 'page' : 'endpoint',
+				);
 				const pattern = getPattern(segments, settings.config.base, trailingSlash);
 				const route = joinSegments(segments);
 				routes.push({
@@ -427,13 +435,14 @@ function groupEntriesByDir(entries: RouteEntry[]): Map<string, RouteEntry[]> {
 	return entriesByDir;
 }
 
-// File-extension routes (e.g. /feed.xml, /api/data.json) always use trailingSlash: 'never',
-// matching the production build behavior in generate.ts.
+// Only endpoints with file extensions (like /feed.xml) should force 'never' for trailing slashes.
+// Pages with dots in their names (like /hello.world) should respect the user's trailingSlash config.
 const trailingSlashForPath = (
 	pathname: string | null,
 	config: AstroConfig,
+	type: 'page' | 'endpoint',
 ): AstroConfig['trailingSlash'] =>
-	pathname && hasFileExtension(pathname) ? 'never' : config.trailingSlash;
+	type === 'endpoint' && pathname && hasFileExtension(pathname) ? 'never' : config.trailingSlash;
 
 function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): RouteData[] {
 	const { config } = settings;
@@ -458,7 +467,7 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Rou
 			? `/${segments.map((segment) => segment[0].content).join('/')}`
 			: null;
 
-		const trailingSlash = trailingSlashForPath(pathname, config);
+		const trailingSlash = trailingSlashForPath(pathname, config, type);
 		const pattern = getPattern(segments, settings.config.base, trailingSlash);
 		const params = segments
 			.flat()

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -436,14 +436,16 @@ function groupEntriesByDir(entries: RouteEntry[]): Map<string, RouteEntry[]> {
 }
 
 // Get trailing slash rule for a path, based on the config and whether the path has an extension.
-// Only endpoints with file extensions (like /feed.xml) should force 'never' for trailing slashes.
-// Pages with dots in their names (like /hello.world) should respect the user's trailingSlash config.
+// Routes with file extensions (like /feed.xml or /api/data.json) should force 'never' for
+// trailing slashes so they are accessible without a trailing slash, regardless of the global
+// trailingSlash config. This matches the production build behavior in generate.ts which also
+// skips trailing-slash appending for file-extension paths.
 const trailingSlashForPath = (
 	pathname: string | null,
 	config: AstroConfig,
-	type: 'page' | 'endpoint',
+	_type: 'page' | 'endpoint',
 ): AstroConfig['trailingSlash'] =>
-	type === 'endpoint' && pathname && hasFileExtension(pathname) ? 'never' : config.trailingSlash;
+	pathname && hasFileExtension(pathname) ? 'never' : config.trailingSlash;
 
 function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): RouteData[] {
 	const { config } = settings;

--- a/packages/astro/test/units/routing/trailing-slash.test.ts
+++ b/packages/astro/test/units/routing/trailing-slash.test.ts
@@ -115,6 +115,25 @@ describe('trailingSlash', () => {
 			assert.equal(match.type, 'match');
 			assert.equal(match.route.route, '/dot.json');
 		});
+
+		it('should match a page with file extension without trailing slash', () => {
+			const pageRouter = new Router(
+				[
+					...makeRoutes(trailingSlash),
+					makeRoute({
+						segments: [[staticPart('api'), staticPart('data.json')]],
+						trailingSlash: 'never',
+						route: '/api/data.json',
+						pathname: '/api/data.json',
+						type: 'page',
+					}),
+				],
+				{ base: '/', trailingSlash, buildFormat: 'directory' },
+			);
+			const match = pageRouter.match('/api/data.json');
+			assert.equal(match.type, 'match');
+			assert.equal(match.route.route, '/api/data.json');
+		});
 	});
 
 	// --- trailingSlash: 'never' with base path ---

--- a/packages/astro/test/units/routing/trailing-slash.test.ts
+++ b/packages/astro/test/units/routing/trailing-slash.test.ts
@@ -116,21 +116,21 @@ describe('trailingSlash', () => {
 			assert.equal(match.route.route, '/dot.json');
 		});
 
-		it('should match a page with file extension without trailing slash', () => {
-			const pageRouter = new Router(
+		it('should match an endpoint with file extension without trailing slash', () => {
+			const endpointRouter = new Router(
 				[
 					...makeRoutes(trailingSlash),
 					makeRoute({
-						segments: [[staticPart('api'), staticPart('data.json')]],
+						segments: [[staticPart('api')], [staticPart('data.json')]],
 						trailingSlash: 'never',
 						route: '/api/data.json',
 						pathname: '/api/data.json',
-						type: 'page',
+						type: 'endpoint',
 					}),
 				],
 				{ base: '/', trailingSlash, buildFormat: 'directory' },
 			);
-			const match = pageRouter.match('/api/data.json');
+			const match = endpointRouter.match('/api/data.json');
 			assert.equal(match.type, 'match');
 			assert.equal(match.route.route, '/api/data.json');
 		});


### PR DESCRIPTION
Fixes #17001

Routes with file extensions (for example `/api/bar.json`) incorrectly required a trailing slash in dev mode when `trailingSlash: 'always'` was enabled.

This happened because `trailingSlashForPath` only forced `'never'` for endpoints, while the dev middleware and production build logic already exempt all file-extension paths from trailing-slash handling.

## Changes

* Removed the endpoint-only restriction in `trailingSlashForPath`
* Treat all file-extension routes as `trailingSlash: 'never'`
* Added a test covering page-type routes with file extensions

## Testing

Added a unit test verifying that a page route such as `/api/data.json` matches without a trailing slash when `trailingSlash: 'always'` is enabled.

## Docs

No documentation changes required. This fixes a discrepancy between development and production behavior.
