### PR TITLE
Fix CSS leak between client:only islands in production builds

### DIFF
--- a/.changeset/itchy-snails-march.md
+++ b/.changeset/itchy-snails-march.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes CSS from `client:only` islands leaking to unrelated pages when Rollup bundles non-CSS-importing modules into the same chunk as CSS-importing modules

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -177,6 +177,11 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 				// client:only component and if so, add its CSS to the page it belongs to.
 				if (this.environment?.name === ASTRO_VITE_ENVIRONMENT_NAMES.client) {
 					for (const id of Object.keys(chunk.modules)) {
+						// Only walk from CSS modules to find client:only parents. When Rollup
+						// merges unrelated modules into the same chunk, walking from every module
+						// would incorrectly attribute the chunk's CSS to pages reached through
+						// modules that have no CSS dependency.
+						if (!isCSSRequest(id)) continue;
 						for (const pageData of getParentClientOnlys(id, this, internals)) {
 							for (const importedCssImport of meta.importedCss) {
 								const cssToInfoRecord = (pagesToCss[pageData.moduleSpecifier] ??= {});

--- a/packages/astro/test/client-only-css-chunk-leak.test.ts
+++ b/packages/astro/test/client-only-css-chunk-leak.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { load as cheerioLoad } from 'cheerio';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('client:only CSS chunk leak', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/client-only-css-chunk-leak/',
+		});
+		await fixture.build();
+	});
+
+	it('does not leak CSS to pages that do not use CSS-importing client:only components', async () => {
+		const html = await fixture.readFile('/about/index.html');
+		const $ = cheerioLoad(html);
+
+		const stylesheets = $('link[rel=stylesheet]');
+		// The about page only uses CurrentTime (no CSS imports).
+		// It should have no stylesheets from the shared chunk.
+		assert.equal(stylesheets.length, 0, 'About page should have no stylesheet links');
+	});
+
+	it('includes CSS on the page that uses the CSS-importing client:only component', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerioLoad(html);
+
+		const stylesheets = await Promise.all(
+			$('link[rel=stylesheet]').map((_, el) => {
+				return fixture.readFile(el.attribs.href);
+			}),
+		);
+		const css = stylesheets.join('');
+
+		assert.match(css, /\.heavy-widget/, 'Home page should include .heavy-widget CSS');
+	});
+});

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/astro.config.mjs
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/astro.config.mjs
@@ -1,0 +1,23 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+export default defineConfig({
+  integrations: [react()],
+  build: { inlineStylesheets: 'never' },
+  vite: {
+    build: {
+      rollupOptions: {
+        output: {
+          // Force StyledPanel (which imports CSS) and formatLabel (a pure utility)
+          // into the same chunk. This simulates what Rollup's default heuristics
+          // do naturally in large apps.
+          manualChunks(id) {
+            if (id.includes('StyledPanel') || id.includes('formatLabel')) {
+              return 'shared-utils';
+            }
+          },
+        },
+      },
+    },
+  },
+});

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/package.json
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/client-only-css-chunk-leak",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/react": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/CurrentTime.tsx
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/CurrentTime.tsx
@@ -1,0 +1,5 @@
+import { formatLabel } from './formatLabel';
+
+export default function CurrentTime() {
+  return <span>{formatLabel('time')}</span>;
+}

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/HeavyWidget.tsx
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/HeavyWidget.tsx
@@ -1,0 +1,6 @@
+import StyledPanel from './StyledPanel';
+import { formatLabel } from './formatLabel';
+
+export default function HeavyWidget() {
+  return <StyledPanel>{formatLabel('Widget')}</StyledPanel>;
+}

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/StyledPanel.css
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/StyledPanel.css
@@ -1,0 +1,1 @@
+.heavy-widget { color: red; font-size: 72px; background: limegreen; padding: 2rem; }

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/StyledPanel.tsx
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/StyledPanel.tsx
@@ -1,0 +1,5 @@
+import './StyledPanel.css';
+
+export default function StyledPanel({ children }: { children: React.ReactNode }) {
+  return <div className="heavy-widget">{children}</div>;
+}

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/formatLabel.ts
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/components/formatLabel.ts
@@ -1,0 +1,3 @@
+export function formatLabel(text: string): string {
+  return `[ ${text.toUpperCase()} ]`;
+}

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/layouts/Layout.astro
@@ -1,0 +1,14 @@
+---
+import CurrentTime from '../components/CurrentTime';
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS Leak Test</title>
+  </head>
+  <body>
+    <CurrentTime client:only="react" />
+    <slot />
+  </body>
+</html>

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/pages/about.astro
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/pages/about.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout>
+  <h1>About</h1>
+</Layout>

--- a/packages/astro/test/fixtures/client-only-css-chunk-leak/src/pages/index.astro
+++ b/packages/astro/test/fixtures/client-only-css-chunk-leak/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../layouts/Layout.astro';
+import HeavyWidget from '../components/HeavyWidget';
+---
+
+<Layout>
+  <h1>Home</h1>
+  <HeavyWidget client:only="react" />
+</Layout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2515,6 +2515,21 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/client-only-css-chunk-leak:
+    dependencies:
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../../../integrations/react
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+
   packages/astro/test/fixtures/code-component:
     dependencies:
       astro:
@@ -4839,7 +4854,7 @@ importers:
         version: link:../../astro-prism
       '@markdoc/markdoc':
         specifier: ^0.5.4
-        version: 0.5.4(@types/react@18.3.28)(react@19.2.4)
+        version: 0.5.4(@types/react@19.2.17)(react@19.2.7)
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -6020,7 +6035,7 @@ importers:
         version: link:../../internal-helpers
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(react@19.2.4)(svelte@5.55.3)(vue@3.5.30)
+        version: 1.6.1(react@19.2.7)(svelte@5.55.3)(vue@3.5.30)
       '@vercel/functions':
         specifier: ^3.4.3
         version: 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.48)
@@ -6853,6 +6868,30 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+
+  triage/gh-17043:
+    dependencies:
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../../packages/integrations/node
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+      react:
+        specifier: ^19.2.5
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.7(react@19.2.7)
 
 packages:
 
@@ -10336,8 +10375,16 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -14568,6 +14615,11 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -14581,6 +14633,10 @@ packages:
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   read-package-up@11.0.0:
@@ -18492,12 +18548,12 @@ snapshots:
       - encoding
       - supports-color
 
-  '@markdoc/markdoc@0.5.4(@types/react@18.3.28)(react@19.2.4)':
+  '@markdoc/markdoc@0.5.4(@types/react@19.2.17)(react@19.2.7)':
     optionalDependencies:
       '@types/linkify-it': 3.0.5
       '@types/markdown-it': 12.2.3
-      '@types/react': 18.3.28
-      react: 19.2.4
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -19982,9 +20038,17 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
   '@types/react@18.3.28':
     dependencies:
       '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@types/react@19.2.17':
+    dependencies:
       csstype: 3.2.3
 
   '@types/retry@0.12.0': {}
@@ -20183,9 +20247,9 @@ snapshots:
     dependencies:
       valibot: 1.2.0(typescript@6.0.3)
 
-  '@vercel/analytics@1.6.1(react@19.2.4)(svelte@5.55.3)(vue@3.5.30)':
+  '@vercel/analytics@1.6.1(react@19.2.7)(svelte@5.55.3)(vue@3.5.30)':
     optionalDependencies:
-      react: 19.2.4
+      react: 19.2.7
       svelte: 5.55.3
       vue: 3.5.30(typescript@6.0.3)
 
@@ -25005,6 +25069,11 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-is@17.0.2: {}
 
   react-refresh@0.18.0: {}
@@ -25014,6 +25083,8 @@ snapshots:
       loose-envify: 1.4.0
 
   react@19.2.4: {}
+
+  react@19.2.7: {}
 
   read-package-up@11.0.0:
     dependencies:


### PR DESCRIPTION
## Changes

- Fixes CSS incorrectly loading on pages that don't import it when using `client:only` islands in production builds
- Adds missing `isCSSRequest` filter to the client:only CSS association loop in `plugin-css.ts`, matching the existing filter in the non-client:only code path  
- Prevents CSS from unrelated modules being associated with pages when Rollup bundles pure utility modules into the same chunk as CSS-importing modules
- Reporter confirmed dramatic CSS reductions: frontpage went from 14 stylesheets/718.2 KB to 1 stylesheet/481.2 KB

## Testing

- Adds reproduction test `client-only-css-chunk-leak.test.ts` that verifies CSS is only loaded on pages that actually import it

## Docs

- No docs update needed — this fixes incorrect behavior to match documented CSS scoping for islands

Closes #17043