### PR TITLE
Pre-bundle transitions virtual module in Cloudflare adapter

### DIFF
--- a/.changeset/sunny-carpets-rescue.md
+++ b/.changeset/sunny-carpets-rescue.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes React invalid hook warning during cold SSR optimizer reload when using ClientRouter

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -330,6 +330,7 @@ export default function createIntegration({
 													'astro/jsx-runtime',
 													'astro/app/entrypoint/dev',
 													'astro/virtual-modules/middleware.js',
+													'astro/virtual-modules/transitions.js',
 													...(isAstroPrismPackageInstalled ? prismFiles : []),
 													...(Array.isArray(userOptimizeDeps?.include)
 														? userOptimizeDeps.include


### PR DESCRIPTION
## Changes

- Adds `astro/virtual-modules/transitions.js` to the Cloudflare adapter's server `optimizeDeps.include` list. This prevents Vite from discovering the module mid-request during cold SSR, which was triggering an optimizer reload that invalidated React's hook dispatcher and caused "Invalid hook call" / `useContext` null errors when using `<ClientRouter />`.

## Testing

- No new tests — the bug only manifests with npm-installed packages (not workspace-linked), so it cannot be reproduced in the monorepo's test suite. The reporter confirmed the fix works in their minimal repro.

## Docs

- No docs update needed — this is an internal dev-server reliability fix.

Closes #17166