### PR TITLE
Fix astro:build:generated not firing for pure-SSR builds with no prerendered pages

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -56,6 +56,11 @@ export async function generatePages(
 	// Exit early when no prerendered pages were discovered to avoid setting up
 	// and tearing down the prerenderer for an empty set of routes.
 	if (!hasPagesToGenerate) {
+		await runHookBuildGenerated({
+			settings: options.settings,
+			logger,
+			routeToHeaders: new Map(),
+		});
 		return;
 	}
 

--- a/packages/astro/test/fixtures/ssr-build-generated/package.json
+++ b/packages/astro/test/fixtures/ssr-build-generated/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@test/ssr-build-generated",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"astro": "workspace:*"
+	}
+}

--- a/packages/astro/test/fixtures/ssr-build-generated/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-build-generated/src/pages/index.astro
@@ -1,0 +1,4 @@
+---
+// Pure SSR page - no prerender
+---
+<html><body><h1>Hello SSR</h1></body></html>

--- a/packages/astro/test/ssr-build-generated.test.ts
+++ b/packages/astro/test/ssr-build-generated.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.ts';
+import { loadFixture } from './test-utils.ts';
+
+describe('astro:build:generated fires for pure-SSR builds', () => {
+	let buildGeneratedFired = false;
+
+	before(async () => {
+		const fixture = await loadFixture({
+			root: './fixtures/ssr-build-generated/',
+			output: 'server',
+			adapter: testAdapter(),
+			integrations: [
+				{
+					name: 'test-build-generated',
+					hooks: {
+						'astro:build:generated': () => {
+							buildGeneratedFired = true;
+						},
+					},
+				},
+			],
+		});
+		await fixture.build();
+	});
+
+	it('should fire astro:build:generated even with zero prerendered pages', () => {
+		assert.equal(buildGeneratedFired, true, 'astro:build:generated should have fired');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3881,6 +3881,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/ssr-build-generated:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/ssr-dynamic:
     dependencies:
       astro:
@@ -4296,15 +4302,6 @@ importers:
       wrangler:
         specifier: ^4.83.0
         version: 4.95.0(@cloudflare/workers-types@4.20260527.1)
-
-  packages/integrations/cloudflare/test/fixtures/base-redirects:
-    dependencies:
-      '@astrojs/cloudflare':
-        specifier: workspace:*
-        version: link:../../..
-      astro:
-        specifier: workspace:*
-        version: link:../../../../../astro
 
   packages/integrations/cloudflare/test/fixtures/binding-image-service:
     dependencies:


### PR DESCRIPTION
## Changes

- `astro:build:generated` now fires for `output: 'server'` builds that have zero prerendered pages, restoring Astro 5 behavior.
- The regression was introduced in PR #15077 (`a164c77336`), which added an early return in `generatePages()` when `!hasPagesToGenerate` to skip prerenderer setup. That early return sat before the `runHookBuildGenerated()` call, silently skipping the hook for all pure-SSR builds. The fix calls `runHookBuildGenerated()` with an empty `routeToHeaders` map before the early return, preserving the optimization while restoring the hook contract.

## Testing

- New fixture at `packages/astro/test/fixtures/ssr-build-generated/` — `output: 'server'` project with a single SSR page and a test integration that records whether `astro:build:generated` fired.
- New test `packages/astro/test/ssr-build-generated.test.ts` — asserts the hook fires for a pure-SSR build with zero prerendered pages.

## Docs

No docs update needed — this restores existing documented behavior; the hook contract is unchanged.

Closes #17112