### PR TITLE
Fix HMR for CSS files imported with ?raw - fixed #17056

### DIFF
--- a/.changeset/spicy-islands-kneel.md
+++ b/.changeset/spicy-islands-kneel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes HMR for `?raw` CSS imports. Changing a CSS file imported with `?raw` now correctly triggers a full page reload during development.

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -41,12 +41,20 @@ export default function hmrReload(): Plugin {
 				const invalidatedModules = new Set<EnvironmentModuleNode>();
 				for (const mod of modules) {
 					if (mod.id == null) continue;
-					if (isStyleModule(mod)) {
-						hasSkippedStyleModules = true;
-						continue;
-					}
 
 					const clientModule = server.environments.client.moduleGraph.getModuleById(mod.id);
+
+					if (isStyleModule(mod)) {
+						// Only skip style modules that the client environment can handle via
+						// Vite's built-in CSS HMR. SSR-only style modules (e.g. ?raw imports)
+						// have no client counterpart and need a full page reload instead.
+						if (clientModule != null) {
+							hasSkippedStyleModules = true;
+							continue;
+						}
+						// Fall through to SSR-only handling below
+					}
+
 					if (clientModule != null) continue;
 
 					this.environment.moduleGraph.invalidateModule(mod, invalidatedModules, timestamp, true);

--- a/packages/astro/src/vite-plugin-hmr-reload/index.ts
+++ b/packages/astro/src/vite-plugin-hmr-reload/index.ts
@@ -54,7 +54,6 @@ export default function hmrReload(): Plugin {
 						}
 						// Fall through to SSR-only handling below
 					}
-
 					if (clientModule != null) continue;
 
 					this.environment.moduleGraph.invalidateModule(mod, invalidatedModules, timestamp, true);

--- a/packages/astro/test/units/dev/hmr-css-invalidation.test.ts
+++ b/packages/astro/test/units/dev/hmr-css-invalidation.test.ts
@@ -68,7 +68,7 @@ describe('astro:hmr-reload CSS invalidation', () => {
 			environments: {
 				client: {
 					moduleGraph: {
-						getModuleById: (_id: string) => null as object | null,
+						getModuleById: (id: string) => ({ id }) as object | null,
 					},
 				},
 			},

--- a/packages/astro/test/units/dev/hmr-css-invalidation.test.ts
+++ b/packages/astro/test/units/dev/hmr-css-invalidation.test.ts
@@ -68,6 +68,7 @@ describe('astro:hmr-reload CSS invalidation', () => {
 			environments: {
 				client: {
 					moduleGraph: {
+						//Returning `null` makes normal CSS bypass the style guards, leaking into the SSR-only path and causing unit test failures.
 						getModuleById: (id: string) => ({ id }) as object | null,
 					},
 				},

--- a/packages/astro/test/units/vite-plugin-hmr-reload/hmr-reload.test.ts
+++ b/packages/astro/test/units/vite-plugin-hmr-reload/hmr-reload.test.ts
@@ -164,12 +164,29 @@ describe('astro:hmr-reload', () => {
 		const ctx = createMockContext({
 			environmentName: 'ssr',
 			modules: [mod],
+			clientModuleIds: ['/src/styles/main.css'], // Normal CSS exists in client graph
 		});
 
 		const result = ctx.call();
 		assert.ok(Array.isArray(result), 'should return an array');
 		assert.equal(result.length, 0, 'should return empty array for styles');
 		assert.equal(ctx.wsSent.length, 0, 'should NOT send full-reload for style modules');
+	});
+
+	it('sends full-reload for ?raw CSS imports (SSR-only style modules)', () => {
+		const rawMod = createMockModule('/src/styles/button.css?raw', '/src/styles/button.css');
+		const cssMod = createMockModule('/src/styles/button.css', '/src/styles/button.css');
+		const ctx = createMockContext({
+			environmentName: 'ssr',
+			modules: [rawMod, cssMod],
+			clientModuleIds: [], // ?raw imports don't exist in client graph
+		});
+
+		const result = ctx.call();
+		assert.ok(Array.isArray(result), 'should return an array');
+		assert.equal(result.length, 0, 'should return empty array');
+		assert.equal(ctx.wsSent.length, 1, 'should send full-reload for SSR-only style modules');
+		assert.deepEqual(ctx.wsSent[0], { type: 'full-reload' });
 	});
 
 	it('invalidates raw CSS imports as SSR-only modules', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4854,7 +4854,7 @@ importers:
         version: link:../../astro-prism
       '@markdoc/markdoc':
         specifier: ^0.5.4
-        version: 0.5.4(@types/react@19.2.17)(react@19.2.7)
+        version: 0.5.4(@types/react@18.3.28)(react@19.2.7)
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -6868,30 +6868,6 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
-
-  triage/gh-17043:
-    dependencies:
-      '@astrojs/node':
-        specifier: workspace:*
-        version: link:../../packages/integrations/node
-      '@astrojs/react':
-        specifier: workspace:*
-        version: link:../../packages/integrations/react
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.17
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
-      astro:
-        specifier: workspace:*
-        version: link:../../packages/astro
-      react:
-        specifier: ^19.2.5
-        version: 19.2.7
-      react-dom:
-        specifier: ^19.2.5
-        version: 19.2.7(react@19.2.7)
 
 packages:
 
@@ -10375,16 +10351,8 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
-    peerDependencies:
-      '@types/react': ^19.2.0
-
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
-
-  '@types/react@19.2.17':
-    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -18548,11 +18516,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@markdoc/markdoc@0.5.4(@types/react@19.2.17)(react@19.2.7)':
+  '@markdoc/markdoc@0.5.4(@types/react@18.3.28)(react@19.2.7)':
     optionalDependencies:
       '@types/linkify-it': 3.0.5
       '@types/markdown-it': 12.2.3
-      '@types/react': 19.2.17
+      '@types/react': 18.3.28
       react: 19.2.7
 
   '@mdx-js/mdx@3.1.1':
@@ -20038,17 +20006,9 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
-  '@types/react-dom@19.2.3(@types/react@19.2.17)':
-    dependencies:
-      '@types/react': 19.2.17
-
   '@types/react@18.3.28':
     dependencies:
       '@types/prop-types': 15.7.15
-      csstype: 3.2.3
-
-  '@types/react@19.2.17':
-    dependencies:
       csstype: 3.2.3
 
   '@types/retry@0.12.0': {}


### PR DESCRIPTION
## Changes
I have fixed the failing unit tests in PR #17056.

Because `clientModules` returns `null` in test environments, the newly added condition inadvertently bypassed the existing `hasSkippedStyleModules = true; continue; logic`, which previously kept other tests passing. I have updated the test code to ensure this original path is still properly handled.

```
if (clientModule != null) {
	hasSkippedStyleModules = true;
	continue;
}
```

## Testing
Please refet to  #17056

## Docs
Please refer to #17056

Close #17032
