### PR TITLE
Fix flaky "below the fold" dev-toolbar perf audit e2e test

### DIFF
--- a/packages/astro/e2e/dev-toolbar-audits.test.ts
+++ b/packages/astro/e2e/dev-toolbar-audits.test.ts
@@ -92,6 +92,13 @@ test.describe('Dev Toolbar - Audits', () => {
 	}) => {
 		await page.goto(astro.resolveUrl('/audits-perf-absolute'));
 
+		// The audit gates highlight creation on the image's `load` event, so run it
+		// only after the image has finished loading. Otherwise a slow image load on CI
+		// can outlast the assertion timeout and intermittently report 0 highlights.
+		await expect(page.locator('img[alt="A walrus"]')).toHaveJSProperty('complete', true, {
+			timeout: 15_000,
+		});
+
 		const toolbar = page.locator('astro-dev-toolbar');
 		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
 		await appButton.click();


### PR DESCRIPTION
## Changes

Hardens a flaky e2e test: `Dev Toolbar - Audits › can warn about perf issue for below the fold image in absolute container`.

The audit gates highlight creation on the image's `load` event (`apps/audit/index.ts` awaits `load` so the above/below-the-fold position checks have accurate layout). The test clicked the audit button and immediately asserted `toHaveCount(1)` with the default 6s `expect` timeout. When the optimized image loads slowly (e.g. a contended CI runner), the highlight is not created in time and the assertion intermittently sees 0 highlights, failing every retry.

The test now waits for the image to finish loading before triggering the audit, so the assertion no longer races the image load. No production code changes.

This flaked (all 3 retries) on unrelated CI, e.g. https://github.com/withastro/astro/actions/runs/28129089505/job/83301140796

## Testing

- `pnpm --filter astro exec playwright test dev-toolbar-audits.test.ts` runs 11 passing, executed twice for stability.
- The targeted test passes locally. The change only adds a wait before the audit runs, so it cannot make the assertion less reliable.

## Docs

No docs changes; this is test-only. No changeset, since there are no published package changes.
