### PR TITLE
fix(language-tools): support multiline script and style lang attributes

### DIFF
--- a/.changeset/fix-multiline-script-style-lang.md
+++ b/.changeset/fix-multiline-script-style-lang.md
@@ -1,0 +1,5 @@
+---
+"astro-vscode": patch
+---
+
+fix(language-tools): support multiline script and style lang attributes

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "Astro",
   "scopeName": "source.astro",
-  "fileTypes": ["astro"],
+  "fileTypes": [
+    "astro"
+  ],
   "injections": {
     "L:(meta.script.astro) (meta.lang.json) - (meta.embedded.block source)": {
       "patterns": [
@@ -689,6 +691,21 @@
         }
       ]
     },
+    "tags-lang-fallback-start-attributes": {
+      "begin": "\\G(?=[^\\n>]*(?:/>|>))",
+      "end": "(?=/>)|>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.astro"
+        }
+      },
+      "name": "meta.tag.start.astro",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
     "tags-start-node": {
       "match": "(<)([^/\\s>/]*)",
       "captures": {
@@ -780,7 +797,7 @@
       "name": "meta.scope.tag.$1.astro meta.$1.astro",
       "patterns": [
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
+          "begin": "(?:\\G|\\s+)(?=[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.json.astro",
           "patterns": [
@@ -790,7 +807,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
+          "begin": "(?:\\G|\\s+)(?=[^>]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.javascript.astro",
           "patterns": [
@@ -800,7 +817,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
+          "begin": "(?:\\G|\\s+)(?=[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.$3.astro",
           "patterns": [
@@ -810,7 +827,7 @@
           ]
         },
         {
-          "include": "#tags-lang-start-attributes"
+          "include": "#tags-lang-fallback-start-attributes"
         }
       ]
     },

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -465,6 +465,15 @@ repository:
     name: meta.tag.start.astro
     patterns: [include: '#attributes']
 
+  # Fallback attributes for script/style tags that do not declare a language
+  # before the opening tag closes.
+  tags-lang-fallback-start-attributes:
+    begin: \G(?=[^\n>]*(?:/>|>))
+    end: (?=/>)|>
+    endCaptures: { 0: { name: punctuation.definition.tag.end.astro } }
+    name: meta.tag.start.astro
+    patterns: [include: '#attributes']
+
   # Matches the beginning (`<name`) section of a tag start node.
   tags-start-node:
     match: (<)([^/\s>/]*)
@@ -505,22 +514,22 @@ repository:
     name: meta.scope.tag.$1.astro meta.$1.astro
     patterns:
       # Injecting into `meta.lang.ld+json` doesn't seem possible, so we set it to `meta.lang.json`
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2)
+      - begin: (?:\G|\s+)(?=[^>]*?(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2)
         end: (?=</|/>)
         name: meta.lang.json.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Treat 'module' as JavaScript
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(module)\2)
+      - begin: (?:\G|\s+)(?=[^>]*?(type|lang)\s*=\s*(['"]|)(module)\2)
         end: (?=</|/>)
         name: meta.lang.javascript.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Tags with a language specified.
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2)
+      - begin: (?:\G|\s+)(?=[^>]*?(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2)
         end: (?=</|/>)
         name: meta.lang.$3.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Fallback to default language.
-      - include: '#tags-lang-start-attributes'
+      - include: '#tags-lang-fallback-start-attributes'
 
   # Void element tags. They must be treated separately due to their lack of end nodes.
   # A void element cannot be differentiated from other tags, unless you look at their name.

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/multiline-lang.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/multiline-lang.astro
@@ -1,0 +1,19 @@
+<script
+  lang="ts"
+>
+  const count: number = 1;
+</script>
+
+<script
+  type="application/ld+json"
+>
+  {
+    "@context": "https://schema.org"
+  }
+</script>
+
+<script
+  type="module"
+>
+  console.log(import.meta.url);
+</script>

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/multiline-lang.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/multiline-lang.astro.snap
@@ -1,0 +1,61 @@
+><script
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+>  lang="ts"
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro
+#  ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#          ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  const count: number = 1;
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.embedded.block.astro source.ts
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><script
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+>  type="application/ld+json"
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro
+#  ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro
+#                           ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  {
+#^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.embedded.block.astro source.json
+>    "@context": "https://schema.org"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.embedded.block.astro source.json
+>  }
+#^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.embedded.block.astro source.json
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><script
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+>  type="module"
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro
+#  ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro
+#              ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  console.log(import.meta.url);
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.embedded.block.astro source.js
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-lang.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-lang.astro
@@ -1,0 +1,27 @@
+<style
+  lang="scss"
+>
+  $primary: red;
+  .bar {
+    color: $primary;
+  }
+</style>
+
+<style
+  lang="less"
+>
+  @base: #f938ab;
+  .bar {
+    color: @base;
+  }
+</style>
+
+<style
+  lang="sass"
+  define:vars={{
+    foo: '#fff',
+  }}
+>
+  .bar
+    color: var(--foo)
+</style>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-lang.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-lang.astro.snap
@@ -1,0 +1,83 @@
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>  lang="scss"
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro
+#  ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#            ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  $primary: red;
+#^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.embedded.block.astro source.css.scss
+>  .bar {
+#^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.embedded.block.astro source.css.scss
+>    color: $primary;
+#^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.embedded.block.astro source.css.scss
+>  }
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.embedded.block.astro source.css.scss
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>  lang="less"
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro
+#  ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#            ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  @base: #f938ab;
+#^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.embedded.block.astro source.css.less
+>  .bar {
+#^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.embedded.block.astro source.css.less
+>    color: @base;
+#^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.embedded.block.astro source.css.less
+>  }
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.less.astro meta.embedded.block.astro source.css.less
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>  lang="sass"
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro
+#  ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#            ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>  define:vars={{
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+#  ^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro entity.other.attribute-name.astro
+#             ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.separator.key-value.astro
+#              ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.begin.astro
+#               ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>    foo: '#fff',
+#^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>  }}
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+#  ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.end.astro
+#   ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  .bar
+#^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+>    color: var(--foo)
+#^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-no-lang.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-no-lang.astro
@@ -1,0 +1,5 @@
+<style
+  class="foo"
+>
+  .astro {}
+</style>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-no-lang.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/multiline-no-lang.astro.snap
@@ -1,0 +1,14 @@
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>  class="foo"
+#^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro
+>  .astro {}
+#^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>


### PR DESCRIPTION
### Problem Statement
When the `lang` or `type` attribute of a `<style>` or `<script>` tag is declared on a different line than the opening tag name itself (or when a multiline tag contains attributes on subsequent lines), the Astro TextMate grammar fails to match the language. This causes the block content to fall back to the default syntax highlighting (e.g., standard CSS or JS), which incorrectly highlights preprocessor language features (like SASS variables or nested CSS rules).

### Root Cause
In `astro.tmLanguage.src.yaml`, the `begin` patterns for specific languages (like `lang="sass"`) used the anchor `\G` to assert matching immediately at the boundary of the style tag match. Since TextMate engines tokenize files line-by-line, the lookahead assertion `(?=\s*[^>]*?(type|lang)\s*=...)` fails if the attributes are on a subsequent line. When all language rules failed, the fallback `tags-lang-start-attributes` matched unconditionally, causing the tag body to get highlighted as default CSS/JS without any language-specific injection.

### Solution
1. **Enable Multiline Match for Lang/Type:** Modified the language begin patterns to match either at the start boundary `\G` or at any whitespace character sequence `\s+`. This allows the language-specific rule to trigger on any line containing the `lang`/`type` attribute within the tag declaration.
2. **Handle Multiline Fallback Safely:** Created `tags-lang-fallback-start-attributes` using a single-line lookahead `\G(?=[^\n>]*(?:/>|>))`. This fallback matches the attributes unconditionally **only if** the start tag closes on the current line. If the tag spans multiple lines and does not declare a language, the engine advances normally through line boundaries, allowing it to correctly parse tag attributes across newlines and highlight the body using default CSS/JS.

### Testing Performed
1. **Added New Fixtures:** 
   - `multiline-lang.astro` under `script` to verify multiline tags for TypeScript, JSON-LD, and JS Modules.
   - `multiline-lang.astro` under `style` to verify multiline tags for SCSS, Less, and SASS.
   - `multiline-no-lang.astro` under `style` to verify multiline style tags with no language specifier.
2. **Snapshot Validation:** Generated and verified snapshot tests (`test:grammar`). All existing snapshots have **zero regressions** under the updated rules. The new snapshots correctly output the language-specific embedded blocks for multiline syntax declarations (e.g. scoping `source.sass` inside the SASS tag instead of `source.css`).