### PR TITLE
chore(head): normalize html charset declarations

### DIFF
--- a/benchmark/static-projects/build-hybrid/src/layouts/BaseLayout.astro
+++ b/benchmark/static-projects/build-hybrid/src/layouts/BaseLayout.astro
@@ -5,7 +5,7 @@ const { title } = Astro.props;
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{title}</title>
 	</head>

--- a/benchmark/static-projects/build-server/src/layouts/BaseLayout.astro
+++ b/benchmark/static-projects/build-server/src/layouts/BaseLayout.astro
@@ -5,7 +5,7 @@ const { title } = Astro.props;
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{title}</title>
 	</head>

--- a/benchmark/static-projects/build-static/src/layouts/BaseLayout.astro
+++ b/benchmark/static-projects/build-static/src/layouts/BaseLayout.astro
@@ -5,7 +5,7 @@ const { title } = Astro.props;
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{title}</title>
 	</head>

--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="icon" href="/favicon.ico" />

--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -12,7 +12,7 @@ const {
 } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="description" property="og:description" content={description} />
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />

--- a/examples/with-markdoc/src/layouts/Layout.astro
+++ b/examples/with-markdoc/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props;
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="icon" href="/favicon.ico" />

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -13,7 +13,7 @@ const { title } = Astro.props;
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />

--- a/packages/astro/e2e/fixtures/tailwindcss/src/components/Layout.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/components/Layout.astro
@@ -1,6 +1,6 @@
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/form-four.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/form-four.astro
@@ -5,7 +5,7 @@ import { ClientRouter } from 'astro:transitions';
 <html>
 	<head>
 		<ClientRouter handleForms />
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 	</head>
 	<body>
 		<h2>Voting Form</h2>

--- a/packages/astro/performance/fixtures/utils/RenderContent.astro
+++ b/packages/astro/performance/fixtures/utils/RenderContent.astro
@@ -10,7 +10,7 @@ const { posts, renderer: ContentRenderer } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Md render test</title>
 </head>

--- a/packages/astro/src/template/4xx.ts
+++ b/packages/astro/src/template/4xx.ts
@@ -25,7 +25,7 @@ export default function template({
 	return `<!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<title>${tabTitle}</title>
 		<style>
 			:root {

--- a/packages/astro/test/fixtures/0-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/index.astro
@@ -31,7 +31,7 @@ import raw from '../styles/raw.css?raw'
 
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <style lang="scss">
       .wrapper {
         margin-left: auto;

--- a/packages/astro/test/fixtures/actions/src/pages/subscribe-prerendered.astro
+++ b/packages/astro/test/fixtures/actions/src/pages/subscribe-prerendered.astro
@@ -9,7 +9,7 @@ const result = Astro.getActionResult(actions.subscribe);
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Document</title>
 	</head>

--- a/packages/astro/test/fixtures/astro-envs/src/pages/info.html
+++ b/packages/astro/test/fixtures/astro-envs/src/pages/info.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/astro-head/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-head/src/components/Head.astro
@@ -4,7 +4,7 @@ const { title } = Astro.props;
 ---
 
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <title>{title}</title>

--- a/packages/astro/test/fixtures/astro-manifest-client-script/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-manifest-client-script/src/pages/index.astro
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8"/>
+	<meta charset="utf-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/astro-manifest-invalid/src/pages/client.astro
+++ b/packages/astro/test/fixtures/astro-manifest-invalid/src/pages/client.astro
@@ -4,7 +4,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8"/>
+	<meta charset="utf-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/astro-manifest/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-manifest/src/pages/index.astro
@@ -7,7 +7,7 @@ const config = JSON.stringify({ base, i18n, build, trailingSlash, compressHTML, 
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8"/>
+	<meta charset="utf-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/astro-manifest/src/pages/server.astro
+++ b/packages/astro/test/fixtures/astro-manifest/src/pages/server.astro
@@ -4,7 +4,7 @@ import { root, outDir, srcDir, build, cacheDir } from "astro:config/server";
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8"/>
+	<meta charset="utf-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
@@ -18,7 +18,7 @@ const {
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 

--- a/packages/astro/test/fixtures/content-layer-remark-plugins/src/pages/[...slug].astro
+++ b/packages/astro/test/fixtures/content-layer-remark-plugins/src/pages/[...slug].astro
@@ -16,7 +16,7 @@ const { Content, remarkPluginFrontmatter } = await render(doc);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/content-layer-remark-plugins/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-layer-remark-plugins/src/pages/index.astro
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/content-ssr-integration/src/pages/deprecated-getdataentrybyid.astro
+++ b/packages/astro/test/fixtures/content-ssr-integration/src/pages/deprecated-getdataentrybyid.astro
@@ -8,7 +8,7 @@ if (!post) {
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/content-ssr-integration/src/pages/deprecated-getentrybyslug.astro
+++ b/packages/astro/test/fixtures/content-ssr-integration/src/pages/deprecated-getentrybyslug.astro
@@ -8,7 +8,7 @@ if (!post) {
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>
 </head>

--- a/packages/astro/test/fixtures/css-import-as-inline/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-import-as-inline/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/packages/astro/test/fixtures/css-inline-stylesheets/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-inline-stylesheets/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ const { title } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
+++ b/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
   </head>
   <body>
     <h1>css no code split</h1>

--- a/packages/astro/test/fixtures/css-order-layout/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/css-order-layout/src/components/MainHead.astro
@@ -2,4 +2,4 @@
 import "../styles/global.css";
 ---
 
-<meta charset="UTF-8" />
+<meta charset="utf-8" />

--- a/packages/astro/test/fixtures/css-order-layout/src/pages/transparent.astro
+++ b/packages/astro/test/fixtures/css-order-layout/src/pages/transparent.astro
@@ -4,7 +4,7 @@ import Item from "../components/Item.astro";
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Basic HTML</title>
 </head>

--- a/packages/astro/test/fixtures/head-propagation-prerender-env/src/components/Layout.astro
+++ b/packages/astro/test/fixtures/head-propagation-prerender-env/src/components/Layout.astro
@@ -5,7 +5,7 @@ const { title } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<title>{title}</title>
 		<ThemeIcons />
 	</head>

--- a/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
@@ -3,7 +3,7 @@ import '../styles/main.scss';
 const { title = 'Static Build', description = 'This is a demo of the static build' } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="description" property="og:description" content={description} />
 <meta name="viewport" content="width=device-width" />
 <title>{title}</title>

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -7,7 +7,7 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/caches.astro
+++ b/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/caches.astro
@@ -4,7 +4,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CACHES</title>
   </head>

--- a/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/d1.astro
+++ b/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/d1.astro
@@ -9,7 +9,7 @@ const result = await db.prepare("SELECT * FROM test").all();
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>D1</title>
 </head>

--- a/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/kv.astro
+++ b/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/kv.astro
@@ -8,7 +8,7 @@ const result = await kv.get("test")
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>KV</title>
 </head>

--- a/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/r2.astro
+++ b/packages/integrations/cloudflare/test/fixtures/astro-dev-platform/src/pages/r2.astro
@@ -8,7 +8,7 @@ const result = await (await bucket.get("test")).text()
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>R2</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/content-layer/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/content-layer/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
@@ -14,7 +14,7 @@ const { Content, headings } = await render(Astro.props);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
@@ -14,7 +14,7 @@ const { Content, headings } = await render(Astro.props);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/propagated-assets/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/propagated-assets/src/pages/[slug].astro
@@ -15,7 +15,7 @@ const { Content } = await render(Astro.props);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{Astro.props.data.title}</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render with-space/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render with-space/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-html/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/render-html/src/pages/[slug].astro
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-null/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-null/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-partials/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-partials/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Content</title>
 	</head>

--- a/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-table-attrs/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-table-attrs/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-typographer/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-typographer/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/pages/index.astro
@@ -8,7 +8,7 @@ const { Content } = await render(post);
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Content</title>
 </head>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
@@ -1,7 +1,7 @@
 ---
 const { title } = Astro.props;
 ---
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />

--- a/packages/integrations/mdx/test/fixtures/mdx-basics/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-basics/src/layouts/Base.astro
@@ -16,7 +16,7 @@ const {
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
@@ -6,7 +6,7 @@ const { frontmatter = defaults, content = defaults } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{frontmatter.title}</title>
 </head>

--- a/packages/integrations/mdx/test/fixtures/mdx-images/src/pages/content-collection.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-images/src/pages/content-collection.astro
@@ -9,7 +9,7 @@ const { Content } = await render(entry)
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Renderer</title>
 </head>

--- a/packages/integrations/mdx/test/fixtures/mdx-images/src/pages/esm-import.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-images/src/pages/esm-import.astro
@@ -6,7 +6,7 @@ import MDX from '../components/Component.mdx';
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Renderer</title>
 </head>

--- a/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
+++ b/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
@@ -4,7 +4,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>404</title>
 </head>


### PR DESCRIPTION
## Changes

- Normalize the `meta charset` declaration from `UTF-8` to `utf-8` across layouts.
- Apply the same charset formatting change consistently in all affected project files.
- Prefer the lowercase `utf-8` form to match the more common usage already present in the codebase.

## Testing

- Tests were run to verify the updated HTML output uses `charset="utf-8"` consistently.
- Confirmed the change is applied across all affected layouts and project files.

## Docs

- No documentation changes needed.