### PR TITLE
Exclude hybrid environments like Warp from dev background auto-detection

### DIFF
--- a/.changeset/common-tools-return.md
+++ b/.changeset/common-tools-return.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro dev` incorrectly starting in background mode for Warp terminal users. Hybrid environments like Warp are no longer treated as AI agents for auto-background detection.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -142,7 +142,7 @@
     "@clack/prompts": "^1.1.0",
     "@oslojs/encoding": "^1.1.0",
     "@rollup/pluginutils": "^5.3.0",
-    "am-i-vibing": "^0.3.0",
+    "am-i-vibing": "^0.4.0",
     "aria-query": "^5.3.2",
     "axobject-query": "^4.1.0",
     "ci-info": "^4.4.0",

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -1,4 +1,4 @@
-import { isAgent } from 'am-i-vibing';
+import { detectAgenticEnvironment } from 'am-i-vibing';
 import colors from 'piccolore';
 import devServer from '../../core/dev/index.js';
 import { pathToFileURL } from 'node:url';
@@ -13,7 +13,10 @@ interface DevOptions {
 
 function isRunByAgent(): boolean {
 	try {
-		return isAgent();
+		// Only treat direct "agent" types as auto-background-worthy.
+		// "hybrid" environments (e.g. Warp terminal) may not actually be running
+		// an AI agent, so we avoid false positives by excluding them.
+		return detectAgenticEnvironment().type === 'agent';
 	} catch {
 		return false;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,8 +552,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       am-i-vibing:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.4.0
+        version: 0.4.0
       aria-query:
         specifier: ^5.3.2
         version: 5.3.2
@@ -6733,6 +6733,24 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
+  triage/gh-16181:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../../packages/integrations/node
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+
+  triage/gh-16522:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+
 packages:
 
   '@anthropic-ai/sdk@0.91.1':
@@ -10381,8 +10399,8 @@ packages:
   alpinejs@3.15.8:
     resolution: {integrity: sha512-zxIfCRTBGvF1CCLIOMQOxAyBuqibxSEwS6Jm1a3HGA9rgrJVcjEWlwLcQTVGAWGS8YhAsTRLVrtQ5a5QT9bSSQ==}
 
-  am-i-vibing@0.3.0:
-    resolution: {integrity: sha512-JTg9e3qPmVP6x8PG9/J4+eCVP6sGx9oS1pSbgf7fpPVlkHzQdRPSNMb6dBlp9BrdBNxDkctMzehPVYSnt16k4w==}
+  am-i-vibing@0.4.0:
+    resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
     hasBin: true
 
   ansi-colors@4.1.3:
@@ -19904,7 +19922,7 @@ snapshots:
     dependencies:
       '@vue/reactivity': 3.1.5
 
-  am-i-vibing@0.3.0:
+  am-i-vibing@0.4.0:
     dependencies:
       process-ancestry: 0.1.0
 


### PR DESCRIPTION
## Changes

- Switches agent detection in `astro dev` from `isAgent()` to `detectAgenticEnvironment().type === "agent"`, excluding `"hybrid"` environments from auto-background mode. `isAgent()` returns `true` for both `"agent"` and `"hybrid"` types, which causes false positives in terminals like Warp that set `TERM_PROGRAM=WarpTerminal`.
- Bumps `am-i-vibing` from `^0.3.0` to `^0.4.0` which classifies Warp as `"hybrid"` and includes the latest provider list.

Reported in https://github.com/ascorbic/am-i-vibing/issues/89 and Discord.

## Testing

- No test changes. The fix is a one-line predicate change in `isRunByAgent()` and there are no existing tests for agent detection.

## Docs

- No docs update needed. This is a bug fix to existing behavior.