### PR TITLE
FIx: inverted logic in a11y-no-redundant-roles rule

### DIFF
--- a/.changeset/loose-chefs-stare.md
+++ b/.changeset/loose-chefs-stare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed a bug where the development toolbar did not output a warning even though the implicit ARIA role and the manually specified role were duplicated.

--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -293,12 +293,15 @@ test.describe('Dev Toolbar - Audits', () => {
 			'astro-dev-toolbar-highlight[data-audit-code="a11y-no-redundant-roles"]',
 		);
 
-		// nav[role=navigation], main[role=main], button[role=button],
-		// h1[role=heading], input[type=checkbox][role=checkbox], input[type=submit][role=button]
-		await expect(highlights).toHaveCount(8);
+		// nav[role=navigation], main[role=main], button[role=button], h1[role=heading],
+		// input[type=checkbox][role=checkbox], input[type=submit][role=button],
+		// a[href][role=link], input[role=textbox],
+		// img[alt="photo"][role=image], aside[role=complementary],
+		// article > aside[aria-label][role=complementary], section[aria-label][role=region]
+		await expect(highlights).toHaveCount(12);
 	});
 
-	test('does not warn about ul/ol/li list-role exceptions or non-redundant roles', async ({
+	test('does not warn about ul/ol/li exceptions, conditional implicit roles, or non-redundant roles', async ({
 		page,
 		astro,
 	}) => {
@@ -313,8 +316,12 @@ test.describe('Dev Toolbar - Audits', () => {
 			'astro-dev-toolbar-highlight[data-audit-code="a11y-no-redundant-roles"]',
 		);
 
-		// ul[role=list], ol[role=list], li[role=listitem] are exempt (CSS workaround),
-		// nav[role=banner], button[role=link], input[type=text][role=combobox] have non-implicit roles
+		// ul/ol[role=list], li[role=listitem]: exempt (CSS list-style:none workaround)
+		// nav[role=banner], button[role=link], input[type=text][role=combobox]: non-implicit roles
+		// a (no href)[role=link]: no implicit role without href
+		// img[alt=""][role=img]: decorative image has no implicit role
+		// article > aside (no name)[role=complementary]: nested aside without accessible name has no implicit role
+		// section (no name)[role=region]: section without accessible name has no implicit role
 		await expect(highlights).toHaveCount(0);
 	});
 });

--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -277,4 +277,44 @@ test.describe('Dev Toolbar - Audits', () => {
 
 		await expect(missingContentHighlights).toHaveCount(1);
 	});
+
+	test('warns about elements whose explicit role matches their implicit ARIA role', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/a11y-redundant-roles'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
+		await appButton.click();
+
+		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
+		const highlights = auditCanvas.locator(
+			'astro-dev-toolbar-highlight[data-audit-code="a11y-no-redundant-roles"]',
+		);
+
+		// nav[role=navigation], main[role=main], button[role=button],
+		// h1[role=heading], input[type=checkbox][role=checkbox], input[type=submit][role=button]
+		await expect(highlights).toHaveCount(8);
+	});
+
+	test('does not warn about ul/ol/li list-role exceptions or non-redundant roles', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/a11y-redundant-roles-valid'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
+		await appButton.click();
+
+		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
+		const highlights = auditCanvas.locator(
+			'astro-dev-toolbar-highlight[data-audit-code="a11y-no-redundant-roles"]',
+		);
+
+		// ul[role=list], ol[role=list], li[role=listitem] are exempt (CSS workaround),
+		// nav[role=banner], button[role=link], input[type=text][role=combobox] have non-implicit roles
+		await expect(highlights).toHaveCount(0);
+	});
 });

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles-valid.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles-valid.astro
@@ -1,0 +1,16 @@
+---
+---
+
+<!-- ul/ol/li with list/listitem roles: exempt as a CSS list-style:none workaround -->
+<ul role="list">
+	<li role="listitem">Item</li>
+</ul>
+<ol role="list">
+	<li role="listitem">Item</li>
+</ol>
+
+<!-- Role differs from each element's implicit role — none should warn -->
+<nav role="banner">Nav</nav>
+<button role="link">Button</button>
+<input type="text" role="combobox" />
+<a role="link"><span>Placeholder Link</span></a>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles-valid.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles-valid.astro
@@ -13,4 +13,9 @@
 <nav role="banner">Nav</nav>
 <button role="link">Button</button>
 <input type="text" role="combobox" />
+
+<!-- testing conditional implicit roles -->
 <a role="link"><span>Placeholder Link</span></a>
+<img alt="" role="img" />
+<article><aside role="complementary"><span>Nested aside without name</span></aside></article>
+<section role="region"><span>Section without name</span></section>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles.astro
@@ -1,0 +1,13 @@
+---
+---
+
+<!-- Each element explicitly sets the same role as its implicit ARIA role — all 6 should warn -->
+<!-- Wrapping text in <span> ensures createAuditProblem's offsetParent check passes -->
+<nav role="navigation"><span>Nav</span></nav>
+<main role="main"><span>Main</span></main>
+<button role="button"><span>Button</span></button>
+<h1 role="heading"><span>Heading</span></h1>
+<label><input type="checkbox" role="checkbox" /></label>
+<input type="submit" role="button" value="Submit" />
+<a href="/" role="link"><span>Link</span></a>
+<input role="textbox" />

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-redundant-roles.astro
@@ -1,8 +1,7 @@
 ---
 ---
 
-<!-- Each element explicitly sets the same role as its implicit ARIA role — all 6 should warn -->
-<!-- Wrapping text in <span> ensures createAuditProblem's offsetParent check passes -->
+<!-- Each element explicitly sets the same role as its implicit ARIA role — all should warn -->
 <nav role="navigation"><span>Nav</span></nav>
 <main role="main"><span>Main</span></main>
 <button role="button"><span>Button</span></button>
@@ -11,3 +10,9 @@
 <input type="submit" role="button" value="Submit" />
 <a href="/" role="link"><span>Link</span></a>
 <input role="textbox" />
+
+<!-- Following items will not trigger warnings as redundant roles -->
+<img alt="cat" role="image" src="dummy-url" />
+<aside role="complementary"><span>Aside</span></aside>
+<article><aside aria-label="sidebar" role="complementary"><span>Nested aside with name</span></aside></article>
+<section aria-label="info" role="region"><span>Section</span></section>

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -448,26 +448,39 @@ export const a11y: AuditRuleWithSelector[] = [
 		title: 'HTML element has redundant ARIA roles',
 		message:
 			'Giving these elements an ARIA role that is already set by the browser has no effect and is redundant.',
-		selector: [...a11y_implicit_semantics.keys()].join(','),
+		// The selector is all elements that have an implicit role, as well as input elements since their implicit role can change based on their attributes
+		selector: `[role]:is(${[...a11y_implicit_semantics.keys()].join(',')},input)`,
 		match(element) {
 			const role = element.getAttribute('role');
+			// No need to check if the role is valid, as that is covered by another rule
+			if (!role) return false;
+
+			const localName = element.localName;
+
+			if(
+				// <ul>, <ol>, and <li> are legitimate workarounds to restore list semantics
+				// that some browsers (e.g., Safari) strip when CSS `list-style: none` is applied.
+				(localName === 'ul' && role === 'list') ||
+				(localName === 'ol' && role === 'list') ||
+				(localName === 'li' && role === 'listitem')
+			) {
+				return false;
+			}
 
 			if (element.localName === 'input') {
-				const type = element.getAttribute('type');
-				if (!type) return true;
-
+				const type = element.getAttribute('type') || 'text';
 				const implicitRoleForType = input_type_to_implicit_role.get(type);
-				if (!implicitRoleForType) return true;
-
-				if (role === implicitRoleForType) return false;
+				
+				// If the input type doesn't have an implicit role, then it can take any role without being redundant
+				return role === implicitRoleForType;
 			}
 
 			// TODO: Handle menuitem and elements that inherit their role from their parent
 
 			const implicitRole = a11y_implicit_semantics.get(element.localName);
-			if (!implicitRole) return true;
+			if (!implicitRole) return false;
 
-			if (role === implicitRole) return false;
+			return role === implicitRole;
 		},
 	},
 	{

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -452,7 +452,6 @@ export const a11y: AuditRuleWithSelector[] = [
 		selector: `[role]:is(${[...a11y_implicit_semantics.keys()].join(',')},input)`,
 		match(element) {
 			const role = element.getAttribute('role');
-			// No need to check if the role is valid, as that is covered by another rule
 			if (!role) return false;
 
 			const localName = element.localName;
@@ -460,6 +459,7 @@ export const a11y: AuditRuleWithSelector[] = [
 			if(
 				// <ul>, <ol>, and <li> are legitimate workarounds to restore list semantics
 				// that some browsers (e.g., Safari) strip when CSS `list-style: none` is applied.
+				// Reference: https://bugs.webkit.org/show_bug.cgi?id=170179
 				(localName === 'ul' && role === 'list') ||
 				(localName === 'ol' && role === 'list') ||
 				(localName === 'li' && role === 'listitem')
@@ -472,6 +472,7 @@ export const a11y: AuditRuleWithSelector[] = [
 				const implicitRoleForType = input_type_to_implicit_role.get(type);
 				
 				// If the input type doesn't have an implicit role, then it can take any role without being redundant
+				// Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#:~:text=phrasing%20content.-,Implicit%20ARIA%20role,-type%3Dbutton%3A
 				return role === implicitRoleForType;
 			}
 

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -226,6 +226,41 @@ function isInteractive(element: Element): boolean {
 	return true;
 }
 
+function hasAccessibleName(element: Element): boolean {
+	return element.hasAttribute('aria-label') || element.hasAttribute('aria-labelledby');
+}
+
+// Returns the effective implicit role, or null if no implicit role applies.
+const conditional_implicit_roles = new Map<string, (el: Element) => string | null>([
+	['a', (el) => (el.hasAttribute('href') ? 'link' : null)],
+	[
+		'aside',
+		(el) => {
+			// <aside> downgrades to 'generic' when nested inside sectioning content/main without an accessible name.
+			// Reference: https://www.w3.org/TR/html-aria/#:~:text=the%20allowed%20roles.-,aside,-role%3Dcomplementary
+			const isNested = !!el.parentElement?.closest('article, aside, nav, section');
+			return !isNested || hasAccessibleName(el) ? 'complementary' : null;
+		},
+	],
+	[
+		'img',
+		(el) => {
+			// alt="" marks the image as decorative (role="presentation"), losing its implicit "image" role.
+			// Reference: https://www.w3.org/TR/html-aria/#:~:text=the%20allowed%20roles.-,img,-If%20the%20img
+			if (el.getAttribute('alt') === '') return null;
+			return 'image';
+		},
+	],
+	[
+		'section',
+		(el) => {
+			// <section> downgrades to 'generic' when it lacks an accessible name (aria-label/aria-labelledby).
+			// Reference: https://www.w3.org/TR/html-aria/#:~:text=the%20allowed%20roles.-,section,-role%3Dregion
+			return hasAccessibleName(el) ? 'region' : null;
+		},
+	],
+]);
+
 export const a11y: AuditRuleWithSelector[] = [
 	{
 		code: 'a11y-accesskey',
@@ -456,7 +491,7 @@ export const a11y: AuditRuleWithSelector[] = [
 
 			const localName = element.localName;
 
-			if(
+			if (
 				// <ul>, <ol>, and <li> are legitimate workarounds to restore list semantics
 				// that some browsers (e.g., Safari) strip when CSS `list-style: none` is applied.
 				// Reference: https://bugs.webkit.org/show_bug.cgi?id=170179
@@ -467,10 +502,9 @@ export const a11y: AuditRuleWithSelector[] = [
 				return false;
 			}
 
-			if (element.localName === 'input') {
+			if (localName === 'input') {
 				const type = element.getAttribute('type') || 'text';
 				const implicitRoleForType = input_type_to_implicit_role.get(type);
-				
 				// If the input type doesn't have an implicit role, then it can take any role without being redundant
 				// Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#:~:text=phrasing%20content.-,Implicit%20ARIA%20role,-type%3Dbutton%3A
 				return role === implicitRoleForType;
@@ -478,7 +512,13 @@ export const a11y: AuditRuleWithSelector[] = [
 
 			// TODO: Handle menuitem and elements that inherit their role from their parent
 
-			const implicitRole = a11y_implicit_semantics.get(element.localName);
+			const getConditionalRole = conditional_implicit_roles.get(localName);
+			if (getConditionalRole) {
+				const effectiveRole = getConditionalRole(element);
+				return effectiveRole ? role === effectiveRole : false;
+			}
+
+			const implicitRole = a11y_implicit_semantics.get(localName);
 			if (!implicitRole) return false;
 
 			return role === implicitRole;


### PR DESCRIPTION
## Changes

- Refactored selector to target only elements with an explicit role attribute: `selector:[role]:is(${[...a11y_implicit_semantics.keys()].join(',')},input)`
- Fixed logic (`if (role === implicitRole) return false;`) that was causing validation failures to be silently ignored.
- Bypass redundant role warnings for implicit ARIA role exceptions.
```
if(
  (localName === 'ul' && role === 'list') || 
  (localName === 'ol' && role === 'list') || 
  (localName === 'li' && role === 'listitem')) 
{ 
  return false; 
}
```


## Testing
- Add e2e tests for a11y-no-redundant-roles
  - Added Playwright tests to verify the fixed dev toolbar audit rule under both violating and valid scenarios.
- Verify 8 redundant role violation cases
  - Ensured that warnings properly trigger when explicit roles duplicate their implicit ARIA.
- Verify 7 valid exception and override cases
  - Confirmed that no false are triggered for legitimate browser-bug workarounds and intentional role overrides.

### Before implementation

<img width="1196" height="601" alt="スクリーンショット 2026-06-14 0 36 16" src="https://github.com/user-attachments/assets/56ea4b5b-7d77-4583-ba85-801f14bb5b26" />


### After implementation

<img width="1184" height="164" alt="スクリーンショット 2026-06-14 0 45 30" src="https://github.com/user-attachments/assets/abed27a8-9116-42e3-9006-b2f17a68e5eb" />


## Docs

Close #17062
Close #15995
