### PR TITLE
chore(language-tools): add package support metadata

### DIFF
--- a/.changeset/real-loops-hope.md
+++ b/.changeset/real-loops-hope.md
@@ -3,4 +3,4 @@
 "@astrojs/ts-plugin": patch
 ---
 
-chore(language-tools): add package support metadata
+Improve npm package links for the Astro language tooling packages.

--- a/.changeset/real-loops-hope.md
+++ b/.changeset/real-loops-hope.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"@astrojs/ts-plugin": patch
+---
+
+chore(language-tools): add package support metadata

--- a/packages/language-tools/language-server/package.json
+++ b/packages/language-tools/language-server/package.json
@@ -8,6 +8,8 @@
     "url": "git+https://github.com/withastro/astro.git",
     "directory": "packages/language-tools/language-server"
   },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://github.com/withastro/astro/tree/main/packages/language-tools/language-server",
   "type": "commonjs",
   "main": "dist/index.js",
   "files": [

--- a/packages/language-tools/ts-plugin/package.json
+++ b/packages/language-tools/ts-plugin/package.json
@@ -9,6 +9,8 @@
     "url": "git+https://github.com/withastro/astro.git",
     "directory": "packages/language-tools/ts-plugin"
   },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://github.com/withastro/astro/tree/main/packages/language-tools/ts-plugin",
   "keywords": [
     "astro",
     "typescript",


### PR DESCRIPTION
## Changes

- Add missing `bugs` metadata for `@astrojs/ts-plugin` and `@astrojs/language-server`.
- Add package-specific `homepage` metadata pointing to each package directory.

## Testing

- Node manifest assertion for both package names, versions, `bugs`, and `homepage` fields
- `npm pack --dry-run --ignore-scripts --json` in `packages/language-tools/ts-plugin`
- `npm pack --dry-run --ignore-scripts --json` in `packages/language-tools/language-server`
- `git diff --check`