### PR TITLE
Add `--no-ai` flag to `create astro` to opt out of agent file creation

### DIFF
--- a/.changeset/easy-corners-laugh.md
+++ b/.changeset/easy-corners-laugh.md
@@ -1,0 +1,5 @@
+---
+'create-astro': minor
+---
+
+Adds a `--no-ai` flag to allow users to opt out of creating `AGENTS.md` and `CLAUDE.md` files when running create astro

--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -52,6 +52,7 @@ May be provided in place of prompts
 | `--install` / `--no-install` | Install dependencies (or not).             |
 | `--add <integrations>`       | Add integrations.                          |
 | `--git` / `--no-git`         | Initialize git repo (or not).              |
+| `--no-ai`                    | Skip creating AI agent files.              |
 | `--yes` (`-y`)               | Skip all prompts by accepting defaults.    |
 | `--no` (`-n`)                | Skip all prompts by declining defaults.    |
 | `--dry-run`                  | Walk through steps without executing.      |

--- a/packages/create-astro/src/actions/context.ts
+++ b/packages/create-astro/src/actions/context.ts
@@ -23,6 +23,7 @@ export interface Context {
 	ref: string;
 	install?: boolean;
 	git?: boolean;
+	ai: boolean;
 	typescript?: string;
 	stdin?: typeof process.stdin;
 	stdout?: typeof process.stdout;
@@ -61,6 +62,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 			'--no-install': Boolean,
 			'--git': Boolean,
 			'--no-git': Boolean,
+			'--no-ai': Boolean,
 			'--skip-houston': Boolean,
 			'--dry-run': Boolean,
 			'--help': Boolean,
@@ -85,6 +87,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 		'--no-install': noInstall,
 		'--git': git,
 		'--no-git': noGit,
+		'--no-ai': noAI,
 		'--fancy': fancy,
 		'--skip-houston': skipHouston,
 		'--dry-run': dryRun,
@@ -137,6 +140,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 		yes,
 		install: install ?? (noInstall ? false : undefined),
 		git: git ?? (noGit ? false : undefined),
+		ai: noAI ? false : true,
 		cwd,
 		exit(code) {
 			process.exit(code);

--- a/packages/create-astro/src/actions/help.ts
+++ b/packages/create-astro/src/actions/help.ts
@@ -12,6 +12,7 @@ export function help() {
 				['--install / --no-install', 'Install dependencies (or not).'],
 				['--add <integrations>', 'Add integrations.'],
 				['--git / --no-git', 'Initialize git repo (or not).'],
+				['--no-ai', 'Skip creating AI agent files.'],
 				['--yes (-y)', 'Skip all prompts by accepting defaults.'],
 				['--no (-n)', 'Skip all prompts by declining defaults.'],
 				['--dry-run', 'Walk through steps without executing.'],

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -211,17 +211,19 @@ async function copyTemplate(tmpl: string, ctx: Context) {
 			throw new Error(`Unable to download template ${color.reset(tmpl)}`);
 		}
 
-		// Generate AGENTS.md for AI coding agents, with a CLAUDE.md link
-		const agentsPath = path.resolve(ctx.cwd, 'AGENTS.md');
-		const claudePath = path.resolve(ctx.cwd, 'CLAUDE.md');
-		fs.writeFileSync(agentsPath, generateAgentsMd());
-		try {
-			fs.symlinkSync('AGENTS.md', claudePath);
-		} catch {
+		if (ctx.ai) {
+			// Generate AGENTS.md for AI coding agents, with a CLAUDE.md link
+			const agentsPath = path.resolve(ctx.cwd, 'AGENTS.md');
+			const claudePath = path.resolve(ctx.cwd, 'CLAUDE.md');
+			fs.writeFileSync(agentsPath, generateAgentsMd());
 			try {
-				fs.linkSync(agentsPath, claudePath);
+				fs.symlinkSync('AGENTS.md', claudePath);
 			} catch {
-				// Link creation failed; AGENTS.md still exists
+				try {
+					fs.linkSync(agentsPath, claudePath);
+				} catch {
+					// Link creation failed; AGENTS.md still exists
+				}
 			}
 		}
 

--- a/packages/create-astro/test/context.test.ts
+++ b/packages/create-astro/test/context.test.ts
@@ -72,6 +72,16 @@ describe('context', () => {
 		assert.deepEqual(ctx.git, false);
 	});
 
+	it('with ai (default)', async () => {
+		const ctx = await getContext([]);
+		assert.deepEqual(ctx.ai, true);
+	});
+
+	it('no ai', async () => {
+		const ctx = await getContext(['--no-ai']);
+		assert.deepEqual(ctx.ai, false);
+	});
+
 	it('--add with --no-install conflicts', async () => {
 		const originalExit = process.exit;
 		let exitCode: number | string | null | undefined;


### PR DESCRIPTION
## Changes

- Adds a `--no-ai` flag to `create astro`, so users can opt out of creating `AGENTS.md` and `CLAUDE.md` files if they don’t need them.
- Avoids people having to manually clean up after running `create astro`.

## Testing

Added a small test to make sure the CLI flag is interpreted correctly.

## Docs

AFAIK we only document the full list of flags in the package README, so I’ve updated that. That’s what’s linked in the docs here: https://docs.astro.build/en/install-and-setup/#cli-installation-flags
/cc @withastro/maintainers-docs for feedback!