### PR TITLE
fix: constrain generated live content types

### DIFF
--- a/.changeset/green-dingos-check.md
+++ b/.changeset/green-dingos-check.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes generated content type declarations so live content collection types satisfy TypeScript generic constraints when declaration checking is enabled

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -124,24 +124,25 @@ declare module 'astro:content' {
 	};
 
 	type ExtractLoaderTypes<T> = T extends import('astro/loaders').LiveLoader<
-		infer TData,
-		infer TEntryFilter,
-		infer TCollectionFilter,
-		infer TError
+		infer TData extends Record<string, any>,
+		infer TEntryFilter extends Record<string, any>,
+		infer TCollectionFilter extends Record<string, any>,
+		infer TError extends Error
 	>
 		? { data: TData; entryFilter: TEntryFilter; collectionFilter: TCollectionFilter; error: TError }
-		: { data: never; entryFilter: never; collectionFilter: never; error: never };
+		: { data: Record<string, any>; entryFilter: never; collectionFilter: never; error: Error };
 	type ExtractEntryFilterType<T> = ExtractLoaderTypes<T>['entryFilter'];
 	type ExtractCollectionFilterType<T> = ExtractLoaderTypes<T>['collectionFilter'];
 	type ExtractErrorType<T> = ExtractLoaderTypes<T>['error'];
 	type ExtractDataType<T> = ExtractLoaderTypes<T>['data'];
 
 	type LiveLoaderDataType<C extends keyof LiveContentConfig['collections']> =
-		LiveContentConfig['collections'][C]['schema'] extends undefined
+		(LiveContentConfig['collections'][C]['schema'] extends undefined
 			? ExtractDataType<LiveContentConfig['collections'][C]['loader']>
 			: import('astro/zod').infer<
 					Exclude<LiveContentConfig['collections'][C]['schema'], undefined>
-				>;
+				>) &
+			Record<string, any>;
 	type LiveLoaderEntryFilterType<C extends keyof LiveContentConfig['collections']> =
 		ExtractEntryFilterType<LiveContentConfig['collections'][C]['loader']>;
 	type LiveLoaderCollectionFilterType<C extends keyof LiveContentConfig['collections']> =

--- a/packages/astro/test/content-collections-type-inference.test.ts
+++ b/packages/astro/test/content-collections-type-inference.test.ts
@@ -1,9 +1,106 @@
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { type Fixture, loadFixture } from './test-utils.ts';
+
+const contentConfigStub = `export type ContentConfig = {
+	collections: {
+		blog: { loader: { schema: import('astro/zod').ZodSchema } };
+		legacy: { schema: import('astro/zod').ZodSchema };
+		schemaless: { loader: {} };
+	};
+};`;
+
+const ambientModuleStubs = `
+declare module 'astro/runtime/server/index.js' {
+	export interface AstroComponentFactory {}
+}
+
+declare module 'astro' {
+	export interface MarkdownHeading {}
+	export interface LiveDataEntry<TData extends Record<string, any> = Record<string, any>> {
+		id: string;
+		data: TData;
+	}
+	export interface LiveDataCollectionResult<
+		TData extends Record<string, any> = Record<string, any>,
+		TError extends Error = Error,
+	> {
+		entries?: Array<LiveDataEntry<TData>>;
+		error?: TError | Error;
+	}
+	export interface LiveDataEntryResult<
+		TData extends Record<string, any> = Record<string, any>,
+		TError extends Error = Error,
+	> {
+		entry?: LiveDataEntry<TData>;
+		error?: TError | Error;
+	}
+}
+
+declare module 'astro/zod' {
+	export interface ZodSchema {}
+	export interface ZodString {}
+	export interface ZodTransform<Output = any, Input = any> {}
+	export interface ZodPipe<A = any, B = any> {}
+	export type infer<T> = any;
+	export type output<T> = any;
+}
+
+declare module 'astro/loaders' {
+	export interface LiveLoader<
+		TData extends Record<string, any> = Record<string, any>,
+		TEntryFilter extends Record<string, any> | never = never,
+		TCollectionFilter extends Record<string, any> | never = never,
+		TError extends Error = Error,
+	> {}
+}
+`;
+
+function assertGeneratedContentDtsTypeChecks(contentDts: string) {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astro-content-dts-'));
+	const tscPath = fileURLToPath(
+		new URL('../../../node_modules/typescript/bin/tsc', import.meta.url),
+	);
+	const source = `${ambientModuleStubs}\n${contentDts.replace(
+		/export type ContentConfig = typeof import\([^;]+;/,
+		contentConfigStub,
+	)}`;
+
+	try {
+		fs.writeFileSync(path.join(tempDir, 'content.d.ts'), source);
+		execFileSync(
+			process.execPath,
+			[
+				tscPath,
+				'--noEmit',
+				'--skipLibCheck',
+				'false',
+				'--strict',
+				'--moduleResolution',
+				'bundler',
+				'--module',
+				'ESNext',
+				'--target',
+				'ESNext',
+				'content.d.ts',
+			],
+			{ cwd: tempDir, encoding: 'utf-8', stdio: 'pipe' },
+		);
+	} catch (err) {
+		const stdout = (err as { stdout?: string }).stdout ?? '';
+		const stderr = (err as { stderr?: string }).stderr ?? '';
+		assert.fail(
+			`Generated content.d.ts failed declaration checking.\n\nstdout:\n${stdout}\n\nstderr:\n${stderr}`,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+}
 
 describe('Content collection type inference', () => {
 	let fixture: Fixture;
@@ -77,5 +174,14 @@ describe('Content collection type inference', () => {
 					`stdout:\n${stdout}\n\nstderr:\n${stderr}`,
 			);
 		}
+	});
+
+	it('generates content.d.ts that passes declaration checking', () => {
+		const contentDts = fs.readFileSync(
+			new URL('./.astro/content.d.ts', fixture.config.root),
+			'utf-8',
+		);
+
+		assertGeneratedContentDtsTypeChecks(contentDts);
 	});
 });


### PR DESCRIPTION
## Changes

- Constrains generated live loader type extraction to the same bounds as `LiveLoader`.
- Ensures `LiveLoaderDataType` satisfies the `Record<string, any>` constraint required by live data result types.
- Adds a focused declaration-checking regression for generated `.astro/content.d.ts` and a patch changeset for `astro`.

Fixes #17025

## Testing

- `pnpm exec prettier --check .changeset/green-dingos-check.md`
- `pnpm exec biome check packages/astro/templates/content/types.d.ts packages/astro/test/content-collections-type-inference.test.ts`
- `pnpm -C packages/astro exec astro-scripts test "test/content-collections-type-inference.test.ts" --strip-types`
- `pnpm --filter astro... build:ci`
- `pnpm -C packages/astro test:types`
- `git diff --check`

## Docs

No docs update; this only fixes generated TypeScript declarations.
