### PR TITLE
Fix Markdoc custom transform dropped for tag/node names with dashes

### DIFF
--- a/.changeset/tidy-markdoc-dashed-keys.md
+++ b/.changeset/tidy-markdoc-dashed-keys.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fixes custom `transform` functions being incorrectly dropped for tags and nodes whose names require bracket access (e.g. `side-note`). The check that detects whether a transform respects a custom `render` component now recognizes bracket notation, optional chaining and whitespace, not only dot notation.

--- a/packages/integrations/markdoc/src/runtime.ts
+++ b/packages/integrations/markdoc/src/runtime.ts
@@ -147,11 +147,15 @@ function syncTagNodeAttributes(config: MergedConfig): void {
  */
 function transformRespectsRender(transform: { toString(): string }, configKey: string): boolean {
 	const source = transform.toString();
-	// Astro's transforms check config.nodes?.X?.render or config.tags?.X?.render
-	return (
-		source.includes(`config.nodes?.${configKey}?.render`) ||
-		source.includes(`config.tags?.${configKey}?.render`)
+	// `configKey` may not be a valid identifier (e.g. `side-note`), so a render-respecting
+	// transform can read `render` via dot or bracket access. Escape the key and match either.
+	const key = configKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const member = (prop: string) =>
+		`(?:\\??\\.\\s*${prop}|\\??\\.?\\s*\\[\\s*['"\`]${prop}['"\`]\\s*\\])`;
+	const pattern = new RegExp(
+		`config\\s*\\??\\.\\s*(?:nodes|tags)\\s*${member(key)}\\s*${member('render')}`,
 	);
+	return pattern.test(source);
 }
 
 export function resolveComponentImports(

--- a/packages/integrations/markdoc/test/resolve-component-imports.test.ts
+++ b/packages/integrations/markdoc/test/resolve-component-imports.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { AstroInstance } from 'astro';
+import { resolveComponentImports } from '../dist/runtime.js';
+
+type MarkdocConfig = Parameters<typeof resolveComponentImports>[0];
+type NodeComponentMap = Parameters<typeof resolveComponentImports>[2];
+
+// Minimal stand-in for an Astro component; only referential identity matters here.
+const Component = (() => null) as unknown as AstroInstance['default'];
+const noNodeComponents = {} as NodeComponentMap;
+
+/**
+ * Regression test for issue #17118: tag/node names containing characters that
+ * require bracket access (e.g. `side-note`) were always treated as not respecting
+ * `render`, because the detection only matched dot notation.
+ */
+describe('Markdoc - resolveComponentImports', () => {
+	it('keeps a render-respecting transform for tag names that need bracket access (e.g. dashes)', () => {
+		const markdocConfig: MarkdocConfig = {
+			tags: {
+				'side-note': {
+					// A dashed key can only read `render` through bracket notation.
+					transform(node, config) {
+						if (config.tags?.['side-note']?.render) return [];
+						return node.transformChildren(config);
+					},
+				},
+			},
+			nodes: {},
+		};
+
+		const resolved = resolveComponentImports(
+			markdocConfig,
+			{ 'side-note': Component },
+			noNodeComponents,
+		);
+
+		assert.equal(resolved.tags['side-note'].render, Component);
+		assert.equal(
+			typeof resolved.tags['side-note'].transform,
+			'function',
+			'a render-respecting transform should be preserved for dashed tag names',
+		);
+	});
+
+	it('removes a transform that does not respect render so the custom component wins', () => {
+		const markdocConfig: MarkdocConfig = {
+			tags: {
+				'side-note': {
+					transform(node, config) {
+						return node.transformChildren(config);
+					},
+				},
+			},
+			nodes: {},
+		};
+
+		const resolved = resolveComponentImports(
+			markdocConfig,
+			{ 'side-note': Component },
+			noNodeComponents,
+		);
+
+		assert.equal(resolved.tags['side-note'].render, Component);
+		assert.equal(
+			resolved.tags['side-note'].transform,
+			undefined,
+			'a non-render-respecting transform should be removed so `render` wins',
+		);
+	});
+});


### PR DESCRIPTION
## Changes

Custom Markdoc `transform` functions were being dropped for tags and nodes whose names need bracket access, like `side-note`.

Here is why. When you set a custom `render` component, `resolveComponentImports` removes the `transform` unless that transform "respects" render (issue #9708, added in #15335). It worked that out by string-matching the transform's source for `config.tags?.<key>?.render` or `config.nodes?.<key>?.render`, which only covers dot notation.

A key like `side-note` can't be read with dot notation at all (`config.tags?.side-note?.render` parses as a subtraction), so those transforms have to use bracket notation: `config.tags?.['side-note']?.render`. The old check never matched that, so the transform was always treated as not respecting render and deleted, which broke the tag.

The detection now handles bracket notation alongside dot notation, plus optional chaining and whitespace. Includes a changeset (`@astrojs/markdoc` patch).

Fixes #17118.

## Testing

Added `packages/integrations/markdoc/test/resolve-component-imports.test.ts`, a unit test over the exported `resolveComponentImports`:

- a render-respecting transform on a dashed tag (`side-note`, via bracket access) is kept;
- a transform that does not respect render is still removed so `render` wins.

I checked it both ways: the first case fails on `main` (transform deleted) and passes with this change. The full package suite is green too. `pnpm --filter @astrojs/markdoc test` runs 50 tests, including the existing `render-with-transform` test for #9708. `tsc -b`, `biome check`, `prettier --check`, and `eslint` are all clean on the changed files.

## Docs

No docs changes. This restores the documented behavior (a custom `render` together with a custom `transform`) for tag and node names that contain dashes, and there is no public API change.
