### PR TITLE
fix(ci): keep turbo exclusion filters absolute in affected test runs

### DIFF
--- a/scripts/turbo-run-affected.js
+++ b/scripts/turbo-run-affected.js
@@ -17,6 +17,12 @@ const hasRange = (value) => /\[[^\]]+\]/.test(value);
 const formatFilter = (value) => {
 	if (!range || hasRange(value)) return value;
 
+	// Exclusion filters must stay absolute. Scoping them to the changed range
+	// (e.g. `!./packages/language-tools/**/*[base...HEAD]`) only excludes packages
+	// that themselves changed, so an excluded package still gets selected when it is
+	// affected by an upstream change. Pass exclusions through unchanged.
+	if (value.startsWith('!')) return value;
+
 	// Turbo needs directory filters wrapped in braces before appending [range].
 	// Example: ./packages/astro -> {./packages/astro}[origin/main...HEAD]
 	const isDirectoryFilter = value.startsWith('.') || value.startsWith('/');


### PR DESCRIPTION
## Changes

- `scripts/turbo-run-affected.js` appended the changed-file range `[origin/<base>...HEAD]` to **every** `--filter`, including exclusions like `!./packages/language-tools/**/*`. That scoped the exclusion to packages that *themselves* changed (and skipped the `{…}` directory wrapping it applies to normal directory filters), so the exclusion stopped applying.
- As a result, an excluded package was still selected when *affected* by an upstream change: `@astrojs/ts-plugin` (affected whenever `astro` changes) got pulled into the `test:integrations` suite, which has no `xvfb`, so its VS Code test segfaults. It normally hides behind a turbo cache hit and only surfaces on a cold cache (e.g. a PR that touches `pnpm-lock.yaml`).
- Fix: pass exclusion filters (`!…`) through unchanged so they stay absolute. The ts-plugin/VS Code tests then run only in the dedicated `test-language-tools` job (which sets up `xvfb` and already marks them non-failing).
- No changeset: this only touches CI scripting, with no changes to any published package.

## Testing

Verified with `turbo run test … --dry=json` (planning only, no tests executed), using the `stabilise-cache` range — a real case where `astro` changed but no language-tools package did, which is what triggers the bug:

- **Inclusion only** — `--filter="@astrojs/*[origin/main...origin/stabilise-cache]"` selects `@astrojs/ts-plugin` and `@astrojs/language-server` (affected via their dependency on `astro`).
- **Old behavior** — adding the range-scoped exclusion `--filter="!./packages/language-tools/**/*[origin/main...origin/stabilise-cache]"` (what the script produced before): ts-plugin and language-server are **still selected**. ❌
- **Fixed behavior** — adding the absolute exclusion `--filter="!./packages/language-tools/**/*"` (what the script produces now): ts-plugin and language-server are **excluded**. ✅

So `test:integrations` no longer pulls in language-tools packages, and the ts-plugin/VS Code tests run only in the dedicated `test-language-tools` job.

## Docs

No docs needed: this is internal CI tooling with no user-facing behavior change.