### PR TITLE
Update triagebot-action to v0.3.5

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm build
 
       - name: Run triagebot
-        uses: withastro/triagebot-action@f78a3fa311d266e3eec4562a77f906650a0263bb # v0.3.3
+        uses: withastro/triagebot-action@df8102badc2fbcef8792749ce6977a7c722a75b8 # v0.3.5
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update issue triage workflow to triagebot-action v0.3.5
- v0.3.5 adds mocked triage-flow integration coverage in triagebot-action

## Testing
- `git diff --check`