### PR TITLE
chore(seo): remove redundant twitter metadata tags

### DIFF
--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -50,7 +50,3 @@ const { title, description, image = FallbackImage } = Astro.props;
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
-<meta property="twitter:title" content={title} />
-<meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image.src, Astro.url)} />

--- a/examples/starlog/src/components/SEO.astro
+++ b/examples/starlog/src/components/SEO.astro
@@ -11,7 +11,6 @@ type SEOMetadata = {
 	title: string;
 	description: string;
 	image?: Image | undefined;
-	canonicalURL?: URL | string | undefined;
 	locale?: string;
 };
 
@@ -42,7 +41,6 @@ const og = {
 	name,
 	title,
 	description,
-	canonicalURL,
 	image,
 	locale,
 	type: 'website',
@@ -51,11 +49,6 @@ const og = {
 
 const twitter = {
 	name,
-	title,
-	description,
-	canonicalURL,
-	image,
-	locale,
 	card: 'summary_large_image',
 	...Astro.props.twitter,
 };
@@ -82,7 +75,3 @@ function normalizeImageUrl(image: string | ImageMetadata) {
 <!-- Twitter Tags -->
 <meta name="twitter:card" content={twitter.card} />
 <meta name="twitter:site" content={twitter.handle} />
-<meta name="twitter:title" content={twitter.title} />
-<meta name="twitter:description" content={twitter.description} />
-{twitter.image && <meta name="twitter:image" content={normalizeImageUrl(twitter.image.src)} />}
-{twitter.image && <meta name="twitter:image:alt" content={twitter.image.alt} />}

--- a/examples/starlog/src/components/SEO.astro
+++ b/examples/starlog/src/components/SEO.astro
@@ -11,6 +11,7 @@ type SEOMetadata = {
 	title: string;
 	description: string;
 	image?: Image | undefined;
+	canonicalURL?: URL | string | undefined;
 	locale?: string;
 };
 

--- a/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
@@ -36,7 +36,3 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
-<meta property="twitter:title" content={title} />
-<meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image, Astro.url)} />

--- a/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
@@ -36,7 +36,3 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
-<meta property="twitter:title" content={title} />
-<meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image, Astro.url)} />


### PR DESCRIPTION
## Changes

* Removed redundant Twitter metadata tags from example and fixture SEO components
* Removed generation of `twitter:title`, `twitter:description`, `twitter:image`, and `twitter:url`
* Simplified the Starlog SEO component by removing unused Twitter-related properties and logic
* Kept essential Twitter metadata such as `twitter:card` and `twitter:site`
* Removed `canonicalURL` declaration from `og` because `og:url` uses `canonicalURL` that's exposed direclty to `Astro.props`, therefore no need for duplicating that behavior

## Testing

* Verified generated HTML no longer includes the removed Twitter meta tags
* Confirmed remaining Twitter metadata continues to render correctly
* Checked example and fixture components for type and build consistency

## Docs

* No documentation updates required
* This change simplifies metadata output without introducing new user-facing functionality

## Resources

Normally the link I'd have shown would've been: https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup
But it doesn't work because they've removed it and you can't find it anywhere.

But Wayback Machine comes to help: https://web.archive.org/web/20240613190853/https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup
As you can see they tell that some of them can be used via `og:*` replacements too, in addition in their guides:
https://web.archive.org/web/20240616101429/https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started
fun fact:
> If an og:type, og:title and og:description exist in the markup but twitter:card is absent, then a summary card may be rendered.
therefore we can even emit `twitter:card` (in Astro case we don't because we're using `summary_large_image`).

```html
<meta name="twitter:card" content="summary" />
<meta name="twitter:site" content="@">
<meta name="twitter:creator" content="@">
<meta property="og:url" content="">
<meta property="og:title" content="">
<meta property="og:description" content="">
<meta property="og:image" content="">
```