### PR TITLE
Move internal response metadata into FetchState

### DIFF
--- a/.changeset/ripe-bottles-fetch.md
+++ b/.changeset/ripe-bottles-fetch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes internal Astro headers leaking from direct `pages()` handler responses

--- a/packages/astro/src/core/app/prepare-response.ts
+++ b/packages/astro/src/core/app/prepare-response.ts
@@ -1,10 +1,9 @@
-import { INTERNAL_RESPONSE_HEADERS, responseSentSymbol } from '../constants.js';
+import { responseSentSymbol } from '../constants.js';
 import { getSetCookiesFromResponse } from '../cookies/index.js';
 
 /**
- * Strips internal-only headers from the response before sending it to the
- * user agent, and optionally appends cookies written via `Astro.cookie.set()`
- * to the `Set-Cookie` header.
+ * Appends cookies written via `Astro.cookie.set()` to the `Set-Cookie` header
+ * and marks the response as sent.
  *
  * This is a pure function with no dependencies on the app; it is shared by
  * `AstroHandler` and the various error handlers.
@@ -13,12 +12,6 @@ export function prepareResponse(
 	response: Response,
 	{ addCookieHeader }: { addCookieHeader: boolean },
 ): void {
-	for (const headerName of INTERNAL_RESPONSE_HEADERS) {
-		if (response.headers.has(headerName)) {
-			response.headers.delete(headerName);
-		}
-	}
-
 	if (addCookieHeader) {
 		for (const setCookieHeaderValue of getSetCookiesFromResponse(response)) {
 			response.headers.append('set-cookie', setCookieHeaderValue);

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -34,11 +34,6 @@ export const REWRITE_DIRECTIVE_HEADER_KEY = 'X-Astro-Rewrite';
 export const REWRITE_DIRECTIVE_HEADER_VALUE = 'yes';
 
 /**
- * This header is set by the no-op Astro middleware.
- */
-export const NOOP_MIDDLEWARE_HEADER = 'X-Astro-Noop';
-
-/**
  * The name for the header used to help i18n middleware, which only needs to act on "page" and "fallback" route types.
  */
 export const ROUTE_TYPE_HEADER = 'X-Astro-Route-Type';
@@ -51,7 +46,6 @@ export const ROUTE_TYPE_HEADER = 'X-Astro-Route-Type';
 export const INTERNAL_RESPONSE_HEADERS = [
 	REROUTE_DIRECTIVE_HEADER,
 	REWRITE_DIRECTIVE_HEADER_KEY,
-	NOOP_MIDDLEWARE_HEADER,
 	ROUTE_TYPE_HEADER,
 ] as const;
 

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -4,52 +4,6 @@ export const ASTRO_VERSION = process.env.PACKAGE_VERSION ?? 'development';
 export const ASTRO_GENERATOR = `Astro v${ASTRO_VERSION}`;
 
 /**
- * The name for the header used to help rerouting behavior.
- * When set to "no", astro will NOT try to reroute an error response to the corresponding error page, which is the default behavior that can sometimes lead to loops.
- *
- * ```ts
- * const response = new Response("keep this content as-is", {
- *     status: 404,
- *     headers: {
- *         // note that using a variable name as the key of an object needs to be wrapped in square brackets in javascript
- *         // without them, the header name will be interpreted as "REROUTE_DIRECTIVE_HEADER" instead of "X-Astro-Reroute"
- *         [REROUTE_DIRECTIVE_HEADER]: 'no',
- *     }
- * })
- * ```
- * Alternatively...
- * ```ts
- * response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
- * ```
- */
-export const REROUTE_DIRECTIVE_HEADER = 'X-Astro-Reroute';
-
-/**
- * Header and value that are attached to a Response object when a **user rewrite** occurs.
- *
- * This metadata is used to determine the origin of a Response. If a rewrite has occurred, it should be prioritised over other logic.
- */
-export const REWRITE_DIRECTIVE_HEADER_KEY = 'X-Astro-Rewrite';
-
-export const REWRITE_DIRECTIVE_HEADER_VALUE = 'yes';
-
-/**
- * The name for the header used to help i18n middleware, which only needs to act on "page" and "fallback" route types.
- */
-export const ROUTE_TYPE_HEADER = 'X-Astro-Route-Type';
-
-/**
- * Internal headers that should be stripped from the response before
- * sending it to the user agent. Add new internal headers here so
- * `prepareResponse` removes them automatically.
- */
-export const INTERNAL_RESPONSE_HEADERS = [
-	REROUTE_DIRECTIVE_HEADER,
-	REWRITE_DIRECTIVE_HEADER_KEY,
-	ROUTE_TYPE_HEADER,
-] as const;
-
-/**
  * Set by internal handlers (e.g. PagesHandler) to signal that a
  * response should be replaced with the corresponding error page.
  */

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -193,6 +193,10 @@ export class FetchState implements AstroFetchState {
 	clientAddress: string | undefined;
 	/** Whether this is a partial render (container API). */
 	partial: boolean | undefined;
+	/** Internal metadata about the current response route type. */
+	responseRouteType: 'page' | 'fallback' | undefined;
+	/** Internal flag to prevent rerouting this response to an error page. */
+	skipErrorReroute = false;
 	/** Whether to inject CSP meta tags. */
 	shouldInjectCspMetaTags: boolean | undefined;
 	/** Request-scoped locals object, shared with user middleware. */
@@ -1123,5 +1127,10 @@ export class FetchState implements AstroFetchState {
 		this.props = null;
 		this.actionApiContext = null;
 		this.apiContext = null;
+	}
+
+	resetResponseMetadata(): void {
+		this.responseRouteType = undefined;
+		this.skipErrorReroute = false;
 	}
 }

--- a/packages/astro/src/core/i18n/handler.ts
+++ b/packages/astro/src/core/i18n/handler.ts
@@ -4,7 +4,6 @@ import { I18nRouter, type I18nRouterContext } from '../../i18n/router.js';
 import { PipelineFeatures } from '../base-pipeline.js';
 import type { SSRManifest } from '../app/types.js';
 import { shouldAppendForwardSlash } from '../build/util.js';
-import { REROUTE_DIRECTIVE_HEADER, ROUTE_TYPE_HEADER } from '../constants.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 
 /**
@@ -59,25 +58,15 @@ export class I18n {
 	async finalize(state: FetchState, response: Response): Promise<Response> {
 		state.pipeline.usedFeatures |= PipelineFeatures.i18n;
 		const i18n = this.#i18n;
-		const headerRouteType = response.headers.get(ROUTE_TYPE_HEADER) as
-			| 'page'
-			| 'fallback'
-			| null;
-		if (headerRouteType) {
-			response.headers.delete(ROUTE_TYPE_HEADER);
-		}
-		const routeType = state.responseRouteType ?? headerRouteType ?? undefined;
-		const skipErrorReroute =
-			state.skipErrorReroute || response.headers.get(REROUTE_DIRECTIVE_HEADER) === 'no';
 
 		// This is a case where we are internally rendering a 404/500, so we
 		// need to bypass checks that were done already.
-		if (skipErrorReroute && typeof i18n.fallback === 'undefined') {
+		if (state.skipErrorReroute && typeof i18n.fallback === 'undefined') {
 			return response;
 		}
 
 		// If the route we're processing is not a page, then we ignore it
-		if (routeType !== 'page' && routeType !== 'fallback') {
+		if (state.responseRouteType !== 'page' && state.responseRouteType !== 'fallback') {
 			return response;
 		}
 
@@ -85,11 +74,11 @@ export class I18n {
 		const currentLocale = state.computeCurrentLocale();
 		const isPrerendered = state.routeData!.prerender;
 
-		// Build context for router (routeType is guaranteed to be 'page' | 'fallback' here)
+		// Build context for router (responseRouteType is guaranteed to be 'page' | 'fallback' here)
 		const routerContext: I18nRouterContext = {
 			currentLocale,
 			currentDomain: url.hostname,
-			routeType: routeType,
+			routeType: state.responseRouteType,
 			isReroute: false,
 		};
 
@@ -141,7 +130,7 @@ export class I18n {
 			// The fallback sentinel (X-Astro-Route-Type: fallback, status 500) signals
 			// that the render pipeline couldn't find this page in the current locale.
 			// Treat it as a 404 so computeFallbackRoute will apply fallback logic.
-			const effectiveStatus = routeType === 'fallback' ? 404 : response.status;
+			const effectiveStatus = state.responseRouteType === 'fallback' ? 404 : response.status;
 			const fallbackDecision = computeFallbackRoute({
 				pathname: url.pathname,
 				responseStatus: effectiveStatus,

--- a/packages/astro/src/core/i18n/handler.ts
+++ b/packages/astro/src/core/i18n/handler.ts
@@ -4,7 +4,6 @@ import { I18nRouter, type I18nRouterContext } from '../../i18n/router.js';
 import { PipelineFeatures } from '../base-pipeline.js';
 import type { SSRManifest } from '../app/types.js';
 import { shouldAppendForwardSlash } from '../build/util.js';
-import { REROUTE_DIRECTIVE_HEADER, ROUTE_TYPE_HEADER } from '../constants.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 
 /**
@@ -59,21 +58,14 @@ export class I18n {
 	async finalize(state: FetchState, response: Response): Promise<Response> {
 		state.pipeline.usedFeatures |= PipelineFeatures.i18n;
 		const i18n = this.#i18n;
-		const typeHeader = response.headers.get(ROUTE_TYPE_HEADER);
-		// We don't need this header anymore, and we shouldn't pass downstream to users.
-		if (typeHeader) {
-			response.headers.delete(ROUTE_TYPE_HEADER);
-		}
-
 		// This is a case where we are internally rendering a 404/500, so we
 		// need to bypass checks that were done already.
-		const isReroute = response.headers.get(REROUTE_DIRECTIVE_HEADER);
-		if (isReroute === 'no' && typeof i18n.fallback === 'undefined') {
+		if (state.skipErrorReroute && typeof i18n.fallback === 'undefined') {
 			return response;
 		}
 
 		// If the route we're processing is not a page, then we ignore it
-		if (typeHeader !== 'page' && typeHeader !== 'fallback') {
+		if (state.responseRouteType !== 'page' && state.responseRouteType !== 'fallback') {
 			return response;
 		}
 
@@ -85,8 +77,8 @@ export class I18n {
 		const routerContext: I18nRouterContext = {
 			currentLocale,
 			currentDomain: url.hostname,
-			routeType: typeHeader as 'page' | 'fallback',
-			isReroute: isReroute === 'yes',
+			routeType: state.responseRouteType,
+			isReroute: false,
 		};
 
 		// Step 1: Apply routing strategy
@@ -113,7 +105,7 @@ export class I18n {
 						status: 404,
 						headers: response.headers,
 					});
-					prerenderedRes.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
+					state.skipErrorReroute = true;
 					if (routeDecision.location) {
 						prerenderedRes.headers.set('Location', routeDecision.location);
 					}
@@ -137,7 +129,7 @@ export class I18n {
 			// The fallback sentinel (X-Astro-Route-Type: fallback, status 500) signals
 			// that the render pipeline couldn't find this page in the current locale.
 			// Treat it as a 404 so computeFallbackRoute will apply fallback logic.
-			const effectiveStatus = typeHeader === 'fallback' ? 404 : response.status;
+			const effectiveStatus = state.responseRouteType === 'fallback' ? 404 : response.status;
 			const fallbackDecision = computeFallbackRoute({
 				pathname: url.pathname,
 				responseStatus: effectiveStatus,

--- a/packages/astro/src/core/i18n/handler.ts
+++ b/packages/astro/src/core/i18n/handler.ts
@@ -4,6 +4,7 @@ import { I18nRouter, type I18nRouterContext } from '../../i18n/router.js';
 import { PipelineFeatures } from '../base-pipeline.js';
 import type { SSRManifest } from '../app/types.js';
 import { shouldAppendForwardSlash } from '../build/util.js';
+import { REROUTE_DIRECTIVE_HEADER, ROUTE_TYPE_HEADER } from '../constants.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 
 /**
@@ -58,14 +59,25 @@ export class I18n {
 	async finalize(state: FetchState, response: Response): Promise<Response> {
 		state.pipeline.usedFeatures |= PipelineFeatures.i18n;
 		const i18n = this.#i18n;
+		const headerRouteType = response.headers.get(ROUTE_TYPE_HEADER) as
+			| 'page'
+			| 'fallback'
+			| null;
+		if (headerRouteType) {
+			response.headers.delete(ROUTE_TYPE_HEADER);
+		}
+		const routeType = state.responseRouteType ?? headerRouteType ?? undefined;
+		const skipErrorReroute =
+			state.skipErrorReroute || response.headers.get(REROUTE_DIRECTIVE_HEADER) === 'no';
+
 		// This is a case where we are internally rendering a 404/500, so we
 		// need to bypass checks that were done already.
-		if (state.skipErrorReroute && typeof i18n.fallback === 'undefined') {
+		if (skipErrorReroute && typeof i18n.fallback === 'undefined') {
 			return response;
 		}
 
 		// If the route we're processing is not a page, then we ignore it
-		if (state.responseRouteType !== 'page' && state.responseRouteType !== 'fallback') {
+		if (routeType !== 'page' && routeType !== 'fallback') {
 			return response;
 		}
 
@@ -73,11 +85,11 @@ export class I18n {
 		const currentLocale = state.computeCurrentLocale();
 		const isPrerendered = state.routeData!.prerender;
 
-		// Build context for router (typeHeader is guaranteed to be 'page' | 'fallback' here)
+		// Build context for router (routeType is guaranteed to be 'page' | 'fallback' here)
 		const routerContext: I18nRouterContext = {
 			currentLocale,
 			currentDomain: url.hostname,
-			routeType: state.responseRouteType,
+			routeType: routeType,
 			isReroute: false,
 		};
 
@@ -129,7 +141,7 @@ export class I18n {
 			// The fallback sentinel (X-Astro-Route-Type: fallback, status 500) signals
 			// that the render pipeline couldn't find this page in the current locale.
 			// Treat it as a 404 so computeFallbackRoute will apply fallback logic.
-			const effectiveStatus = state.responseRouteType === 'fallback' ? 404 : response.status;
+			const effectiveStatus = routeType === 'fallback' ? 404 : response.status;
 			const fallbackDecision = computeFallbackRoute({
 				pathname: url.pathname,
 				responseStatus: effectiveStatus,

--- a/packages/astro/src/core/middleware/noop-middleware.ts
+++ b/packages/astro/src/core/middleware/noop-middleware.ts
@@ -1,8 +1,6 @@
 import type { MiddlewareHandler } from '../../types/public/common.js';
-import { NOOP_MIDDLEWARE_HEADER } from '../constants.js';
 
 export const NOOP_MIDDLEWARE_FN: MiddlewareHandler = async (_ctx, next) => {
 	const response = await next();
-	response.headers.set(NOOP_MIDDLEWARE_HEADER, 'true');
 	return response;
 };

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -3,13 +3,7 @@ import { renderPage } from '../../runtime/server/index.js';
 import type { APIContext } from '../../types/public/context.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 import type { Pipeline } from '../base-pipeline.js';
-import {
-	ASTRO_ERROR_HEADER,
-	REROUTE_DIRECTIVE_HEADER,
-	REWRITE_DIRECTIVE_HEADER_KEY,
-	REWRITE_DIRECTIVE_HEADER_VALUE,
-	ROUTE_TYPE_HEADER,
-} from '../constants.js';
+import { ASTRO_ERROR_HEADER, REROUTABLE_STATUS_CODES } from '../constants.js';
 import { getCookiesFromResponse } from '../cookies/response.js';
 
 // Shared empty-slots object so we don't allocate `{}` on every render for
@@ -39,6 +33,7 @@ export class PagesHandler {
 	async handle(state: FetchState, ctx: APIContext): Promise<Response> {
 		const pipeline = this.#pipeline;
 		const { logger, streaming } = pipeline;
+		state.resetResponseMetadata();
 
 		let response: Response;
 
@@ -51,6 +46,9 @@ export class PagesHandler {
 					state.routeData!.prerender,
 					logger,
 				);
+				if (REROUTABLE_STATUS_CODES.includes(response.status)) {
+					state.skipErrorReroute = true;
+				}
 				break;
 			}
 			case 'page': {
@@ -74,13 +72,10 @@ export class PagesHandler {
 				}
 
 				// Signal to the i18n middleware to maybe act on this response
-				response.headers.set(ROUTE_TYPE_HEADER, 'page');
+				state.responseRouteType = 'page';
 				// Signal to the error-page-rerouting infra to let this response pass through to avoid loops
 				if (state.routeData!.route === '/404' || state.routeData!.route === '/500') {
-					response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
-				}
-				if (state.isRewriting) {
-					response.headers.set(REWRITE_DIRECTIVE_HEADER_KEY, REWRITE_DIRECTIVE_HEADER_VALUE);
+					state.skipErrorReroute = true;
 				}
 				break;
 			}
@@ -88,7 +83,8 @@ export class PagesHandler {
 				return new Response(null, { status: 404, headers: { [ASTRO_ERROR_HEADER]: 'true' } });
 			}
 			case 'fallback': {
-				return new Response(null, { status: 500, headers: { [ROUTE_TYPE_HEADER]: 'fallback' } });
+				state.responseRouteType = 'fallback';
+				return new Response(null, { status: 500 });
 			}
 		}
 		// We need to merge the cookies from the response back into the cookies

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -3,7 +3,7 @@ import { renderPage } from '../../runtime/server/index.js';
 import type { APIContext } from '../../types/public/context.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 import type { Pipeline } from '../base-pipeline.js';
-import { ASTRO_ERROR_HEADER, REROUTABLE_STATUS_CODES } from '../constants.js';
+import { ASTRO_ERROR_HEADER } from '../constants.js';
 import { getCookiesFromResponse } from '../cookies/response.js';
 
 // Shared empty-slots object so we don't allocate `{}` on every render for
@@ -45,10 +45,8 @@ export class PagesHandler {
 					ctx,
 					state.routeData!.prerender,
 					logger,
+					state,
 				);
-				if (REROUTABLE_STATUS_CODES.includes(response.status)) {
-					state.skipErrorReroute = true;
-				}
 				break;
 			}
 			case 'page': {
@@ -56,14 +54,14 @@ export class PagesHandler {
 				const actionApiContext = state.getActionAPIContext();
 				const result = await state.createResult(componentInstance!, actionApiContext);
 				try {
-					response = await renderPage(
+				response = await renderPage(
 						result,
 						componentInstance?.default as any,
 						props,
 						state.slots ?? EMPTY_SLOTS,
 						streaming,
 						state.routeData!,
-					);
+				);
 				} catch (e) {
 					// If there is an error in the page's frontmatter or instantiation of the RenderTemplate fails midway,
 					// we signal to the rest of the internals that we can ignore the results of existing renders and avoid kicking off more of them.

--- a/packages/astro/src/core/routing/handler.ts
+++ b/packages/astro/src/core/routing/handler.ts
@@ -1,10 +1,6 @@
 import { ActionHandler } from '../../actions/handler.js';
 import type { APIContext } from '../../types/public/context.js';
-import {
-	REROUTABLE_STATUS_CODES,
-	REROUTE_DIRECTIVE_HEADER,
-	REWRITE_DIRECTIVE_HEADER_KEY,
-} from '../constants.js';
+import { REROUTABLE_STATUS_CODES } from '../constants.js';
 import { TrailingSlashHandler } from './trailing-slash-handler.js';
 import { CacheHandler, provideCache } from '../cache/handler.js';
 import { I18n } from '../i18n/handler.js';
@@ -159,13 +155,11 @@ export class AstroHandler {
 				response = await this.#cacheHandler.handle(state, runPipeline);
 			}
 
-			const isRewrite = response.headers.has(REWRITE_DIRECTIVE_HEADER_KEY);
-
 			this.#app.logThisRequest({
 				pathname,
 				method: request.method,
 				statusCode: response.status,
-				isRewrite,
+				isRewrite: state.isRewriting,
 				timeStart: state.timeStart,
 			});
 		} catch (err: any) {
@@ -186,7 +180,7 @@ export class AstroHandler {
 			// If the body isn't null, that means the user sets the 404 status
 			// but uses the current route to handle the 404
 			response.body === null &&
-			response.headers.get(REROUTE_DIRECTIVE_HEADER) !== 'no'
+			!state.skipErrorReroute
 		) {
 			return this.#app.renderError(request, {
 				...state.renderOptions,

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -7,6 +7,7 @@ import type { RoutingStrategies } from '../core/app/common.js';
 import type { SSRManifest } from '../core/app/types.js';
 import { shouldAppendForwardSlash } from '../core/build/util.js';
 import { REROUTE_DIRECTIVE_HEADER } from '../core/constants.js';
+import { getFetchStateFromAPIContext } from '../core/fetch/fetch-state.js';
 import { i18nNoLocaleFoundInPath, MissingLocale } from '../core/errors/errors-data.js';
 import { AstroError } from '../core/errors/index.js';
 import type { AstroConfig, Locales, ValidRedirectStatus } from '../types/public/config.js';
@@ -331,8 +332,15 @@ export function redirectToDefaultLocale({
 // NOTE: public function exported to the users via `astro:i18n` module
 export function notFound({ base, locales, fallback }: MiddlewarePayload) {
 	return function (context: APIContext, response?: Response): Response | undefined {
+		let fetchState;
+		try {
+			fetchState = getFetchStateFromAPIContext(context);
+		} catch {
+			// `notFound()` is public and may be called with mocked APIContext objects in tests.
+		}
+
 		if (
-			response?.headers.get(REROUTE_DIRECTIVE_HEADER) === 'no' &&
+			(response?.headers.get(REROUTE_DIRECTIVE_HEADER) === 'no' || fetchState?.skipErrorReroute) &&
 			typeof fallback === 'undefined'
 		) {
 			return response;
@@ -344,8 +352,13 @@ export function notFound({ base, locales, fallback }: MiddlewarePayload) {
 		// - the URL doesn't contain a locale
 		const isRoot = url.pathname === base + '/' || url.pathname === base;
 		if (!(isRoot || pathHasLocale(url.pathname, locales))) {
+			if (fetchState) {
+				fetchState.skipErrorReroute = true;
+			}
 			if (response) {
-				response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
+				if (!fetchState) {
+					response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
+				}
 				return new Response(response.body, {
 					status: 404,
 					headers: response.headers,
@@ -353,9 +366,7 @@ export function notFound({ base, locales, fallback }: MiddlewarePayload) {
 			} else {
 				return new Response(null, {
 					status: 404,
-					headers: {
-						[REROUTE_DIRECTIVE_HEADER]: 'no',
-					},
+					headers: fetchState ? undefined : { [REROUTE_DIRECTIVE_HEADER]: 'no' },
 				});
 			}
 		}

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -6,7 +6,6 @@ import {
 import type { RoutingStrategies } from '../core/app/common.js';
 import type { SSRManifest } from '../core/app/types.js';
 import { shouldAppendForwardSlash } from '../core/build/util.js';
-import { REROUTE_DIRECTIVE_HEADER } from '../core/constants.js';
 import { getFetchStateFromAPIContext } from '../core/fetch/fetch-state.js';
 import { i18nNoLocaleFoundInPath, MissingLocale } from '../core/errors/errors-data.js';
 import { AstroError } from '../core/errors/index.js';
@@ -332,17 +331,9 @@ export function redirectToDefaultLocale({
 // NOTE: public function exported to the users via `astro:i18n` module
 export function notFound({ base, locales, fallback }: MiddlewarePayload) {
 	return function (context: APIContext, response?: Response): Response | undefined {
-		let fetchState;
-		try {
-			fetchState = getFetchStateFromAPIContext(context);
-		} catch {
-			// `notFound()` is public and may be called with mocked APIContext objects in tests.
-		}
+		const fetchState = getFetchStateFromAPIContext(context);
 
-		if (
-			(response?.headers.get(REROUTE_DIRECTIVE_HEADER) === 'no' || fetchState?.skipErrorReroute) &&
-			typeof fallback === 'undefined'
-		) {
+		if (fetchState.skipErrorReroute && typeof fallback === 'undefined') {
 			return response;
 		}
 
@@ -352,13 +343,8 @@ export function notFound({ base, locales, fallback }: MiddlewarePayload) {
 		// - the URL doesn't contain a locale
 		const isRoot = url.pathname === base + '/' || url.pathname === base;
 		if (!(isRoot || pathHasLocale(url.pathname, locales))) {
-			if (fetchState) {
-				fetchState.skipErrorReroute = true;
-			}
+			fetchState.skipErrorReroute = true;
 			if (response) {
-				if (!fetchState) {
-					response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
-				}
 				return new Response(response.body, {
 					status: 404,
 					headers: response.headers,
@@ -366,7 +352,6 @@ export function notFound({ base, locales, fallback }: MiddlewarePayload) {
 			} else {
 				return new Response(null, {
 					status: 404,
-					headers: fetchState ? undefined : { [REROUTE_DIRECTIVE_HEADER]: 'no' },
 				});
 			}
 		}

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -1,5 +1,4 @@
 import colors from 'piccolore';
-import { REROUTABLE_STATUS_CODES, REROUTE_DIRECTIVE_HEADER } from '../../core/constants.js';
 import { AstroError } from '../../core/errors/errors.js';
 import { EndpointDidNotReturnAResponse } from '../../core/errors/errors-data.js';
 import type { AstroLogger } from '../../core/logger/core.js';
@@ -61,25 +60,6 @@ export async function renderEndpoint(
 
 	if (!response || response instanceof Response === false) {
 		throw new AstroError(EndpointDidNotReturnAResponse);
-	}
-
-	// Endpoints explicitly returning 404 or 500 response status should
-	// NOT be subject to rerouting to 404.astro or 500.astro.
-	if (REROUTABLE_STATUS_CODES.includes(response.status)) {
-		try {
-			response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
-		} catch (err) {
-			// In some cases the response may have immutable headers
-			// This is the case if, for example, the user directly returns a `fetch` response
-			// There's no clean way to check if the headers are immutable, so we just catch the error
-			// Note that response.clone() still has immutable headers!
-			if ((err as Error).message?.includes('immutable')) {
-				response = new Response(response.body, response);
-				response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
-			} else {
-				throw err;
-			}
-		}
 	}
 
 	if (method === 'HEAD') {

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -1,6 +1,8 @@
 import colors from 'piccolore';
+import { REROUTABLE_STATUS_CODES } from '../../core/constants.js';
 import { AstroError } from '../../core/errors/errors.js';
 import { EndpointDidNotReturnAResponse } from '../../core/errors/errors-data.js';
+import type { FetchState } from '../../core/fetch/fetch-state.js';
 import type { AstroLogger } from '../../core/logger/core.js';
 import type { APIRoute } from '../../types/public/common.js';
 import type { APIContext } from '../../types/public/context.js';
@@ -13,6 +15,7 @@ export async function renderEndpoint(
 	context: APIContext,
 	isPrerendered: boolean,
 	logger: AstroLogger,
+	state?: FetchState,
 ) {
 	const { request, url } = context;
 
@@ -57,9 +60,14 @@ export async function renderEndpoint(
 	}
 
 	let response = await handler.call(mod, context);
-
 	if (!response || response instanceof Response === false) {
 		throw new AstroError(EndpointDidNotReturnAResponse);
+	}
+
+	// Endpoints explicitly returning 404 or 500 response status should
+	// NOT be subject to rerouting to 404.astro or 500.astro.
+	if (state && REROUTABLE_STATUS_CODES.includes(response.status)) {
+		state.skipErrorReroute = true;
 	}
 
 	if (method === 'HEAD') {

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -274,6 +274,8 @@ describe('pages()', () => {
 		const response = await pages(state);
 
 		assert.equal(response.status, 200);
+		assert.equal(response.headers.get('x-astro-route-type'), null);
+		assert.equal(response.headers.get('x-astro-reroute'), null);
 		const text = await response.text();
 		assert.match(text, /<h1>Hello<\/h1>/);
 	});
@@ -292,6 +294,8 @@ describe('pages()', () => {
 		const response = await pages(state);
 
 		assert.equal(response.status, 404);
+		assert.equal(response.headers.get('x-astro-route-type'), null);
+		assert.equal(response.headers.get('x-astro-reroute'), null);
 		const text = await response.text();
 		assert.match(text, /<h1>Not Found<\/h1>/);
 	});
@@ -314,6 +318,8 @@ describe('pages()', () => {
 		const response = await pages(state);
 
 		assert.equal(response.status, 200);
+		assert.equal(response.headers.get('x-astro-route-type'), null);
+		assert.equal(response.headers.get('x-astro-reroute'), null);
 		assert.equal(response.headers.get('Content-Type'), 'application/json');
 		const body = await response.json();
 		assert.equal(body.ok, true);
@@ -329,6 +335,8 @@ describe('pages()', () => {
 		const response = await pages(state);
 
 		assert.equal(response.status, 404);
+		assert.equal(response.headers.get('x-astro-route-type'), null);
+		assert.equal(response.headers.get('x-astro-reroute'), null);
 	});
 });
 
@@ -363,9 +371,8 @@ describe('i18n()', () => {
 		const request = stampApp(new Request('http://example.com/about'), app);
 		const state = new FetchState(request);
 
-		const pageResponse = new Response('page body', {
-			headers: { 'X-Astro-Route-Type': 'page' },
-		});
+		state.responseRouteType = 'page';
+		const pageResponse = new Response('page body');
 		const result = await i18n(state, pageResponse);
 
 		assert.equal(result.status, 404);

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -393,9 +393,8 @@ describe('i18n()', () => {
 		const request = stampApp(new Request('http://example.com/en/about'), app);
 		const state = new FetchState(request);
 
-		const pageResponse = new Response('page body', {
-			headers: { 'X-Astro-Route-Type': 'page' },
-		});
+		state.responseRouteType = 'page';
+		const pageResponse = new Response('page body');
 		const result = await i18n(state, pageResponse);
 
 		assert.equal(result.status, 200);
@@ -417,7 +416,7 @@ describe('i18n()', () => {
 		const request = stampApp(new Request('http://example.com/api/data'), app);
 		const state = new FetchState(request);
 
-		// No X-Astro-Route-Type header — simulates an endpoint response
+		// No responseRouteType — simulates an endpoint response
 		const apiResponse = new Response('{"ok":true}');
 		const result = await i18n(state, apiResponse);
 

--- a/packages/astro/test/units/i18n/i18n-middleware.test.ts
+++ b/packages/astro/test/units/i18n/i18n-middleware.test.ts
@@ -3,13 +3,13 @@ import { beforeEach, describe, it } from 'node:test';
 import type { MiddlewareHandler } from 'astro';
 import type { RoutingStrategies } from '../../../dist/core/app/common.js';
 import type { Locales } from '../../../dist/types/public/config.js';
+import { getFetchStateFromAPIContext } from '../../../dist/core/fetch/fetch-state.js';
 import { createI18nMiddleware } from '../../../dist/i18n/middleware.js';
 import { createMockAPIContext } from '../mocks.ts';
 
 /**
  * Creates a "page" response that mimics what the render pipeline returns.
- * The `X-Astro-Route-Type: page` header is what the i18n middleware reads
- * to decide whether to apply routing logic.
+ * Route type metadata is stored on FetchState by the render pipeline.
  */
 function makePageResponse(
 	body: string,
@@ -18,14 +18,13 @@ function makePageResponse(
 ): Response {
 	return new Response(body, {
 		status,
-		headers: { 'X-Astro-Route-Type': 'page', ...extraHeaders },
+		headers: extraHeaders,
 	});
 }
 
 function makeFallbackSentinelResponse(): Response {
 	return new Response(null, {
 		status: 500,
-		headers: { 'X-Astro-Route-Type': 'fallback' },
 	});
 }
 
@@ -57,9 +56,14 @@ function makeI18nManifest(overrides: I18nManifestOverrides = {}) {
 /** Calls the handler and asserts the result is a Response (not void). */
 async function callHandler(
 	handler: MiddlewareHandler,
-	...args: Parameters<MiddlewareHandler>
+	context: Parameters<MiddlewareHandler>[0],
+	next: Parameters<MiddlewareHandler>[1],
+	routeType: 'page' | 'fallback' | null = 'page',
 ): Promise<Response> {
-	const result = await handler(...args);
+	if (routeType) {
+		getFetchStateFromAPIContext(context).responseRouteType = routeType;
+	}
+	const result = await handler(context, next);
 	assert.ok(result instanceof Response, 'expected handler to return a Response');
 	return result;
 }
@@ -213,7 +217,7 @@ describe('createI18nMiddleware', () => {
 			} as any);
 			const next = async () => makeFallbackSentinelResponse();
 
-			const result = await callHandler(handler, ctx, next);
+			const result = await callHandler(handler, ctx, next, 'fallback');
 
 			assert.equal(result.status, 200);
 			assert.match(await result.text(), /about page/);
@@ -221,7 +225,7 @@ describe('createI18nMiddleware', () => {
 	});
 
 	describe('early-return guards', () => {
-		it('passes through when X-Astro-Reroute is no and no fallback is configured', async () => {
+		it('passes through when skipErrorReroute is true and no fallback is configured', async () => {
 			const handler = createI18nMiddleware(
 				makeI18nManifest({ fallback: undefined }),
 				'/',
@@ -229,10 +233,8 @@ describe('createI18nMiddleware', () => {
 				'directory',
 			);
 			const ctx = createMockAPIContext({ url: 'http://localhost/404' });
-			const pageResponse = new Response('not found', {
-				status: 404,
-				headers: { 'X-Astro-Route-Type': 'page', 'X-Astro-Reroute': 'no' },
-			});
+			const pageResponse = new Response('not found', { status: 404 });
+			getFetchStateFromAPIContext(ctx).skipErrorReroute = true;
 
 			const result = await callHandler(handler, ctx, async () => pageResponse);
 
@@ -242,11 +244,9 @@ describe('createI18nMiddleware', () => {
 		it('passes through when route type is not page or fallback', async () => {
 			const handler = createI18nMiddleware(makeI18nManifest(), '/', 'ignore', 'directory');
 			const ctx = createMockAPIContext({ url: 'http://localhost/api/data' });
-			const endpointResponse = new Response('{"ok":true}', {
-				headers: { 'X-Astro-Route-Type': 'endpoint' },
-			});
+			const endpointResponse = new Response('{"ok":true}');
 
-			const result = await callHandler(handler, ctx, async () => endpointResponse);
+			const result = await callHandler(handler, ctx, async () => endpointResponse, null);
 
 			assert.equal(result, endpointResponse, 'should return the exact same response');
 		});

--- a/packages/astro/test/units/i18n/manual-routing.test.ts
+++ b/packages/astro/test/units/i18n/manual-routing.test.ts
@@ -9,7 +9,7 @@ import {
 	notFound,
 	redirectToFallback,
 } from '../../../dist/i18n/index.js';
-import { REROUTE_DIRECTIVE_HEADER } from '../../../dist/core/constants.js';
+import { getFetchStateFromAPIContext } from '../../../dist/core/fetch/fetch-state.js';
 import type { Locales } from '../../../dist/types/public/config.js';
 import { createManualRoutingContext, createMiddlewarePayload } from './test-helpers.ts';
 
@@ -654,7 +654,7 @@ describe('notFound', () => {
 			assert.equal(response!.status, 404);
 		});
 
-		it('should set REROUTE_DIRECTIVE_HEADER to no', () => {
+		it('should set skipErrorReroute on FetchState', () => {
 			const payload = createMiddlewarePayload({
 				base: '',
 				locales: ['en', 'es'],
@@ -664,7 +664,8 @@ describe('notFound', () => {
 
 			const response = notFoundFn(context);
 
-			assert.equal(response!.headers.get(REROUTE_DIRECTIVE_HEADER), 'no');
+			assert.equal(response!.headers.get('x-astro-reroute'), null);
+			assert.equal(getFetchStateFromAPIContext(context).skipErrorReroute, true);
 		});
 	});
 
@@ -795,7 +796,7 @@ describe('notFound', () => {
 			assert.equal(response!.status, 404);
 		});
 
-		it('should set REROUTE_DIRECTIVE_HEADER on passed Response', () => {
+		it('should set skipErrorReroute on passed Response', () => {
 			const payload = createMiddlewarePayload({
 				base: '',
 				locales: ['en', 'es'],
@@ -806,10 +807,11 @@ describe('notFound', () => {
 
 			const response = notFoundFn(context, originalResponse);
 
-			assert.equal(response!.headers.get(REROUTE_DIRECTIVE_HEADER), 'no');
+			assert.equal(response!.headers.get('x-astro-reroute'), null);
+			assert.equal(getFetchStateFromAPIContext(context).skipErrorReroute, true);
 		});
 
-		it('should return original response when REROUTE_DIRECTIVE_HEADER is no and no fallback', () => {
+		it('should return original response when skipErrorReroute is true and no fallback', () => {
 			const payload = createMiddlewarePayload({
 				base: '',
 				locales: ['en', 'es'],
@@ -817,9 +819,8 @@ describe('notFound', () => {
 			});
 			const notFoundFn = notFound(payload);
 			const context = createManualRoutingContext({ pathname: '/blog' });
-			const originalResponse = new Response('body', {
-				headers: { [REROUTE_DIRECTIVE_HEADER]: 'no' },
-			});
+			getFetchStateFromAPIContext(context).skipErrorReroute = true;
+			const originalResponse = new Response('body');
 
 			const response = notFoundFn(context, originalResponse);
 
@@ -842,7 +843,7 @@ describe('notFound', () => {
 			assert.equal(response!.status, 404);
 		});
 
-		it('should not return original response with fallback when REROUTE_DIRECTIVE_HEADER is no', () => {
+		it('should not return original response with fallback when skipErrorReroute is true', () => {
 			const payload = createMiddlewarePayload({
 				base: '',
 				locales: ['en', 'es'],
@@ -850,9 +851,8 @@ describe('notFound', () => {
 			});
 			const notFoundFn = notFound(payload);
 			const context = createManualRoutingContext({ pathname: '/blog' });
-			const originalResponse = new Response('body', {
-				headers: { [REROUTE_DIRECTIVE_HEADER]: 'no' },
-			});
+			getFetchStateFromAPIContext(context).skipErrorReroute = true;
+			const originalResponse = new Response('body');
 
 			const response = notFoundFn(context, originalResponse);
 

--- a/packages/astro/test/units/i18n/test-helpers.ts
+++ b/packages/astro/test/units/i18n/test-helpers.ts
@@ -1,6 +1,9 @@
 import type { RoutingStrategies } from '../../../dist/core/app/common.js';
 import type { Locales } from '../../../dist/types/public/config.js';
 import type { MiddlewarePayload } from '../../../dist/i18n/index.js';
+import { FetchState } from '../../../dist/core/fetch/fetch-state.js';
+import { fetchStateSymbol } from '../../../dist/core/constants.js';
+import { createBasicPipeline } from '../test-utils.ts';
 
 export function makeI18nRouterConfig({
 	strategy = 'pathname-prefix-other-locales',
@@ -81,7 +84,7 @@ export function createManualRoutingContext({
 	const request = new Request(url.toString(), { method });
 
 	// Cast to any — this is a partial mock of APIContext for unit tests
-	return {
+	const context = {
 		url,
 		request,
 		currentLocale,
@@ -92,6 +95,8 @@ export function createManualRoutingContext({
 			});
 		},
 	} as any;
+	Reflect.set(context, fetchStateSymbol, new FetchState(createBasicPipeline(), request));
+	return context;
 }
 
 export function createMiddlewarePayload({


### PR DESCRIPTION
## Changes

- Moves internal route/reroute metadata from response headers onto `FetchState`, preventing direct `pages()` responses from leaking `x-astro-route-type` or `x-astro-reroute`.
- Updates routing, i18n, endpoint, and no-op middleware handling to use state fields instead of internal response headers.

## Testing

- Updated fetch unit tests to assert direct `pages()` responses do not expose Astro internal headers.
- Verified fetch, i18n, routing, and endpoint tests.

## Docs

- No docs needed — internal metadata handling with no user-facing API changes.