### PR TITLE
fix: allow valid encoded reserved pathnames

### DIFF
--- a/.changeset/fair-paths-decode.md
+++ b/.changeset/fair-paths-decode.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix false-positive pathname rejection for valid encoded reserved characters.

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -13,6 +13,7 @@ import {
 	trimSlashes,
 } from '../path.js';
 import { createRequest } from '../request.js';
+import { validateAndDecodePathname } from '../util/pathname.js';
 import { DEFAULT_404_ROUTE } from './astro-designed-error-pages.js';
 
 type FindRouteToRewrite = {
@@ -98,7 +99,7 @@ export function findRouteToRewrite({
 		newUrl.pathname = joinPaths(...[base, pathname].filter(Boolean));
 	}
 
-	const decodedPathname = decodeURI(pathname);
+	const decodedPathname = validateAndDecodePathname(pathname);
 	let foundRoute;
 	for (const route of routes) {
 		if (route.pattern.test(decodedPathname)) {

--- a/packages/astro/src/core/util/pathname.ts
+++ b/packages/astro/src/core/util/pathname.ts
@@ -1,31 +1,30 @@
+const MAX_DECODE_ITERATIONS = 10;
+
 /**
- * Validates that a pathname is not multi-level encoded.
- * Detects if a pathname contains encoding that was encoded again (e.g., %2561dmin where %25 decodes to %).
- * This prevents double/triple encoding bypasses of security checks.
+ * Decodes a pathname to its canonical form.
+ * This prevents middleware/routing mismatches caused by partially decoded paths.
  *
  * @param pathname - The pathname to validate
- * @returns The decoded pathname if valid
- * @throws Error if multi-level encoding is detected
+ * @returns The canonical decoded pathname
+ * @throws Error if the pathname has invalid encoding or too many levels of encoding
  */
 export function validateAndDecodePathname(pathname: string): string {
-	let decoded: string;
+	let decoded = pathname;
 
-	try {
-		decoded = decodeURI(pathname);
-	} catch (_e) {
-		throw new Error('Invalid URL encoding');
+	for (let i = 0; i < MAX_DECODE_ITERATIONS; i++) {
+		let next: string;
+		try {
+			next = decodeURI(decoded);
+		} catch (_e) {
+			throw new Error('Invalid URL encoding');
+		}
+
+		if (next === decoded) {
+			return decoded;
+		}
+
+		decoded = next;
 	}
 
-	// Check if the decoded path is different from the original
-	// AND still contains URL-encoded sequences.
-	// This indicates the original had encoding that got partially decoded, suggesting double encoding.
-	// Example: /%2561dmin -> decodeURI -> /%61dmin (different AND still has %)
-	const hasDecoding = decoded !== pathname;
-	const decodedStillHasEncoding = /%[0-9a-fA-F]{2}/.test(decoded);
-
-	if (hasDecoding && decodedStillHasEncoding) {
-		throw new Error('Multi-level URL encoding is not allowed');
-	}
-
-	return decoded;
+	throw new Error('Multi-level URL encoding is not allowed');
 }

--- a/packages/astro/test/fixtures/middleware space/src/pages/encoded/[name].astro
+++ b/packages/astro/test/fixtures/middleware space/src/pages/encoded/[name].astro
@@ -1,0 +1,12 @@
+---
+export const prerender = false;
+---
+
+<html>
+<head>
+	<title>Encoded path</title>
+</head>
+<body>
+	<p>This page accepts encoded reserved characters in its path</p>
+</body>
+</html>

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -113,18 +113,25 @@ describe('Middleware in DEV mode', () => {
 			assert.equal(res.headers.get('location'), '/');
 		});
 
-		it('should reject double-encoded paths with 404', async () => {
+		it('should NOT allow accessing /admin with double encoding', async () => {
 			const res = await fixture.fetch('/%2561dmin', { redirect: 'manual' });
-			assert.equal(res.status, 404);
+			assert.equal(res.status, 302);
+			assert.equal(res.headers.get('location'), '/');
 		});
 
-		it('should reject triple-encoded paths with 404', async () => {
+		it('should NOT allow accessing /admin with triple encoding', async () => {
 			const res = await fixture.fetch('/%252561dmin', { redirect: 'manual' });
-			assert.equal(res.status, 404);
+			assert.equal(res.status, 302);
+			assert.equal(res.headers.get('location'), '/');
 		});
 
 		it('should allow legitimate single-encoded paths like /path%20with%20spaces', async () => {
 			const res = await fixture.fetch('/path%20with%20spaces');
+			assert.equal(res.status, 200);
+		});
+
+		it('should allow encoded reserved characters after decoded path characters', async () => {
+			const res = await fixture.fetch('/encoded/foo%20%26bar');
 			assert.equal(res.status, 200);
 		});
 	});
@@ -399,16 +406,22 @@ describe('Middleware API in PROD mode, SSR', () => {
 			assert.equal(response.status, 302);
 		});
 
-		it('should reject double-encoded paths with 404', async () => {
+		it('should NOT allow accessing /admin with double encoding', async () => {
 			const request = new Request('http://example.com/%2561dmin');
 			const response = await app.render(request);
-			assert.equal(response.status, 404);
+			assert.equal(response.status, 302);
 		});
 
-		it('should reject triple-encoded paths with 404', async () => {
+		it('should NOT allow accessing /admin with triple encoding', async () => {
 			const request = new Request('http://example.com/%252561dmin');
 			const response = await app.render(request);
-			assert.equal(response.status, 404);
+			assert.equal(response.status, 302);
+		});
+
+		it('should allow encoded reserved characters after decoded path characters', async () => {
+			const request = new Request('http://example.com/encoded/foo%20%26bar');
+			const response = await app.render(request);
+			assert.equal(response.status, 200);
 		});
 	});
 

--- a/packages/astro/test/units/util/validate-and-decode-pathname.test.js
+++ b/packages/astro/test/units/util/validate-and-decode-pathname.test.js
@@ -1,0 +1,27 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { validateAndDecodePathname } from '../../../dist/core/util/pathname.js';
+
+describe('validateAndDecodePathname', () => {
+	it('allows encoded reserved characters after decoded path characters', () => {
+		assert.equal(validateAndDecodePathname('/foo%20%26bar'), '/foo %26bar');
+		assert.equal(validateAndDecodePathname('/docs/a%20%26b'), '/docs/a %26b');
+	});
+
+	it('keeps existing single-level encoded pathname behavior', () => {
+		assert.equal(validateAndDecodePathname('/foo%20bar'), '/foo bar');
+		assert.equal(validateAndDecodePathname('/foo%26bar'), '/foo%26bar');
+		assert.equal(validateAndDecodePathname('/foo%3Fbar'), '/foo%3Fbar');
+	});
+
+	it('rejects invalid URL encoding', () => {
+		assert.throws(() => validateAndDecodePathname('/foo%'), /Invalid URL encoding/);
+		assert.throws(() => validateAndDecodePathname('/foo%2'), /Invalid URL encoding/);
+		assert.throws(() => validateAndDecodePathname('/foo%ZZ'), /Invalid URL encoding/);
+	});
+
+	it('canonicalizes multi-level encoded pathnames', () => {
+		assert.equal(validateAndDecodePathname('/api/%2561dmin'), '/api/admin');
+		assert.equal(validateAndDecodePathname('/%252e%252e/secret'), '/../secret');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a false-positive pathname validation failure in Astro 5 where valid encoded paths containing both decoded characters and encoded reserved URI characters could fail before route matching.

For example, `/foo%20%26bar` is valid: `decodeURI()` decodes `%20` to a space but intentionally leaves `%26` encoded because `&` is reserved. Astro 5 treated the remaining `%26` as multi-level encoding and returned 404 before a matching route could render.

## Changes

- Canonicalizes pathnames by repeatedly applying `decodeURI()` until stable with a bounded iteration limit.
- Reuses the shared pathname canonicalization for rewrite route matching.
- Adds unit coverage for encoded reserved characters, invalid encodings, and multi-level encoded paths.
- Adds middleware coverage showing `/encoded/foo%20%26bar` routes successfully while encoded `/admin` aliases are still blocked by auth middleware.
- Adds a patch changeset for `astro`.

## Testing

- `pnpm --filter astro build:ci`
- `cd packages/astro && node --test test/units/util/validate-and-decode-pathname.test.js`
- `cd packages/astro && node --test test/middleware.test.js`
- `cd packages/astro && pnpm run test:unit`
- `cd packages/astro && pnpm run test:match "test/middleware.test.js"`