### PR TITLE
Fix @astrojs/cloudflare dev server OOM by migrating frontmatter scan plugin to Rolldown

### DIFF
--- a/.changeset/floppy-chefs-admire.md
+++ b/.changeset/floppy-chefs-admire.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes `astro dev` OOM crashes for `@astrojs/cloudflare` users on Vite 8 by migrating the frontmatter scan plugin to Rolldown-compatible options.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { createRedirectsFromAstroRoutes, printAsRedirects } from '@astrojs/underscore-redirects';
 import { cloudflare as cfVitePlugin, type PluginConfig } from '@cloudflare/vite-plugin';
 import type { AstroConfig, AstroIntegration, IntegrationResolvedRoute } from 'astro';
-import { astroFrontmatterScanPlugin } from './esbuild-plugin-astro-frontmatter.js';
+import { rolldownAstroFrontmatterScanPlugin } from './rolldown-plugin-astro-frontmatter.js';
 import { getParts } from './utils/generate-routes-json.js';
 import { buildAssetsHeadersContent } from './utils/headers.js';
 import {
@@ -346,16 +346,8 @@ export default function createIntegration({
 														? userOptimizeDeps.exclude
 														: []),
 												],
-												esbuildOptions: {
-													// Suppress Vite's `createRequire(import.meta.url)` banner to work around
-													// https://github.com/vitejs/vite/issues/22004 — Vite's SSR transform
-													// incorrectly rewrites identifiers inside `import.meta` when an imported
-													// binding shares the same name (e.g. zod v4 exports `meta`).
-													banner: { js: '' },
-													plugins: [astroFrontmatterScanPlugin()],
-													...(userOptimizeDeps?.esbuildOptions?.loader
-														? { loader: userOptimizeDeps.esbuildOptions.loader }
-														: {}),
+												rolldownOptions: {
+													plugins: [rolldownAstroFrontmatterScanPlugin()],
 												},
 											},
 										};

--- a/packages/integrations/cloudflare/src/rolldown-plugin-astro-frontmatter.ts
+++ b/packages/integrations/cloudflare/src/rolldown-plugin-astro-frontmatter.ts
@@ -1,0 +1,61 @@
+import { readFile } from 'node:fs/promises';
+import type { Plugin } from 'vite';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+// Matches tokens to skip (strings, template literals, comments) OR a top-level `return`.
+// The first alternative is preserved as-is; only the second is rewritten.
+// Negative lookbehind `(?<!\.)` prevents matching member accesses like `gen.return()`.
+const RETURN_REPLACE_RE =
+	/(\/\/[^\n]*|\/\*[\s\S]*?\*\/|`(?:[^`\\]|\\.)*`|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|(?<!\.)\breturn(\s*;|\b)/g;
+
+function replaceTopLevelReturns(code: string): string {
+	return code.replace(RETURN_REPLACE_RE, (_match, skip: string | undefined, tail: string) => {
+		if (skip !== undefined) return skip;
+		return tail.trim() === ';' ? 'throw 0;' : 'throw ';
+	});
+}
+
+/**
+ * A Rolldown plugin that extracts frontmatter from .astro files during
+ * dependency optimization scanning. This allows Vite to discover imports
+ * in the server-side frontmatter code.
+ *
+ * This is the Rolldown equivalent of the esbuild plugin in
+ * `esbuild-plugin-astro-frontmatter.ts`, needed because Vite 8 uses Rolldown
+ * for dependency optimization and ignores `optimizeDeps.esbuildOptions`.
+ */
+export function rolldownAstroFrontmatterScanPlugin(): Plugin {
+	return {
+		name: 'astro-frontmatter-scan',
+		async load(id) {
+			if (!id.endsWith('.astro')) return;
+
+			let code: string;
+			try {
+				code = await readFile(id, 'utf-8');
+			} catch {
+				// Ignore read errors, return empty with a default export
+				return { code: 'export default {}', moduleType: 'ts' };
+			}
+
+			// Extract frontmatter content between --- markers
+			const frontmatterMatch = FRONTMATTER_RE.exec(code);
+			if (frontmatterMatch) {
+				// Replace `return` with `throw` to avoid "Top-level return" errors during scanning.
+				// This aligns with Astro's core compiler logic for frontmatter error handling.
+				const contents = replaceTopLevelReturns(frontmatterMatch[1]);
+
+				// Append `export default {}` so that default imports of .astro files
+				// resolve correctly during the dep scan.
+				return {
+					code: contents + '\nexport default {}',
+					moduleType: 'ts',
+				};
+			}
+
+			// No frontmatter, return empty with a default export
+			return { code: 'export default {}', moduleType: 'ts' };
+		},
+	};
+}


### PR DESCRIPTION
## Changes

- Fixes `astro dev` OOM crashes for `@astrojs/cloudflare` users on Vite 8. The adapter's `.astro` frontmatter scan plugin was registered via `optimizeDeps.esbuildOptions.plugins`, which Vite 8 deprecates and ignores. Without the plugin, Vite's HTML scanner misparses `.astro` frontmatter comments containing backticks (e.g. `` // Use a `<script>` tag ``), causing a Rolldown `PARSE_ERROR` that skips pre-bundling entirely and can OOM the workerd isolate at startup.
- Adds a Rolldown-compatible frontmatter scan plugin (`rolldown-plugin-astro-frontmatter.ts`) and switches the `configEnvironment` hook to register it via `optimizeDeps.rolldownOptions`. Also removes the `banner: { js: '' }` workaround, which was esbuild-specific and no longer needed.

Closes #17168

## Testing

- No new tests added — existing suites (`ssr-deps`, `top-level-return`, `ts-astro-import`, `user-optimize-deps`) already cover the frontmatter scan plugin behavior and all pass with the new Rolldown plugin.

## Docs

- No docs update needed; this is a bug fix with no user-facing API changes.
