### PR TITLE
Fix prerendered redirect targets inflating SSR bundle in hybrid mode

### DIFF
--- a/.changeset/brown-cloths-start.md
+++ b/.changeset/brown-cloths-start.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes prerendered redirect targets being incorrectly bundled into the SSR function in hybrid mode, causing massive bundle size inflation

--- a/packages/astro/src/vite-plugin-pages/pages.ts
+++ b/packages/astro/src/vite-plugin-pages/pages.ts
@@ -16,16 +16,18 @@ interface PagesPluginOptions {
 
 /**
  * Filters routes for a specific build environment.
- * Redirects need their target route included so the redirect response can be generated at runtime.
+ *
+ * Redirect target routes do not need special handling here: they already
+ * appear in the routes list with their own `prerender` flag and are
+ * included when it matches `isPrerender`. At SSR runtime, redirect
+ * responses are generated from route metadata alone (no component is
+ * loaded), so the target's component is never needed in the SSR page map.
  */
 function getRoutesForEnvironment(routes: RouteData[], isPrerender: boolean): Set<RouteData> {
 	const result = new Set<RouteData>();
 	for (const route of routes) {
 		if (route.prerender === isPrerender) {
 			result.add(route);
-		}
-		if (route.redirectRoute) {
-			result.add(route.redirectRoute);
 		}
 	}
 	return result;

--- a/packages/astro/src/vite-plugin-pages/pages.ts
+++ b/packages/astro/src/vite-plugin-pages/pages.ts
@@ -23,7 +23,7 @@ interface PagesPluginOptions {
  * responses are generated from route metadata alone (no component is
  * loaded), so the target's component is never needed in the SSR page map.
  */
-function getRoutesForEnvironment(routes: RouteData[], isPrerender: boolean): Set<RouteData> {
+export function getRoutesForEnvironment(routes: RouteData[], isPrerender: boolean): Set<RouteData> {
 	const result = new Set<RouteData>();
 	for (const route of routes) {
 		if (route.prerender === isPrerender) {

--- a/packages/astro/test/units/redirects/environment-filtering.test.ts
+++ b/packages/astro/test/units/redirects/environment-filtering.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getRoutesForEnvironment } from '../../../dist/vite-plugin-pages/pages.js';
+import type { RouteData } from '../../../dist/types/public/internal.js';
+
+describe('getRoutesForEnvironment', () => {
+	it('does not include prerendered redirect targets in SSR routes', () => {
+		const staticTarget = { component: 'src/pages/target.astro', prerender: true } as RouteData;
+		const ssrRedirect = {
+			component: '/old',
+			prerender: false,
+			type: 'redirect',
+			redirectRoute: staticTarget,
+		} as RouteData;
+
+		const ssrRoutes = getRoutesForEnvironment([staticTarget, ssrRedirect], false);
+
+		assert.ok(ssrRoutes.has(ssrRedirect), 'SSR redirect should be in SSR routes');
+		assert.ok(!ssrRoutes.has(staticTarget), 'prerendered target should NOT be in SSR routes');
+	});
+
+	it('includes prerendered redirect targets in prerender routes', () => {
+		const staticTarget = { component: 'src/pages/target.astro', prerender: true } as RouteData;
+		const staticRedirect = {
+			component: '/old',
+			prerender: true,
+			type: 'redirect',
+			redirectRoute: staticTarget,
+		} as RouteData;
+
+		const prerenderRoutes = getRoutesForEnvironment([staticTarget, staticRedirect], true);
+
+		assert.ok(prerenderRoutes.has(staticRedirect), 'prerendered redirect should be in prerender routes');
+		assert.ok(prerenderRoutes.has(staticTarget), 'prerendered target should be in prerender routes');
+	});
+
+	it('includes SSR redirect targets in SSR routes', () => {
+		const ssrTarget = { component: 'src/pages/target.astro', prerender: false } as RouteData;
+		const ssrRedirect = {
+			component: '/old',
+			prerender: false,
+			type: 'redirect',
+			redirectRoute: ssrTarget,
+		} as RouteData;
+
+		const ssrRoutes = getRoutesForEnvironment([ssrTarget, ssrRedirect], false);
+
+		assert.ok(ssrRoutes.has(ssrRedirect), 'SSR redirect should be in SSR routes');
+		assert.ok(ssrRoutes.has(ssrTarget), 'SSR target should be in SSR routes');
+	});
+
+	it('does not include SSR redirect targets in prerender routes', () => {
+		const ssrTarget = { component: 'src/pages/target.astro', prerender: false } as RouteData;
+		const prerenderRedirect = {
+			component: '/old',
+			prerender: true,
+			type: 'redirect',
+			redirectRoute: ssrTarget,
+		} as RouteData;
+
+		const prerenderRoutes = getRoutesForEnvironment([ssrTarget, prerenderRedirect], true);
+
+		assert.ok(prerenderRoutes.has(prerenderRedirect), 'prerendered redirect should be in prerender routes');
+		assert.ok(!prerenderRoutes.has(ssrTarget), 'SSR target should NOT be in prerender routes');
+	});
+});


### PR DESCRIPTION
## Changes

- Removes the unconditional `redirectRoute` inclusion from `getRoutesForEnvironment` in `packages/astro/src/vite-plugin-pages/pages.ts`. In hybrid mode (`output: 'static'` + adapter), this was pulling prerendered pages into the SSR bundle when they were targets of config-level redirects, inflating the bundle by orders of magnitude (reporter saw 68MB vs ~1.4MB).
- This is a simpler alternative to #17061. That PR added a `route.redirectRoute.prerender === isPrerender` guard, which is correct but redundant — redirect targets already appear in the routes list with their own `prerender` flag and are included by the existing `route.prerender === isPrerender` check during their own iteration. Removing the block entirely is the right fix because:
  - SSR redirect responses are generated from route metadata alone (`renderRedirect` uses `segments`/`pathname` for the `Location` header). No component is loaded — `AstroHandler.render()` short-circuits before `getModuleForRoute` is ever called.
  - The only codepath that needs the target's component is prerendering (for `getStaticPaths` on dynamic targets), but prerendered redirects and their targets share the same `prerender` flag, so both are already in the prerender environment's route set.

Closes #17060
Supersedes #17061

## Testing

- Added `packages/astro/test/units/redirects/environment-filtering.test.ts` with 4 test cases covering all combinations of redirect/target prerender flags: SSR redirect to prerendered target (must exclude target from SSR set), prerendered redirect to prerendered target (both included), SSR redirect to SSR target (both included), prerendered redirect to SSR target (must exclude target from prerender set).

## Docs

- No docs update needed — this is an internal build optimization fix with no user-facing API change.