### PR TITLE
docs: correct build.client and build.server @default to include trailing slash

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1103,7 +1103,7 @@ export interface AstroUserConfig<
 		 * @docs
 		 * @name build.client
 		 * @type {string}
-		 * @default `'./client'`
+		 * @default `'./client/'`
 		 * @description
 		 * Controls the output directory of your client-side CSS and JavaScript when building a website with server-rendered pages.
 		 * `outDir` controls where the code is built to.
@@ -1124,7 +1124,7 @@ export interface AstroUserConfig<
 		 * @docs
 		 * @name build.server
 		 * @type {string}
-		 * @default `'./server'`
+		 * @default `'./server/'`
 		 * @description
 		 * Controls the output directory of server JavaScript when building to SSR.
 		 *


### PR DESCRIPTION
The `@default` annotations for `build.client` and `build.server` drop the trailing slash that the real defaults carry: `ASTRO_CONFIG_DEFAULTS` sets `client: './client/'` and `server: './server/'`, while the JSDoc documents `'./client'` and `'./server'`. This corrects the annotations to match the resolved values shown in the config reference.
