### PR TITLE
Update triagebot-action to v0.3.6

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm build
 
       - name: Run triagebot
-        uses: withastro/triagebot-action@df8102badc2fbcef8792749ce6977a7c722a75b8 # v0.3.5
+        uses: withastro/triagebot-action@bc2a0856b28255f37ba097ca51b7b774b8de01f3 # v0.3.6
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update issue triage workflow to triagebot-action v0.3.6
- v0.3.6 fixes verified-fix PR creation for legacy `flue/fix-*` branches and delays the issue verified label until PR creation succeeds

## Testing
- `git diff --check`