### PR TITLE
Update triagebot-action to v0.3.7

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm build
 
       - name: Run triagebot
-        uses: withastro/triagebot-action@bc2a0856b28255f37ba097ca51b7b774b8de01f3 # v0.3.6
+        uses: withastro/triagebot-action@71fe1464976e329b345ba42527ba99638a3fea8e # v0.3.7
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update issue triage workflow to triagebot-action v0.3.7
- v0.3.7 adds Flue event logging so triage runs show thinking/tool/log progress in Actions

## Testing
- `git diff --check`