### PR TITLE
Document route cache invalidation behavior

### DIFF
--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -91,8 +91,13 @@ interface RouteCacheEntry {
 
 /**
  * Manage the route cache, responsible for caching data related to each route,
- * including the result of calling getStaticPath() so that it can be reused across
- * responses during dev and only ever called once during build.
+ * including the result of calling getStaticPaths(). This gives route matching,
+ * params/props resolution, and prerender generation a shared static-path table.
+ *
+ * In dev, this cache intentionally survives requests. It is invalidated by route
+ * module identity changes after HMR or by explicit cache clears from content data
+ * changes, not by each request. Dev route matching can call getStaticPaths()
+ * before rendering, and render-time props resolution may ask for it again.
  */
 export class RouteCache {
 	private logger: AstroLogger;

--- a/packages/astro/src/vite-plugin-app/app.ts
+++ b/packages/astro/src/vite-plugin-app/app.ts
@@ -190,6 +190,10 @@ export class AstroServerApp extends BaseApp<RunnablePipeline> {
 
 		const self = this;
 		await self.#loadFetchHandler();
+		// RouteCache is intentionally not cleared per request. devMatch() can use
+		// getStaticPaths() to test dynamic route candidates before the later render
+		// resolves props from the same static-path table. HMR/content invalidation
+		// clears stale entries through module identity checks or content-change events.
 
 		let handled = true;
 		await runWithErrorHandling({


### PR DESCRIPTION
## Changes

- Clarifies that RouteCache provides a shared static-path table for matching, props resolution, and prerender generation.
- Documents why dev request handling does not clear the route cache per request.

## Testing

- Not run; comment-only change.

## Docs

- No user-facing docs update needed; this only documents an internal invariant.