### PR TITLE
Preserve `Astro.props.error` on the custom 500 page when middleware throws

### DIFF
--- a/.changeset/fix-middleware-500-error-prop.md
+++ b/.changeset/fix-middleware-500-error-prop.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes the custom `500.astro` page receiving an empty `error` prop when the error originated in middleware. While rendering the error page the error handler re-runs middleware; when that throws again it retries with middleware skipped, but the retry was dropping the original error, leaving `Astro.props.error` undefined. The error is now carried through, so the 500 page can show what failed on every path (the standard adapter and the `astro/hono` composable handlers alike).
+Fixes the custom `500.astro` page receiving an empty `error` prop when the error originated in middleware.

--- a/.changeset/fix-middleware-500-error-prop.md
+++ b/.changeset/fix-middleware-500-error-prop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the custom `500.astro` page receiving an empty `error` prop when the error originated in middleware. While rendering the error page the error handler re-runs middleware; when that throws again it retries with middleware skipped, but the retry was dropping the original error, leaving `Astro.props.error` undefined. The error is now carried through, so the 500 page can show what failed on every path (the standard adapter and the `astro/hono` composable handlers alike).

--- a/packages/astro/src/core/errors/default-handler.ts
+++ b/packages/astro/src/core/errors/default-handler.ts
@@ -123,10 +123,6 @@ export class DefaultErrorHandler implements ErrorHandler {
 					return this.renderError(request, {
 						...resolvedRenderOptions,
 						status,
-						// Preserve the original error across the skip-middleware retry so the
-						// custom 500 page still receives it via `Astro.props.error`. Without
-						// this it falls out of the spread and the error page renders blank
-						// whenever middleware is what threw.
 						error,
 						response: originalResponse,
 						skipMiddleware: true,

--- a/packages/astro/src/core/errors/default-handler.ts
+++ b/packages/astro/src/core/errors/default-handler.ts
@@ -123,6 +123,11 @@ export class DefaultErrorHandler implements ErrorHandler {
 					return this.renderError(request, {
 						...resolvedRenderOptions,
 						status,
+						// Preserve the original error across the skip-middleware retry so the
+						// custom 500 page still receives it via `Astro.props.error`. Without
+						// this it falls out of the spread and the error page renders blank
+						// whenever middleware is what threw.
+						error,
 						response: originalResponse,
 						skipMiddleware: true,
 						pathname: resolvedPathname,

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -284,6 +284,35 @@ describe('middleware()', () => {
 		assert.match(text, /<h1>my custom 500<\/h1>/);
 	});
 
+	it('passes the thrown error to the custom 500 page when user middleware throws', async () => {
+		// Rendering the 500 page re-runs the middleware chain, which throws again,
+		// so the error handler retries with middleware skipped. That retry must
+		// still carry the original error through to `Astro.props.error`.
+		const errorPage = createComponent((_result: any, props: any, _slots: any) => {
+			const err = props.error;
+			const message = err instanceof Error ? err.message : String(err ?? '');
+			return render`<h1>my custom 500</h1><pre>${message}</pre>`;
+		});
+		const app = createTestApp(
+			[createPage(simplePage, { route: '/' }), createPage(errorPage, { route: '/500' })],
+			{
+				middleware: async () => ({
+					onRequest: async () => {
+						throw new Error('boom from middleware');
+					},
+				}),
+			},
+		);
+		const request = stampApp(new Request('http://example.com/'), app);
+		const state = new FetchState(request);
+
+		const response = await middleware(state, async () => new Response('page'));
+
+		assert.equal(response.status, 500);
+		const text = await response.text();
+		assert.match(text, /boom from middleware/);
+	});
+
 	it('re-throws errors from the next callback instead of rendering the 500 page', async () => {
 		// A throw from `next` originates downstream of Astro's middleware (the
 		// host framework's chain), so it must propagate to the host's own error

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -285,9 +285,6 @@ describe('middleware()', () => {
 	});
 
 	it('passes the thrown error to the custom 500 page when user middleware throws', async () => {
-		// Rendering the 500 page re-runs the middleware chain, which throws again,
-		// so the error handler retries with middleware skipped. That retry must
-		// still carry the original error through to `Astro.props.error`.
 		const errorPage = createComponent((_result: any, props: any, _slots: any) => {
 			const err = props.error;
 			const message = err instanceof Error ? err.message : String(err ?? '');


### PR DESCRIPTION
## Changes

Follow-up to #17041 and #17097. The #17097 description flagged one item as out of scope: on the composable `astro/hono` path the custom `500.astro` rendered with an empty `error` prop, so `Astro.props.error` was undefined and the page could not show what threw. It turns out this is not specific to `astro/hono`, and not a middleware-handler issue. It lives in the production error handler and affects the standard adapter as well.

When middleware throws, the path's catch calls `app.renderError(..., { error })`. `DefaultErrorHandler.renderError` then renders the matching `500.astro` by running the middleware chain again (so middleware can still set headers, locals, etc. on the error page). The error state reuses the original request, so the same user middleware runs again and throws again. The handler catches that and retries with `skipMiddleware: true` ("middleware may be the cause of the error"), but the retry object dropped the original `error`. It fell out of the spread and reached the error page as `undefined`.

The result: any path that rendered a custom 500 for a middleware-thrown error lost `Astro.props.error` (the standard `@astrojs/node` adapter, the all-in-one `astro()` handler, and the composable `middleware()`). Page-render errors via `pages()` were unaffected, because the middleware does not re-throw on the error render, so the first attempt succeeds with the error intact. The dev error handler was also unaffected; it already forwards an error on its retry.

The fix carries the original error through the skip-middleware retry (one line in `packages/astro/src/core/errors/default-handler.ts`). `BuildErrorHandler` delegates to `DefaultErrorHandler`, so prerendered error pages pick up the same fix.

## Testing

- Added a unit test in `test/units/fetch/index.test.ts` (the `middleware()` block): user middleware throws and the custom `/500` page echoes `Astro.props.error`, asserting the thrown message reaches the page. It fails before the change (the error page renders blank) and passes after. The full unit suite stays green (2942 passing, 3 skipped).
- Verified end to end against the #17092 reproduction (Hono, `app.use(middleware())` + `app.use(pages())`, node standalone, a `500.astro` that prints `Astro.props.error`):
  - `GET /boom` (middleware throws) now renders `500.astro` with the message `boom from middleware`, previously blank.
  - `GET /page-throws` still renders `500.astro` with its message (no regression).
  - `GET /does-not-exist` still renders the custom `404`, and `GET /` still returns `200`.

## Notes

- The retry passes the original error (the cause of the 500), which is what every non-retry path already passes. The dev handler instead forwards the re-thrown error on its retry; aligning the two is cosmetic and left out of this change.
- The deliberate "no error to report" reroute paths (the status-code 404/500 reroutes that pass `error: null`/`undefined`) are unchanged.
