### PR TITLE
Fix trailing slash handling for dynamic file endpoints in dev mode

### DIFF
--- a/.changeset/fix-dynamic-file-endpoint-trailing-slash.md
+++ b/.changeset/fix-dynamic-file-endpoint-trailing-slash.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes trailing slash handling for dynamic file endpoints in dev mode
+
+Dynamic file endpoints (e.g., `src/pages/api/[name].json.ts`) with `trailingSlash: "always"` incorrectly required a trailing slash in dev mode, returning 404 for `/api/bar.json` and 200 for `/api/bar.json/`. This was because `trailingSlashForPath` relied on `pathname`, which is `null` for dynamic routes, causing it to skip the file extension check. The fix uses the route string (from `joinSegments`) as a fallback, which preserves file extensions even for dynamic segments.

--- a/.changeset/fix-dynamic-file-endpoint-trailing-slash.md
+++ b/.changeset/fix-dynamic-file-endpoint-trailing-slash.md
@@ -2,6 +2,4 @@
 'astro': patch
 ---
 
-Fixes trailing slash handling for dynamic file endpoints in dev mode
-
-Dynamic file endpoints (e.g., `src/pages/api/[name].json.ts`) with `trailingSlash: "always"` incorrectly required a trailing slash in dev mode, returning 404 for `/api/bar.json` and 200 for `/api/bar.json/`. This was because `trailingSlashForPath` relied on `pathname`, which is `null` for dynamic routes, causing it to skip the file extension check. The fix uses the route string (from `joinSegments`) as a fallback, which preserves file extensions even for dynamic segments.
+Fixes trailing slash handling for dynamic file endpoints in dev mode. Dynamic file endpoints (e.g., `src/pages/api/[name].json.ts`) with `trailingSlash: "always"` incorrectly required a trailing slash in dev mode, returning 404 for `/api/bar.json` and 200 for `/api/bar.json/`.

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -241,13 +241,14 @@ function createFileBasedRoutes(
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
 					: null;
+				const route = joinSegments(segments);
 				const trailingSlash = trailingSlashForPath(
 					pathname,
 					settings.config,
 					item.isPage ? 'page' : 'endpoint',
+					route,
 				);
 				const pattern = getPattern(segments, settings.config.base, trailingSlash);
-				const route = joinSegments(segments);
 				routes.push({
 					route,
 					isIndex: item.isIndex,
@@ -386,13 +387,14 @@ function createRoutesFromEntriesByDir(
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
 					: null;
+				const route = joinSegments(segments);
 				const trailingSlash = trailingSlashForPath(
 					pathname,
 					settings.config,
 					item.isPage ? 'page' : 'endpoint',
+					route,
 				);
 				const pattern = getPattern(segments, settings.config.base, trailingSlash);
-				const route = joinSegments(segments);
 				routes.push({
 					route,
 					isIndex: item.isIndex,
@@ -442,8 +444,9 @@ const trailingSlashForPath = (
 	pathname: string | null,
 	config: AstroConfig,
 	type: 'page' | 'endpoint',
+	route?: string,
 ): AstroConfig['trailingSlash'] =>
-	type === 'endpoint' && pathname && hasFileExtension(pathname) ? 'never' : config.trailingSlash;
+	type === 'endpoint' && hasFileExtension(pathname ?? route ?? '') ? 'never' : config.trailingSlash;
 
 function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): RouteData[] {
 	const { config } = settings;
@@ -468,13 +471,13 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Rou
 			? `/${segments.map((segment) => segment[0].content).join('/')}`
 			: null;
 
-		const trailingSlash = trailingSlashForPath(pathname, config, type);
+		const route = joinSegments(segments);
+		const trailingSlash = trailingSlashForPath(pathname, config, type, route);
 		const pattern = getPattern(segments, settings.config.base, trailingSlash);
 		const params = segments
 			.flat()
 			.filter((p) => p.dynamic)
 			.map((p) => p.content);
-		const route = joinSegments(segments);
 
 		routes.push({
 			type,

--- a/packages/astro/test/units/routing/manifest.test.ts
+++ b/packages/astro/test/units/routing/manifest.test.ts
@@ -517,6 +517,36 @@ describe('routing - createRoutesList', () => {
 		);
 	});
 
+	it('dynamic file endpoints force trailingSlash never. issues#17001', async () => {
+		const fixture = await createFixture({
+			'/src/pages/api/[name].json.ts': `export const GET = () => new Response('{}')`,
+		});
+
+		const settings = await createBasicSettings({
+			root: fixture.path,
+			trailingSlash: 'always',
+		});
+		const manifest = await createRoutesList(
+			{
+				cwd: fixture.path,
+				settings,
+			},
+			defaultLogger,
+		);
+		const route = manifest.routes.find((r) => r.route === '/api/[name].json');
+		assert.ok(route, 'dynamic file endpoint route should exist');
+		assert.equal(
+			route.pattern.test('/api/bar.json'),
+			true,
+			'should match without trailing slash',
+		);
+		assert.equal(
+			route.pattern.test('/api/bar.json/'),
+			false,
+			'should not match with trailing slash',
+		);
+	});
+
 	it('should concatenate each part of the segment. issues#10122', async () => {
 		const fixture = await createFixture({
 			'/src/pages/a-[b].astro': `<h1>test</h1>`,


### PR DESCRIPTION
## Changes

- Dynamic file endpoints like `src/pages/api/[name].json.ts` with `trailingSlash: "always"` now correctly return 200 for `/api/bar.json` and 404 for `/api/bar.json/` in dev mode, matching production behavior and the documented Astro v6 rule that file endpoints are never served with a trailing slash.
- Root cause: `trailingSlashForPath` checked `pathname && hasFileExtension(pathname)`, but `pathname` is `null` for dynamic routes (any segment with a param). The fix adds an optional `route` fallback parameter — the string from `joinSegments` — which preserves file extensions even for dynamic segments (e.g., `/api/[name].json`), allowing the file-extension check to work correctly.

## Testing

- Added `'dynamic file endpoints force trailingSlash never. issues#17001'` in `packages/astro/test/units/routing/manifest.test.ts`: creates a `[name].json.ts` page under `trailingSlash: "always"` and asserts the generated route pattern matches without a trailing slash and rejects with one.

## Docs

- No docs update needed — this restores already-documented Astro v6 behavior.

Closes #17001