### PR TITLE
ci: restore "needs repro" workflow

### DIFF
--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -1,35 +1,21 @@
-# Action taken down due to https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
-#name: "Issue: Needs Repro"
-#
-#on:
-#  issues:
-#    types: [labeled]
-#  schedule:
-#    - cron: "0 0 * * *"
-#
-#jobs:
-#  on-labeled:
-#    if: github.event_name == 'issues' && github.event.label.name == 'needs repro'
-#    runs-on: ubuntu-latest
-#    permissions:
-#      issues: write
-#    steps:
-#      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-#        with:
-#          actions: "create-comment, remove-labels"
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          issue-number: ${{ github.event.issue.number }}
-#          body: |
-#            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new/repro). Issues marked with `needs repro` will be closed if they have no activity within 3 days.
-#          labels: "needs triage"
-#
-#  close-stale:
-#    if: github.event_name == 'schedule' && github.repository == 'withastro/astro'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-#        with:
-#          actions: "close-issues"
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          labels: "needs repro"
-#          inactive-day: 3
+name: "Issue: Needs Repro"
+
+on:
+  issues:
+    types: [ labeled ]
+
+jobs:
+  reply-labeled:
+    if: github.repository == 'withastro/astro'
+    runs-on: depot-ubuntu-24.04-arm-small
+    steps:
+      - name: Remove triaging label
+        if: github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'needs repro')
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new/repro). Issues marked with `needs repro` will be closed if they have no activity within 3 days."
+
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "needs triage"


### PR DESCRIPTION
## Changes

This PR restore our "Needs repro" workflow by using the `gh` CLI. To note that I used the houston bot token.

## Testing

I already created a similar workflow and it should work for us.
Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
