### PR TITLE
Generate default AGENTS.md in new projects

### DIFF
--- a/.changeset/eleven-mice-wink.md
+++ b/.changeset/eleven-mice-wink.md
@@ -1,0 +1,5 @@
+---
+'create-astro': minor
+---
+
+Adds a default `AGENTS.md` file to new projects with dev server instructions and documentation links. Also creates a `CLAUDE.md` symlink (with hard link fallback) pointing to `AGENTS.md`.

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -106,7 +106,7 @@ const FILES_TO_UPDATE = {
 };
 
 export function generateAgentsMd(): string {
-	return `# Development
+	return `## Development
 
 Start the dev server in background mode:
 

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -120,12 +120,14 @@ Manage the background server with \`astro dev stop\`, \`astro dev status\`, and 
 
 Full documentation: https://docs.astro.build
 
-Commonly needed references:
+Consult these guides before working on related tasks:
 
-- [Routing](https://docs.astro.build/en/guides/routing/)
-- [Astro Components](https://docs.astro.build/en/basics/astro-components/)
-- [Content Collections](https://docs.astro.build/en/guides/content-collections/)
-- [Internationalization](https://docs.astro.build/en/guides/internationalization/)
+- [Adding pages, dynamic routes, or middleware](https://docs.astro.build/en/guides/routing/)
+- [Working with Astro components](https://docs.astro.build/en/basics/astro-components/)
+- [Using React, Vue, Svelte, or other framework components](https://docs.astro.build/en/guides/framework-components/)
+- [Adding or managing content](https://docs.astro.build/en/guides/content-collections/)
+- [Adding styles or using Tailwind](https://docs.astro.build/en/guides/styling/)
+- [Supporting multiple languages](https://docs.astro.build/en/guides/internationalization/)
 `;
 }
 

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -105,6 +105,30 @@ const FILES_TO_UPDATE = {
 		}),
 };
 
+export function generateAgentsMd(): string {
+	return `# Development
+
+Start the dev server in background mode:
+
+\`\`\`
+astro dev --background
+\`\`\`
+
+Manage the background server with \`astro dev stop\`, \`astro dev status\`, and \`astro dev logs\`.
+
+# Documentation
+
+Full documentation: https://docs.astro.build
+
+Commonly needed references:
+
+- [Routing](https://docs.astro.build/en/guides/routing/)
+- [Astro Components](https://docs.astro.build/en/basics/astro-components/)
+- [Content Collections](https://docs.astro.build/en/guides/content-collections/)
+- [Internationalization](https://docs.astro.build/en/guides/internationalization/)
+`;
+}
+
 export function getTemplateTarget(tmpl: string, ref = 'latest') {
 	// Handle Starlight templates
 	if (tmpl === 'starlight' || tmpl.startsWith('starlight/')) {
@@ -183,6 +207,20 @@ async function copyTemplate(tmpl: string, ctx: Context) {
 				}
 			} catch {}
 			throw new Error(`Unable to download template ${color.reset(tmpl)}`);
+		}
+
+		// Generate AGENTS.md for AI coding agents, with a CLAUDE.md link
+		const agentsPath = path.resolve(ctx.cwd, 'AGENTS.md');
+		const claudePath = path.resolve(ctx.cwd, 'CLAUDE.md');
+		fs.writeFileSync(agentsPath, generateAgentsMd());
+		try {
+			fs.symlinkSync('AGENTS.md', claudePath);
+		} catch {
+			try {
+				fs.linkSync(agentsPath, claudePath);
+			} catch {
+				// Link creation failed; AGENTS.md still exists
+			}
 		}
 
 		// Post-process in parallel

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -108,7 +108,7 @@ const FILES_TO_UPDATE = {
 export function generateAgentsMd(): string {
 	return `## Development
 
-Start the dev server in background mode:
+When starting the dev server, use background mode:
 
 \`\`\`
 astro dev --background

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -116,7 +116,7 @@ astro dev --background
 
 Manage the background server with \`astro dev stop\`, \`astro dev status\`, and \`astro dev logs\`.
 
-# Documentation
+## Documentation
 
 Full documentation: https://docs.astro.build
 

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -9,7 +9,11 @@ import { projectName } from './actions/project-name.js';
 import { template } from './actions/template.js';
 import { verify } from './actions/verify.js';
 
-export { processTemplateReadme, removeTemplateMarkerSections } from './actions/template.js';
+export {
+	generateAgentsMd,
+	processTemplateReadme,
+	removeTemplateMarkerSections,
+} from './actions/template.js';
 export { setStdout } from './messages.js';
 
 const exit = () => process.exit(0);

--- a/packages/create-astro/test/template-processing.test.ts
+++ b/packages/create-astro/test/template-processing.test.ts
@@ -1,6 +1,25 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { processTemplateReadme, removeTemplateMarkerSections } from '../dist/index.js';
+import {
+	generateAgentsMd,
+	processTemplateReadme,
+	removeTemplateMarkerSections,
+} from '../dist/index.js';
+
+describe('generateAgentsMd', async () => {
+	it('includes background dev command', async () => {
+		const result = generateAgentsMd();
+		assert.ok(result.includes('astro dev --background'));
+	});
+
+	it('includes documentation links', async () => {
+		const result = generateAgentsMd();
+		assert.ok(result.includes('https://docs.astro.build/en/guides/routing/'));
+		assert.ok(result.includes('https://docs.astro.build/en/basics/astro-components/'));
+		assert.ok(result.includes('https://docs.astro.build/en/guides/content-collections/'));
+		assert.ok(result.includes('https://docs.astro.build/en/guides/internationalization/'));
+	});
+});
 
 describe('removeTemplateMarkerSections', async () => {
 	it('removes HTML template marker sections', async () => {

--- a/packages/create-astro/test/template-processing.test.ts
+++ b/packages/create-astro/test/template-processing.test.ts
@@ -16,7 +16,9 @@ describe('generateAgentsMd', async () => {
 		const result = generateAgentsMd();
 		assert.ok(result.includes('https://docs.astro.build/en/guides/routing/'));
 		assert.ok(result.includes('https://docs.astro.build/en/basics/astro-components/'));
+		assert.ok(result.includes('https://docs.astro.build/en/guides/framework-components/'));
 		assert.ok(result.includes('https://docs.astro.build/en/guides/content-collections/'));
+		assert.ok(result.includes('https://docs.astro.build/en/guides/styling/'));
 		assert.ok(result.includes('https://docs.astro.build/en/guides/internationalization/'));
 	});
 });


### PR DESCRIPTION
## Changes

- `create-astro` now generates an `AGENTS.md` in new projects with dev server background mode instructions and links to commonly needed Astro docs.
- Creates a `CLAUDE.md` symlink pointing to `AGENTS.md`, with a hard link fallback for Windows environments without Developer Mode.

## Testing

- Added `generateAgentsMd` tests verifying the background dev command and documentation links are present.

## Docs

- No docs update needed. This is a scaffolding change that generates a file for AI coding agents, not a user-facing API.