### PR TITLE
Show a specific error in `@astrojs/upgrade` when pnpm's `minimumReleaseAge` policy blocks installation

### DIFF
--- a/.changeset/flat-aliens-lose.md
+++ b/.changeset/flat-aliens-lose.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/upgrade': patch
+---
+
+Fixes `@astrojs/upgrade` showing a generic error when pnpm's `minimumReleaseAge` policy blocks installation. The error message now explains that pnpm's policy blocked the update and suggests running the install command manually.

--- a/packages/upgrade/src/actions/install.ts
+++ b/packages/upgrade/src/actions/install.ts
@@ -179,10 +179,18 @@ async function runInstallCommand(
 				),
 			].join(' ');
 			newline();
-			error(
-				'error',
-				`Dependencies failed to install, please run the following command manually:\n${color.bold(manualInstallCommand)}`,
-			);
+			// pnpm's minimumReleaseAge policy can block installs when run non-interactively
+			if (errorMessage.includes('MINIMUM_RELEASE_AGE')) {
+				error(
+					'error',
+					`pnpm's ${color.bold('minimumReleaseAge')} policy blocked the installation. Run the following command manually to confirm the update:\n${color.bold(manualInstallCommand)}`,
+				);
+			} else {
+				error(
+					'error',
+					`Dependencies failed to install, please run the following command manually:\n${color.bold(manualInstallCommand)}`,
+				);
+			}
 			return ctx.exit(1);
 		}
 	};

--- a/packages/upgrade/src/shell.ts
+++ b/packages/upgrade/src/shell.ts
@@ -72,7 +72,7 @@ export async function shell(
 		throw new Error('Timeout');
 	}
 	if (exitCode !== 0) {
-		throw new Error(stderr || `Process exited with code ${exitCode}`);
+		throw new Error(stderr || stdout || `Process exited with code ${exitCode}`);
 	}
 	return { stdout, stderr, exitCode };
 }

--- a/packages/upgrade/test/install.test.ts
+++ b/packages/upgrade/test/install.test.ts
@@ -349,6 +349,40 @@ describe('install', () => {
 		assert.equal(fixture.hasMessage('Dependencies failed to install'), true);
 	});
 
+	it('pnpm minimumReleaseAge error shows specific message', async () => {
+		const mockShell = mock.fn<ShellFunction>(async () => {
+			throw new Error(
+				'[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 5 lockfile entries failed verification',
+			);
+		});
+
+		let exitCode: number | undefined;
+		const context: Context = {
+			...ctx,
+			dryRun: false,
+			cwd: tmpUrl,
+			packageManager: { name: 'pnpm', agent: 'pnpm' },
+			exit: (code: number): never => {
+				exitCode = code;
+				return undefined as never;
+			},
+			packages: [
+				{
+					name: 'astro',
+					currentVersion: '1.0.0',
+					targetVersion: '1.1.0',
+				},
+			],
+		};
+
+		await install(context, mockShell);
+
+		assert.equal(mockShell.mock.callCount(), 1);
+		assert.equal(exitCode, 1);
+		assert.equal(fixture.hasMessage('minimumReleaseAge'), true);
+		assert.equal(fixture.hasMessage('Dependencies failed to install'), false);
+	});
+
 	it('pnpm peer dependency error does not retry', async () => {
 		const mockShell = mock.fn<ShellFunction>(async () => {
 			throw new Error('pnpm ERR! peer dependencies conflict');


### PR DESCRIPTION
## Changes

- When pnpm's `minimumReleaseAge` policy blocks an install, `@astrojs/upgrade` now shows a clear message explaining that pnpm's policy is the cause, instead of the generic "Dependencies failed to install" message.
- Fixes `shell.ts` falling back to `stdout` when `stderr` is empty on failure. pnpm writes its `MINIMUM_RELEASE_AGE_VIOLATION` error to stdout, so the previous code discarded it entirely and threw a meaningless "Process exited with code 1" error.

## Testing

- Adds `'pnpm minimumReleaseAge error shows specific message'` in `packages/upgrade/test/install.test.ts`: verifies that a `MINIMUM_RELEASE_AGE_VIOLATION` shell error surfaces the `minimumReleaseAge` message and suppresses the generic fallback.

## Docs

- No docs update needed — this is a CLI error message improvement with no API or configuration surface change.

Closes #17182