### PR TITLE
docs: update v7 docs links

### DIFF
--- a/.changeset/wacky-bugs-act.md
+++ b/.changeset/wacky-bugs-act.md
@@ -39,4 +39,4 @@ Replace any occurrence of the other APIs using the lifecycle event names directl
 +console.log('astro:after-swap');
 ```
 
-Learn more about all utilities available in the [View Transitions Router API Reference](https://v7.docs.astro.build/en/reference/modules/astro-transitions/).
+Learn more about all utilities available in the [View Transitions Router API Reference](https://docs.astro.build/en/reference/modules/astro-transitions/).

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -303,7 +303,7 @@
   +console.log('astro:after-swap');
   ```
 
-  Learn more about all utilities available in the [View Transitions Router API Reference](https://v7.docs.astro.build/en/reference/modules/astro-transitions/).
+  Learn more about all utilities available in the [View Transitions Router API Reference](https://docs.astro.build/en/reference/modules/astro-transitions/).
 
 ### Patch Changes
 

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1426,7 +1426,7 @@ export interface AstroUserConfig<
 	 * });
 	 * ```
 	 *
-	 * Learn more about customizing the request pipeline in the [advanced routing guide](https://v7.docs.astro.build/en/guides/routing/#advanced-routing).
+	 * Learn more about customizing the request pipeline in the [advanced routing guide](https://docs.astro.build/en/guides/routing/#advanced-routing).
 	 */
 	fetchFile?: string | null;
 
@@ -1441,7 +1441,7 @@ export interface AstroUserConfig<
 	 *
 	 * Configures how Astro logs messages during development and production.
 	 *
-	 * By default, Astro uses a built-in logger that outputs human-friendly logs to the console. You can customize this behavior by providing [your own logger handler](https://v7.docs.astro.build/en/reference/logger-reference/#custom-loggers) or by using one of the [built-in log handlers](https://v7.docs.astro.build/en/reference/logger-reference/#built-in-loggers):
+	 * By default, Astro uses a built-in logger that outputs human-friendly logs to the console. You can customize this behavior by providing [your own logger handler](https://docs.astro.build/en/reference/logger-reference/#custom-loggers) or by using one of the [built-in log handlers](https://docs.astro.build/en/reference/logger-reference/#built-in-loggers):
 	 *
 	 * ```js
 	 * // astro.config.mjs
@@ -1452,7 +1452,7 @@ export interface AstroUserConfig<
 	 * });
 	 * ```
 	 *
-	 * See [the logger API reference](https://v7.docs.astro.build/en/reference/logger-reference/) for more information.
+	 * See [the logger API reference](https://docs.astro.build/en/reference/logger-reference/) for more information.
 	 */
 	logger?: LoggerHandlerConfig;
 


### PR DESCRIPTION
## Changes

Replaces all the `v7.docs.` links with `docs.` as v7 is the latest version.

## Testing

N/A

## Docs

This is docs, no changeset required for this.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
