### PR TITLE
ci: allow releases from 6-legacy

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -2,7 +2,7 @@ name: Preview release
 
 on:
   pull_request:
-    branches: [main, next, 5-legacy]
+    branches: [main, next, 5-legacy, 6-legacy]
     types: [labeled]
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
       - "3-legacy"
       - "4-legacy"
       - "5-legacy"
+      - "6-legacy"
 
 defaults:
   run:


### PR DESCRIPTION
## Changes

This PR updates our workflows to release form 6-legacy branch

Closes AST-180

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
