### PR TITLE
fix(deps): exclude @napi-rs/wasm-runtime and @tybys/wasm-util from minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,8 @@ minimumReleaseAgeExclude:
   - 'satteri'
   - '@bruits/*'
   - vite@8.1.0
+  - '@napi-rs/wasm-runtime@1.1.6'
+  - '@tybys/wasm-util@0.10.3'
 peerDependencyRules:
   allowAny:
     - 'astro'


### PR DESCRIPTION
## Changes

Needed for smoke tests

## Testing

Smoke tests should pass!

## Docs

N/A