### PR TITLE
Fix i18n URL helpers to respect `trailingSlash: 'never'` configuration

### DIFF
--- a/.changeset/all-badgers-peel.md
+++ b/.changeset/all-badgers-peel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `getRelativeLocaleUrl`, `getAbsoluteLocaleUrl`, and `getAbsoluteLocaleUrlList` to strip trailing slashes when `trailingSlash: 'never'` is configured

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -1,4 +1,4 @@
-import { appendForwardSlash, joinPaths } from '@astrojs/internal-helpers/path';
+import { appendForwardSlash, joinPaths, removeTrailingForwardSlash } from '@astrojs/internal-helpers/path';
 import type { RoutingStrategies } from '../core/app/common.js';
 import type { SSRManifest } from '../core/app/types.js';
 import { shouldAppendForwardSlash } from '../core/build/util.js';
@@ -106,7 +106,7 @@ export function getLocaleRelativeUrl({
 	if (shouldAppendForwardSlash(trailingSlash, format)) {
 		relativePath = appendForwardSlash(joinPaths(...pathsToJoin));
 	} else {
-		relativePath = joinPaths(...pathsToJoin);
+		relativePath = removeTrailingForwardSlash(joinPaths(...pathsToJoin));
 	}
 
 	if (relativePath === '') {

--- a/packages/astro/test/units/i18n/astro_i18n.test.ts
+++ b/packages/astro/test/units/i18n/astro_i18n.test.ts
@@ -263,6 +263,88 @@ describe('getLocaleRelativeUrl', () => {
 		);
 	});
 
+	it('should not add trailing slash when trailingSlash is "never" and path is empty or "/" (#17034)', () => {
+		const config = {
+			i18n: {
+				defaultLocale: 'en',
+				locales: ['en', 'pl'],
+			},
+		};
+
+		// path omitted vs path='' should produce the same result
+		assert.equal(
+			relativeUrl({
+				locale: 'pl',
+				base: '/',
+				...config.i18n,
+				trailingSlash: 'never',
+				format: 'directory',
+			}),
+			'/pl',
+		);
+		assert.equal(
+			relativeUrl({
+				locale: 'pl',
+				base: '/',
+				...config.i18n,
+				trailingSlash: 'never',
+				format: 'directory',
+				path: '',
+			}),
+			'/pl',
+		);
+		assert.equal(
+			relativeUrl({
+				locale: 'pl',
+				base: '/',
+				...config.i18n,
+				trailingSlash: 'never',
+				format: 'directory',
+				path: '/',
+			}),
+			'/pl',
+		);
+
+		// prependWith + trailing slash in path
+		assert.equal(
+			relativeUrl({
+				locale: 'pl',
+				base: '/',
+				...config.i18n,
+				trailingSlash: 'never',
+				format: 'directory',
+				path: 'docs/setup/',
+				prependWith: 'blog',
+			}),
+			'/blog/pl/docs/setup',
+		);
+
+		// absolute URL should also strip trailing slash
+		assert.equal(
+			absoluteUrl({
+				locale: 'pl',
+				base: '/',
+				...config.i18n,
+				trailingSlash: 'never',
+				format: 'directory',
+				path: '',
+				site: 'https://example.com',
+			}),
+			'https://example.com/pl',
+		);
+
+		// absoluteUrlList should be consistent across all locales
+		const list = absoluteUrlList({
+			base: '/',
+			...config.i18n,
+			trailingSlash: 'never',
+			format: 'directory',
+			path: '',
+			site: 'https://example.com',
+		});
+		assert.deepEqual(list, ['https://example.com', 'https://example.com/pl']);
+	});
+
 	it('should normalize locales by default', () => {
 		const config = {
 			base: '/blog',


### PR DESCRIPTION
## Changes

- Fixes `getRelativeLocaleUrl`, `getAbsoluteLocaleUrl`, and `getAbsoluteLocaleUrlList` to strip trailing slashes when `trailingSlash: 'never'` is configured
- Wraps `joinPaths()` call with `removeTrailingForwardSlash()` in the else branch of `getLocaleRelativeUrl` to ensure consistent slash handling
- Resolves issue where Astro would 301-redirect its own generated locale URLs, causing unnecessary round trips and SEO issues for language switchers and hreflang blocks

## Testing

- Added regression test `packages/astro/test/units/i18n/astro_i18n.test.ts`: "should not add trailing slash when trailingSlash is 'never' and path is empty or '/' (#17034)"
- Test covers all reported failure cases including empty path, root path, `prependWith` option, absolute URLs, and URL lists
- All 37 existing i18n unit tests continue to pass

## Docs

- No docs update needed — this restores the documented behavior where `trailingSlash: 'never'` ensures no URLs end with trailing slashes

Closes #17034