### PR TITLE
Fix custom 500 page rendering for render-time errors with experimental.advancedRouting astro/hono handlers

### DIFF
--- a/.changeset/fix-advanced-routing-500-fallback.md
+++ b/.changeset/fix-advanced-routing-500-fallback.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a bug where `experimental.advancedRouting` with `astro/hono` handlers returned the host framework's default `Internal Server Error` response instead of rendering the custom `500.astro` page when a page threw during render.
+Fixes a bug where the advanced routing `astro/hono` / `astro/fetch` `pages()` handler returned the host framework's default `Internal Server Error` response instead of rendering the custom `500.astro` page when a page threw during render. Unmatched requests with a prerendered (or absent) custom 404 page now render the 404 error page instead of failing the same way.

--- a/.changeset/fix-advanced-routing-500-fallback.md
+++ b/.changeset/fix-advanced-routing-500-fallback.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where `experimental.advancedRouting` with `astro/hono` handlers returned the host framework's default `Internal Server Error` response instead of rendering the custom `500.astro` page when a page threw during render.

--- a/packages/astro/src/core/fetch/index.ts
+++ b/packages/astro/src/core/fetch/index.ts
@@ -92,7 +92,9 @@ const pagesHandlers = new WeakMap<BaseApp<Pipeline>, PagesHandler>();
 
 /**
  * Dispatches the request to the matched route (endpoint, page, redirect,
- * or fallback). Lazily creates the render context if needed.
+ * or fallback). Lazily creates the render context if needed. Unmatched
+ * routes render the 404 error page; render-time errors are logged and
+ * render the 500 error page.
  */
 export function pages(state: FetchState): Promise<Response> {
 	const app = getApp(state.request);
@@ -101,7 +103,7 @@ export function pages(state: FetchState): Promise<Response> {
 		handler = new PagesHandler(app.pipeline);
 		pagesHandlers.set(app, handler);
 	}
-	return handler.handle(state, state.getAPIContext());
+	return handler.handleWithErrorFallback(app, state);
 }
 
 /**

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -1,6 +1,7 @@
 import { renderEndpoint } from '../../runtime/server/endpoint.js';
 import { renderPage } from '../../runtime/server/index.js';
 import type { APIContext } from '../../types/public/context.js';
+import type { BaseApp } from '../app/base.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 import type { Pipeline } from '../base-pipeline.js';
 import {
@@ -99,5 +100,40 @@ export class PagesHandler {
 		}
 		state.response = response;
 		return response;
+	}
+
+	/**
+	 * Like `handle`, but mirrors the app-level error handling that
+	 * `AstroHandler` provides on the standard path: unmatched routes
+	 * render the app's 404 error page, and render-time errors are logged
+	 * and render the 500 error page instead of propagating to the host
+	 * framework.
+	 *
+	 * Used by the composable `astro/fetch` `pages()` entry point, where
+	 * there is no surrounding `AstroHandler` to supply this fallback.
+	 */
+	async handleWithErrorFallback(app: BaseApp<Pipeline>, state: FetchState): Promise<Response> {
+		// `FetchState` falls back to an SSR 404 route when nothing matches,
+		// so routeData is only missing when the custom 404 page is
+		// prerendered (or absent) — let the error handler serve the
+		// pre-built page instead.
+		if (!state.routeData) {
+			return app.renderError(state.request, {
+				...state.renderOptions,
+				status: 404,
+				pathname: state.pathname,
+			});
+		}
+		try {
+			return await this.handle(state, state.getAPIContext());
+		} catch (err: any) {
+			app.logger.error(null, err.stack || err.message || String(err));
+			return app.renderError(state.request, {
+				...state.renderOptions,
+				status: 500,
+				error: err,
+				pathname: state.pathname,
+			});
+		}
 	}
 }

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -105,7 +105,8 @@ export class PagesHandler {
 	/**
 	 * Like `handle`, but mirrors the app-level error handling that
 	 * `AstroHandler` provides on the standard path: unmatched routes
-	 * render the app's 404 error page, and render-time errors are logged
+	 * return a 404 marked with `X-Astro-Error` for the app's post-check
+	 * to render the 404 error page, and render-time errors are logged
 	 * and render the 500 error page instead of propagating to the host
 	 * framework.
 	 *
@@ -115,18 +116,17 @@ export class PagesHandler {
 	async handleWithErrorFallback(app: BaseApp<Pipeline>, state: FetchState): Promise<Response> {
 		// `FetchState` falls back to an SSR 404 route when nothing matches,
 		// so routeData is only missing when the custom 404 page is
-		// prerendered (or absent) — let the error handler serve the
-		// pre-built page instead.
+		// prerendered (or absent). Return a marked 404 and let the app's
+		// `X-Astro-Error` post-check render the error page a level up,
+		// the same way the un-dispatched `redirect` case above does.
 		if (!state.routeData) {
-			return app.renderError(state.request, {
-				...state.renderOptions,
-				status: 404,
-				pathname: state.pathname,
-			});
+			return new Response(null, { status: 404, headers: { [ASTRO_ERROR_HEADER]: 'true' } });
 		}
 		try {
 			return await this.handle(state, state.getAPIContext());
 		} catch (err: any) {
+			// The header marker can't carry the error object, so render the
+			// 500 page directly to preserve `error` and the logged stack.
 			app.logger.error(null, err.stack || err.message || String(err));
 			return app.renderError(state.request, {
 				...state.renderOptions,

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -296,6 +296,44 @@ describe('pages()', () => {
 		assert.match(text, /<h1>Not Found<\/h1>/);
 	});
 
+	it('renders the custom 500 page when a page throws during render', async () => {
+		const throwingPage = createComponent((_result: any, _props: any, _slots: any) => {
+			throw new Error('boom');
+		});
+		const errorPage = createComponent((_result: any, _props: any, _slots: any) => {
+			return render`<h1>my custom 500</h1>`;
+		});
+		const app = createTestApp([
+			createPage(simplePage, { route: '/' }),
+			createPage(throwingPage, { route: '/boom' }),
+			createPage(errorPage, { route: '/500' }),
+		]);
+		const request = stampApp(new Request('http://example.com/boom'), app);
+		const state = new FetchState(request);
+
+		const response = await pages(state);
+
+		assert.equal(response.status, 500);
+		const text = await response.text();
+		assert.match(text, /<h1>my custom 500<\/h1>/);
+	});
+
+	it('serves a 404 via the error handler when the custom 404 route is prerendered', async () => {
+		const notFoundPage = createComponent((_result: any, _props: any, _slots: any) => {
+			return render`<h1>Not Found</h1>`;
+		});
+		const app = createTestApp([
+			createPage(simplePage, { route: '/' }),
+			createPage(notFoundPage, { route: '/404', prerender: true }),
+		]);
+		const request = stampApp(new Request('http://example.com/does-not-exist'), app);
+		const state = new FetchState(request);
+
+		const response = await pages(state);
+
+		assert.equal(response.status, 404);
+	});
+
 	it('renders an endpoint', async () => {
 		const app = createTestApp([
 			createEndpoint(

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -318,7 +318,7 @@ describe('pages()', () => {
 		assert.match(text, /<h1>my custom 500<\/h1>/);
 	});
 
-	it('serves a 404 via the error handler when the custom 404 route is prerendered', async () => {
+	it('returns a marked 404 for the app post-check when the custom 404 route is prerendered', async () => {
 		const notFoundPage = createComponent((_result: any, _props: any, _slots: any) => {
 			return render`<h1>Not Found</h1>`;
 		});
@@ -332,6 +332,7 @@ describe('pages()', () => {
 		const response = await pages(state);
 
 		assert.equal(response.status, 404);
+		assert.equal(response.headers.get('X-Astro-Error'), 'true');
 	});
 
 	it('renders an endpoint', async () => {


### PR DESCRIPTION
## Changes

Under `experimental.advancedRouting`, the composable `astro/hono` `pages()` handler delegated straight to `PagesHandler.handle()`, with none of the app-level error handling that `AstroHandler` provides on the standard path. A page throwing during render therefore propagated to the host framework, which answered with its own default error response (Hono: plain-text `Internal Server Error`) instead of rendering the custom `500.astro` page (#16952).

- Added `PagesHandler.handleWithErrorFallback(app, state)` (`core/pages/handler.ts`): wraps route dispatch in a try/catch that logs the error and renders it via `app.renderError(..., { status: 500, error })`, the same behaviour `AstroHandler.render()` has on the standard path. Forwarding `error` keeps the documented `error` prop on `500.astro` working. The logic lives in the handler module because `core/fetch/index.ts` deliberately keeps its exports as thin, logic-free wrappers.
- When no route matched, `handleWithErrorFallback()` returns a 404 response marked with `X-Astro-Error` (the same pattern `handle()` uses for the un-dispatched redirect case), so the app's existing post-check renders the 404 error page a level up. This case is reachable because #16911 intentionally leaves `routeData` unset when the custom 404 route is prerendered (or absent), where `PagesHandler.handle()` would otherwise throw a `TypeError` and the catch would turn those unmatched requests into 500s. The 500 path keeps calling `renderError()` directly: the marker cannot carry the error object, so `500.astro` would lose its `error` prop and the stack would not be logged.
- Switched `pages()` in `core/fetch/index.ts` to delegate to the new method (delegation only, no logic added).
- Added a changeset (`astro` patch).

## Testing

- Added `'renders the custom 500 page when a page throws during render'` - verifies the full `pages()` pipeline returns HTTP 500 with the custom 500 page content when a page throws during render
- Added `'returns a marked 404 for the app post-check when the custom 404 route is prerendered'` - verifies unmatched requests return HTTP 404 carrying the `X-Astro-Error` marker instead of throwing
- Verified end-to-end against the reproduction from #16952 (Hono + `app.use(pages())`, node standalone): `GET /boom` -> `500` with the custom 500 page (previously Hono's plain-text `Internal Server Error`), `GET /does-not-exist` -> `404` serving the prerendered 404 page with the marker stripped from the final response, `GET /` -> `200`; the thrown error is logged with its stack trace

## Out of scope (noticed while testing)

Errors thrown by Astro middleware itself (`src/middleware.ts`) on the composable path (`app.use(middleware())`) still reach the host framework's default error handler instead of `500.astro`. On the standard path, `AstroHandler.render()`'s try/catch wraps the whole middleware chain, so middleware errors get the same `500.astro` treatment. The equivalent catch can't simply live inside the composable `middleware()`: its `next` is the host's `next()`, so it would also intercept errors thrown by host middleware running below it in the chain and hide them from the user's own `app.onError`. The all-in-one `astro()` handler already provides full parity. A possible follow-up would be an error-page helper exported from `astro/hono` (e.g. `app.onError(onError())`) so composable users can opt in - happy to open a separate issue for this.

## Docs

- No docs update needed, this fixes broken functionality in an experimental feature so it matches the documented custom-error-page behavior (the 404 counterpart was #16911)

Closes #16952
