### PR TITLE
Remove legacy "X-UA-Compatible" meta tags

### DIFF
--- a/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
+++ b/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
@@ -6,7 +6,6 @@ import '../../../styles/global.css'
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<meta http-equiv="x-ua-compatible" content="ie=edge" />
 		<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
 	</head>
 	<body>

--- a/packages/astro/performance/fixtures/utils/RenderContent.astro
+++ b/packages/astro/performance/fixtures/utils/RenderContent.astro
@@ -11,7 +11,6 @@ const { posts, renderer: ContentRenderer } = Astro.props;
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Md render test</title>
 </head>

--- a/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
@@ -19,7 +19,6 @@ const {
 
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 

--- a/packages/integrations/markdoc/test/fixtures/content-layer/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/content-layer/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
@@ -15,7 +15,6 @@ const { Content, headings } = await render(Astro.props);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
@@ -15,7 +15,6 @@ const { Content, headings } = await render(Astro.props);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/propagated-assets/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/propagated-assets/src/pages/[slug].astro
@@ -16,7 +16,6 @@ const { Content } = await render(Astro.props);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{Astro.props.data.title}</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render with-space/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render with-space/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-html/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/render-html/src/pages/[slug].astro
@@ -19,7 +19,6 @@ export async function getStaticPaths() {
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-null/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-null/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-partials/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-partials/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Content</title>
 	</head>

--- a/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-typographer/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-typographer/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/pages/index.astro
@@ -9,7 +9,6 @@ const { Content } = await render(post);
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/mdx/test/fixtures/mdx-basics/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-basics/src/layouts/Base.astro
@@ -17,7 +17,6 @@ const {
 
 <head>
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
@@ -7,7 +7,6 @@ const { frontmatter = defaults, content = defaults } = Astro.props;
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{frontmatter.title}</title>
 </head>

--- a/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
+++ b/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
@@ -5,7 +5,6 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>404</title>
 </head>


### PR DESCRIPTION
For https://github.com/withastro/roadmap/discussions/1381

## Changes

- Remove obsolete `<meta http-equiv="X-UA-Compatible" content="IE=edge">` tags from Astro examples, fixtures, and templates.
- Keep the rest of the head markup unchanged.
- Simplify HTML output and remove legacy IE-only boilerplate.

## Testing

- Updated the affected fixtures and example files.
- Verified the change is limited to removing the legacy meta tag.

## Docs

- No docs update needed.
- This change removes a legacy browser compatibility tag that is no longer useful for modern browser output.