### PR TITLE
Fix MDX build failure when importing Container API without satteri installed

### DIFF
--- a/.changeset/fix-mdx-satteri-optional-peer-dep.md
+++ b/.changeset/fix-mdx-satteri-optional-peer-dep.md
@@ -1,0 +1,12 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fixes a build error (`[MISSING_EXPORT] "satteriCollectImagesPlugin"`) when using `@astrojs/mdx` without `@astrojs/markdown-satteri` installed.
+
+The error occurred because Rolldown (Vite 8's bundler) eagerly follows dynamic imports and encountered static imports from the optional peer dep `@astrojs/markdown-satteri` in `satteri/index.js`. This was triggered when user code imported `getContainerRenderer` from `@astrojs/mdx` (e.g. for RSS feeds using the Container API).
+
+The fix:
+1. Converts static imports from `@astrojs/markdown-satteri` and `satteri` to lazy dynamic imports in `satteri/index.ts`
+2. Makes the Vite plugin imports in `index.ts` lazy to avoid dragging the satteri code path into the bundle
+3. Externalizes `@astrojs/markdown-satteri` and `satteri` in the Rolldown build config to prevent bundling of uninstalled optional peer deps

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -17,8 +17,7 @@ import type { PluggableList } from 'unified';
 import { isSatteriProcessor, isUnifiedProcessor } from './processor-guards.js';
 import type { OptimizeOptions } from './rehype-optimize-static.js';
 import { ignoreStringPlugins, safeParseFrontmatter } from './utils.js';
-import { type VitePluginMdxOptions, vitePluginMdx } from './vite-plugin-mdx.js';
-import { vitePluginMdxPostprocess } from './vite-plugin-mdx-postprocess.js';
+import type { VitePluginMdxOptions } from './vite-plugin-mdx.js';
 
 // `gfm`/`smartypants` are deprecated and stay unset unless the user opts in; the
 // MDX pipelines treat an absent value as the default (on), like the `.md` processors.
@@ -116,9 +115,25 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 					handlePropagation: true,
 				});
 
+				// Lazy-load the Vite plugins so that `@astrojs/mdx`'s main entry can be
+				// imported at the page level (e.g. for `getContainerRenderer`) without
+				// dragging in the satteri/markdown-satteri optional peer dep chain via
+				// Rolldown's aggressive dynamic-import following.
+				const { vitePluginMdx } = await import('./vite-plugin-mdx.js');
+				const { vitePluginMdxPostprocess } = await import('./vite-plugin-mdx-postprocess.js');
+
 				updateConfig({
 					vite: {
 						plugins: [vitePluginMdx(vitePluginMdxOptions), vitePluginMdxPostprocess(config)],
+						build: {
+							rollupOptions: {
+								// `@astrojs/markdown-satteri` and its `satteri` dep are optional peer deps.
+								// Rolldown (Vite 8) follows dynamic imports eagerly and errors on missing
+								// named exports from the optional-peer-dep stub. Externalizing them
+								// prevents Rolldown from trying to bundle modules that may not be installed.
+								external: ['@astrojs/markdown-satteri', 'satteri'],
+							},
+						},
 					},
 				});
 			},

--- a/packages/integrations/mdx/src/satteri/index.ts
+++ b/packages/integrations/mdx/src/satteri/index.ts
@@ -1,19 +1,8 @@
 import { pathToFileURL } from 'node:url';
 import type { MarkdownHeading } from '@astrojs/internal-helpers/markdown';
 import type { SatteriResolvedOptions } from '@astrojs/markdown-satteri';
-import {
-	satteriCollectImagesPlugin,
-	satteriCreateHighlightFn,
-	satteriHeadingIdsPlugin,
-	satteriHighlightPlugin,
-} from '@astrojs/markdown-satteri';
 import { createDefaultAstroMetadata } from 'astro/markdown';
-import {
-	mdxToJs,
-	type HastPluginDefinition,
-	type MdastPluginDefinition,
-	type MdxCompileOptions,
-} from 'satteri';
+import type { HastPluginDefinition, MdastPluginDefinition, MdxCompileOptions } from 'satteri';
 import { ASTRO_IMAGE_IMPORT, USES_ASTRO_IMAGE_FLAG } from '../image-constants.js';
 import type { ResolvedMdxOptions } from '../index.js';
 import { shouldAddCharset } from './charset.js';
@@ -40,6 +29,16 @@ interface CreateMdxProcessorContext {
 	srcDir: URL;
 }
 
+// Lazy-load `@astrojs/markdown-satteri` and `satteri` so Rolldown doesn't try to
+// resolve the optional peer deps when this module is merely discovered (but never executed).
+async function loadSatteriPlugins() {
+	return await import('@astrojs/markdown-satteri');
+}
+
+async function loadSatteri() {
+	return await import('satteri');
+}
+
 export function createMdxProcessor(
 	mdxOptions: ResolvedMdxOptions,
 	satteriOptions: SatteriResolvedOptions,
@@ -47,13 +46,21 @@ export function createMdxProcessor(
 ) {
 	let highlightFn: HighlightFn | undefined;
 	let initPromise: Promise<void> | undefined;
+	let satteriPluginsPromise: ReturnType<typeof loadSatteriPlugins> | undefined;
+
+	function getSatteriPlugins() {
+		satteriPluginsPromise ??= loadSatteriPlugins();
+		return satteriPluginsPromise;
+	}
 
 	function initHighlighter() {
-		initPromise = satteriCreateHighlightFn(mdxOptions.syntaxHighlight, mdxOptions.shikiConfig).then(
-			(fn) => {
+		initPromise = getSatteriPlugins()
+			.then(({ satteriCreateHighlightFn }) =>
+				satteriCreateHighlightFn(mdxOptions.syntaxHighlight, mdxOptions.shikiConfig),
+			)
+			.then((fn) => {
 				highlightFn = fn;
-			},
-		);
+			});
 	}
 
 	return {
@@ -66,6 +73,8 @@ export function createMdxProcessor(
 				initHighlighter();
 			}
 			if (initPromise) await initPromise;
+
+			const { satteriCollectImagesPlugin, satteriHeadingIdsPlugin } = await getSatteriPlugins();
 
 			const headings: MarkdownHeading[] = [];
 			const localImagePaths = new Set<string>();
@@ -96,6 +105,7 @@ export function createMdxProcessor(
 
 			const hastPlugins: HastPluginDefinition[] = [];
 			if (highlightFn) {
+				const { satteriHighlightPlugin } = await getSatteriPlugins();
 				// `mdx: true` wraps the highlighted HTML in a JSX `<Fragment set:html>` node
 				// rather than a raw HTML node, since the Sätteri pipeline is compiling to JSX.
 				hastPlugins.push(satteriHighlightPlugin(highlightFn, excludeLangs, { mdx: true }));
@@ -119,6 +129,7 @@ export function createMdxProcessor(
 				};
 			}
 
+			const { mdxToJs } = await loadSatteri();
 			const mdxResult = await mdxToJs(content, {
 				mdastPlugins: allMdastPlugins,
 				hastPlugins,

--- a/packages/integrations/mdx/test/units/satteri-lazy-imports.test.ts
+++ b/packages/integrations/mdx/test/units/satteri-lazy-imports.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('satteri/index.js lazy imports', () => {
+	// The `satteri/index.js` module must not contain static (top-level) imports
+	// from `@astrojs/markdown-satteri` or `satteri`, which are optional peer
+	// deps. Rolldown (Vite 8) follows dynamic imports eagerly and errors on
+	// missing named exports from optional-peer-dep stubs, so these imports must
+	// stay lazy (dynamic `import()` calls inside function bodies).
+	it('does not statically import from optional peer deps', () => {
+		const code = fs.readFileSync(new URL('../../dist/satteri/index.js', import.meta.url), 'utf-8');
+
+		// Static imports appear at the top of the file before any function body.
+		// Dynamic imports use `import("...")` or `import('...')` syntax.
+		// We check that the only occurrences of these specifiers are inside
+		// dynamic import() calls, not top-level `import ... from` statements.
+		const staticImportRe =
+			/^import\s+(?:\{[^}]*\}|\*\s+as\s+\w+)\s+from\s+["'](?:@astrojs\/markdown-satteri|satteri)["']/m;
+		assert.equal(
+			staticImportRe.test(code),
+			false,
+			'satteri/index.js must not statically import from @astrojs/markdown-satteri or satteri. ' +
+				'Use dynamic import() instead to avoid Rolldown errors when these optional peer deps are not installed.',
+		);
+	});
+
+	it('does not statically import vite-plugin-mdx from the main entry', () => {
+		const code = fs.readFileSync(new URL('../../dist/index.js', import.meta.url), 'utf-8');
+
+		const staticImportRe =
+			/^import\s+(?:\{[^}]*\}|\*\s+as\s+\w+)\s+from\s+["']\.\/vite-plugin-mdx(?:\.js)?["']/m;
+		assert.equal(
+			staticImportRe.test(code),
+			false,
+			'index.js must not statically import vite-plugin-mdx.js. ' +
+				'Use dynamic import() instead so that importing getContainerRenderer from @astrojs/mdx ' +
+				'does not pull the satteri optional peer dep chain into the Rolldown bundle.',
+		);
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes `astro build` failure when importing `getContainerRenderer` from `@astrojs/mdx` without the optional `@astrojs/markdown-satteri` dependency installed. Previously threw `[MISSING_EXPORT] "satteriCollectImagesPlugin"` in Astro 7 beta.
- Converts static imports from `@astrojs/markdown-satteri` and `satteri` in `satteri/index.ts` to lazy dynamic imports, preventing Rolldown from following the import chain to missing optional dependencies.
- Moves Vite plugin imports in `index.ts` to dynamic imports within the `astro:config:setup` hook and externalizes both packages in the Rolldown build config.

## Testing

- Added `packages/integrations/mdx/test/units/satteri-lazy-imports.test.ts` to verify built dist files don't contain static imports from optional peer dependencies.
- All 82 existing MDX unit tests continue to pass, including satteri processor functionality when the dependency is installed.

## Docs

- No docs update needed — this fixes a build regression without changing public API behavior.

Closes #17068