### PR TITLE
docs: fix malformed Wikipedia URL for Rosalind Franklin (rover) in 3 fixtures

### DIFF
--- a/.changeset/fix-rosalind-franklin-wikipedia-url.md
+++ b/.changeset/fix-rosalind-franklin-wikipedia-url.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/cloudflare': patch
+'astro': patch
+'@test/astro-cloudflare': patch
+'@test/astro-cloudflare-vite-plugin': patch
+'@test/content-layer': patch
+---
+
+Fixes a malformed Wikipedia URL for the Rosalind Franklin (rover) article in three fixture files. The closing parenthesis was outside the link, so the browser fetched `Rosalind_Franklin_(rover` (no close paren), which Wikipedia returns 404 for. Percent-encodes the parentheses so the link parses correctly.

--- a/packages/astro/e2e/fixtures/cloudflare/src/content/space/exomars.md
+++ b/packages/astro/e2e/fixtures/cloudflare/src/content/space/exomars.md
@@ -5,6 +5,6 @@ publishedDate: '2022-09-19'
 tags: [space, 2020s]
 # slug: rosalind-franklin-rover
 ---
-**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_%28rover%29)
 
 The Rosalind Franklin rover is a planned robotic Mars rover, part of the ExoMars mission led by the European Space Agency and the Russian space agency Roscosmos. The mission is scheduled to launch in September 2022, and the rover is expected to land on Mars in June 2023. The rover is named after the British biophysicist Rosalind Franklin, who made key contributions to the discovery of the structure of DNA.

--- a/packages/astro/test/fixtures/content-layer/src/content/space/exomars.md
+++ b/packages/astro/test/fixtures/content-layer/src/content/space/exomars.md
@@ -5,6 +5,6 @@ publishedDate: '2022-09-19'
 tags: [space, 2020s]
 # slug: rosalind-franklin-rover
 ---
-**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_%28rover%29)
 
 The Rosalind Franklin rover is a planned robotic Mars rover, part of the ExoMars mission led by the European Space Agency and the Russian space agency Roscosmos. The mission is scheduled to launch in September 2022, and the rover is expected to land on Mars in June 2023. The rover is named after the British biophysicist Rosalind Franklin, who made key contributions to the discovery of the structure of DNA.

--- a/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/content/space/exomars.md
+++ b/packages/integrations/cloudflare/test/fixtures/vite-plugin/src/content/space/exomars.md
@@ -5,6 +5,6 @@ publishedDate: '2022-09-19'
 tags: [space, 2020s]
 # slug: rosalind-franklin-rover
 ---
-**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover))
+**Source:** [Wikipedia](https://en.wikipedia.org/wiki/Rosalind_Franklin_%28rover%29)
 
 The Rosalind Franklin rover is a planned robotic Mars rover, part of the ExoMars mission led by the European Space Agency and the Russian space agency Roscosmos. The mission is scheduled to launch in September 2022, and the rover is expected to land on Mars in June 2023. The rover is named after the British biophysicist Rosalind Franklin, who made key contributions to the discovery of the structure of DNA.


### PR DESCRIPTION
Reopens #17103 with a changeset added. Three fixture files reference `https://en.wikipedia.org/wiki/Rosalind_Franklin_(rover)` but the markdown link ends at the first closing parenthesis, so the browser fetches the URL without the close paren — Wikipedia returns 404. Percent-encodes the parens: `Rosalind_Franklin_%28rover%29`. Verified 200 via HEAD.