### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "root",
   "type": "module",
   "version": "0.0.0",
+  "bugs": {
+    "url": "https://github.com/withastro/astro/issues"
+  },
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.