### PR TITLE
fix(node): decode URL path before static file lookup for non-ASCII slugs

### DIFF
--- a/.changeset/node-decode-uri-non-ascii.md
+++ b/.changeset/node-decode-uri-non-ascii.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/node": patch
+---
+
+Fix prerendered routes with non-ASCII slugs incorrectly redirecting to the trailing-slash variant in standalone mode when `trailingSlash` is set to `"never"`.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -58,7 +58,16 @@ export function createStaticHandler(
 			}
 
 			const [urlPath, urlQuery] = fullUrl.split('?');
-			const { isDirectory } = resolveStaticPath(client, app.removeBase(urlPath));
+			// Decode the path before filesystem lookup so non-ASCII slugs
+			// (e.g. Thai, Korean, Chinese) match the on-disk directory names.
+			// Guard against malformed percent-encoding (cf. #16916).
+			let fsPath: string;
+			try {
+				fsPath = decodeURI(app.removeBase(urlPath));
+			} catch {
+				fsPath = app.removeBase(urlPath);
+			}
+			const { isDirectory } = resolveStaticPath(client, fsPath);
 
 			const hasSlash = urlPath.endsWith('/');
 			let pathname = urlPath;

--- a/packages/integrations/node/test/encoded-standalone.test.ts
+++ b/packages/integrations/node/test/encoded-standalone.test.ts
@@ -1,0 +1,39 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import type { PreviewServer } from 'astro';
+import nodejs from '../dist/index.js';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('Encoded Pathname (standalone)', () => {
+	let fixture: Fixture;
+	let devPreview: PreviewServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/encoded-standalone/',
+			output: 'server',
+			adapter: nodejs({ mode: 'standalone' }),
+			trailingSlash: 'never',
+		});
+		await fixture.build();
+		devPreview = await fixture.preview();
+	});
+
+	after(async () => {
+		await devPreview.stop();
+	});
+
+	it('ASCII prerendered route serves 200 without trailing slash', async () => {
+		const response = await fixture.fetch('/hello');
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		assert.equal(html.includes('<h1>hello</h1>'), true);
+	});
+
+	it('Non-ASCII prerendered route serves 200 without trailing slash', async () => {
+		const response = await fixture.fetch('/什么');
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		assert.equal(html.includes('<h1>什么</h1>'), true);
+	});
+});

--- a/packages/integrations/node/test/fixtures/encoded-standalone/package.json
+++ b/packages/integrations/node/test/fixtures/encoded-standalone/package.json
@@ -1,3 +1,9 @@
 {
-  "name": "@test/encoded-standalone"
+  "name": "@test/encoded-standalone",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/node": "workspace:*",
+    "astro": "workspace:*"
+  }
 }

--- a/packages/integrations/node/test/fixtures/encoded-standalone/package.json
+++ b/packages/integrations/node/test/fixtures/encoded-standalone/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@test/encoded-standalone"
+}

--- a/packages/integrations/node/test/fixtures/encoded-standalone/src/pages/hello.astro
+++ b/packages/integrations/node/test/fixtures/encoded-standalone/src/pages/hello.astro
@@ -1,0 +1,4 @@
+---
+export const prerender = true;
+---
+<h1>hello</h1>

--- a/packages/integrations/node/test/fixtures/encoded-standalone/src/pages/什么.astro
+++ b/packages/integrations/node/test/fixtures/encoded-standalone/src/pages/什么.astro
@@ -1,0 +1,4 @@
+---
+export const prerender = true;
+---
+<h1>什么</h1>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5557,6 +5557,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/node/test/fixtures/encoded-standalone:
+    dependencies:
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/node/test/fixtures/errors:
     dependencies:
       '@astrojs/node':
@@ -12483,7 +12492,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}


### PR DESCRIPTION
Fixes #16989

Prerendered routes with non-ASCII slugs could incorrectly redirect to the trailing-slash variant in `@astrojs/node` standalone mode when `trailingSlash: "never"` was configured.

The static file lookup was using the encoded URL path, causing directory detection to fail for non-ASCII paths.

## Changes

* Decode URL paths before resolving static files in standalone mode
* Handle invalid percent-encoding safely with a `try/catch`
* Align static file lookup behavior with existing URL decoding logic

## Testing

Added a standalone-mode test covering prerendered routes with non-ASCII slugs and verifying they return `200` without a trailing slash.

## Docs

No documentation changes required. This is a bug fix that restores expected behavior.
