### PR TITLE
Fix HMR for files in middleware folder

### DIFF
--- a/.changeset/long-cloths-smoke.md
+++ b/.changeset/long-cloths-smoke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes HMR not triggering for files inside the `src/middleware/` directory during dev

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -44,7 +44,12 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 				if (!normalizedPath.startsWith(normalizedSrcDir)) return;
 				const relativePath = normalizedPath.slice(normalizedSrcDir.length);
 				// Dot ensures we match "middleware.ts" but not e.g. "middleware-utils.ts"
-				if (!relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}.`)) return;
+				// Slash matches files inside the "middleware/" directory
+				if (
+					!relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}.`) &&
+					!relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}/`)
+				)
+					return;
 
 				for (const name of [
 					ASTRO_VITE_ENVIRONMENT_NAMES.ssr,

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -20,6 +20,13 @@ export const MIDDLEWARE_MODULE_ID = 'virtual:astro:middleware';
 const MIDDLEWARE_RESOLVED_MODULE_ID = '\0' + MIDDLEWARE_MODULE_ID;
 const NOOP_MIDDLEWARE = '\0noop-middleware';
 
+export function isMiddlewarePath(relativePath: string): boolean {
+	return (
+		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}.`) ||
+		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}/`)
+	);
+}
+
 export function vitePluginMiddleware({ settings }: { settings: AstroSettings }): VitePlugin {
 	let resolvedMiddlewareId: string | undefined = undefined;
 	const hasIntegrationMiddleware =
@@ -43,13 +50,7 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 				// Check if the changed file is a middleware file under srcDir
 				if (!normalizedPath.startsWith(normalizedSrcDir)) return;
 				const relativePath = normalizedPath.slice(normalizedSrcDir.length);
-				// Dot ensures we match "middleware.ts" but not e.g. "middleware-utils.ts"
-				// Slash matches files inside the "middleware/" directory
-				if (
-					!relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}.`) &&
-					!relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}/`)
-				)
-					return;
+				if (!isMiddlewarePath(relativePath)) return;
 
 				for (const name of [
 					ASTRO_VITE_ENVIRONMENT_NAMES.ssr,

--- a/packages/astro/test/units/middleware/middleware-hmr.test.ts
+++ b/packages/astro/test/units/middleware/middleware-hmr.test.ts
@@ -7,7 +7,7 @@ import { MIDDLEWARE_PATH_SEGMENT_NAME } from '../../../dist/core/constants.js';
  * file watcher to decide whether a changed file should trigger middleware
  * HMR invalidation. See: packages/astro/src/core/middleware/vite-plugin.ts
  */
-function isMiddlewarePath(relativePath) {
+function isMiddlewarePath(relativePath: string) {
 	return (
 		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}.`) ||
 		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}/`)

--- a/packages/astro/test/units/middleware/middleware-hmr.test.ts
+++ b/packages/astro/test/units/middleware/middleware-hmr.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MIDDLEWARE_PATH_SEGMENT_NAME } from '../../../dist/core/constants.js';
+
+/**
+ * Mirrors the path-matching logic used by the middleware vite plugin's
+ * file watcher to decide whether a changed file should trigger middleware
+ * HMR invalidation. See: packages/astro/src/core/middleware/vite-plugin.ts
+ */
+function isMiddlewarePath(relativePath) {
+	return (
+		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}.`) ||
+		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}/`)
+	);
+}
+
+describe('middleware HMR path matching', () => {
+	it('matches middleware.ts (single-file pattern)', () => {
+		assert.ok(isMiddlewarePath('middleware.ts'));
+	});
+
+	it('matches middleware.js', () => {
+		assert.ok(isMiddlewarePath('middleware.js'));
+	});
+
+	it('matches middleware/index.ts (directory pattern)', () => {
+		assert.ok(isMiddlewarePath('middleware/index.ts'));
+	});
+
+	it('matches middleware/test.ts (file inside middleware directory)', () => {
+		assert.ok(isMiddlewarePath('middleware/test.ts'));
+	});
+
+	it('matches middleware/nested/deep.ts (nested file)', () => {
+		assert.ok(isMiddlewarePath('middleware/nested/deep.ts'));
+	});
+
+	it('does not match middleware-utils.ts (similarly named file)', () => {
+		assert.ok(!isMiddlewarePath('middleware-utils.ts'));
+	});
+
+	it('does not match pages/middleware.ts (wrong directory)', () => {
+		assert.ok(!isMiddlewarePath('pages/middleware.ts'));
+	});
+
+	it('does not match other unrelated files', () => {
+		assert.ok(!isMiddlewarePath('components/Header.astro'));
+	});
+});

--- a/packages/astro/test/units/middleware/middleware-hmr.test.ts
+++ b/packages/astro/test/units/middleware/middleware-hmr.test.ts
@@ -1,18 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { MIDDLEWARE_PATH_SEGMENT_NAME } from '../../../dist/core/constants.js';
-
-/**
- * Mirrors the path-matching logic used by the middleware vite plugin's
- * file watcher to decide whether a changed file should trigger middleware
- * HMR invalidation. See: packages/astro/src/core/middleware/vite-plugin.ts
- */
-function isMiddlewarePath(relativePath: string) {
-	return (
-		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}.`) ||
-		relativePath.startsWith(`${MIDDLEWARE_PATH_SEGMENT_NAME}/`)
-	);
-}
+import { isMiddlewarePath } from '../../../dist/core/middleware/vite-plugin.js';
 
 describe('middleware HMR path matching', () => {
 	it('matches middleware.ts (single-file pattern)', () => {


### PR DESCRIPTION
Closes #17039

## Changes

- Middleware file watcher now triggers HMR for files inside the `src/middleware/` directory, not just `src/middleware.{ts,js}` files directly
- Updates the Vite plugin path matcher to include both `middleware.` (existing) and `middleware/` (new) prefixes, matching the fix pattern used for actions in #16932

## Testing

- Added `packages/astro/test/units/middleware/middleware-hmr.test.ts` with 8 test cases covering path matching for both file and directory patterns

## Docs

- No docs update needed — this fixes existing documented behavior that was broken for directory-based middleware organization