### PR TITLE
Add Cloudflare Actions build regression coverage

### DIFF
--- a/packages/integrations/cloudflare/test/actions-build.test.ts
+++ b/packages/integrations/cloudflare/test/actions-build.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'node:assert/strict';
+import { rm } from 'node:fs/promises';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('Actions build', () => {
+	let fixture: Fixture;
+	let viteCacheDir: URL;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/actions-build/',
+		});
+		viteCacheDir = new URL('./node_modules/.vite/', fixture.config.root);
+		await rm(fileURLToPath(viteCacheDir), { recursive: true, force: true });
+	});
+
+	after(async () => {
+		await fixture.clean();
+		await rm(fileURLToPath(viteCacheDir), { recursive: true, force: true });
+	});
+
+	it('builds repeatedly with a warm Vite dependency cache', async () => {
+		await fixture.build();
+		assert.match(await fixture.readFile('/client/index.html'), /<h1>Actions build<\/h1>/);
+
+		// Keep node_modules/.vite between builds to cover the stale dependency cache
+		// that previously caused Cloudflare builds with Actions to fail.
+		await fixture.clean();
+		await fixture.build();
+		assert.match(await fixture.readFile('/client/index.html'), /<h1>Actions build<\/h1>/);
+	});
+});

--- a/packages/integrations/cloudflare/test/fixtures/actions-build/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/actions-build/astro.config.mjs
@@ -1,0 +1,8 @@
+import cloudflare from '@astrojs/cloudflare';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	adapter: cloudflare({
+		prerenderEnvironment: 'node',
+	}),
+});

--- a/packages/integrations/cloudflare/test/fixtures/actions-build/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/actions-build/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@test/astro-cloudflare-actions-build",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"@astrojs/cloudflare": "workspace:*",
+		"astro": "workspace:*"
+	}
+}

--- a/packages/integrations/cloudflare/test/fixtures/actions-build/src/actions/index.ts
+++ b/packages/integrations/cloudflare/test/fixtures/actions-build/src/actions/index.ts
@@ -1,0 +1,12 @@
+import { defineAction } from 'astro:actions';
+import { z } from 'astro:schema';
+
+export const server = {
+	contact: defineAction({
+		accept: 'form',
+		input: z.object({
+			email: z.string().email(),
+		}),
+		handler: async ({ email }) => ({ email }),
+	}),
+};

--- a/packages/integrations/cloudflare/test/fixtures/actions-build/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/actions-build/src/pages/index.astro
@@ -1,0 +1,1 @@
+<h1>Actions build</h1>

--- a/packages/integrations/cloudflare/test/test-utils.ts
+++ b/packages/integrations/cloudflare/test/test-utils.ts
@@ -18,25 +18,5 @@ export async function loadFixture(inlineConfig: AstroInlineConfig): Promise<Fixt
 		root: new URL(inlineConfig.root as string, import.meta.url).toString(),
 	});
 
-	// For unknown reasons, the error below could raise during testing. We add a retry mechanism to handle it.
-	// Some further investigation is needed to understand the root cause.
-	//
-	// Unable to build fixture for the attempt 1: Error: There is a new version of the pre-bundle for "/astro/packages/integrations/cloudflare/test/fixtures/with-svelte/node_modules/.vite/deps_ssr/svelte_server.js?v=9924cddf", a page reload is going to ask for it.
-	const buildWithRetry: Fixture['build'] = async (...args) => {
-		let err: unknown;
-		for (let attempt = 1; attempt <= 3; attempt++) {
-			try {
-				return await fixture.build(...args);
-			} catch (error) {
-				console.error(`Unable to build fixture for the attempt ${attempt}:`, error);
-				err = error;
-			}
-		}
-
-		if (err) {
-			throw err;
-		}
-	};
-
-	return { ...fixture, build: buildWithRetry };
+	return fixture;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4259,6 +4259,15 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
 
+  packages/integrations/cloudflare/test/fixtures/actions-build:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/cloudflare/test/fixtures/allowed-hosts:
     dependencies:
       '@astrojs/cloudflare':


### PR DESCRIPTION
## What changed

- adds a Cloudflare fixture with an Astro Action
- verifies two consecutive builds succeed while reusing the warm Vite dependency cache
- removes the broad three-attempt fixture build retry that masked stale prebundle failures

## Why

Astro issue #16933 reported Cloudflare builds failing when `src/actions/index.ts` was present because dependency optimization could observe a stale prebundle. The runtime startup change in #16961 addressed the production failure; this PR adds deterministic regression coverage so that behavior remains protected and optimizer races fail visibly instead of being hidden by retries.

## Validation

- Cloudflare integration build passes
- optimizer-sensitive test subset: 11 passed
- full Cloudflare adapter suite: 263 passed, 1 skipped, 0 failed
- Biome and Prettier checks pass
- lockfile frozen install check passes