### PR TITLE
docs(agents): remove dead llms.txt reference

### DIFF
--- a/.agents/skills/astro-developer/SKILL.md
+++ b/.agents/skills/astro-developer/SKILL.md
@@ -127,6 +127,6 @@ See [testing.md](testing.md) for complete patterns and examples.
 
 - Root: [/AGENTS.md](../../../AGENTS.md)
 - Root: [/CONTRIBUTING.md](../../../CONTRIBUTING.md)
-- Astro docs: https://docs.astro.build/llms.txt
+- Astro docs: https://docs.astro.build/
 - Package: packages/astro/src/core/README.md
 - Build plugins: packages/astro/src/core/build/plugins/README.md

--- a/.changeset/sanjibani-remove-dead-llms-txt.md
+++ b/.changeset/sanjibani-remove-dead-llms-txt.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Removes a dead `llms.txt` reference from the bundled `AGENTS.md` and the `astro-developer` skill, where the link target never existed.

--- a/.changeset/sanjibani-remove-dead-llms-txt.md
+++ b/.changeset/sanjibani-remove-dead-llms-txt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes a dead `llms.txt` reference from the bundled `AGENTS.md` and the `astro-developer` skill, where the link target never existed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,7 @@ Use `pnpm -C <dir> <command>` for project-local script commands when working in 
 - Use `astro check` to run type checking and diagnostics.
 - Use `astro sync` to generate and update TypeScript types.
 - Use `astro add` to install and configure an official integration.
-- Fetch **LLM-optimized** docs at https://docs.astro.build/llms.txt.
-- Fetch **Full docs** at https://docs.astro.build/ (primary source, use when llms.txt lacks info).
+- Fetch **Full docs** at https://docs.astro.build/ (primary source for the latest reference).
 
 # `bgproc`
 


### PR DESCRIPTION
The `/llms.txt` endpoint at docs.astro.build currently returns 404 (along with the related `/llms-full.txt`, `/llms.md`, and `/llms-ctx.txt` variants).

This PR updates the AI-agent skill files in `AGENTS.md` and `.agents/skills/astro-developer/SKILL.md` to point at the canonical docs root (`https://docs.astro.build/`) instead of the dead LLM-specific endpoint. Two affected lines, both with verified 404 status.