### PR TITLE
Wrap responsive image styles in `@layer astro.images` to respect CSS cascade layers

### DIFF
--- a/.changeset/seven-peaches-roll.md
+++ b/.changeset/seven-peaches-roll.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes responsive image CSS overriding user styles defined inside CSS `@layer` blocks. The generated image styles are now wrapped in `@layer astro.images`, ensuring they have lower cascade priority than user-defined layers.

--- a/packages/astro/src/assets/utils/generateImageStylesCSS.ts
+++ b/packages/astro/src/assets/utils/generateImageStylesCSS.ts
@@ -72,7 +72,7 @@ export function generateImageStylesCSS(
 }`
 		: '';
 
-	return `
+	const rules = `
 :where([data-astro-image]) {
   height: auto;
 }
@@ -87,4 +87,8 @@ ${defaultFitStyle}
 ${positionStyles}
 ${defaultPositionStyle}
 `.trim();
+
+	// Wrap in a @layer so these low-priority defaults don't override user
+	// styles that live inside CSS cascade layers.
+	return `@layer astro.images {\n${rules}\n}`;
 }

--- a/packages/astro/test/units/assets/utils.test.ts
+++ b/packages/astro/test/units/assets/utils.test.ts
@@ -351,6 +351,12 @@ describe('generateImageStylesCSS', () => {
 		const css = generateImageStylesCSS();
 		assert.ok(!css.includes(':where([data-astro-image]:not([data-astro-image-pos]))'));
 	});
+
+	it('wraps output in @layer so user layer styles can override', () => {
+		const css = generateImageStylesCSS();
+		assert.ok(css.startsWith('@layer astro.images {'), 'should start with @layer astro.images');
+		assert.ok(css.endsWith('}'), 'should end with closing brace');
+	});
 });
 // #endregion
 


### PR DESCRIPTION
Closes #17139

## Changes

- Wraps all CSS generated by `generateImageStylesCSS()` in `@layer astro.images { … }`. Per the CSS cascade spec, unlayered styles always beat layered styles regardless of specificity — so the previous unlayered `:where([data-astro-image=constrained]){max-width:100%}` was silently overriding any user `max-width` defined inside a `@layer`, even though `:where()` has zero specificity. Putting these defaults into a named layer restores the original intent of `:where()`: Astro's image styles should always be easy for users to override.
- The layer name `astro.images` uses a dotted namespace to avoid collisions with user-defined layer names while remaining valid for CSS processors (e.g. lightningcss).
- **Note for users:** to guarantee `astro.images` sits below your own layers, declare the order explicitly: `@layer astro.images, layout, page, components;`. Without an explicit order declaration, the first-seen layer wins — which may or may not be `astro.images` depending on stylesheet load order.

## Testing

- Updated assertions in `packages/astro/test/units/assets/utils.test.ts` to expect the `@layer astro.images { … }` wrapper around the generated CSS output.

## Docs

- No docs update needed. `image.responsiveStyles` is already documented as producing overridable defaults; this fix makes that promise actually true when users write CSS layers.