### PR TITLE
Update triagebot-action to v0.3.2

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm build
 
       - name: Run triagebot
-        uses: withastro/triagebot-action@d0a6310373034f5ce08467b906c78f2912b9839c # v0.3.1
+        uses: withastro/triagebot-action@887f99779cdba9b625c64154376ccf2e169ba71b # v0.3.2
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update issue triage workflow to use triagebot-action v0.3.2
- v0.3.2 fixes Flue session initialization now that the triage code runs as a standalone GitHub Action instead of under `flue run`

## Testing
- `git diff --check`