### PR TITLE
Harden Netlify remotePatterns regex to match canonical wildcard semantics

### DIFF
--- a/.changeset/yummy-hoops-grin.md
+++ b/.changeset/yummy-hoops-grin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Hardens `remotePatterns` regex generation to match canonical wildcard semantics more strictly

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -53,12 +53,12 @@ export function remotePatternToRegex(
 
 	if (hostname) {
 		if (hostname.startsWith('**.')) {
-			// match any number of subdomains
-			regexStr += '([a-z0-9-]+\\.)*';
+			// match one or more subdomains
+			regexStr += '([a-z0-9-]+\\.)+';
 			hostname = hostname.substring(3);
 		} else if (hostname.startsWith('*.')) {
-			// match one subdomain
-			regexStr += '([a-z0-9-]+\\.)?';
+			// match exactly one subdomain
+			regexStr += '([a-z0-9-]+\\.)';
 			hostname = hostname.substring(2); // Remove '*.' from the beginning
 		}
 		// Escape dots in the hostname
@@ -78,8 +78,7 @@ export function remotePatternToRegex(
 		if (pathname.endsWith('/**')) {
 			// Match any path.
 			regexStr += `(\\${pathname.replace('/**', '')}.*)`;
-		}
-		if (pathname.endsWith('/*')) {
+		} else if (pathname.endsWith('/*')) {
 			// Match one level of path
 			regexStr += `(\\${pathname.replace('/*', '')}\/[^/?#]+)\/?`;
 		} else {
@@ -94,6 +93,8 @@ export function remotePatternToRegex(
 		// Match query, but only if it's not already matched by the pathname
 		regexStr += '([?][^#]*)?';
 	}
+	// Anchor to end of string so .test() can't match a prefix
+	regexStr += '$';
 	try {
 		// nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
 		// This only validates the generated pattern before handing it to Netlify.

--- a/packages/integrations/netlify/test/functions/image-cdn.test.ts
+++ b/packages/integrations/netlify/test/functions/image-cdn.test.ts
@@ -89,7 +89,11 @@ describe('Image CDN', { timeout: 120000 }, () => {
 
 		it('generates correct config for remotePatterns', async () => {
 			const patterns = regexes[2]!;
-			assert.equal(patterns.test('https://example.org/images/1.jpg'), true, 'should match domain');
+			assert.equal(
+				patterns.test('https://example.org/images/1.jpg'),
+				false,
+				'apex hostname should not match for *.example.org',
+			);
 			assert.equal(
 				patterns.test('https://www.example.org/images/2.jpg'),
 				true,
@@ -104,6 +108,11 @@ describe('Image CDN', { timeout: 120000 }, () => {
 				patterns.test('https://example.org/not-images/2.jpg'),
 				false,
 				'wrong path should not match',
+			);
+			assert.equal(
+				patterns.test('https://www.example.org/images/a/b.jpg'),
+				false,
+				'deeper path should not match for /images/*',
 			);
 		});
 


### PR DESCRIPTION
## Changes

- Tightens the regex produced by `remotePatternToRegex` so wildcard hostname and pathname patterns match strictly:
  - `*.` requires exactly one subdomain (bare apex no longer matches)
  - `**.` requires one or more subdomains (zero subdomains no longer matches)
  - `/*` matches a single path segment only, not deeper paths
- Anchors the generated regex with `$` so partial prefix matches are not possible

## Testing

- Updated existing assertion: `*.example.org` no longer matches bare `example.org`
- Added assertion: `/images/*` does not match `/images/a/b.jpg`

## Docs

- No docs update needed -- this is an internal regex generation change with no user-facing API impact.