### PR TITLE
Escape source and enclosure fields in RSS feed generation

### DIFF
--- a/.changeset/harden-rss-field-escaping.md
+++ b/.changeset/harden-rss-field-escaping.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Hardens RSS feed generation by escaping the `source` and `enclosure` item fields. These fields are now serialized as structured XML values, ensuring that special characters in values like `source.title` and `enclosure.type` are always treated as text rather than markup, consistent with how other feed fields are handled.

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -251,17 +251,20 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 				: createCanonicalURL(result.commentsUrl, rssOptions.trailingSlash, site);
 		}
 		if (result.source) {
-			item.source = parser.parse(
-				`<source url="${result.source.url}">${result.source.title}</source>`,
-			).source;
+			item.source = {
+				'#text': result.source.title,
+				'@_url': result.source.url,
+			};
 		}
 		if (result.enclosure) {
 			const enclosureURL = isValidURL(result.enclosure.url)
 				? result.enclosure.url
 				: createCanonicalURL(result.enclosure.url, rssOptions.trailingSlash, site);
-			item.enclosure = parser.parse(
-				`<enclosure url="${enclosureURL}" length="${result.enclosure.length}" type="${result.enclosure.type}"/>`,
-			).enclosure;
+			item.enclosure = {
+				'@_url': enclosureURL,
+				'@_length': result.enclosure.length,
+				'@_type': result.enclosure.type,
+			};
 		}
 		return item;
 	});

--- a/packages/astro-rss/test/rss.test.ts
+++ b/packages/astro-rss/test/rss.test.ts
@@ -271,6 +271,72 @@ describe('getRssString', () => {
 		assert.equal(error, null);
 	});
 
+	it('should escape XML special characters in source fields', async () => {
+		const sourceTitle = 'Real Title</source><source url="https://evil.example.com">Fake';
+		const str = await getRssString({
+			title,
+			description,
+			items: [
+				{
+					title: 'Title',
+					pubDate: new Date(),
+					description: 'Description',
+					link: '/link',
+					source: {
+						url: 'https://example.com/source',
+						title: sourceTitle,
+					},
+				},
+			],
+			site,
+		});
+
+		// The crafted value must not produce additional <source> elements.
+		assert.equal(str.match(/<source/g)?.length, 1);
+
+		const { err, result } = parseXmlString(str);
+		assert.equal(err, null);
+		const item = (result as any).rss.channel[0].item[0];
+		assert.equal(item.source.length, 1);
+		// The raw value is preserved verbatim as text, not interpreted as markup.
+		assert.equal(item.source[0]._, sourceTitle);
+		assert.equal(item.source[0].$.url, 'https://example.com/source');
+	});
+
+	it('should escape XML special characters in enclosure fields', async () => {
+		const enclosureType = 'audio/mpeg"><injected>x</injected><enclosure fake="';
+		const str = await getRssString({
+			title,
+			description,
+			items: [
+				{
+					title: 'Title',
+					pubDate: new Date(),
+					description: 'Description',
+					link: '/link',
+					enclosure: {
+						url: '/podcast.mp3',
+						length: 256,
+						type: enclosureType,
+					},
+				},
+			],
+			site,
+		});
+
+		// The crafted value must not produce additional <enclosure> elements.
+		assert.equal(str.match(/<enclosure/g)?.length, 1);
+		assert.equal(str.includes('<injected>'), false);
+
+		const { err, result } = parseXmlString(str);
+		assert.equal(err, null);
+		const item = (result as any).rss.channel[0].item[0];
+		assert.equal(item.enclosure.length, 1);
+		// The raw value is preserved verbatim as an attribute, not interpreted as markup.
+		assert.equal(item.enclosure[0].$.type, enclosureType);
+		assert.equal(item.enclosure[0].$.url, `${site}/podcast.mp3`);
+	});
+
 	it('should not fail when an enclosure has a length of 0', async () => {
 		let error = null;
 		try {


### PR DESCRIPTION
## Changes

- Builds the `source` and `enclosure` item elements as structured XML objects instead of interpolating values into a string and re-parsing them. This ensures special characters in fields like `source.title` and `enclosure.type` are always serialized as text, consistent with how every other feed field is already handled.

## Testing

- Adds two cases covering `source` and `enclosure` fields containing XML special characters, asserting the values round-trip verbatim and produce exactly one element each.

## Docs

- No docs update needed; this is an internal serialization change with no API surface change.