### PR TITLE
Fix fix-verification workflow model ID

### DIFF
--- a/.flue/workflows/fix-verification.ts
+++ b/.flue/workflows/fix-verification.ts
@@ -17,7 +17,7 @@ const agent = createAgent(() => ({
 			GH_TOKEN: GITHUB_TOKEN_BASE,
 		},
 	}),
-	model: 'anthropic/claude-sonnet-4-20250801',
+	model: 'anthropic/claude-sonnet-4-6',
 }));
 
 export async function run({ init, payload }: FlueContext) {


### PR DESCRIPTION
## Changes

- Updates the fix-verification flue workflow model from `claude-sonnet-4-20250801` (which does not exist) to `claude-sonnet-4-6` (Claude Sonnet 4.6, the current production Sonnet). The previous model `claude-sonnet-4-20250514` was deprecated, and #17100 attempted to update it but used a non-existent model ID.

## Testing

- No test changes. The fix-verification workflow runs in CI via the Fix Verify GitHub Action — a successful run confirms the model resolves correctly.

## Docs

- No docs needed; internal CI workflow change only.