### PR TITLE
Update triagebot-action to v0.3.3

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm build
 
       - name: Run triagebot
-        uses: withastro/triagebot-action@887f99779cdba9b625c64154376ccf2e169ba71b # v0.3.2
+        uses: withastro/triagebot-action@f78a3fa311d266e3eec4562a77f906650a0263bb # v0.3.3
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update issue triage workflow to triagebot-action v0.3.3
- v0.3.3 fixes the bundled action syntax error from duplicate `createRequire` declarations
- v0.3.3 also adds integration tests that run the built action entrypoint and standalone Flue session initialization

## Testing
- `git diff --check`