### PR TITLE
Fix `extendMarkdownConfig: false` not preventing MDX from inheriting the global `markdown.processor`

### DIFF
--- a/.changeset/proud-cougars-matter.md
+++ b/.changeset/proud-cougars-matter.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fixes a bug where `extendMarkdownConfig: false` did not prevent MDX from inheriting the global `markdown.processor`. MDX now correctly uses a fresh default processor with no plugins when `extendMarkdownConfig` is disabled.

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -12,6 +12,7 @@ import type {
 	HookParameters,
 } from 'astro';
 import type { MarkdownProcessor } from 'astro/markdown';
+import { unified } from '@astrojs/markdown-remark';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import type { PluggableList } from 'unified';
 import { isSatteriProcessor, isUnifiedProcessor } from './processor-guards.js';
@@ -137,7 +138,9 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 					defaults: markdownConfigToMdxOptions(markdownConfig, logger),
 				});
 
-				const processor = partialMdxOptions.processor ?? config.markdown.processor;
+				const processor =
+					partialMdxOptions.processor ??
+					(extendMarkdownConfig ? config.markdown.processor : unified());
 
 				if (extendMarkdownConfig && isUnifiedProcessor(processor)) {
 					// MDX inherits from the processor only when the user did NOT pass that option

--- a/packages/integrations/mdx/test/mdx-plugins.test.ts
+++ b/packages/integrations/mdx/test/mdx-plugins.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import mdx from '@astrojs/mdx';
+import { unified } from '@astrojs/markdown-remark';
 import { parseHTML } from 'linkedom';
 import remarkToc from 'remark-toc';
 import {
@@ -131,6 +132,30 @@ describe('MDX plugins - Astro config integration', () => {
 			});
 		});
 	}
+
+	it('does not inherit global processor when extendMarkdownConfig is false', async () => {
+		const fixture = await buildFixture({
+			outDir: './dist/mdx-plugins-no-inherit-processor/',
+			markdown: {
+				processor: unified({
+					rehypePlugins: [rehypeExamplePlugin],
+				}),
+			},
+			integrations: [
+				mdx({
+					extendMarkdownConfig: false,
+				}),
+			],
+		});
+		const html = await fixture.readFile(FILE);
+		const { document } = parseHTML(html);
+
+		assert.equal(
+			selectRehypeExample(document),
+			null,
+			'Global processor rehype plugin should not be applied to MDX when extendMarkdownConfig is false.',
+		);
+	});
 });
 
 async function buildFixture(config: AstroInlineConfig = {}): Promise<Fixture> {


### PR DESCRIPTION
## Changes

- When `extendMarkdownConfig: false` is set on the MDX integration, MDX now correctly uses a fresh `unified()` processor with no plugins, matching the documented behavior. Previously, the processor fallback (`partialMdxOptions.processor ?? config.markdown.processor`) was not gated on `extendMarkdownConfig`, so processor-level plugins (e.g. `hastPlugins` from `satteri()`) leaked into MDX files even when the flag was explicitly disabled.
- The fix is a one-line change in the `astro:config:done` hook in `packages/integrations/mdx/src/index.ts`: the fallback now resolves to `unified()` instead of `config.markdown.processor` when `extendMarkdownConfig` is `false`.

Closes #17030

## Testing

- Added `'does not inherit global processor when extendMarkdownConfig is false'` in `packages/integrations/mdx/test/mdx-plugins.test.ts`. It builds a fixture with a global `markdown.processor` carrying a rehype plugin and asserts that the plugin is not applied to MDX output when `extendMarkdownConfig: false`.

## Docs

- No docs update needed — this fix brings the implementation in line with what the existing [Markdown guide](https://docs.astro.build/en/guides/markdown-content/#extending-markdown-config-from-mdx) already documents.
