### PR TITLE
Validate X-Forwarded-Host against allowedDomains when resolving clientAddress

### DIFF
--- a/.changeset/tidy-forwarded-host.md
+++ b/.changeset/tidy-forwarded-host.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens forwarded header handling so the internal request helper validates `X-Forwarded-Host` against `security.allowedDomains` before trusting `X-Forwarded-For` for `clientAddress`. Previously it only checked that the header was present, which was inconsistent with the public `createRequest` helper. This aligns both code paths; behavior is unchanged for correctly configured proxies.

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -104,9 +104,16 @@ export function createRequestFromNodeRequest(
 		protocol,
 		allowedDomains,
 	);
-	const forwardedHost = getFirstForwardedValue(req.headers['x-forwarded-host']);
-	const hostValidated =
-		validatedHostname !== undefined || (forwardedHost !== undefined && allowedDomains.length > 0);
+	// Only treat X-Forwarded-Host as trusted when it actually matches
+	// allowedDomains, mirroring `createRequest`. Checking that the header
+	// is merely present would accept any value.
+	const validatedForwardedHost = validateForwardedHeaders(
+		undefined,
+		getFirstForwardedValue(req.headers['x-forwarded-host']),
+		undefined,
+		allowedDomains,
+	).host;
+	const hostValidated = validatedHostname !== undefined || validatedForwardedHost !== undefined;
 	const forwardedClientIp = hostValidated
 		? getFirstForwardedValue(req.headers['x-forwarded-for'])
 		: undefined;

--- a/packages/astro/test/units/app/node.test.ts
+++ b/packages/astro/test/units/app/node.test.ts
@@ -1,7 +1,11 @@
 import * as assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { describe, it } from 'node:test';
-import { createRequest, writeResponse } from '../../../dist/core/app/node.js';
+import {
+	createRequest,
+	createRequestFromNodeRequest,
+	writeResponse,
+} from '../../../dist/core/app/node.js';
 
 // Minimal mock satisfying the subset of IncomingMessage used by createRequest.
 // We intentionally omit the full IncomingMessage interface members not exercised here.
@@ -853,6 +857,68 @@ describe('node', () => {
 					{ allowedDomains: [{ hostname: 'example.com' }] },
 				);
 				assert.equal(result.url, 'https://example.com:3000/');
+			});
+		});
+	});
+
+	describe('createRequestFromNodeRequest', () => {
+		describe('x-forwarded-for', () => {
+			it('trusts x-forwarded-for when host matches allowedDomains', () => {
+				const result = createRequestFromNodeRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com',
+							'x-forwarded-for': '1.1.1.1',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal((result as any)[Symbol.for('astro.clientAddress')], '1.1.1.1');
+			});
+
+			it('trusts x-forwarded-for when x-forwarded-host matches allowedDomains', () => {
+				const result = createRequestFromNodeRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'evil.com',
+							'x-forwarded-host': 'example.com',
+							'x-forwarded-for': '1.1.1.1',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				assert.equal((result as any)[Symbol.for('astro.clientAddress')], '1.1.1.1');
+			});
+
+			it('ignores x-forwarded-for when x-forwarded-host does not match allowedDomains', () => {
+				const result = createRequestFromNodeRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'evil.com',
+							'x-forwarded-host': 'bad.net',
+							'x-forwarded-for': '1.1.1.1',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				// Neither the Host nor the X-Forwarded-Host matches allowedDomains,
+				// so x-forwarded-for must not be trusted.
+				assert.equal((result as any)[Symbol.for('astro.clientAddress')], '2.2.2.2');
+			});
+
+			it('ignores x-forwarded-for when no allowedDomains is configured', () => {
+				const result = createRequestFromNodeRequest({
+					...mockNodeRequest,
+					headers: {
+						host: 'example.com',
+						'x-forwarded-host': 'example.com',
+						'x-forwarded-for': '1.1.1.1',
+					},
+				});
+				assert.equal((result as any)[Symbol.for('astro.clientAddress')], '2.2.2.2');
 			});
 		});
 	});


### PR DESCRIPTION
## Changes

- Aligns the internal `createRequestFromNodeRequest` helper with the public `createRequest`: `X-Forwarded-For` is only trusted for `clientAddress` when `X-Forwarded-Host` actually matches `security.allowedDomains`, instead of just checking that the header is present.
- No behavior change for correctly configured proxies; this only tightens consistency between the two request helpers.

## Testing

- Adds a `createRequestFromNodeRequest` test block covering: trusted `Host`, trusted `X-Forwarded-Host`, a non-matching `X-Forwarded-Host` (now falls back to the socket address), and the no-`allowedDomains` case.

## Docs

- No docs update needed; `allowedDomains` behavior is unchanged from a user's perspective.
