### PR TITLE
Prevent `@astrojs/upgrade` from downgrading packages when a dist-tag points to an older version

### DIFF
--- a/packages/upgrade/src/actions/verify.ts
+++ b/packages/upgrade/src/actions/verify.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { color } from '@astrojs/cli-kit';
 import semverCoerce from 'semver/functions/coerce.js';
 import semverDiff from 'semver/functions/diff.js';
+import semverGt from 'semver/functions/gt.js';
 import semverParse from 'semver/functions/parse.js';
 import { bannerAbort, error, getRegistry, info, newline } from '../messages.js';
 import type { Context, PackageInfo } from './context.js';
@@ -135,7 +136,10 @@ async function verifyVersions(
 	return true;
 }
 
-async function resolveTargetVersion(packageInfo: PackageInfo, registry: string): Promise<void> {
+export async function resolveTargetVersion(
+	packageInfo: PackageInfo,
+	registry: string,
+): Promise<void> {
 	const packageMetadata = await fetch(`${registry}/${packageInfo.name}`, {
 		headers: { accept: 'application/vnd.npm.install-v1+json' },
 	});
@@ -145,8 +149,16 @@ async function resolveTargetVersion(packageInfo: PackageInfo, registry: string):
 	const { 'dist-tags': distTags } = await packageMetadata.json();
 	let version = distTags[packageInfo.targetVersion];
 	if (version) {
-		packageInfo.tag = packageInfo.targetVersion;
-		packageInfo.targetVersion = version;
+		const currentCoerced = semverCoerce(packageInfo.currentVersion);
+		const targetParsed = semverParse(version);
+		// If the dist-tag points to a version older than the installed one, fall back to latest.
+		if (currentCoerced && targetParsed && semverGt(currentCoerced, targetParsed)) {
+			packageInfo.targetVersion = 'latest';
+			version = distTags.latest;
+		} else {
+			packageInfo.tag = packageInfo.targetVersion;
+			packageInfo.targetVersion = version;
+		}
 	} else {
 		packageInfo.targetVersion = 'latest';
 		version = distTags.latest;

--- a/packages/upgrade/src/index.ts
+++ b/packages/upgrade/src/index.ts
@@ -2,7 +2,7 @@ import { getContext } from './actions/context.js';
 
 import { help } from './actions/help.js';
 import { install } from './actions/install.js';
-import { collectPackageInfo, verify } from './actions/verify.js';
+import { collectPackageInfo, resolveTargetVersion, verify } from './actions/verify.js';
 import { setStdout } from './messages.js';
 
 const exit = () => process.exit(0);
@@ -29,4 +29,4 @@ export async function main() {
 	process.exit(0);
 }
 
-export { getContext, install, setStdout, verify, collectPackageInfo };
+export { getContext, install, setStdout, verify, collectPackageInfo, resolveTargetVersion };

--- a/packages/upgrade/test/verify.test.ts
+++ b/packages/upgrade/test/verify.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import type { PackageInfo } from '../src/actions/context.ts';
 import { collectPackageInfo, resolveTargetVersion } from '../dist/index.js';
 
 describe('collectPackageInfo', () => {
@@ -83,16 +84,16 @@ describe('resolveTargetVersion', () => {
 		globalThis.fetch = originalFetch;
 	});
 
-	function mockFetch(distTags) {
+	function mockFetch(distTags: Record<string, string>) {
 		globalThis.fetch = mock.fn(async () => ({
 			status: 200,
 			json: async () => ({ 'dist-tags': distTags }),
-		}));
+		} as unknown as Response));
 	}
 
 	it('does not downgrade when beta dist-tag is older than installed version', async () => {
 		mockFetch({ latest: '3.7.3', beta: '3.6.1-beta.3' });
-		const packageInfo = {
+		const packageInfo: PackageInfo = {
 			name: '@astrojs/sitemap',
 			currentVersion: '^3.7.3',
 			targetVersion: 'beta',
@@ -108,7 +109,7 @@ describe('resolveTargetVersion', () => {
 
 	it('uses beta dist-tag when it is newer than installed version', async () => {
 		mockFetch({ latest: '6.4.5', beta: '7.0.0-beta.3' });
-		const packageInfo = {
+		const packageInfo: PackageInfo = {
 			name: 'astro',
 			currentVersion: '^6.4.5',
 			targetVersion: 'beta',

--- a/packages/upgrade/test/verify.test.ts
+++ b/packages/upgrade/test/verify.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict';
-import { beforeEach, describe, it } from 'node:test';
-import { collectPackageInfo } from '../dist/index.js';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import { collectPackageInfo, resolveTargetVersion } from '../dist/index.js';
 
 describe('collectPackageInfo', () => {
 	const context = {
@@ -73,5 +73,59 @@ describe('collectPackageInfo', () => {
 	it('ignores tag', async () => {
 		collectPackageInfo(context, { '@astrojs/preact': 'beta' }, {});
 		assert.deepEqual(context.packages, []);
+	});
+});
+
+describe('resolveTargetVersion', () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function mockFetch(distTags) {
+		globalThis.fetch = mock.fn(async () => ({
+			status: 200,
+			json: async () => ({ 'dist-tags': distTags }),
+		}));
+	}
+
+	it('does not downgrade when beta dist-tag is older than installed version', async () => {
+		mockFetch({ latest: '3.7.3', beta: '3.6.1-beta.3' });
+		const packageInfo = {
+			name: '@astrojs/sitemap',
+			currentVersion: '^3.7.3',
+			targetVersion: 'beta',
+		};
+		await resolveTargetVersion(packageInfo, 'https://registry.npmjs.org');
+		// Should fall back to latest, not downgrade to 3.6.1-beta.3
+		assert.ok(
+			!packageInfo.targetVersion.includes('3.6.1-beta.3'),
+			`Expected no downgrade, got targetVersion=${packageInfo.targetVersion}`,
+		);
+		assert.equal(packageInfo.tag, undefined);
+	});
+
+	it('uses beta dist-tag when it is newer than installed version', async () => {
+		mockFetch({ latest: '6.4.5', beta: '7.0.0-beta.3' });
+		const packageInfo = {
+			name: 'astro',
+			currentVersion: '^6.4.5',
+			targetVersion: 'beta',
+		};
+		await resolveTargetVersion(packageInfo, 'https://registry.npmjs.org');
+		assert.equal(packageInfo.targetVersion, '7.0.0-beta.3');
+		assert.equal(packageInfo.tag, 'beta');
+	});
+
+	it('falls back to latest when dist-tag does not exist', async () => {
+		mockFetch({ latest: '3.7.3' });
+		const packageInfo = {
+			name: '@astrojs/sitemap',
+			currentVersion: '^3.6.0',
+			targetVersion: 'beta',
+		};
+		await resolveTargetVersion(packageInfo, 'https://registry.npmjs.org');
+		assert.equal(packageInfo.targetVersion, '^3.7.3');
 	});
 });


### PR DESCRIPTION
## Changes

- `resolveTargetVersion()` now compares the dist-tag version against the currently installed version before applying it. If the dist-tag resolves to an older version than what's installed, the function falls back to `latest` instead of downgrading.
- Fixes the case where `pnpm dlx @astrojs/upgrade beta` would silently downgrade companion packages (e.g. `@astrojs/sitemap` from `3.7.3` → `3.6.1-beta.3`) when their `beta` dist-tag pointed to a pre-release that predated the current stable.
- `resolveTargetVersion` is now exported so it can be unit-tested directly.

## Testing

- Added `describe('resolveTargetVersion')` in `packages/upgrade/test/verify.test.ts` with three cases: no-downgrade when the beta dist-tag is older than the installed version; correct upgrade when the beta dist-tag is newer; and fallback to `latest` when the requested dist-tag doesn't exist on the registry.

## Docs

- No docs update needed; this is a bug fix for internal `@astrojs/upgrade` behavior with no API surface change.

Closes #17024