### PR TITLE
chore: trigger beta release for some packages

### DIFF
--- a/.changeset/trigger-beta.md
+++ b/.changeset/trigger-beta.md
@@ -1,0 +1,17 @@
+---
+'@astrojs/alpinejs': patch
+'@astrojs/cloudflare': patch
+'@astrojs/markdoc': patch
+'@astrojs/mdx': patch
+'@astrojs/netlify': patch
+'@astrojs/node': patch
+'@astrojs/preact': patch
+'@astrojs/react': patch
+'@astrojs/solid-js': patch
+'@astrojs/svelte': patch
+'@astrojs/vercel': patch
+'@astrojs/vue': patch
+'@astrojs/markdown-satteri': patch
+---
+
+Triggers beta prereleases for packages that are still on alpha


### PR DESCRIPTION
## Changes

Some packages in `next` branch still have alpha version. For example, `@astrojs/cloudflare` has `version": "14.0.0-alpha.1"`. This PR bumps all of these alpha version packages to beta version, so that `pnpm dlx @astrojs/upgrade beta` can grab the newest prerelease version. 

After merging this PR and releasing some new beta versions, the following issue will probably be resolved.


> I attempted the [v7.0 beta upgrade](https://v7.docs.astro.build/en/guides/upgrade-to/v7/) with `pnpm dlx @astrojs/upgrade beta` and it reverted @astrojs/markdown-remark from 7.2.0 (latest) to 7.0.0-beta.11. Looks like @astrojs/cloudflare was also downgraded from 13.7.0 (latest) to 13.0.0-beta.14. Seems like a bug in the upgrade script?

Related issue: https://github.com/withastro/astro/issues/17024 

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
