### PR TITLE
fix(markdoc): replace every hyphen in tag names, not just the first

### DIFF
--- a/.changeset/markdoc-multi-hyphen-tags.md
+++ b/.changeset/markdoc-multi-hyphen-tags.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fix Markdoc tag names containing two or more hyphens (e.g. `lead-capture-inline`) breaking the build with a confusing Rollup parse error. `toImportName` now replaces every hyphen with an underscore instead of only the first one, so the generated import statements use a valid JS identifier.

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -380,8 +380,13 @@ function getStringifiedImports(
 }
 
 function toImportName(unsafeName: string) {
-	// TODO: more checks that name is a safe JS variable name
-	return unsafeName.replace('-', '_');
+	// TODO: more checks that name is a safe JS variable name.
+	// `String.prototype.replace` with a string pattern only replaces the first
+	// occurrence — a tag named `lead-capture-inline` would become
+	// `lead_capture-inline`, which is an invalid JS identifier and breaks the
+	// generated import statement with a confusing Rollup parse error. Use the
+	// global form so every hyphen is rewritten. See #17021.
+	return unsafeName.replaceAll('-', '_');
 }
 
 /**

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/markdoc.config.ts
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/markdoc.config.ts
@@ -28,5 +28,12 @@ export default defineMarkdocConfig({
 		'deeply-nested': {
 			render: component('./src/components/DeeplyNested.astro'),
 		},
+		// Two-hyphen tag name — regression guard for #17021. `toImportName`
+		// must replace ALL hyphens, otherwise the generated import statement
+		// uses an invalid JS identifier and the build fails with a confusing
+		// Rollup parse error.
+		'my-cool-tag': {
+			render: component('./src/components/MultiHyphen.astro'),
+		},
 	},
 });

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/src/components/MultiHyphen.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/src/components/MultiHyphen.astro
@@ -1,0 +1,1 @@
+<div data-multi-hyphen {...Astro.props}><slot /></div>

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/src/content/blog/with-components.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/src/content/blog/with-components.mdoc
@@ -26,3 +26,7 @@ const isRenderedWithShikiInside = true;
 ```
 
 {% /if %}
+
+{% my-cool-tag %}
+multi-hyphen content
+{% /my-cool-tag %}

--- a/packages/integrations/markdoc/test/render-components.test.ts
+++ b/packages/integrations/markdoc/test/render-components.test.ts
@@ -30,6 +30,21 @@ describe('Markdoc - render components', () => {
 
 			renderComponentsInsidePartialsChecks(html);
 		});
+
+		// Regression for #17021. `toImportName` previously used
+		// `String.prototype.replace('-', '_')`, which only swaps the first
+		// hyphen. A tag named `my-cool-tag` produced an invalid JS identifier
+		// in the generated import (`Tagmy_cool-tag`) and broke the build with
+		// a confusing Rollup parse error before render even started — so this
+		// test fails at `fixture.build()` time on the pre-fix code rather than
+		// at this assertion.
+		it('renders content - with multi-hyphen tag names', async () => {
+			const html = await fixture.readFile('/index.html');
+			const { document } = parseHTML(html);
+			const multiHyphen = document.querySelector('[data-multi-hyphen]');
+			assert.notEqual(multiHyphen, null);
+			assert.match(multiHyphen!.textContent ?? '', /multi-hyphen content/);
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

Closes #17021.

`toImportName()` in `@astrojs/markdoc` builds the JS identifier used for generated component imports from a Markdoc tag name by replacing hyphens with underscores:

```ts
function toImportName(unsafeName: string) {
  return unsafeName.replace('-', '_');
}
```

`String.prototype.replace` with a string pattern only replaces the first occurrence, so a tag named `lead-capture-inline` becomes `lead_capture-inline` — not a valid JS identifier — and the generated import statement is rejected by Rollup with a confusing parse error that points at the `.mdoc` file's frontmatter instead of the real cause:

```
[ERROR] [vite] ✗ Build failed
src/content/articles/example.mdoc (8:22): Expected ',', got '-'
(Note that you need plugins to import files that are not JavaScript)
```

Single-hyphen tags worked because the one replacement covers them; the incomplete fix dates back to PR #7599 (2023), whose only fixture was `marquee-element` (one hyphen), so multi-hyphen tags were never exercised.

## Fix

```diff
 function toImportName(unsafeName: string) {
-  return unsafeName.replace('-', '_');
+  return unsafeName.replaceAll('-', '_');
 }
```

## Tests

The existing `render-with-components` fixture gains:

- a `my-cool-tag` (two hyphens) registration in `markdoc.config.ts`
- a `MultiHyphen.astro` component
- usage in `with-components.mdoc`
- a `renders content - with multi-hyphen tag names` assertion in `render-components.test.ts`

The test fails at `fixture.build()` time on the pre-fix code (the build itself errors with the Rollup parse error before render even starts), so it's a clean regression guard.

## Test plan

- [x] `pnpm test` in `packages/integrations/markdoc` — **48/48 pass** on this branch (47 existing + 1 new)
- [x] Verified the new test fails on `main` by stashing only the `toImportName` change and re-running — **1 failed | 45 passed**, confirming the test catches the actual regression and not just vacuous coverage
- [x] Changeset added (`@astrojs/markdoc` patch)

## Notes for review

- An `astrobot-houston` triage report on the issue thread proposed the same one-character fix; this PR ships it with the supporting fixture wiring + regression test.
- I intentionally did NOT widen `toImportName()` to do broader JS-identifier sanitization beyond hyphens (the `TODO: more checks that name is a safe JS variable name` comment hints at it). That's a separate, larger scope worth its own discussion.