### PR TITLE
chore: fix prerelease peer dep versions

### DIFF
--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -50,7 +50,7 @@
     "vfile": "^6.0.3"
   },
   "peerDependencies": {
-    "@astrojs/markdown-satteri": "0.3.0",
+    "@astrojs/markdown-satteri": "^0.3.1-alpha.0",
 	"astro": "^7.0.0-alpha.0"
 	},
   "peerDependenciesMeta": {

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -38,7 +38,7 @@
     "server-destroy": "^1.0.1"
   },
   "peerDependencies": {
-    "astro": "^7.3.0-alpha.0"
+    "astro": "^7.0.0-alpha.2"
   },
   "devDependencies": {
     "@fastify/middie": "^9.1.0",

--- a/packages/markdown/satteri/package.json
+++ b/packages/markdown/satteri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrojs/markdown-satteri",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.1-alpha.0",
   "type": "module",
   "author": "withastro",
   "license": "MIT",


### PR DESCRIPTION
## Changes

1. Update the version for `@astrojs/markdown-satteri` from 0.3.0-alpha.0 to 0.3.1-alpha.0, because 0.3.0 is already released on `main` at https://github.com/withastro/astro/pull/16972. We want the `next` branch has a higher version number than `main`. 

2. Update some peerDenpendencies to reflect the actual version numbers. Otherwise Changeset will print the following warnings. (They are just warnings and won't block the release workflow)

```
$ changeset version
Package "@astrojs/mdx" must depend on the current version of "@astrojs/markdown-satteri": "0.3.0-alpha.0" vs "0.3.0"
Package "@astrojs/node" must depend on the current version of "astro": "7.0.0-alpha.2" vs "^7.3.0-alpha.0"
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
