### PR TITLE
chore(head): remove meta title tag in favor of standard title tag

### DIFF
--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -39,7 +39,6 @@ const { title, description, image = FallbackImage } = Astro.props;
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>
-<meta name="title" content={title} />
 <meta name="description" content={description} />
 
 <!-- Open Graph / Facebook -->

--- a/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
@@ -25,7 +25,6 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>
-<meta name="title" content={title} />
 <meta name="description" content={description} />
 
 <!-- Open Graph / Facebook -->

--- a/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
@@ -25,7 +25,6 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>
-<meta name="title" content={title} />
 <meta name="description" content={description} />
 
 <!-- Open Graph / Facebook -->


### PR DESCRIPTION
## Changes

- Removed `<meta name="title" content={title} />` in favor of relying on the standard `<title>` tag
- Updated `BaseHead.astro` in the blog example and E2E fixture components
- Ensures consistent use of HTML standard for document titles across Astro templates

## Testing

- Verified changes in affected `BaseHead.astro` components
- Confirmed page titles still render correctly via `<title>` tag
- Ran local build and checked output HTML for correctness

## Docs

- No user-facing behavior changes expected
- This aligns with standard HTML metadata practices, so no documentation updates required