### PR TITLE
Harden transition directive attribute rendering

### DIFF
--- a/.changeset/crisp-tables-allow.md
+++ b/.changeset/crisp-tables-allow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensures transition directive values are HTML-escaped when rendered on hydrated islands

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -179,7 +179,7 @@ export async function generateHydrateScript(
 
 	transitionDirectivesToCopyOnIsland.forEach((name) => {
 		if (typeof props[name] !== 'undefined') {
-			island.props[name] = props[name];
+			island.props[name] = escapeHTML(String(props[name]));
 		}
 	});
 

--- a/packages/astro/test/units/render/hydration.test.ts
+++ b/packages/astro/test/units/render/hydration.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { extractDirectives } from '../../../dist/runtime/server/hydration.js';
+import {
+	extractDirectives,
+	generateHydrateScript,
+} from '../../../dist/runtime/server/hydration.js';
+import { renderElement } from '../../../dist/runtime/server/render/util.js';
 
 // Minimal clientDirectives map matching what Astro registers by default
 const clientDirectives = new Map([
@@ -143,5 +147,38 @@ describe('extractDirectives', () => {
 				return true;
 			},
 		);
+	});
+});
+
+describe('generateHydrateScript', () => {
+	it('escapes transition directive values before rendering island attributes', async () => {
+		const payload = '"><img src=x onerror=alert(1)>';
+		const island = await generateHydrateScript(
+			{
+				renderer: {
+					clientEntrypoint: 'renderer.js',
+				} as any,
+				result: {
+					resolve: async (path: string) => path,
+				} as any,
+				astroId: 'abc123',
+				props: {
+					'data-astro-transition-persist': payload,
+				},
+				attrs: undefined,
+			},
+			{
+				hydrate: 'load',
+				componentUrl: 'component.jsx',
+				componentExport: { value: 'default' },
+				displayName: 'Island',
+			} as any,
+		);
+		const html = renderElement('astro-island', island, false);
+
+		assert.ok(
+			html.includes('data-astro-transition-persist="&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"'),
+		);
+		assert.ok(!html.includes(`data-astro-transition-persist="${payload}"`));
 	});
 });


### PR DESCRIPTION
## Changes

- HTML-escapes transition directive values before copying them onto hydrated island attributes.
- Keeps transition attributes on the island wrapper while preserving the existing render path.

## Testing

- Adds hydration unit coverage that renders generated island HTML and asserts transition directive attribute values are encoded.

## Docs

- No docs update needed; this aligns internal island attribute rendering with existing escaping behavior.