### PR TITLE
Spawn node directly for background dev server on Windows

### DIFF
--- a/.changeset/thick-geese-play.md
+++ b/.changeset/thick-geese-play.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro dev --background` failing on Windows with "Failed to spawn background dev server process"

--- a/packages/astro/src/cli/dev/background.ts
+++ b/packages/astro/src/cli/dev/background.ts
@@ -99,12 +99,14 @@ export async function background({
 	}
 	const logFd = openSync(logFilePath, 'w');
 
-	// Find the astro binary
+	// Spawn node directly with astro's entry point, bypassing the .bin shim.
+	// On Windows, .bin shims are .cmd batch files that cannot be spawned without
+	// a shell, so we avoid the shim entirely for cross-platform compatibility.
 	const rootPath = fileURLToPath(root);
-	const astroBin = resolve(rootPath, 'node_modules', '.bin', 'astro');
+	const astroBin = resolve(rootPath, 'node_modules', 'astro', 'bin', 'astro.mjs');
 
 	// Spawn the dev server as a detached child process
-	const child = spawn(astroBin, args, {
+	const child = spawn(process.execPath, [astroBin, ...args], {
 		detached: true,
 		stdio: ['ignore', logFd, logFd],
 		cwd: rootPath,


### PR DESCRIPTION
## Changes

- Spawns `process.execPath` (node) directly with `node_modules/astro/bin/astro.mjs` instead of going through the `node_modules/.bin/astro` shim. On Windows, npm/pnpm/yarn create `.cmd` batch file shims in `.bin/` that cannot be executed by `child_process.spawn()` without `shell: true`, causing `spawn()` to fail and `child.pid` to be `undefined`.

Closes #17146

## Testing

- No new tests. The spawn codepath in `background.ts` has no integration test coverage on any platform — existing tests only cover pure formatting/parsing helpers.

## Docs

- No docs changes needed. This is an internal bug fix; the `--background` flag API is unchanged.