### PR TITLE
docs: fix malformed Wikipedia URL for Rosalind Franklin (rover) in 3 fixture files

### DIFF
--- a/packages/astro/e2e/fixtures/cloudflare/src/content/space/exomars.md
+++ b/packages/astro/e2e/fixtures/cloudflare/src/content/space/exomars.md
@@ -5,6 +5,6 @@ publishedDate: '2022-09-19'
 tags: [space, 2020s]
 # slug: rosalind-franklin-rover
 ---
-**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_%28rover%29)
 
 The Rosalind Franklin rover is a planned robotic Mars rover, part of the ExoMars mission led by the European Space Agency and the Russian space agency Roscosmos. The mission is scheduled to launch in September 2022, and the rover is expected to land on Mars in June 2023. The rover is named after the British biophysicist Rosalind Franklin, who made key contributions to the discovery of the structure of DNA.

--- a/packages/astro/test/fixtures/content-layer/src/content/space/exomars.md
+++ b/packages/astro/test/fixtures/content-layer/src/content/space/exomars.md
@@ -5,6 +5,6 @@ publishedDate: '2022-09-19'
 tags: [space, 2020s]
 # slug: rosalind-franklin-rover
 ---
-**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_%28rover%29)
 
 The Rosalind Franklin rover is a planned robotic Mars rover, part of the ExoMars mission led by the European Space Agency and the Russian space agency Roscosmos. The mission is scheduled to launch in September 2022, and the rover is expected to land on Mars in June 2023. The rover is named after the British biophysicist Rosalind Franklin, who made key contributions to the discovery of the structure of DNA.

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/content/space/exomars.md
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/content/space/exomars.md
@@ -5,6 +5,6 @@ publishedDate: '2022-09-19'
 tags: [space, 2020s]
 # slug: rosalind-franklin-rover
 ---
-**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_%28rover%29)
 
 The Rosalind Franklin rover is a planned robotic Mars rover, part of the ExoMars mission led by the European Space Agency and the Russian space agency Roscosmos. The mission is scheduled to launch in September 2022, and the rover is expected to land on Mars in June 2023. The rover is named after the British biophysicist Rosalind Franklin, who made key contributions to the discovery of the structure of DNA.


### PR DESCRIPTION
## Summary

Three fixture files in the `space` content collection reference a Wikipedia page for the Rosalind Franklin rover, but the markdown link ends at the first closing parenthesis, producing a malformed URL that 404s.

```markdown
**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
```

The actual URL the browser fetches is `https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover` (no close paren), which Wikipedia returns 404 for.

## Fix

Percent-encode the parentheses in the URL so the link parses correctly:

```diff
-**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_%28rover%29))
```

(The link checker flagged this as a 404 on HEAD, confirmed manually with `curl -I`.)

## Files changed

- `packages/astro/e2e/fixtures/cloudflare/src/content/space/exomars.md`
- `packages/astro/test/fixtures/content-layer/src/content/space/exomars.md`
- `packages/integrations/cloudflare/test/fixtures/vite-plugin/src/content/space/exomars.md`