### PR TITLE
fix(integrations): Export container renderers from a dedicated export path to fix bundling issues

### DIFF
--- a/.changeset/container-renderer-export.md
+++ b/.changeset/container-renderer-export.md
@@ -7,15 +7,15 @@
 '@astrojs/mdx': minor
 ---
 
-Adds a new `container-renderer` entrypoint for use with the Container API
+Replaces the import entrypoint of `getContainerRenderer()`
 
-When rendering components with the Container API, import `getContainerRenderer` from this new entrypoint instead of from the package root:
+A new `container-renderer` entrypoint exporting `getContainerRenderer()` has been added to the following integrations: React, Preact, Svelte, SolidJS, Vue, and MDX. This prevents bundlers from trying to bundle unrelated exports from the package root when only the Container API is used.
+
+If you are using the Container API, update your import statements to use the new entrypoint. The following example updates the `getContainerRenderer()` import for React:
 
 ```diff
 - import { getContainerRenderer } from '@astrojs/react';
 + import { getContainerRenderer } from '@astrojs/react/container-renderer';
 ```
 
-This change was done in order to avoid bundlers trying to bundle unrelated exports from the package root when only the Container API is being used.
-
-Importing `getContainerRenderer` from the package root still works, but is now deprecated and logs a warning.
+Importing `getContainerRenderer()` from the package root still works, but is now deprecated and logs a warning.

--- a/.changeset/container-renderer-export.md
+++ b/.changeset/container-renderer-export.md
@@ -1,0 +1,21 @@
+---
+'@astrojs/react': minor
+'@astrojs/preact': minor
+'@astrojs/svelte': minor
+'@astrojs/solid-js': minor
+'@astrojs/vue': minor
+'@astrojs/mdx': minor
+---
+
+Adds a new `container-renderer` entrypoint for use with the Container API
+
+When rendering components with the Container API, import `getContainerRenderer` from this new entrypoint instead of from the package root:
+
+```diff
+- import { getContainerRenderer } from '@astrojs/react';
++ import { getContainerRenderer } from '@astrojs/react/container-renderer';
+```
+
+This change was done in order to avoid bundlers trying to bundle unrelated exports from the package root when only the Container API is being used.
+
+Importing `getContainerRenderer` from the package root still works, but is now deprecated and logs a warning.

--- a/examples/container-with-vitest/test/ReactWrapper.test.ts
+++ b/examples/container-with-vitest/test/ReactWrapper.test.ts
@@ -1,5 +1,5 @@
 import { loadRenderers } from 'astro:container';
-import { getContainerRenderer } from '@astrojs/react';
+import { getContainerRenderer } from '@astrojs/react/container-renderer';
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { expect, test } from 'vitest';
 import ReactWrapper from '../src/components/ReactWrapper.astro';

--- a/packages/astro/src/virtual-modules/container.ts
+++ b/packages/astro/src/virtual-modules/container.ts
@@ -5,7 +5,7 @@ import type { SSRLoadedRenderer } from '../types/public/internal.js';
  * Use this function to provide renderers to the `AstroContainer`:
  *
  * ```js
- * import { getContainerRenderer } from "@astrojs/react";
+ * import { getContainerRenderer } from "@astrojs/react/container-renderer";
  * import { experimental_AstroContainer as AstroContainer } from "astro/container";
  * import { loadRenderers } from "astro:container"; // use this only when using vite/vitest
  *

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/mdx/",
   "exports": {
     ".": "./dist/index.js",
+    "./container-renderer": "./dist/container-renderer.js",
     "./server.js": "./dist/server.js",
     "./package.json": "./package.json"
   },

--- a/packages/integrations/mdx/src/container-renderer.ts
+++ b/packages/integrations/mdx/src/container-renderer.ts
@@ -1,0 +1,8 @@
+import type { AstroRenderer } from 'astro';
+
+export function getContainerRenderer(): AstroRenderer {
+	return {
+		name: 'astro:jsx',
+		serverEntrypoint: '@astrojs/mdx/server.js',
+	};
+}

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -14,6 +14,7 @@ import type {
 import type { MarkdownProcessor } from 'astro/markdown';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import type { PluggableList } from 'unified';
+import { getContainerRenderer as getContainerRendererImpl } from './container-renderer.js';
 import { isSatteriProcessor, isUnifiedProcessor } from './processor-guards.js';
 import type { OptimizeOptions } from './rehype-optimize-static.js';
 import { ignoreStringPlugins, safeParseFrontmatter } from './utils.js';
@@ -72,11 +73,14 @@ type SetupHookParams = HookParameters<'astro:config:setup'> & {
 	addContentEntryType: (contentEntryType: ContentEntryType) => void;
 };
 
+/**
+ * @deprecated Import `getContainerRenderer` from `@astrojs/mdx/container-renderer` instead.
+ */
 export function getContainerRenderer(): AstroRenderer {
-	return {
-		name: 'astro:jsx',
-		serverEntrypoint: '@astrojs/mdx/server.js',
-	};
+	console.warn(
+		'[@astrojs/mdx] Importing `getContainerRenderer` from `@astrojs/mdx` is deprecated. Import it from `@astrojs/mdx/container-renderer` instead.',
+	);
+	return getContainerRendererImpl();
 }
 
 export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroIntegration {

--- a/packages/integrations/mdx/test/fixtures/mdx-astro-container-escape/src/pages/index.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-astro-container-escape/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { experimental_AstroContainer } from "astro/container";
 import { loadRenderers } from "astro:container";
-import { getContainerRenderer } from "@astrojs/mdx";
+import { getContainerRenderer } from "@astrojs/mdx/container-renderer";
 import { Content } from '../posts/post.mdx'
 
 const renderers = await loadRenderers([getContainerRenderer()]);

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/preact/",
   "exports": {
     ".": "./dist/index.js",
+    "./container-renderer": "./dist/container-renderer.js",
     "./client.js": "./dist/client.js",
     "./client-dev.js": "./dist/client-dev.js",
     "./server.js": "./dist/server.js",

--- a/packages/integrations/preact/src/container-renderer.ts
+++ b/packages/integrations/preact/src/container-renderer.ts
@@ -1,0 +1,11 @@
+import type { AstroRenderer } from 'astro';
+
+export function getRenderer(development: boolean): AstroRenderer {
+	return {
+		name: '@astrojs/preact',
+		clientEntrypoint: development ? '@astrojs/preact/client-dev.js' : '@astrojs/preact/client.js',
+		serverEntrypoint: '@astrojs/preact/server.js',
+	};
+}
+
+export const getContainerRenderer = (): AstroRenderer => getRenderer(false);

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -3,19 +3,23 @@ import { preact, type PreactPluginOptions as VitePreactPluginOptions } from '@pr
 import type { AstroIntegration, AstroRenderer, ViteUserConfig } from 'astro';
 import * as devalue from 'devalue';
 import type { EnvironmentOptions, Plugin } from 'vite';
+import {
+	getContainerRenderer as getContainerRendererImpl,
+	getRenderer,
+} from './container-renderer.js';
 import type { VirtualModuleOptions } from './types.js';
 
 const babelCwd = new URL('../', import.meta.url);
 
-function getRenderer(development: boolean): AstroRenderer {
-	return {
-		name: '@astrojs/preact',
-		clientEntrypoint: development ? '@astrojs/preact/client-dev.js' : '@astrojs/preact/client.js',
-		serverEntrypoint: '@astrojs/preact/server.js',
-	};
+/**
+ * @deprecated Import `getContainerRenderer` from `@astrojs/preact/container-renderer` instead.
+ */
+export function getContainerRenderer(): AstroRenderer {
+	console.warn(
+		'[@astrojs/preact] Importing `getContainerRenderer` from `@astrojs/preact` is deprecated. Import it from `@astrojs/preact/container-renderer` instead.',
+	);
+	return getContainerRendererImpl();
 }
-
-export const getContainerRenderer = (): AstroRenderer => getRenderer(false);
 
 function optionsPlugin(include: Options['include'], exclude: Options['exclude']): Plugin {
 	const virtualModule = 'astro:preact:opts';

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/react/",
   "exports": {
     ".": "./dist/index.js",
+    "./container-renderer": "./dist/container-renderer.js",
     "./actions": "./dist/actions.js",
     "./client.js": "./dist/client.js",
     "./client-v17.js": "./dist/client-v17.js",

--- a/packages/integrations/react/src/container-renderer.ts
+++ b/packages/integrations/react/src/container-renderer.ts
@@ -1,0 +1,23 @@
+import type { AstroRenderer } from 'astro';
+import {
+	getReactMajorVersion,
+	isSupportedReactVersion,
+	type ReactVersionConfig,
+	versionsConfig,
+} from './version.js';
+
+export function getRenderer(reactConfig: ReactVersionConfig): AstroRenderer {
+	return {
+		name: '@astrojs/react',
+		clientEntrypoint: reactConfig.client,
+		serverEntrypoint: reactConfig.server,
+	};
+}
+
+export function getContainerRenderer(): AstroRenderer {
+	const majorVersion = getReactMajorVersion();
+	if (!isSupportedReactVersion(majorVersion)) {
+		throw new Error(`Unsupported React version: ${majorVersion}.`);
+	}
+	return getRenderer(versionsConfig[majorVersion]);
+}

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -2,6 +2,10 @@ import react, { type Options as ViteReactPluginOptions } from '@vitejs/plugin-re
 import type { AstroIntegration, AstroRenderer } from 'astro';
 import type * as vite from 'vite';
 import {
+	getContainerRenderer as getContainerRendererImpl,
+	getRenderer,
+} from './container-renderer.js';
+import {
 	getReactMajorVersion,
 	isSupportedReactVersion,
 	type ReactVersionConfig,
@@ -23,14 +27,6 @@ export type ReactIntegrationOptions = Pick<
 };
 
 const FAST_REFRESH_PREAMBLE = react.preambleCode;
-
-function getRenderer(reactConfig: ReactVersionConfig) {
-	return {
-		name: '@astrojs/react',
-		clientEntrypoint: reactConfig.client,
-		serverEntrypoint: reactConfig.server,
-	};
-}
 
 function optionsPlugin({
 	include,
@@ -213,10 +209,12 @@ export default function ({
 	};
 }
 
+/**
+ * @deprecated Import `getContainerRenderer` from `@astrojs/react/container-renderer` instead.
+ */
 export function getContainerRenderer(): AstroRenderer {
-	const majorVersion = getReactMajorVersion();
-	if (!isSupportedReactVersion(majorVersion)) {
-		throw new Error(`Unsupported React version: ${majorVersion}.`);
-	}
-	return getRenderer(versionsConfig[majorVersion]);
+	console.warn(
+		'[@astrojs/react] Importing `getContainerRenderer` from `@astrojs/react` is deprecated. Import it from `@astrojs/react/container-renderer` instead.',
+	);
+	return getContainerRendererImpl();
 }

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/solid-js/",
   "exports": {
     ".": "./dist/index.js",
+    "./container-renderer": "./dist/container-renderer.js",
     "./client.js": "./dist/client.js",
     "./server.js": "./dist/server.js",
     "./package.json": "./package.json"

--- a/packages/integrations/solid/src/container-renderer.ts
+++ b/packages/integrations/solid/src/container-renderer.ts
@@ -1,0 +1,9 @@
+import type { AstroRenderer } from 'astro';
+
+export function getContainerRenderer(): AstroRenderer {
+	return {
+		name: '@astrojs/solid-js',
+		clientEntrypoint: '@astrojs/solid-js/client.js',
+		serverEntrypoint: '@astrojs/solid-js/server.js',
+	};
+}

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -1,6 +1,7 @@
 import type { AstroIntegration, AstroIntegrationLogger, AstroRenderer } from 'astro';
 import type { PluginOption, Plugin } from 'vite';
 import solid, { type Options as ViteSolidPluginOptions } from 'vite-plugin-solid';
+import { getContainerRenderer as getContainerRendererImpl } from './container-renderer.js';
 
 // TODO: keep in sync with https://github.com/thetarnav/solid-devtools/blob/main/packages/main/src/vite/index.ts#L7
 type DevtoolsPluginOptions = {
@@ -56,15 +57,15 @@ function getViteConfiguration(
 	return { plugins };
 }
 
-function getRenderer(): AstroRenderer {
-	return {
-		name: '@astrojs/solid-js',
-		clientEntrypoint: '@astrojs/solid-js/client.js',
-		serverEntrypoint: '@astrojs/solid-js/server.js',
-	};
+/**
+ * @deprecated Import `getContainerRenderer` from `@astrojs/solid-js/container-renderer` instead.
+ */
+export function getContainerRenderer(): AstroRenderer {
+	console.warn(
+		'[@astrojs/solid-js] Importing `getContainerRenderer` from `@astrojs/solid-js` is deprecated. Import it from `@astrojs/solid-js/container-renderer` instead.',
+	);
+	return getContainerRendererImpl();
 }
-
-export { getRenderer as getContainerRenderer };
 
 export interface Options extends Pick<ViteSolidPluginOptions, 'include' | 'exclude'> {
 	devtools?: boolean;
@@ -86,7 +87,7 @@ export default function (options: Options = {}): AstroIntegration {
 					!!options.devtools && command === 'dev',
 				);
 
-				addRenderer(getRenderer());
+				addRenderer(getContainerRendererImpl());
 				updateConfig({
 					vite: getViteConfiguration(options, devtoolsPlugin),
 				});

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/svelte/",
   "exports": {
     ".": "./dist/index.js",
+    "./container-renderer": "./dist/container-renderer.js",
     "./editor": "./dist/editor.cjs",
     "./client.js": "./dist/client.svelte.js",
     "./server.js": "./dist/server.js",

--- a/packages/integrations/svelte/src/container-renderer.ts
+++ b/packages/integrations/svelte/src/container-renderer.ts
@@ -1,0 +1,9 @@
+import type { AstroRenderer } from 'astro';
+
+export function getContainerRenderer(): AstroRenderer {
+	return {
+		name: '@astrojs/svelte',
+		clientEntrypoint: '@astrojs/svelte/client.js',
+		serverEntrypoint: '@astrojs/svelte/server.js',
+	};
+}

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -4,23 +4,24 @@ import type { AstroIntegration, AstroRenderer } from 'astro';
 import { fileURLToPath } from 'node:url';
 import type { Plugin } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
+import { getContainerRenderer as getContainerRendererImpl } from './container-renderer.js';
 
-function getRenderer(): AstroRenderer {
-	return {
-		name: '@astrojs/svelte',
-		clientEntrypoint: '@astrojs/svelte/client.js',
-		serverEntrypoint: '@astrojs/svelte/server.js',
-	};
+/**
+ * @deprecated Import `getContainerRenderer` from `@astrojs/svelte/container-renderer` instead.
+ */
+export function getContainerRenderer(): AstroRenderer {
+	console.warn(
+		'[@astrojs/svelte] Importing `getContainerRenderer` from `@astrojs/svelte` is deprecated. Import it from `@astrojs/svelte/container-renderer` instead.',
+	);
+	return getContainerRendererImpl();
 }
-
-export { getRenderer as getContainerRenderer };
 
 export default function svelteIntegration(options?: Options): AstroIntegration {
 	return {
 		name: '@astrojs/svelte',
 		hooks: {
 			'astro:config:setup': async ({ config, updateConfig, addRenderer }) => {
-				addRenderer(getRenderer());
+				addRenderer(getContainerRendererImpl());
 
 				// Svelte component libraries from `node_modules` must go through
 				// Vite's transform pipeline because Node can't import `.svelte`

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/vue/",
   "exports": {
     ".": "./dist/index.js",
+    "./container-renderer": "./dist/container-renderer.js",
     "./editor": "./dist/editor.cjs",
     "./client.js": "./dist/client.js",
     "./server.js": "./dist/server.js",

--- a/packages/integrations/vue/src/container-renderer.ts
+++ b/packages/integrations/vue/src/container-renderer.ts
@@ -1,0 +1,9 @@
+import type { AstroRenderer } from 'astro';
+
+export function getContainerRenderer(): AstroRenderer {
+	return {
+		name: '@astrojs/vue',
+		clientEntrypoint: '@astrojs/vue/client.js',
+		serverEntrypoint: '@astrojs/vue/server.js',
+	};
+}

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -6,6 +6,7 @@ import { MagicString } from '@vue/compiler-sfc';
 import type { AstroIntegration, AstroRenderer, HookParameters } from 'astro';
 import type { EnvironmentOptions, Plugin, PluginOption } from 'vite';
 import type { VitePluginVueDevToolsOptions } from 'vite-plugin-vue-devtools';
+import { getContainerRenderer as getContainerRendererImpl } from './container-renderer.js';
 
 const VIRTUAL_MODULE_ID = 'virtual:astro:vue-app';
 const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
@@ -16,14 +17,6 @@ interface Options extends VueOptions {
 	devtools?: boolean | Omit<VitePluginVueDevToolsOptions, 'appendTo'>;
 }
 
-function getRenderer(): AstroRenderer {
-	return {
-		name: '@astrojs/vue',
-		clientEntrypoint: '@astrojs/vue/client.js',
-		serverEntrypoint: '@astrojs/vue/server.js',
-	};
-}
-
 function getJsxRenderer(): AstroRenderer {
 	return {
 		name: '@astrojs/vue (jsx)',
@@ -32,7 +25,15 @@ function getJsxRenderer(): AstroRenderer {
 	};
 }
 
-export { getRenderer as getContainerRenderer };
+/**
+ * @deprecated Import `getContainerRenderer` from `@astrojs/vue/container-renderer` instead.
+ */
+export function getContainerRenderer(): AstroRenderer {
+	console.warn(
+		'[@astrojs/vue] Importing `getContainerRenderer` from `@astrojs/vue` is deprecated. Import it from `@astrojs/vue/container-renderer` instead.',
+	);
+	return getContainerRendererImpl();
+}
 
 function virtualAppEntrypoint(options?: Options): Plugin {
 	let isBuild: boolean;
@@ -191,7 +192,7 @@ export default function (options?: Options): AstroIntegration {
 		name: '@astrojs/vue',
 		hooks: {
 			'astro:config:setup': async ({ addRenderer, updateConfig, command }) => {
-				addRenderer(getRenderer());
+				addRenderer(getContainerRendererImpl());
 				if (options?.jsx) {
 					addRenderer(getJsxRenderer());
 				}


### PR DESCRIPTION
## Changes

Integration entrypoints are unsafe to import inside the app because they're:
- Not written with bundling in mind
- Can import some build-time only stuff

This PR fixes this by exporting the container renderer definition from a separate entrypoint, deprecating the old one for all integrations.

Fixes https://github.com/withastro/astro/issues/16954
Fixes https://github.com/withastro/astro/issues/17068

## Testing

Updated tests to import from the new entrypoint

## Docs

https://github.com/withastro/docs/pull/14077