### PR TITLE
fix(head): use correct name attribute for twitter:card meta tag

### DIFF
--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -49,4 +49,4 @@ const { title, description, image = FallbackImage } = Astro.props;
 <meta property="og:image" content={new URL(image.src, Astro.url)} />
 
 <!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image" />
+<meta name="twitter:card" content="summary_large_image" />

--- a/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
@@ -35,4 +35,4 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta property="og:image" content={new URL(image, Astro.url)} />
 
 <!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image" />
+<meta name="twitter:card" content="summary_large_image" />

--- a/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
@@ -35,4 +35,4 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta property="og:image" content={new URL(image, Astro.url)} />
 
 <!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image" />
+<meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
It is better to merge #17179 first (while it does change only the remaining `twitter:*` meta tags).

## Changes

- Corrected the `twitter:card` meta tag to use `name` instead of `property`. [Resource](https://css-tricks.com/essential-meta-tags-social-media/)
- Applied the fix in the blog component and matching e2e fixtures.

## Testing

- Verified generated HTML no longer includes the Twitter meta tags as `property` but `name`.
- Confirmed remaining Twitter metadata continues to render correctly.

## Docs

- No docs changes needed.

## Resources

> Is there a resource or something that states that those tags are redundant? You should provide those resources together with the PR

Normally the link I'd have shown would've been: https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup
But it doesn't work because they've removed it and one cannot find it anywhere.

But Wayback Machine comes to help:
- https://web.archive.org/web/20240613190853/https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup
- https://web.archive.org/web/20240616101429/https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started

As you can see for `twitter:*` meta tags, `name` is used.
```html
<meta name="twitter:card" content="summary" />
<meta name="twitter:site" content="@">
<meta name="twitter:creator" content="@">
<meta property="og:url" content="">
<meta property="og:title" content="">
<meta property="og:description" content="">
<meta property="og:image" content="">
```