### PR TITLE
Update changeset baseBranch from next to main

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "origin/next",
+  "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
## Changes

- Updates `.changeset/config.json` `baseBranch` from `origin/next` to `origin/main`. After the v7 release merged `next` into `main`, `main` is the active development branch. The stale `origin/next` ref causes `pnpm changeset status` to fail in CI workflows like preview releases.

## Testing

- No test changes. This is a config-only fix.

## Docs

- No docs needed.