### PR TITLE
Unescape literal newlines in triage bot comments

### DIFF
--- a/.flue/workflows/issue-triage.ts
+++ b/.flue/workflows/issue-triage.ts
@@ -367,12 +367,17 @@ export async function run({ init, payload }: FlueContext) {
 		),
 	});
 
-	await postGitHubComment(issueNumber, comment);
+	// The LLM sometimes returns literal "\n" (two characters) instead of actual
+	// newlines when producing a string via a tool-call result. Unescape them so
+	// the GitHub comment renders with real line breaks.
+	const normalizedComment = comment.replace(/\\n/g, '\n');
+
+	await postGitHubComment(issueNumber, normalizedComment);
 
 	if (triageResult.reproducible) {
 		await removeGitHubLabel(issueNumber, 'needs triage');
 		const selectedLabels = await selectTriageLabels(session, {
-			comment,
+			comment: normalizedComment,
 			priorityLabels,
 			packageLabels,
 		});


### PR DESCRIPTION
## Changes

- The LLM returns literal `\n` (backslash + n) instead of actual newlines when producing a string via tool-call results. Unescapes them before posting to GitHub so comments render with real line breaks.

## Testing

- No test changes. The `.flue/` workflow code has no test harness; verified by inspecting the hex dump of the [affected comment](https://github.com/withastro/astro/issues/17101#issuecomment-3077153160) (bytes `5c 6e` instead of `0a`).

## Docs

- No docs needed — internal bot infrastructure change.