### PR TITLE
Harden addAttribute to reject invalid attribute names

### DIFF
--- a/.changeset/hot-walls-grin.md
+++ b/.changeset/hot-walls-grin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens `addAttribute` to drop attribute names containing characters that are invalid per the HTML spec (`"`, `'`, `>`, `/`, `=`, whitespace)

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -14,6 +14,9 @@ const DOUBLE_QUOTE_REGEX = /"/g;
 
 const STATIC_DIRECTIVES = new Set(['set:html', 'set:text']);
 
+// Per the HTML spec, attribute names must not contain ASCII whitespace, ", ', >, /, or =.
+const INVALID_ATTR_NAME_CHAR = /[\s"'>/=]/;
+
 // converts (most) arbitrary strings to valid JS identifiers
 const toIdent = (k: string) =>
 	k.trim().replace(/(?!^)\b\w|\s+|\W+/g, (match, index) => {
@@ -80,6 +83,11 @@ function handleBooleanAttribute(
 // on the compiler side because it is used only for custom elements
 export function addAttribute(value: any, key: string, shouldEscape = true, tagName = '') {
 	if (value == null) {
+		return '';
+	}
+
+	// Reject attribute names with characters that could break out of the attribute context.
+	if (INVALID_ATTR_NAME_CHAR.test(key)) {
 		return '';
 	}
 

--- a/packages/astro/test/units/render/html-primitives.test.ts
+++ b/packages/astro/test/units/render/html-primitives.test.ts
@@ -209,6 +209,60 @@ describe('renderElement', () => {
 // createComponent/createTestApp — no Vite build needed.
 // ---------------------------------------------------------------------------
 
+describe('addAttribute rejects invalid attribute keys', () => {
+	it('drops keys containing double quotes', () => {
+		const result = String(addAttribute('val', 'x" onmousemove="alert(1)" y'));
+		assert.equal(result, '');
+	});
+
+	it('drops keys containing spaces', () => {
+		const result = String(addAttribute('val', ' onerror=alert(1) '));
+		assert.equal(result, '');
+	});
+
+	it('drops keys containing >', () => {
+		const result = String(addAttribute('val', 'x><script>alert(1)</script'));
+		assert.equal(result, '');
+	});
+
+	it('drops keys containing single quotes', () => {
+		const result = String(addAttribute('val', "x' onclick='alert(1)"));
+		assert.equal(result, '');
+	});
+
+	it('drops keys containing =', () => {
+		const result = String(addAttribute('val', 'x=y'));
+		assert.equal(result, '');
+	});
+
+	it('allows normal attribute names', () => {
+		assert.equal(String(addAttribute('v', 'id')), ' id="v"');
+		assert.equal(String(addAttribute('v', 'data-foo')), ' data-foo="v"');
+		assert.equal(String(addAttribute('v', 'aria-label')), ' aria-label="v"');
+	});
+
+	it('allows namespaced attributes', () => {
+		assert.equal(String(addAttribute('v', 'on:click')), ' on:click="v"');
+		assert.equal(String(addAttribute('v', 'xmlns:happy')), ' xmlns:happy="v"');
+	});
+});
+
+describe('spreadAttributes rejects invalid attribute keys', () => {
+	it('drops malicious keys while keeping valid ones', () => {
+		const result = String(
+			internalSpreadAttributes(
+				{ 'class': 'safe', 'x" onclick="alert(1)" y': 'bad', 'id': 'ok' },
+				true,
+				'div',
+			),
+		);
+		assert.ok(result.includes('class="safe"'));
+		assert.ok(result.includes('id="ok"'));
+		assert.ok(!result.includes('onclick'));
+		assert.ok(!result.includes('alert'));
+	});
+});
+
 describe('Correctly serializes boolean attributes (#astro-basic)', async () => {
 	// h1 data-something and h2 not-data-ok are both empty-string boolean-ish attrs
 	it('renders empty-value attribute for data-* attr with no value', () => {


### PR DESCRIPTION
## Changes

- Validates attribute names in `addAttribute()` against the HTML spec before interpolating them into output. Keys containing characters invalid in attribute names (`"`, `'`, `>`, `/`, `=`, or whitespace) are silently dropped.

## Testing

- Added `addAttribute rejects invalid attribute keys` suite (7 cases) covering keys with `"`, spaces, `>`, `'`, `=`, plus positive cases for normal names (`data-foo`, `aria-label`) and namespaced attributes (`on:click`, `xmlns:happy`).
- Added `spreadAttributes rejects invalid attribute keys` suite (1 case) verifying invalid keys are dropped while valid siblings are preserved.

## Docs

- No docs update needed. Internal rendering hardening with no user-facing API change.