### PR TITLE
chore: bump mdx ahead of main merge

### DIFF
--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -13,7 +13,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/mdx": "^6.0.0-alpha.1",
+    "@astrojs/mdx": "^7.0.0-alpha.1",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.0.0-alpha.2",

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -13,7 +13,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/mdx": "^6.0.0-alpha.1",
+    "@astrojs/mdx": "^7.0.0-alpha.1",
     "@astrojs/preact": "^6.0.0-alpha.0",
     "astro": "^7.0.0-alpha.2",
     "preact": "^10.28.4"

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -13,7 +13,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/mdx": "^6.0.0-alpha.1",
+    "@astrojs/mdx": "^7.0.0-alpha.1",
     "@tailwindcss/vite": "^4.2.1",
     "@types/canvas-confetti": "^1.9.0",
     "astro": "^7.0.0-alpha.2",

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/mdx",
   "description": "Add support for MDX pages in your Astro site",
-  "version": "6.0.0-alpha.1",
+  "version": "7.0.0-alpha.1",
   "type": "module",
   "types": "./dist/index.d.ts",
   "author": "withastro",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
   examples/blog:
     dependencies:
       '@astrojs/mdx':
-        specifier: ^6.0.0-alpha.1
+        specifier: ^7.0.0-alpha.1
         version: link:../../packages/integrations/mdx
       '@astrojs/rss':
         specifier: ^4.0.18
@@ -465,7 +465,7 @@ importers:
   examples/with-mdx:
     dependencies:
       '@astrojs/mdx':
-        specifier: ^6.0.0-alpha.1
+        specifier: ^7.0.0-alpha.1
         version: link:../../packages/integrations/mdx
       '@astrojs/preact':
         specifier: ^6.0.0-alpha.0
@@ -498,7 +498,7 @@ importers:
   examples/with-tailwindcss:
     dependencies:
       '@astrojs/mdx':
-        specifier: ^6.0.0-alpha.1
+        specifier: ^7.0.0-alpha.1
         version: link:../../packages/integrations/mdx
       '@tailwindcss/vite':
         specifier: ^4.2.1


### PR DESCRIPTION
## Changes

I checked the package version in `main` branch (commit ca26d0e233002cde049e212507270cd80bec9350) and the `next` branch (commit 1645177cc7352e97b238b9961f2039080a9bff3c). Result shown below:

| package | `main` version | `next` version | status |
| --- | --- | --- | --- |
| @astrojs/alpinejs | 0.5.0 | 1.0.0-alpha.0 | ⬆️ |
| @astrojs/check | 0.9.9 | 0.9.9 | 🟰 |
| @astrojs/cloudflare | 13.6.1 | 14.0.0-alpha.1 | ⬆️ |
| @astrojs/db | 0.21.2 | 1.0.0-alpha.0 | ⬆️ |
| @astrojs/internal-helpers | 0.10.0 | 0.10.0 | 🟰 |
| @astrojs/language-server | 2.16.10 | 2.16.10 | 🟰 |
| @astrojs/markdoc | 1.0.6 | 2.0.0-alpha.0 | ⬆️ |
| @astrojs/markdown-remark | 7.2.0 | 7.2.0 | 🟰 |
| @astrojs/markdown-satteri | 0.2.2 | 0.3.0-alpha.0 | ⬆️ |
| @astrojs/mdx | 6.0.2 | 6.0.0-alpha.1 | 🔴 |
| @astrojs/netlify | 7.0.12 | 8.0.0-alpha.0 | ⬆️ |
| @astrojs/node | 10.1.3 | 11.0.0-alpha.0 | ⬆️ |
| @astrojs/partytown | 2.1.7 | 2.1.7 | 🟰 |
| @astrojs/preact | 5.1.5 | 6.0.0-alpha.0 | ⬆️ |
| @astrojs/prism | 4.0.2 | 4.0.2 | 🟰 |
| @astrojs/react | 5.0.7 | 6.0.0-alpha.0 | ⬆️ |
| @astrojs/rss | 4.0.18 | 4.0.18 | 🟰 |
| @astrojs/sitemap | 3.7.3 | 3.7.3 | 🟰 |
| @astrojs/solid-js | 6.0.1 | 7.0.0-alpha.0 | ⬆️ |
| @astrojs/svelte | 8.1.2 | 9.0.0-alpha.2 | ⬆️ |
| @astrojs/telemetry | 3.3.2 | 3.3.2 | 🟰 |
| @astrojs/ts-plugin | 1.10.9 | 1.10.9 | 🟰 |
| @astrojs/underscore-redirects | 1.0.3 | 1.0.3 | 🟰 |
| @astrojs/upgrade | 0.7.2 | 0.7.2 | 🟰 |
| @astrojs/vercel | 10.0.8 | 11.0.0-alpha.0 | ⬆️ |
| @astrojs/vue | 6.0.1 | 7.0.0-alpha.0 | ⬆️ |
| @astrojs/yaml2ts | 0.2.4 | 0.2.4 | 🟰 |
| astro | 6.4.4 | 7.0.0-alpha.2 | ⬆️ |
| astro-vscode | 2.16.16 | 2.16.16 | 🟰 |
| create-astro | 5.0.6 | 5.0.6 | 🟰 |

Notice that `@astrojs/mdx` is 6.0.2 on `main` but 6.0.0-alpha.1 on `next`, so `next` has a **lower** version.

This PR manually bump the version of `@astrojs/mdx` to 7.0.0-alpha.1, so that we won't lower the version of `@astrojs/mdx` when we merge `next` into `main`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Green CI 

## Docs

No change for users so no docs. 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
