### PR TITLE
fix(transitions): skip ClientRouter transition when `from` and `to` are the same URL

### DIFF
--- a/.changeset/skip-transition-same-url.md
+++ b/.changeset/skip-transition-same-url.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an unnecessary page reload during ClientRouter back/forward transitions when the browser's Navigation API is used to intercept same-URL navigations

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/same-url-guard.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/same-url-guard.astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../components/Layout.astro';
+---
+<Layout>
+	<p id="guard-test">Guard Test Page</p>
+	<script>
+		document.addEventListener('astro:before-preparation', (e) => {
+			if (e.from.pathname === e.to.pathname) {
+				e.preventDefault();
+			}
+		});
+		// Fake an external navigation so originalLocation goes stale on back
+		history.pushState({}, '', location.pathname + '?fake=1');
+	</script>
+</Layout>

--- a/packages/astro/e2e/view-transitions.test.ts
+++ b/packages/astro/e2e/view-transitions.test.ts
@@ -320,6 +320,23 @@ test.describe('View Transitions', () => {
 		await expect(p, 'should have content').toHaveText('Page 1');
 	});
 
+	test('Back after external pushState with same URL guard does not reload', async ({ page, astro }) => {
+		const expectLoads = collectLoads(page);
+
+		await page.goto(astro.resolveUrl('/same-url-guard'));
+		const p = page.locator('#guard-test');
+		await expect(p, 'should have content').toHaveText('Guard Test Page');
+		await expectLoads(1);
+
+		// The page script already pushed ?fake=1 into history.
+		// Pressing back goes to the original URL, making from === to inside transition().
+		await page.goBack();
+		await expect(p, 'should have content').toHaveText('Guard Test Page');
+
+		// Still only one page load — no reload triggered.
+		await expectLoads(1);
+	});
+
 	test('click self link (w/o hash) does not do navigation', async ({ page, astro }) => {
 		const expectLoads = collectLoads(page);
 

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -346,6 +346,8 @@ async function transition(
 	// e.g. by calling navigate() from a transition event.
 	// Invariant: all but the most recent navigation are already aborted.
 
+	if (historyState && from.href === to.href) return;
+
 	const currentNavigation = abortAndRecreateMostRecentNavigation();
 
 	// not ours


### PR DESCRIPTION
## Changes

Prevents an unnecessary page reload during ClientRouter back/forward navigations when the browser's Navigation API handles the transition before `popstate` fires, making `from` and `to` the same URL.

## Testing

Update: Added a test case that reproduces the bug by pushing a fake history entry, then pressing back

---

Manually tested in an Astro project where `/work` and its sub-routes (e.g. `/work/slug-1`) run as a SPA kept in sync via the browser's Navigation API. Other routes like `/about` or `/` still trigger Astro's View Transitions normally. For `/work` and its sub-routes:

1. Listening to `astro:before-preparation` and calling `preventDefault()` when both the current and destination URLs are under `/work`, which stops ClientRouter from fetching new HTML.

2. Using the browser's Navigation API (`event.intercept()`) to update the app's own state instead.

Pressing back from `/work/slug-1` to `/work/` causes two things to happen in sequence:

1. The browser's Navigation API fires. Our `event.intercept()` handler runs, updating the app's state and changing the URL to `/work/`.

2. `popstate` fires. The ClientRouter's `onPopState` calls `transition()`.

At this point the URL is already `/work/`. But `originalLocation` was never updated to `/work/slug-1` — because that earlier forward navigation was done via `nav.navigate()`, which the ClientRouter doesn't track. So `transition()` sees `from` as `/work/` (the stale `originalLocation`) and `to` as `/work/` (the current URL). They match, the ClientRouter thinks nothing changed, falls through to `doPreparation()`, and eventually calls `location.href = to.href`, which triggers an unnecessary full page navigation.

With the guard added to `transition()`, `from.href === to.href` returns early before any of that happens, and the full page navigation never occurs.

## Docs

No docs needed. Bugfix with no API or behavior change.

