### PR TITLE
Render custom 500/404 error pages on the composable astro/hono middleware() path

### DIFF
--- a/.changeset/fix-composable-middleware-500.md
+++ b/.changeset/fix-composable-middleware-500.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the advanced routing `astro/hono` / `astro/fetch` `middleware()` handler returned the host framework's default `Internal Server Error` response instead of rendering the custom `500.astro` page when middleware threw. Unmatched requests with a prerendered (or absent) custom 404 page now render the 404 error page instead of failing the same way. Errors surfaced through `next` (the host framework's downstream chain) still propagate to the host's own error handler.

--- a/packages/astro/src/core/fetch/index.ts
+++ b/packages/astro/src/core/fetch/index.ts
@@ -72,8 +72,11 @@ const middlewareInstances = new WeakMap<BaseApp<Pipeline>, AstroMiddleware>();
 
 /**
  * Runs Astro's middleware chain for the given state, calling `next` at
- * the bottom of the chain to produce the response. Lazily creates
- * the render context if needed.
+ * the bottom of the chain to produce the response. Lazily creates the
+ * render context if needed. Unmatched routes render the 404 error page;
+ * errors thrown by user middleware are logged and render the 500 error
+ * page; errors surfaced through `next` (the host framework's downstream
+ * chain) propagate to the host instead.
  */
 export function middleware(
 	state: FetchState,
@@ -85,7 +88,7 @@ export function middleware(
 		mw = new AstroMiddleware(app.pipeline);
 		middlewareInstances.set(app, mw);
 	}
-	return mw.handle(state, (s, _ctx) => next(s));
+	return mw.handleWithErrorFallback(app, state, (s, _ctx) => next(s));
 }
 
 const pagesHandlers = new WeakMap<BaseApp<Pipeline>, PagesHandler>();

--- a/packages/astro/src/core/middleware/astro-middleware.ts
+++ b/packages/astro/src/core/middleware/astro-middleware.ts
@@ -1,7 +1,9 @@
 import type { FetchState } from '../fetch/fetch-state.js';
 import type { RewritePayload } from '../../types/public/common.js';
 import type { APIContext } from '../../types/public/context.js';
+import type { BaseApp } from '../app/base.js';
 import { type Pipeline, PipelineFeatures } from '../base-pipeline.js';
+import { ASTRO_ERROR_HEADER } from '../constants.js';
 import { attachCookiesToResponse } from '../cookies/index.js';
 import { applyRewriteToState } from '../rewrites/handler.js';
 import { callMiddleware } from './callMiddleware.js';
@@ -73,6 +75,61 @@ export class AstroMiddleware {
 		response = this.#finalize(state, response);
 		state.response = response;
 		return response;
+	}
+
+	/**
+	 * Like `handle`, but mirrors the app-level error handling that
+	 * `AstroHandler` provides on the standard path, the same way
+	 * `PagesHandler.handleWithErrorFallback` does for `pages()`. When no
+	 * route matched it returns a 404 marked with `X-Astro-Error` for the
+	 * app's post-check; when Astro's own middleware chain throws it logs the
+	 * error and renders the custom `500.astro`.
+	 *
+	 * Errors surfaced through `renderRouteCallback` (the host framework's
+	 * `next`, e.g. host middleware mounted below `middleware()`) are
+	 * re-thrown instead, so the host's own error handling still runs rather
+	 * than being swallowed into Astro's 500 page. A sentinel tells the two
+	 * apart.
+	 *
+	 * Used by the composable `astro/fetch` `middleware()` entry point, where
+	 * there is no surrounding `AstroHandler` to supply this fallback.
+	 */
+	async handleWithErrorFallback(
+		app: BaseApp<Pipeline>,
+		state: FetchState,
+		renderRouteCallback: RenderRouteCallback,
+	): Promise<Response> {
+		// `FetchState` falls back to an SSR 404 route when nothing matches, so
+		// routeData is only missing when the custom 404 page is prerendered (or
+		// absent). Returning a marked 404 lets the app's `X-Astro-Error`
+		// post-check render the 404 page a level up, mirroring
+		// `PagesHandler.handleWithErrorFallback`; running user middleware here
+		// would throw on the missing route (no component to load).
+		if (!state.routeData) {
+			return new Response(null, { status: 404, headers: { [ASTRO_ERROR_HEADER]: 'true' } });
+		}
+		let nextError: unknown;
+		try {
+			return await this.handle(state, async (s, ctx) => {
+				try {
+					return await renderRouteCallback(s, ctx);
+				} catch (err) {
+					nextError = err;
+					throw err;
+				}
+			});
+		} catch (err: any) {
+			if (err === nextError) throw err;
+			// User middleware threw: log the stack and render the custom 500
+			// page, the same way `AstroHandler` does on the standard path.
+			app.logger.error(null, err.stack || err.message || String(err));
+			return app.renderError(state.request, {
+				...state.renderOptions,
+				status: 500,
+				error: err,
+				pathname: state.pathname,
+			});
+		}
 	}
 
 	#finalize(state: FetchState, response: Response): Response {

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -259,6 +259,87 @@ describe('middleware()', () => {
 		assert.equal(response.headers.get('x-user-middleware'), 'true');
 		assert.equal(await response.text(), 'page');
 	});
+
+	it('renders the custom 500 page when user middleware throws', async () => {
+		const errorPage = createComponent((_result: any, _props: any, _slots: any) => {
+			return render`<h1>my custom 500</h1>`;
+		});
+		const app = createTestApp(
+			[createPage(simplePage, { route: '/' }), createPage(errorPage, { route: '/500' })],
+			{
+				middleware: async () => ({
+					onRequest: async () => {
+						throw new Error('boom from middleware');
+					},
+				}),
+			},
+		);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		const response = await middleware(state, async () => new Response('page'));
+
+		assert.equal(response.status, 500);
+		const text = await response.text();
+		assert.match(text, /<h1>my custom 500<\/h1>/);
+	});
+
+	it('re-throws errors from the next callback instead of rendering the 500 page', async () => {
+		// A throw from `next` originates downstream of Astro's middleware (the
+		// host framework's chain), so it must propagate to the host's own error
+		// handling rather than be swallowed into Astro's 500 page.
+		const errorPage = createComponent((_result: any, _props: any, _slots: any) => {
+			return render`<h1>my custom 500</h1>`;
+		});
+		const app = createTestApp([
+			createPage(simplePage, { route: '/' }),
+			createPage(errorPage, { route: '/500' }),
+		]);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		const downstreamError = new Error('boom from next');
+		await assert.rejects(
+			middleware(state, async () => {
+				throw downstreamError;
+			}),
+			(err: unknown) => err === downstreamError,
+		);
+	});
+
+	it('returns a marked 404 without running middleware when the custom 404 route is prerendered', async () => {
+		const notFoundPage = createComponent((_result: any, _props: any, _slots: any) => {
+			return render`<h1>Not Found</h1>`;
+		});
+		const app = createTestApp(
+			[
+				createPage(simplePage, { route: '/' }),
+				createPage(notFoundPage, { route: '/404', prerender: true }),
+			],
+			{
+				middleware: async () => ({
+					onRequest: async (_ctx: any, next: any) => {
+						const response = await next();
+						response.headers.set('x-user-middleware', 'true');
+						return response;
+					},
+				}),
+			},
+		);
+		const request = stampApp(new Request('http://example.com/does-not-exist'), app);
+		const state = new FetchState(request);
+
+		let nextCalled = false;
+		const response = await middleware(state, async () => {
+			nextCalled = true;
+			return new Response('page');
+		});
+
+		assert.equal(response.status, 404);
+		assert.equal(response.headers.get('X-Astro-Error'), 'true');
+		assert.equal(response.headers.get('x-user-middleware'), null, 'user middleware should not run');
+		assert.equal(nextCalled, false, 'next should not be called for an unmatched route');
+	});
 });
 
 // #endregion


### PR DESCRIPTION
## Changes

On the composable `astro/hono` path, `middleware()` delegated straight to `AstroMiddleware.handle()`, with none of the app-level error handling `AstroHandler` provides on the standard path. A throw in the user's own `src/middleware.ts` therefore reached the host framework's default error handler (Hono: plain-text `Internal Server Error`) instead of rendering the custom `500.astro`. The all-in-one `astro()` handler and the standard adapter path both render `500.astro` for the same throw, so the gap was specific to composing `middleware()` on its own. This is the middleware counterpart of #16952 / #17041, which fixed the `pages()` side and flagged this as out of scope (#17092).

- Added `AstroMiddleware.handleWithErrorFallback(app, state, renderRouteCallback)` (`core/middleware/astro-middleware.ts`): wraps the middleware chain in a try/catch that logs the error and renders it via `app.renderError(..., { status: 500, error })`, the same behaviour `AstroHandler.render()` has on the standard path and `PagesHandler.handleWithErrorFallback()` got in #17041.
- #17041 noted the catch couldn't simply live here, because `middleware()`'s `next` is the host's `next()`: a plain try/catch would also swallow errors thrown by host middleware running below it in the chain and hide them from the user's own `app.onError`. A sentinel handles that. Errors surfaced through the route-dispatch callback (the host's `next`, i.e. middleware mounted below `middleware()`) are tracked and re-thrown, so only errors from Astro's own middleware become `500.astro` while host errors still reach `app.onError`.
- Added the same unmatched-route guard `pages()` got in #17041. When no route matched (the custom 404 page is prerendered or absent, so `routeData` is unset), it returns a 404 marked with `X-Astro-Error` for the app's post-check instead of running middleware against a missing route. Without the guard, `AstroMiddleware.handle()` calls `getProps()` on the missing route, throws a `TypeError`, and the 500 catch above turns the unmatched request into a `500`. This matches `AstroHandler`, which 404s before running middleware on the standard path.
- Switched `middleware()` in `core/fetch/index.ts` to delegate to the new method (delegation only, no logic added - that file keeps its exports as thin wrappers).
- Added a changeset (`astro` patch).

The triage on #17092 explored the same sentinel approach.

## Testing

- Added `'renders the custom 500 page when user middleware throws'` - verifies a throw in user middleware returns HTTP 500 with the custom 500 page content.
- Added `'re-throws errors from the next callback instead of rendering the 500 page'` - verifies an error surfaced through `next` propagates to the caller (so the host's error handling still runs) instead of being rendered as `500.astro`.
- Added `'returns a marked 404 without running middleware when the custom 404 route is prerendered'` - verifies an unmatched request returns HTTP 404 with the `X-Astro-Error` marker and that user middleware and `next` are not run.
- Verified end-to-end against the reproduction from #17092 (updated to cover both gaps; Hono, `app.use(middleware())` + `app.use(pages())`, node standalone), and confirmed the composable path now matches the all-in-one `astro()` on every case:
  - `GET /boom` (throws in `src/middleware.ts`) -> `500` with the custom 500 page, previously Hono's plain-text `Internal Server Error`.
  - `GET /page-throws` -> `500` with the custom 500 page (the #17041 path, still working).
  - `GET /` -> `200`.
  - With a host (Hono) middleware mounted below `middleware()` that throws, the request still reaches `app.onError` rather than `500.astro`.
  - `GET /does-not-exist` (unmatched) with a prerendered custom 404 -> `404` rendering the custom 404 page, previously `500`; with no custom 404 -> the default `404` page.

## Out of scope (noticed while testing)

On the middleware path the rendered `500.astro` gets an empty `error` prop, so the page can't show what threw. This looks pre-existing rather than introduced here: the all-in-one `astro()` handler behaves the same, while page-render errors via `pages()` do populate `error`. Better addressed separately.

## Docs

- No docs update needed - this restores the documented custom-error-page behaviour on the composable path (the `pages()` counterpart was #17041).

Closes #17092
