### PR TITLE
Fix getStaticPaths error in one route blocking other matching routes in dev

### DIFF
--- a/.changeset/dirty-bananas-worry.md
+++ b/.changeset/dirty-bananas-worry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where an error thrown inside one route's `getStaticPaths()` would prevent other valid routes from being matched in dev mode

--- a/packages/astro/src/core/routing/dev.ts
+++ b/packages/astro/src/core/routing/dev.ts
@@ -32,6 +32,7 @@ export async function matchRoute(
 		manifest,
 	});
 
+	let firstError: unknown = null;
 	for await (const { route: maybeRoute, filePath } of preloadedMatches) {
 		// attempt to get static paths
 		// if this fails, we have a bad URL match!
@@ -56,8 +57,18 @@ export async function matchRoute(
 			if (isAstroError(e) && e.title === NoMatchingStaticPathFound.title) {
 				continue;
 			}
-			throw e;
+			// Store the first error but keep trying other candidate routes.
+			// A user error in one route's getStaticPaths() should not prevent
+			// other matching routes from being attempted.
+			firstError ??= e;
+			continue;
 		}
+	}
+
+	// If we exhausted all candidates and one threw a non-routing error,
+	// re-throw it so the dev server can surface it.
+	if (firstError) {
+		throw firstError;
 	}
 
 	// Try without `.html` extensions or `index.html` in request URLs to mimic

--- a/packages/astro/test/units/routing/dev-match-fallthrough.test.ts
+++ b/packages/astro/test/units/routing/dev-match-fallthrough.test.ts
@@ -5,11 +5,15 @@ import { makeRoute, dynamicPart } from './test-helpers.ts';
 import { defaultLogger } from '../test-utils.ts';
 import { RouteCache } from '../../../dist/core/render/route-cache.js';
 
+import type { RunnablePipeline } from '../../../dist/vite-plugin-app/pipeline.js';
+import type { RouteData } from '../../../dist/types/public/index.js';
+import type { SSRManifest } from '../../../dist/core/app/types.js';
+
 /**
  * Creates a minimal mock pipeline and manifest for testing matchRoute.
  * `componentModules` maps route component paths to their module exports.
  */
-function createMockPipelineAndManifest(componentModules) {
+function createMockPipelineAndManifest(componentModules: Record<string, any>) {
 	const routeCache = new RouteCache(defaultLogger);
 	const manifest = {
 		serverLike: false,
@@ -19,15 +23,15 @@ function createMockPipelineAndManifest(componentModules) {
 		routes: [],
 		buildClientDir: new URL('file:///fake/client/'),
 		outDir: new URL('file:///fake/'),
-	};
+	} as unknown as SSRManifest;
 	const pipeline = {
 		logger: defaultLogger,
 		routeCache,
 		manifest,
-		getComponentByRoute(route) {
+		getComponentByRoute(route: RouteData) {
 			return componentModules[route.component];
 		},
-	};
+	} as unknown as RunnablePipeline;
 	return { pipeline, manifest };
 }
 

--- a/packages/astro/test/units/routing/dev-match-fallthrough.test.ts
+++ b/packages/astro/test/units/routing/dev-match-fallthrough.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { matchRoute } from '../../../dist/core/routing/dev.js';
+import { makeRoute, dynamicPart } from './test-helpers.ts';
+import { defaultLogger } from '../test-utils.ts';
+import { RouteCache } from '../../../dist/core/render/route-cache.js';
+
+/**
+ * Creates a minimal mock pipeline and manifest for testing matchRoute.
+ * `componentModules` maps route component paths to their module exports.
+ */
+function createMockPipelineAndManifest(componentModules) {
+	const routeCache = new RouteCache(defaultLogger);
+	const manifest = {
+		serverLike: false,
+		base: '/',
+		trailingSlash: 'ignore',
+		rootDir: new URL('file:///fake/'),
+		routes: [],
+		buildClientDir: new URL('file:///fake/client/'),
+		outDir: new URL('file:///fake/'),
+	};
+	const pipeline = {
+		logger: defaultLogger,
+		routeCache,
+		manifest,
+		getComponentByRoute(route) {
+			return componentModules[route.component];
+		},
+	};
+	return { pipeline, manifest };
+}
+
+describe('matchRoute in dev', () => {
+	it('continues to next route when getStaticPaths throws a user error', async () => {
+		const trailingSlash = 'ignore';
+
+		// Route A: [c]/[b]/[a] — getStaticPaths throws
+		const routeA = makeRoute({
+			segments: [[dynamicPart('c')], [dynamicPart('b')], [dynamicPart('a')]],
+			trailingSlash,
+			route: '/[c]/[b]/[a]',
+			pathname: undefined,
+			component: 'src/pages/[c]/[b]/[a].astro',
+			prerender: true,
+		});
+
+		// Route B: [c]/[d]/[b] (index) — getStaticPaths returns valid params
+		const routeB = makeRoute({
+			segments: [[dynamicPart('c')], [dynamicPart('d')], [dynamicPart('b')]],
+			trailingSlash,
+			route: '/[c]/[d]/[b]',
+			pathname: undefined,
+			component: 'src/pages/[c]/[d]/[b]/index.astro',
+			prerender: true,
+			isIndex: true,
+		});
+
+		const componentModules = {
+			'src/pages/[c]/[b]/[a].astro': {
+				getStaticPaths() {
+					throw new Error('static paths error');
+				},
+			},
+			'src/pages/[c]/[d]/[b]/index.astro': {
+				getStaticPaths() {
+					return [{ params: { c: '1', d: '2', b: '4' } }];
+				},
+			},
+		};
+
+		const { pipeline, manifest } = createMockPipelineAndManifest(componentModules);
+
+		const routesList = { routes: [routeA, routeB] };
+		const result = await matchRoute('/1/2/4', routesList, pipeline, manifest);
+
+		assert.ok(result, 'Expected a matched route');
+		assert.equal(result.route.component, 'src/pages/[c]/[d]/[b]/index.astro');
+	});
+
+	it('throws error when no other route matches after getStaticPaths error', async () => {
+		const trailingSlash = 'ignore';
+
+		const routeA = makeRoute({
+			segments: [[dynamicPart('c')], [dynamicPart('b')], [dynamicPart('a')]],
+			trailingSlash,
+			route: '/[c]/[b]/[a]',
+			pathname: undefined,
+			component: 'src/pages/[c]/[b]/[a].astro',
+			prerender: true,
+		});
+
+		const componentModules = {
+			'src/pages/[c]/[b]/[a].astro': {
+				getStaticPaths() {
+					throw new Error('static paths error');
+				},
+			},
+		};
+
+		const { pipeline, manifest } = createMockPipelineAndManifest(componentModules);
+
+		const routesList = { routes: [routeA] };
+		await assert.rejects(
+			() => matchRoute('/1/2/3', routesList, pipeline, manifest),
+			(err) => {
+				assert.ok(err instanceof Error);
+				assert.equal(err.message, 'static paths error');
+				return true;
+			},
+		);
+	});
+});


### PR DESCRIPTION
## Changes

- In dev mode, when multiple routes match a URL pattern, an error thrown inside one route's `getStaticPaths()` no longer prevents other candidate routes from being tried. Previously, any non-routing error was immediately re-thrown, causing valid sibling routes to return a 500 instead of their correct response.
- The fix stores the first non-routing error and defers re-throwing it until all candidates are exhausted without a match, so the error still surfaces when there's genuinely no valid route.

Closes #9819

## Testing

- Added `packages/astro/test/units/routing/dev-match-fallthrough.test.ts` with two cases: one verifying that route B is matched when route A's `getStaticPaths` throws, and one verifying the error is still re-thrown when no valid alternative exists.

## Docs

- No docs update needed; this is a dev-mode bug fix with no API or user-facing behavior change beyond the bug itself.
