### PR TITLE
Fix `public/_redirects` stranded under base path in Cloudflare adapter

### DIFF
--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -501,7 +501,7 @@ export default function createIntegration({
 				// Move platform files from the base-prefixed client dir to the
 				// original client root, since Cloudflare reads them from there.
 				if (_config.base !== '/') {
-					for (const file of ['.assetsignore', '_headers']) {
+					for (const file of ['.assetsignore', '_headers', '_redirects']) {
 						try {
 							await rename(
 								new URL(`./${file}`, _config.build.client),

--- a/packages/integrations/cloudflare/test/fixtures/with-base/public/_redirects
+++ b/packages/integrations/cloudflare/test/fixtures/with-base/public/_redirects
@@ -1,0 +1,1 @@
+/external/old /external/new 301

--- a/packages/integrations/cloudflare/test/with-base.test.ts
+++ b/packages/integrations/cloudflare/test/with-base.test.ts
@@ -75,6 +75,18 @@ describe('base', () => {
 		);
 	});
 
+	it('keeps _redirects at the client root', async () => {
+		assert.ok(
+			fixture.pathExists('client/_redirects'),
+			'_redirects should be at client/_redirects (not under base)',
+		);
+	});
+
+	it('preserves user-defined redirects from public/_redirects', async () => {
+		const content = await fixture.readFile('client/_redirects');
+		assert.match(content, /\/external\/old\s+\/external\/new\s+301/);
+	});
+
 	it('injects cache headers for assets with base prefix', async () => {
 		const content = await fixture.readFile('client/_headers');
 		assert.match(content, /\/blog\/_astro\/\*/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4291,6 +4291,15 @@ importers:
         specifier: ^4.83.0
         version: 4.95.0(@cloudflare/workers-types@4.20260527.1)
 
+  packages/integrations/cloudflare/test/fixtures/base-redirects:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/cloudflare/test/fixtures/binding-image-service:
     dependencies:
       '@astrojs/cloudflare':


### PR DESCRIPTION
## Changes

- When a non-root `base` is set, the Cloudflare adapter now relocates `public/_redirects` to the assets root (`dist/client/_redirects`) alongside `.assetsignore` and `_headers`. Previously, the file was left at `dist/client/<base>/_redirects` where Cloudflare Workers Assets can't find it, silently dropping all user-defined redirects in production.
- Because relocation happens before the auto-generated-redirects step, user-defined rules land at the root first and any route-derived redirects are correctly appended afterward.

## Testing

- Added two test cases to `with-base.test.ts`: one verifying `_redirects` exists at the client root (not nested under the base path), and one verifying user-defined redirect content from `public/_redirects` is preserved after build.
- Added `public/_redirects` to the `with-base` fixture.

## Docs

- No docs update needed; this is a bug fix restoring behavior consistent with the default `base: '/'` case.

Closes #17101