### PR TITLE
Update triagebot-action to v0.3.1

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm build
 
       - name: Run triagebot
-        uses: withastro/triagebot-action@c803c9e72bf22da3f70fc1ec239cae15967fe4a3 # v0.3.0
+        uses: withastro/triagebot-action@d0a6310373034f5ce08467b906c78f2912b9839c # v0.3.1
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update issue triage workflow to use triagebot-action v0.3.1
- v0.3.1 fixes hyphenated action input parsing for inputs like `read-token`

## Testing
- `git diff --check`