### PR TITLE
Fix prerendered redirect targets being bundled into SSR in hybrid mode

### DIFF
--- a/packages/astro/src/vite-plugin-pages/pages.ts
+++ b/packages/astro/src/vite-plugin-pages/pages.ts
@@ -18,13 +18,13 @@ interface PagesPluginOptions {
  * Filters routes for a specific build environment.
  * Redirects need their target route included so the redirect response can be generated at runtime.
  */
-function getRoutesForEnvironment(routes: RouteData[], isPrerender: boolean): Set<RouteData> {
+export function getRoutesForEnvironment(routes: RouteData[], isPrerender: boolean): Set<RouteData> {
 	const result = new Set<RouteData>();
 	for (const route of routes) {
 		if (route.prerender === isPrerender) {
 			result.add(route);
 		}
-		if (route.redirectRoute) {
+		if (route.redirectRoute && route.redirectRoute.prerender === isPrerender) {
 			result.add(route.redirectRoute);
 		}
 	}

--- a/packages/astro/test/units/redirects/environment-filtering.test.ts
+++ b/packages/astro/test/units/redirects/environment-filtering.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getRoutesForEnvironment } from '../../../dist/vite-plugin-pages/pages.js';
+import type { RouteData } from '../../../dist/types/public/internal.js';
+
+describe('getRoutesForEnvironment', () => {
+	it('does not include prerendered redirect targets in SSR routes', () => {
+		const staticTarget = { component: 'src/pages/static-target.astro', prerender: true, type: 'page' } as RouteData;
+		const ssrPage = { component: 'src/pages/ssr-page.astro', prerender: false, type: 'page' } as RouteData;
+		const redirect = { component: '', prerender: false, type: 'redirect', redirectRoute: staticTarget } as RouteData;
+
+		const ssrRoutes = getRoutesForEnvironment([staticTarget, ssrPage, redirect], false);
+
+		// SSR routes should include the SSR page and the redirect itself
+		assert.ok(ssrRoutes.has(ssrPage), 'SSR page should be in SSR routes');
+		assert.ok(ssrRoutes.has(redirect), 'redirect route should be in SSR routes');
+		// The prerendered target should NOT be in SSR routes
+		assert.ok(!ssrRoutes.has(staticTarget), 'prerendered redirect target should not be in SSR routes');
+	});
+
+	it('includes prerendered redirect targets in prerender routes', () => {
+		const staticTarget = { component: 'src/pages/static-target.astro', prerender: true, type: 'page' } as RouteData;
+		const redirect = { component: '', prerender: true, type: 'redirect', redirectRoute: staticTarget } as RouteData;
+
+		const prerenderRoutes = getRoutesForEnvironment([staticTarget, redirect], true);
+
+		assert.ok(prerenderRoutes.has(staticTarget), 'prerendered target should be in prerender routes');
+		assert.ok(prerenderRoutes.has(redirect), 'redirect should be in prerender routes');
+	});
+
+	it('includes SSR redirect targets in SSR routes', () => {
+		const ssrTarget = { component: 'src/pages/ssr-target.astro', prerender: false, type: 'page' } as RouteData;
+		const redirect = { component: '', prerender: false, type: 'redirect', redirectRoute: ssrTarget } as RouteData;
+
+		const ssrRoutes = getRoutesForEnvironment([ssrTarget, redirect], false);
+
+		assert.ok(ssrRoutes.has(ssrTarget), 'SSR target should be in SSR routes');
+		assert.ok(ssrRoutes.has(redirect), 'redirect should be in SSR routes');
+	});
+
+	it('does not include SSR redirect targets in prerender routes', () => {
+		const ssrTarget = { component: 'src/pages/ssr-target.astro', prerender: false, type: 'page' } as RouteData;
+		const redirect = { component: '', prerender: true, type: 'redirect', redirectRoute: ssrTarget } as RouteData;
+
+		const prerenderRoutes = getRoutesForEnvironment([ssrTarget, redirect], true);
+
+		assert.ok(prerenderRoutes.has(redirect), 'redirect should be in prerender routes');
+		assert.ok(!prerenderRoutes.has(ssrTarget), 'SSR target should not be in prerender routes');
+	});
+});


### PR DESCRIPTION
Closes #17060

## Problem

In hybrid mode (`output: 'static'` + adapter), prerendered pages that are redirect targets were incorrectly being included in the SSR bundle, causing massive bundle size inflation. The reporter saw their deployment grow from ~1.4MB to 68MB due to this issue.

## Root Cause

The `getRoutesForEnvironment` function in `packages/astro/src/vite-plugin-pages/pages.ts` was unconditionally adding redirect target routes to the result set without checking their prerender flag. This meant that even when a redirect target was meant to be prerendered (and thus should only exist in the static environment), it would still get bundled into the SSR function.

## Solution

Added a prerender check to the redirect target filtering logic:

```typescript
if (route.redirectRoute && route.redirectRoute.prerender === isPrerender)
```

This ensures redirect targets are only included in their appropriate environment - prerendered redirects stay in static, and SSR redirects stay in SSR.

## Verification

- All 65 existing redirect tests continue to pass
- Added comprehensive unit tests covering the environment filtering logic
- Issue reporter (@spaceemotion) confirmed the fix works - their deployment is now 990KB (down from 68MB) and builds 30 seconds faster

## Files Changed

- `packages/astro/src/vite-plugin-pages/pages.ts` — Added prerender check to redirect target filtering  
- `packages/astro/test/units/redirects/environment-filtering.test.ts` — New unit tests covering the filtering logic