### PR TITLE
fix(cloudflare): propagate prerender render errors without failing intentional non-2xx pages

### DIFF
--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -136,16 +136,11 @@ export function createCloudflarePrerenderer({
 
 			// Check for prerender errors surfaced by the workerd handler via header
 			// (the response body may be stripped by the Vite preview server).
+			// Only the header marks a failure: pages may intentionally return
+			// non-2xx responses while prerendering (e.g. a custom 404 page).
 			const prerenderError = response.headers.get('x-astro-prerender-error');
 			if (prerenderError) {
 				throw new Error(`Failed to prerender ${request.url}: ${prerenderError}`);
-			}
-
-			if (!response.ok && response.status !== 301 && response.status !== 302 && response.status !== 307 && response.status !== 308) {
-				const details = await response.text().catch(() => '');
-				throw new Error(
-					`Failed to prerender ${request.url}: ${details || `${response.status} ${response.statusText}`}`,
-				);
 			}
 
 			return response;

--- a/packages/integrations/cloudflare/src/utils/handler.ts
+++ b/packages/integrations/cloudflare/src/utils/handler.ts
@@ -12,6 +12,7 @@ import {
 	handlePrerenderRequest,
 	isStaticImagesRequest,
 	handleStaticImagesRequest,
+	installPrerenderErrorPropagation,
 } from './prerender.js';
 import {
 	type Runtime,
@@ -35,6 +36,10 @@ declare global {
 type CfResponse = Awaited<ReturnType<Required<ExportedHandler<Env>>['fetch']>>;
 
 const app = createApp();
+
+if (isPrerender) {
+	installPrerenderErrorPropagation(app);
+}
 
 export async function handle(
 	request: Request,

--- a/packages/integrations/cloudflare/src/utils/prerender.ts
+++ b/packages/integrations/cloudflare/src/utils/prerender.ts
@@ -14,7 +14,7 @@
  * available in production or development.
  */
 
-import type { BaseApp } from 'astro/app';
+import type { BaseApp, RenderErrorOptions } from 'astro/app';
 import { serializeRouteData, deserializeRouteData } from 'astro/app/manifest';
 import { StaticPaths } from 'astro:static-paths';
 import type {
@@ -28,6 +28,28 @@ import {
 	PRERENDER_ENDPOINT,
 	STATIC_IMAGES_ENDPOINT,
 } from './prerender-constants.js';
+
+/**
+ * Replicates core's `BuildErrorHandler` semantics on the worker app during
+ * the prerender phase. The production app converts render errors into a
+ * rendered 500 error page, which makes a crash indistinguishable from a page
+ * that intentionally returns an error status. During prerendering, a render
+ * error must instead propagate as a throw so `handlePrerenderRequest` can
+ * surface it to the build process, while intentional non-2xx responses
+ * (e.g. a custom 404 page) still render through the default error handler.
+ */
+export function installPrerenderErrorPropagation(app: BaseApp): void {
+	const originalRenderError = app.renderError.bind(app);
+	app.renderError = async (request: Request, options: RenderErrorOptions): Promise<Response> => {
+		if (options.status === 500) {
+			if (options.response) {
+				return options.response;
+			}
+			throw options.error;
+		}
+		return originalRenderError(request, options);
+	};
+}
 
 /**
  * Checks if the request is for the static paths prerender endpoint.


### PR DESCRIPTION
Follow-up to #17049, fixing the E2E failures discussed in https://github.com/withastro/astro/pull/17049#issuecomment-4691226320. Root-cause analysis in https://github.com/withastro/astro/pull/17049#issuecomment-4691438764 — this PR targets the `flue/fix-17047` branch so it can be merged into #17049 directly.

## Changes

- **`src/prerenderer.ts`**: drop the status-based failure check. It treated any non-2xx prerender response as a build failure, but pages may intentionally return non-2xx while prerendering — the E2E Cloudflare fixture's `missing.astro` returns `new Response(null, { status: 404 })` in production builds, which is what broke the E2E jobs. The `x-astro-prerender-error` header is now the only failure signal.
- **`src/utils/prerender.ts`**: add `installPrerenderErrorPropagation()`. The header path was previously dead code: `app.render()` never rejects on render errors because `AstroHandler` catches the throw and the production `DefaultErrorHandler` renders a 500 error page, so the buffering `catch` in `handlePrerenderRequest` never fired (the new test was passing only via the status check). This override replicates core's `BuildErrorHandler` semantics on the worker app: render errors (status 500 with an `error` and no `response`) are rethrown, while intentional error responses and 404s flow through the default handler unchanged.
- **`src/utils/handler.ts`**: install the override when `isPrerender` is true.

Error flow for a genuine render crash: throw → `AstroHandler` catch → patched `renderError` rethrows → `app.render` rejects → `handlePrerenderRequest` catch → 500 + `x-astro-prerender-error` header → Node-side `render()` throws → build fails.

## Testing

- `test/prerenderer-errors.test.ts` passes (both tests) — a page throwing during prerendering still fails the build.
- `packages/astro/e2e/fixtures/cloudflare` builds successfully again with the intentional 404 in `missing.astro` — the exact case that failed the E2E jobs.
- Full adapter test suite results match a baseline run of the unmodified #17049 code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
