### PR TITLE
fix(markdoc): replace all hyphens in component import names

### DIFF
--- a/.changeset/markdoc-multi-hyphen-tag-names.md
+++ b/.changeset/markdoc-multi-hyphen-tag-names.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fixes a build failure when a Markdoc tag rendered with the `component()` utility has a name containing two or more hyphens (e.g. `my-cool-tag`). The generated import identifier only replaced the first hyphen, producing invalid JavaScript.

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -381,7 +381,7 @@ function getStringifiedImports(
 
 function toImportName(unsafeName: string) {
 	// TODO: more checks that name is a safe JS variable name
-	return unsafeName.replace('-', '_');
+	return unsafeName.replaceAll('-', '_');
 }
 
 /**


### PR DESCRIPTION
### Changes

- Fixes #17021
- `toImportName` in `@astrojs/markdoc`'s `content-entry-type.ts` used `String.prototype.replace` with a string pattern, which only replaces the **first** hyphen. A Markdoc tag named e.g. `my-cool-tag` rendered via the `component()` utility generated `import Tagmy_cool-tag from …` — an invalid JS identifier — and the build failed with a misleading Rollup parse error pointing at the `.mdoc` frontmatter.
- One-line fix: `replace('-', '_')` → `replaceAll('-', '_')`.

### Testing

- Reproduced on a real project: a `lead-capture-inline` tag mapped to an `.astro` component via `component()` breaks `astro build` before the fix and builds/renders correctly after (verified against the built HTML output).
- Single-hyphen tags are unaffected (`replaceAll` is a strict superset of the previous behavior).
- `toImportName` is module-private, so no unit test is attached; happy to add a fixture-based test to `packages/integrations/markdoc/test` if preferred.

### Docs

No docs change needed — multi-hyphen tag names were already expected to work; this restores the documented `component()` behavior.
