### PR TITLE
fix: resolve manual chunk component entrypoints

### DIFF
--- a/.changeset/twenty-bushes-clean.md
+++ b/.changeset/twenty-bushes-clean.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes hydrated component URLs when component entry chunks are merged with Rollup manualChunks

--- a/packages/astro/src/core/build/plugins/plugin-internals.ts
+++ b/packages/astro/src/core/build/plugins/plugin-internals.ts
@@ -16,6 +16,31 @@ function getRollupInputAsSet(rollupInput: Rollup.InputOption | undefined): Set<s
 	}
 }
 
+function getResolvedComponentEntryChunk(
+	chunk: Rollup.OutputChunk,
+	bundle: Rollup.OutputBundle,
+): Rollup.OutputChunk {
+	if (!chunk.facadeModuleId) return chunk;
+
+	const normalizedEntryId = normalizeEntryId(chunk.facadeModuleId);
+	if (normalizedEntryId in chunk.modules) {
+		return chunk;
+	}
+
+	for (const output of Object.values(bundle)) {
+		if (
+			output.type === 'chunk' &&
+			output !== chunk &&
+			normalizedEntryId in output.modules &&
+			chunk.imports.includes(output.fileName)
+		) {
+			return output;
+		}
+	}
+
+	return chunk;
+}
+
 export function pluginInternals(
 	options: StaticBuildOptions,
 	internals: BuildInternals,
@@ -84,9 +109,10 @@ export function pluginInternals(
 				}
 
 				if (chunk.type === 'chunk' && chunk.facadeModuleId) {
-					const specifiers = mapping.get(chunk.facadeModuleId) || new Set([chunk.facadeModuleId]);
+					const entryChunk = getResolvedComponentEntryChunk(chunk, bundle);
+					const specifiers = mapping.get(chunk.facadeModuleId) ?? new Set([chunk.facadeModuleId]);
 					for (const specifier of specifiers) {
-						internals.entrySpecifierToBundleMap.set(normalizeEntryId(specifier), chunk.fileName);
+						internals.entrySpecifierToBundleMap.set(normalizeEntryId(specifier), entryChunk.fileName);
 					}
 				}
 			}

--- a/packages/integrations/vue/test/app-entrypoint.test.ts
+++ b/packages/integrations/vue/test/app-entrypoint.test.ts
@@ -39,6 +39,31 @@ describe('App Entrypoint', () => {
 
 		assert.notEqual(client, undefined);
 	});
+
+	it('points hydrated Vue component-url at manual chunk', async () => {
+		const data = await fixture.readFile('/index.html');
+		const { document } = parseHTML(data);
+		const island = document.querySelector('astro-island')!;
+		const componentUrl = island.getAttribute('component-url')!;
+		const jsFiles = await fixture.glob('_astro/*.js');
+		const referencedJs = [
+			...Array.from(document.querySelectorAll('script[src]')).map((el) => el.getAttribute('src')),
+			...Array.from(document.querySelectorAll('astro-island')).map((el) =>
+				el.getAttribute('component-url'),
+			),
+		].filter(Boolean);
+
+		assert.match(componentUrl, /\/_astro\/components\.[^/]+\.js$/);
+		assert.ok(
+			jsFiles.some((file) => /^_astro\/components\.[^/]+\.js$/.test(file)),
+			'Expected Rollup manual chunk components.*.js to be emitted',
+		);
+		assert.equal(
+			referencedJs.some((src) => /\/_astro\/Foo\.[^/]+\.js$/.test(src!)),
+			false,
+			'HTML should not reference the Foo component proxy chunk',
+		);
+	});
 });
 
 describe('App Entrypoint no export default (dev)', () => {

--- a/packages/integrations/vue/test/fixtures/app-entrypoint/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint/astro.config.mjs
@@ -1,14 +1,25 @@
 import vue from '@astrojs/vue';
 import { defineConfig } from 'astro/config';
-import ViteSvgLoader from 'vite-svg-loader'
+import ViteSvgLoader from 'vite-svg-loader';
 
 export default defineConfig({
-  integrations: [vue({
-		appEntrypoint: '/src/pages/_app'
-	})],
+	integrations: [
+		vue({
+			appEntrypoint: '/src/pages/_app',
+		}),
+	],
 	vite: {
-    plugins: [
-      ViteSvgLoader(),
-    ],
+		plugins: [ViteSvgLoader()],
+		build: {
+			rollupOptions: {
+				output: {
+					manualChunks(id) {
+						if (id.includes('.vue')) {
+							return 'components';
+						}
+					},
+				},
+			},
+		},
 	},
-})
+});


### PR DESCRIPTION
## Changes

Fixes component URL resolution when hydrated component entry chunks are merged by Rollup `manualChunks`.

When a user configures `manualChunks()` to merge framework component modules, Rollup can emit a small proxy chunk for the component entry that re-exports from the final manual chunk. Astro previously mapped the hydrated component entry to that proxy chunk, causing `astro-island` `component-url` to reference the intermediary chunk instead of the final merged chunk.

This change resolves those proxy entry chunks to the directly imported output chunk that contains the original component module, while preserving the existing chunk when it already contains the entry module.

## Testing

Added regression coverage for a Vue hydrated component fixture with `manualChunks(id) { if (id.includes('.vue')) return 'components'; }`.

The test verifies that:

- `astro-island` `component-url` points at the emitted `components.*.js` manual chunk
- the manual chunk is emitted
- generated HTML does not reference the intermediary `Foo.*.js` proxy chunk

## Validation

- `rtk pnpm -C packages/astro build`
- `rtk pnpm -C packages/integrations/vue exec astro-scripts test "test/app-entrypoint.test.ts" --match "manual chunk"`
- `rtk pnpm -C packages/integrations/vue exec astro-scripts test "test/app-entrypoint.test.ts"`
- `rtk git diff --check`

Fixes https://github.com/withastro/astro/issues/17016