### PR TITLE
fix(internal-helpers): preserve last segment slash in joinPaths when skipping non-string args

### DIFF
--- a/.changeset/fix-join-paths-skipped-segments.md
+++ b/.changeset/fix-join-paths-skipped-segments.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/internal-helpers': patch
+---
+
+Fixes `joinPaths()` mishandling the last path segment when an earlier argument is a non-string (e.g. `undefined`)
+
+`joinPaths()` filters out non-string arguments, but the check that identifies the last segment compared the index against the original (unfiltered) argument count. When a skipped argument preceded the final one, the real last segment was treated as a middle segment and had its trailing slash stripped. As a result, `joinPaths('/base', undefined, 'docs/setup/')` returned `/base/docs/setup` instead of `/base/docs/setup/`. The last-segment check now uses the filtered segment count, so a skipped argument no longer changes the result of the remaining segments.

--- a/packages/internal-helpers/src/path.ts
+++ b/packages/internal-helpers/src/path.ts
@@ -87,12 +87,12 @@ export function isInternalPath(path: string) {
 }
 
 export function joinPaths(...paths: (string | undefined)[]) {
-	return paths
-		.filter(isString)
+	const segments = paths.filter(isString);
+	return segments
 		.map((path, i) => {
 			if (i === 0) {
 				return removeTrailingForwardSlash(path);
-			} else if (i === paths.length - 1) {
+			} else if (i === segments.length - 1) {
 				return removeLeadingForwardSlash(path);
 			} else {
 				return trimSlashes(path);

--- a/packages/internal-helpers/test/path.test.ts
+++ b/packages/internal-helpers/test/path.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { isParentDirectory, isRemotePath, normalizePathname } from '../dist/path.js';
+import { isParentDirectory, isRemotePath, joinPaths, normalizePathname } from '../dist/path.js';
 
 describe('isRemotePath', () => {
 	const remotePaths = [
@@ -846,5 +846,36 @@ describe('normalizePathname', () => {
 			assert.equal(normalizePathname('/about/', 'preserve', 'always'), '/about/');
 			assert.equal(normalizePathname('/', 'preserve', 'ignore'), '/');
 		});
+	});
+});
+
+describe('joinPaths', () => {
+	it('should join simple segments', () => {
+		assert.equal(joinPaths('a', 'b', 'c'), 'a/b/c');
+		assert.equal(joinPaths('/foo', 'bar'), '/foo/bar');
+	});
+
+	it('should trim inner slashes but keep the first leading and last trailing slash', () => {
+		assert.equal(joinPaths('/foo/', '/bar/', '/baz/'), '/foo/bar/baz/');
+	});
+
+	it('should ignore non-string arguments without affecting slash handling of the last segment', () => {
+		// A skipped (undefined) argument must produce the same result as omitting it.
+		assert.equal(
+			joinPaths('/foo', undefined, '/bar/'),
+			joinPaths('/foo', '/bar/'),
+			'undefined in the middle should not change the result',
+		);
+		// Regression: the trailing slash of the real last segment must be preserved
+		// even when an earlier argument is skipped (previously stripped because the
+		// last-element check compared against the unfiltered argument count).
+		assert.equal(joinPaths('/foo', undefined, '/bar/'), '/foo/bar/');
+		assert.equal(joinPaths('/base', undefined, 'pl', 'docs/setup/'), '/base/pl/docs/setup/');
+		assert.equal(joinPaths(undefined, 'pl', 'docs/setup/'), 'pl/docs/setup/');
+	});
+
+	it('should ignore a trailing non-string argument', () => {
+		assert.equal(joinPaths('/foo', 'bar/', undefined), joinPaths('/foo', 'bar/'));
+		assert.equal(joinPaths('/foo', 'bar/', undefined), '/foo/bar/');
 	});
 });


### PR DESCRIPTION
## What this fixes

`joinPaths()` in `@astrojs/internal-helpers` filters out non-string arguments (so callers can pass `undefined` for optional segments), but the branch that detects the **last** segment compared the map index against the *original*, unfiltered argument count:

```ts
export function joinPaths(...paths: (string | undefined)[]) {
	return paths
		.filter(isString)
		.map((path, i) => {
			if (i === 0) {
				return removeTrailingForwardSlash(path);
			} else if (i === paths.length - 1) { // ← unfiltered length
				return removeLeadingForwardSlash(path);
			} else {
				return trimSlashes(path);
			}
		})
		.join('/');
}
```

When a skipped (`undefined`) argument precedes the final one, the filtered array is shorter than `paths.length`, so the real last segment no longer matches `i === paths.length - 1`. It falls into the `else` branch and gets `trimSlashes()`, which strips its **trailing** slash — even though `joinPaths` is supposed to preserve the trailing slash of the last segment (that is exactly what `removeLeadingForwardSlash` does, as opposed to `trimSlashes`).

### Reproduction

```js
joinPaths('/base', undefined, 'docs/setup/'); // → '/base/docs/setup'  (expected '/base/docs/setup/')
joinPaths('/foo', 'bar/', undefined);         // → '/foo/bar'          (expected '/foo/bar/')
joinPaths(undefined, 'pl', 'docs/setup/');    // → 'pl/docs/setup'     (expected 'pl/docs/setup/')
```

The invariant being violated: a skipped argument should yield the same result as omitting it. `joinPaths(a, undefined, b)` must equal `joinPaths(a, b)`.

## The fix

Compute the filtered array once and base the last-segment check on its length:

```ts
export function joinPaths(...paths: (string | undefined)[]) {
	const segments = paths.filter(isString);
	return segments
		.map((path, i) => {
			if (i === 0) {
				return removeTrailingForwardSlash(path);
			} else if (i === segments.length - 1) {
				return removeLeadingForwardSlash(path);
			} else {
				return trimSlashes(path);
			}
		})
		.join('/');
}
```

Calls where every argument is a string (the vast majority of call sites, e.g. `joinPaths(base, route)`) are unchanged, since `segments.length === paths.length` in that case.

This is the underlying utility bug behind the `prependWith`-with-trailing-slash case noted in the root-cause analysis of #17034 (where `getLocaleRelativeUrl` calls `joinPaths(base, prependWith, locale, path)` with `prependWith` possibly `undefined`).

## Tests

Added a `joinPaths` test block to `packages/internal-helpers/test/path.test.ts` covering simple joins, inner-slash trimming, and the skipped-argument regression. The new assertions fail on `main` and pass with this change.

- `pnpm --filter @astrojs/internal-helpers test` → 64 passing
- `astro` i18n unit tests (`test/units/i18n/astro_i18n.test.ts`) → 37 passing, unchanged

Related: #17034
