### PR TITLE
Update fix-verification model to non-EOL version

### DIFF
--- a/.flue/workflows/fix-verification.ts
+++ b/.flue/workflows/fix-verification.ts
@@ -17,7 +17,7 @@ const agent = createAgent(() => ({
 			GH_TOKEN: GITHUB_TOKEN_BASE,
 		},
 	}),
-	model: 'anthropic/claude-sonnet-4-20250514',
+	model: 'anthropic/claude-sonnet-4-20250801',
 }));
 
 export async function run({ init, payload }: FlueContext) {


### PR DESCRIPTION
## Changes

- Updates the fix-verification flue workflow model from `claude-sonnet-4-20250514` (EOL) to `claude-sonnet-4-20250801`. The old model is no longer available, causing verification runs to fail.

## Testing

- No test changes — config-only update.

## Docs

- No docs needed — internal CI workflow change.