### PR TITLE
Fix spurious header access warning for prerendered pages with allowedDomains

### DIFF
--- a/.changeset/fix-prerender-allowed-domains-warning.md
+++ b/.changeset/fix-prerender-allowed-domains-warning.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a spurious `Astro.request.headers` warning on prerendered pages when `security.allowedDomains` is configured. The internal `allowedDomains` header validation now skips prerendered routes, since they use synthetic requests with no real headers.

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -306,7 +306,7 @@ export class FetchState implements AstroFetchState {
 		// allowedDomains — without it, forwarded headers are never trusted
 		// and the validation is a no-op. This avoids header lookups on the
 		// hot path for the vast majority of apps.
-		if (pipeline.manifest.allowedDomains && pipeline.manifest.allowedDomains.length > 0) {
+		if (pipeline.manifest.allowedDomains && pipeline.manifest.allowedDomains.length > 0 && !this.routeData?.prerender) {
 			this.#applyForwardedHeaders();
 		}
 

--- a/packages/astro/test/units/app/prerender-allowed-domains.test.ts
+++ b/packages/astro/test/units/app/prerender-allowed-domains.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { FetchState } from '../../../dist/core/fetch/fetch-state.js';
+import { createRouteData } from '../mocks.ts';
+import { createBasicPipeline, SpyLogger } from '../test-utils.ts';
+
+describe('FetchState with allowedDomains and prerendered routes', () => {
+	it('does not access request.headers for prerendered routes', () => {
+		const spy = new SpyLogger();
+		const pipeline = createBasicPipeline({
+			logger: spy,
+			manifest: {
+				allowedDomains: [{ hostname: 'example.com' }],
+			},
+		});
+
+		const routeData = createRouteData({
+			route: '/',
+			prerender: true,
+		});
+
+		// Set up a request with a headers trap (mimics createRequest with isPrerendered: true)
+		const request = new Request('http://localhost:4321/');
+		let headersAccessed = false;
+		const originalHeaders = request.headers;
+		Object.defineProperty(request, 'headers', {
+			get() {
+				headersAccessed = true;
+				return originalHeaders;
+			},
+		});
+
+		new FetchState(pipeline, request, {
+			routeData,
+			addCookieHeader: false,
+			clientAddress: undefined,
+			locals: undefined,
+			prerenderedErrorPageFetch: fetch,
+			waitUntil: undefined,
+		});
+
+		assert.equal(headersAccessed, false, 'request.headers should not be accessed for prerendered routes');
+	});
+
+	it('accesses request.headers for non-prerendered routes when allowedDomains is set', () => {
+		const spy = new SpyLogger();
+		const pipeline = createBasicPipeline({
+			logger: spy,
+			manifest: {
+				allowedDomains: [{ hostname: 'example.com' }],
+			},
+		});
+
+		const routeData = createRouteData({
+			route: '/',
+			prerender: false,
+		});
+
+		const request = new Request('http://localhost:4321/');
+		let headersAccessed = false;
+		const originalHeaders = request.headers;
+		Object.defineProperty(request, 'headers', {
+			get() {
+				headersAccessed = true;
+				return originalHeaders;
+			},
+		});
+
+		new FetchState(pipeline, request, {
+			routeData,
+			addCookieHeader: false,
+			clientAddress: undefined,
+			locals: undefined,
+			prerenderedErrorPageFetch: fetch,
+			waitUntil: undefined,
+		});
+
+		assert.equal(headersAccessed, true, 'request.headers should be accessed for non-prerendered routes');
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes spurious `Astro.request.headers` warning when using `security.allowedDomains` with prerendered pages. The warning was incorrectly triggered by Astro's internal forwarded header resolution, not by user code.
- Skips the `#applyForwardedHeaders()` call for prerendered routes since forwarded headers are meaningless for synthetic requests with no real headers.

## Testing

- Added `packages/astro/test/units/app/prerender-allowed-domains.test.ts` with tests verifying no header access warnings for prerendered routes and that header access still works for non-prerendered routes.

## Docs

- No docs update needed, this fixes a bug without changing user-facing behavior.

Closes #17077