### PR TITLE
Fix astro check failing to resolve dependencies from the project directory

### DIFF
--- a/.changeset/tame-cli-resolve-deps.md
+++ b/.changeset/tame-cli-resolve-deps.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro check` (and other commands that auto-install dependencies) failing to find `typescript` and `@astrojs/check` when Astro is installed outside of the project directory (e.g. a pnpm global or virtual store). Dependencies are now resolved and imported from the project directory instead of from Astro's own location.

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 import * as clack from '@clack/prompts';
 import ci from 'ci-info';
 import { detect, resolveCommand } from 'package-manager-detector';
@@ -15,18 +16,24 @@ type GetPackageOptions = {
 	cwd?: string;
 };
 
+// Resolve and import the package from the user's project (`cwd`) rather than from
+// Astro's own location, so dependencies are found even when Astro lives outside the
+// project (e.g. a pnpm global or virtual store). Resolving first with `require.resolve`
+// also avoids caching a failed ESM import before the package gets installed.
+async function importPackageFromCwd<T>(packageName: string, cwd: string): Promise<T> {
+	const resolved = require.resolve(packageName, { paths: [cwd] });
+	return (await import(pathToFileURL(resolved).href)) as T;
+}
+
 export async function getPackage<T>(
 	packageName: string,
 	logger: AstroLogger,
 	options: GetPackageOptions,
 	otherDeps: string[] = [],
 ): Promise<T | undefined> {
+	const cwd = options.cwd ?? process.cwd();
 	try {
-		// Try to resolve with `createRequire` first to prevent ESM caching of the package
-		// if it errors and fails here
-		require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
-		const packageImport = await import(packageName);
-		return packageImport as T;
+		return await importPackageFromCwd<T>(packageName, cwd);
 	} catch {
 		if (options.optional) return undefined;
 		let message = `To continue, Astro requires the following dependency to be installed: ${bold(
@@ -46,8 +53,7 @@ export async function getPackage<T>(
 		const result = await installPackage([packageName, ...otherDeps], options, logger);
 
 		if (result) {
-			const packageImport = await import(packageName);
-			return packageImport;
+			return await importPackageFromCwd<T>(packageName, cwd);
 		} else {
 			return undefined;
 		}

--- a/packages/astro/test/units/cli/install-package.test.ts
+++ b/packages/astro/test/units/cli/install-package.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { getPackage } from '../../../dist/cli/install-package.js';
+import { defaultLogger } from '../test-utils.ts';
+
+describe('CLI install-package', () => {
+	describe('getPackage()', () => {
+		const packageName = '@astro-test/cwd-only-pkg';
+		let projectDir: string;
+
+		before(() => {
+			// Create a project whose dependency lives only in its own node_modules,
+			// i.e. somewhere Astro's own module resolution cannot reach.
+			projectDir = mkdtempSync(join(tmpdir(), 'astro-get-package-'));
+			const pkgDir = join(projectDir, 'node_modules', '@astro-test', 'cwd-only-pkg');
+			mkdirSync(pkgDir, { recursive: true });
+			writeFileSync(
+				join(pkgDir, 'package.json'),
+				JSON.stringify({ name: packageName, version: '1.0.0', type: 'module', main: 'index.js' }),
+			);
+			writeFileSync(join(pkgDir, 'index.js'), 'export const marker = "loaded-from-cwd";\n');
+		});
+
+		after(() => {
+			rmSync(projectDir, { recursive: true, force: true });
+		});
+
+		it('resolves a dependency from the provided cwd, not from Astro’s own location', async () => {
+			const pkg = await getPackage<{ marker: string }>(packageName, defaultLogger, {
+				cwd: projectDir,
+				optional: true,
+				skipAsk: true,
+			});
+
+			assert.ok(pkg, 'expected the package to be resolved from the project cwd');
+			assert.equal(pkg.marker, 'loaded-from-cwd');
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- `astro check` (and any command that auto-installs dependencies through `getPackage`) failed to find `typescript` and `@astrojs/check` when Astro itself is installed **outside** the project directory (e.g. a pnpm global/virtual store, or a monorepo where the store isn't under the project).
- Root cause: `getPackage` resolved the dependency with `require.resolve(pkg, { paths: [cwd] })` but then loaded it with a bare `import(pkg)`. A bare specifier resolves relative to Astro's own location, not the project, so the import threw `ERR_MODULE_NOT_FOUND` even though the package existed in the project.
- Fix: import the **resolved absolute path** via `pathToFileURL(...)`, so dependencies are loaded from the project directory. The same fix is applied to the post-install import path. Resolving first with `require.resolve` is preserved (it also avoids caching a failed ESM import before installing).
- Added a changeset (`astro` patch).

Fixes #17135.

> Note: the root cause was already diagnosed by @astrobot-houston in the issue, and @matthewp verified the same fix via the `pkg.pr.new` preview (`astro@9a53f77`). Since the previous fix branch was lost, this PR provides a ready implementation **with a regression test**.

## Testing

- Added `packages/astro/test/units/cli/install-package.test.ts`: installs a dependency only inside a temporary project's `node_modules` (outside Astro's resolution scope) and asserts `getPackage` loads it from the provided `cwd`. This fails on the old bare-`import` behavior and passes with the fix.
- `pnpm --filter astro exec astro-scripts test "test/units/cli/install-package.test.ts" --strip-types` → **1 passing**.
- `biome check`, `prettier --check`, and `eslint` pass on the changed files.

## Docs

No docs changes needed — this restores the documented behavior (resolving dependencies from the user's project) without changing any public API.
