### PR TITLE
Update agent docs for background dev servers

### DIFF
--- a/.agents/skills/astro-developer/debugging.md
+++ b/.agents/skills/astro-developer/debugging.md
@@ -336,7 +336,7 @@ HMR testing requires a browser. **Do not use `curl`** for HMR issues.
 
 ```bash
 # Start dev server in background
-pnpm exec bgproc start -n devserver --wait-for-port 10 -- pnpm -C examples/minimal dev
+pnpm -C examples/minimal dev --background
 
 # Open browser
 agent-browser open http://localhost:4321
@@ -348,10 +348,10 @@ agent-browser snapshot -i
 # Verify HMR updates the page
 
 # View logs
-pnpm exec bgproc logs -n devserver
+pnpm -C examples/minimal dev logs
 
 # Cleanup
-pnpm exec bgproc stop -n devserver
+pnpm -C examples/minimal dev stop
 ```
 
 ### Check HMR Boundaries
@@ -471,11 +471,11 @@ See [testing.md](testing.md) for comprehensive test debugging.
 **Fix:**
 
 ```bash
-# List running processes
-pnpm exec bgproc list
+# Check dev server status
+pnpm -C examples/minimal dev status
 
-# Stop specific server
-pnpm exec bgproc stop -n devserver
+# Stop dev server
+pnpm -C examples/minimal dev stop
 
 # Kill all node processes (nuclear option)
 killall node

--- a/.agents/skills/triage/diagnose.md
+++ b/.agents/skills/triage/diagnose.md
@@ -55,7 +55,7 @@ After adding logs:
 2. Re-run the reproduction (Example: `pnpm -C <triageDir> build|dev|preview`)
 3. Observe the debug output.
 
-**Server management:** If re-running requires a dev/preview server, always stop existing servers first (`bgproc stop --all`). If the server fails to start twice, bail out — write your diagnosis with the data you have rather than looping on server restarts. Prefer `astro build` over dev/preview when possible. Never background servers with `&` — always use `bgproc`.
+**Server management:** If re-running requires a dev server, always stop the existing project server first (`pnpm -C <triageDir> dev stop`). If the server fails to start twice, bail out — write your diagnosis with the data you have rather than looping on server restarts. Prefer `astro build` over dev/preview when possible. Never background servers with `&` — use `pnpm -C <triageDir> dev --background` for dev servers.
 
 Iterate until you understand:
 

--- a/.agents/skills/triage/reproduce.md
+++ b/.agents/skills/triage/reproduce.md
@@ -148,11 +148,11 @@ Use all of the tools at your disposal — `pnpm run dev|build|preview|test`, `cu
 
 Running dev/preview servers is often necessary for reproduction, but server problems must not consume your time budget. Follow these rules:
 
-- **Bail out after 2 failed server starts.** If `bgproc start` or a manual server command fails twice in a row, stop trying. Do NOT loop endlessly with variations. Write your report with what you already know.
-- **Always stop servers before restarting.** Run `bgproc stop -n <name>` (or `bgproc stop --all`) before starting a new server. If `bgproc` doesn't work, try `pkill -f "astro dev\|astro preview\|node.*entry.mjs"` as a fallback. If that also fails, use a different port (`--port 4322`) rather than fighting the stale process.
+- **Bail out after 2 failed server starts.** If `astro dev --background` or a manual server command fails twice in a row, stop trying. Do NOT loop endlessly with variations. Write your report with what you already know.
+- **Always stop servers before restarting.** Run `pnpm -C <triageDir> dev stop` before starting a new dev server. If that doesn't work, try `pkill -f "astro dev\|astro preview\|node.*entry.mjs"` as a fallback. If that also fails, use a different port (`--port 4322`) rather than fighting the stale process.
 - **One reproduction run is enough.** Once you have confirmed or denied the bug, do NOT restart the server to re-test with minor config variations. Additional testing belongs in the diagnose step, not here. Write your findings and move on.
 - **Prefer `astro build` over dev/preview when possible.** Build-time reproduction avoids server lifecycle issues entirely. Only use dev/preview servers when the bug specifically requires a running server (e.g., HMR, runtime SSR, request handling).
-- **Always use `bgproc` for servers — never `&`.** Do not background servers with `&` (e.g., `pnpm dev &`). This hangs in CI. Always use `bgproc start` / `bgproc stop` for server lifecycle management.
+- **Always use Astro's background dev server — never `&`.** Do not background servers with `&` (e.g., `pnpm dev &`). This hangs in CI. Use `pnpm -C <triageDir> dev --background` / `pnpm -C <triageDir> dev stop` for dev server lifecycle management.
 
 ## Step 5: Write Output
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,18 +113,18 @@ Use `pnpm -C <dir> <command>` for project-local script commands when working in 
 - Use `astro add` to install and configure an official integration.
 - Fetch **Full docs** at https://docs.astro.build/ (primary source for the latest reference).
 
-# `bgproc`
+# Background Dev Servers
 
-Use `pnpm exec bgproc` to start, stop, and manage long-running `astro dev` & `astro preview` servers in the background. Do not manually start detached servers with `&` if you can use `bgproc` instead.
-
-Use `pnpm exec bgproc --help` to see all available commands.
+Use `astro dev --background` to start and manage long-running dev servers in the background. Do not manually start detached servers with `&`.
 
 Workflow:
 
-1. `pnpm exec bgproc start -n devserver --wait-for-port 10 --force -- pnpm -C examples/minimal dev` - Start the dev server
-2. `pnpm exec bgproc logs -n devserver` - View logs from the dev server. Useful for debugging server logs.
-3. `pnpm exec bgproc stop -n devserver` - Stop the dev server when your work is complete
-4. `pnpm exec bgproc list` - List all running servers, background processes. Useful for cleanup.
+1. `pnpm -C examples/minimal dev --background` - Start the dev server in the background
+2. `pnpm -C examples/minimal dev logs` - View logs from the dev server. Useful for debugging server logs.
+3. `pnpm -C examples/minimal dev status` - Check whether a dev server is running
+4. `pnpm -C examples/minimal dev stop` - Stop the dev server when your work is complete
+
+Use `pnpm -C examples/minimal dev logs --follow` to stream logs. If a stale dev server is blocking startup, stop it first or use `pnpm -C examples/minimal dev --background --force` to replace it.
 
 # `agent-browser`
 


### PR DESCRIPTION
## Changes

- Replaces the old bgproc guidance in AGENTS.md with Astro's native background dev server commands.
- Updates repo-local agent skills to use `astro dev --background`, `astro dev stop`, `astro dev status`, and `astro dev logs` for dev server lifecycle management.

## Testing

- No test code changed; this is a documentation-only update.

## Docs

- Updates internal agent guidance and local skill docs directly.