### PR TITLE
Fix `create-astro` failing to install dependencies with pnpm v11+

### DIFF
--- a/.changeset/tasty-icons-wink.md
+++ b/.changeset/tasty-icons-wink.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes dependency installation when creating Astro projects with pnpm 11+

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -122,7 +122,34 @@ async function astroAdd({
 
 async function install({ packageManager, cwd }: { packageManager: string; cwd: string }) {
 	if (packageManager === 'yarn') await ensureYarnLock({ cwd });
+	if (packageManager === 'pnpm') await ensurePnpmBuildsAllowed({ cwd });
 	return shell(packageManager, ['install'], { cwd, timeout: 90_000, stdio: 'ignore' });
+}
+
+/**
+ * pnpm v11+ enables `strictDepBuilds` by default, which causes `pnpm install` to fail
+ * with a non-zero exit code if any dependencies have unapproved build scripts (postinstall).
+ * Astro depends on `esbuild` and `sharp` which both have build scripts.
+ *
+ * This function ensures those packages are pre-approved in `pnpm-workspace.yaml`
+ * so that `pnpm install` succeeds without user intervention.
+ * See https://pnpm.io/settings#allowbuilds
+ */
+async function ensurePnpmBuildsAllowed({ cwd }: { cwd: string }) {
+	const workspaceFile = path.join(cwd, 'pnpm-workspace.yaml');
+	const packagesToAllow = ['esbuild', 'sharp'];
+
+	let content = '';
+	if (fs.existsSync(workspaceFile)) {
+		content = await fs.promises.readFile(workspaceFile, 'utf-8');
+	}
+
+	// If allowBuilds is already configured, don't touch it
+	if (content.includes('allowBuilds')) return;
+
+	const separator = content.length > 0 ? '\n' : '';
+	const allowBuildsBlock = `${separator}allowBuilds:\n${packagesToAllow.map((pkg) => `  ${pkg}: true`).join('\n')}\n`;
+	return fs.promises.writeFile(workspaceFile, content + allowBuildsBlock, 'utf-8');
 }
 
 /**


### PR DESCRIPTION
Closes #17204
Closes #17091

## Changes

- Adds an `ensurePnpmBuildsAllowed()` helper that writes `allowBuilds` entries for `esbuild` and `sharp` into `pnpm-workspace.yaml` before running `pnpm install`. This mirrors the existing `ensureYarnLock()` pattern for Yarn Berry.
- pnpm v11.0.0 set [`strictDepBuilds`](https://pnpm.io/settings#strictdepbuilds) to `true` by default, causing `pnpm install` to exit non-zero when any dependency has an unapproved build script. Both `esbuild` and `sharp` (Astro dependencies) have postinstall scripts, so `pnpm create astro` would fail with `ERR_PNPM_IGNORED_BUILDS` and leave `node_modules` uninstalled.
- If `allowBuilds` is already present in `pnpm-workspace.yaml`, the helper skips writing to avoid overriding user configuration.

## Testing

- No new tests added — the helper runs during the live `pnpm install` call and is difficult to unit test in isolation. All 120 existing tests continue to pass.
- Confirmed end-to-end by issue reporter (@jettwayio): `npx create-astro --template starlight` now creates `node_modules` successfully with pnpm v11.

## Docs

- No docs update needed — this is an internal scaffolding fix with no user-facing API change.

> **Note:** A changeset for `create-astro` is needed before merging.