### PR TITLE
docs(logger): correct logHandlers @example to use top-level logger option

### DIFF
--- a/packages/astro/src/core/logger/handlers.ts
+++ b/packages/astro/src/core/logger/handlers.ts
@@ -9,9 +9,7 @@ export const logHandlers = {
 	 * @example
 	 * ```js
 	 * export default defineConfig({
-	 *   experimental: {
-	 *     logger: logHandlers.json({ pretty: true })
-	 *   }
+	 *   logger: logHandlers.json({ pretty: true })
 	 * })
 	 * ```
 	 */
@@ -27,9 +25,7 @@ export const logHandlers = {
 	 * @example
 	 * ```js
 	 * export default defineConfig({
-	 *   experimental: {
-	 *     logger: logHandlers.node({ pretty: true })
-	 *   }
+	 *   logger: logHandlers.node({ pretty: true })
 	 * })
 	 * ```
 	 */
@@ -45,9 +41,7 @@ export const logHandlers = {
 	 * @example
 	 * ```js
 	 * export default defineConfig({
-	 *   experimental: {
-	 *     logger: logHandlers.console({ pretty: true })
-	 *   }
+	 *   logger: logHandlers.console({ pretty: true })
 	 * })
 	 * ```
 	 */
@@ -64,12 +58,10 @@ export const logHandlers = {
 	 * @example
 	 * ```js
 	 * export default defineConfig({
-	 *   experimental: {
-	 *     logger: logHandlers.compose(
-	 *       logHandlers.console(),
-	 *       logHandlers.json(),
-	 *     )
-	 *   }
+	 *   logger: logHandlers.compose(
+	 *     logHandlers.console(),
+	 *     logHandlers.json(),
+	 *   )
 	 * })
 	 * ```
 	 */


### PR DESCRIPTION
The `logHandlers` `@example` blocks place `logger` inside an `experimental` block, but `logger` is a top-level config option - the nested form would be rejected by config validation (`experimental` is a strict object). Updated all four examples (`json`, `node`, `console`, `compose`) to put `logger` directly under `defineConfig`, matching the documented config shape.
