### PR TITLE
Extend CSS filter to include additional preprocessors

### DIFF
--- a/.changeset/fine-bags-end.md
+++ b/.changeset/fine-bags-end.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Extend CSS @import rewrite to also work for SCSS, Sass, less, and stylus

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -110,7 +110,7 @@ export default function configAliasVitePlugin({
 			transform: {
 				filter: {
 					id: {
-						include: /\.css$/,
+						include: /\.(css|scss|sass|less|styl)$/,
 					},
 				},
 				handler(code) {

--- a/packages/astro/test/fixtures/alias-tsconfig/src/components/Style.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/components/Style.astro
@@ -1,2 +1,9 @@
 <p id="style-blue">i am blue</p>
 <p id="style-red">i am red</p>
+<p id="style-scss">i am scss</p>
+
+<style lang="scss">
+  /* `@styles/*` is a tsconfig path alias; it must resolve inside an
+     .astro `<style lang="scss">` block (virtual id `…&lang.scss`). */
+  @import "@styles/extra.scss";
+</style>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/more-styles/extra.scss
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/more-styles/extra.scss
@@ -1,0 +1,5 @@
+$scss-alias-color: #abcdef;
+
+#style-scss {
+  color: $scss-alias-color;
+}


### PR DESCRIPTION
## Changes

With the upgrade to Astro 7 I ran into:
```
[sass] Error: Can't find stylesheet to import.
    ╷
  2 │     @import "@styles/_variables.scss";
```
in .astro files that have  `<style lang="scss">`.

This extends the workaround fix for aliases.

## Testing

Tested it by changing this locally.
Extended the css test case to also test scss imports.

## Docs

No doc updates needed, just restores previous behavior.
