### PR TITLE
Fix triage bot push failures after flue 0.8 upgrade

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -58,6 +58,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # Do not persist the default GITHUB_TOKEN as a git credential.
+          # checkout sets an http.extraheader that overrides any credentials
+          # embedded in push URLs, including the FREDKBOT_GITHUB_TOKEN used
+          # by gitPush(). With persist-credentials enabled, git always
+          # authenticates as github-actions[bot] (read-only), causing pushes
+          # to fail with 403.
+          persist-credentials: false
 
       - name: Configure Git identity
         run: |


### PR DESCRIPTION
## Changes

- Disables `persist-credentials` on the checkout step in the issue triage workflow. When credentials are persisted, git always uses the default `GITHUB_TOKEN` (read-only) for pushes, even when `gitPush()` explicitly provides `FREDKBOT_GITHUB_TOKEN`. Disabling it lets the privileged token be used as intended.

## Testing

- No test changes. CI-only fix verified against [this failed run](https://github.com/withastro/astro/actions/runs/27215432701/job/80355576556).

## Docs

- No docs needed — CI-only change.