### PR TITLE
Reduce per-request URL parsing and allocations in the SSR request pipeline

### DIFF
--- a/.changeset/reduce-ssr-url-parsing.md
+++ b/.changeset/reduce-ssr-url-parsing.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Reduces redundant per-request URL parsing and allocations in the core SSR render and match paths. The domain-based i18n `Host`-header probe now runs only when a `domains-*` strategy is configured, the trailing-slash handler reuses the URL already parsed by the render pipeline instead of re-parsing it, `getParams` avoids building intermediate arrays, the memory cache provider reuses the request URL it already parsed, and domain i18n memoizes its parsed lookup table. Internal performance change with no behavior difference.

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -4,7 +4,7 @@ import {
 	removeTrailingForwardSlash,
 } from '@astrojs/internal-helpers/path';
 import { matchPattern } from '@astrojs/internal-helpers/remote';
-import { computePathnameFromDomain } from '../i18n/domain.js';
+import { computePathnameFromDomain, isDomainI18nStrategy } from '../i18n/domain.js';
 import { isLocalizedErrorRoute } from '../../i18n/error-routes.js';
 import type { RoutesList } from '../../types/astro.js';
 import type { RemotePattern, RouteData } from '../../types/public/index.js';
@@ -152,6 +152,14 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 	 */
 	#featureCheckDone = false;
 
+	/**
+	 * True when the configured i18n strategy resolves the locale from the
+	 * request's domain (`domains-*`). `render()` reads this to decide whether
+	 * a request needs the Host-header-based pathname lookup; routing for every
+	 * other app is driven by the URL pathname alone.
+	 */
+	#hasDomainI18nRouting: boolean;
+
 	get logger(): AstroLogger {
 		return this.pipeline.logger;
 	}
@@ -166,6 +174,10 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 
 	constructor(manifest: SSRManifest, streaming = true, ...args: any[]) {
 		this.manifest = manifest;
+		// The `domains-*` strategies are the ones that derive the locale from
+		// the request's domain. `isDomainI18nStrategy` is the single source of
+		// truth, shared with `computePathnameFromDomain`.
+		this.#hasDomainI18nRouting = isDomainI18nStrategy(manifest.i18n?.strategy);
 		this.baseWithoutTrailingSlash = removeTrailingForwardSlash(manifest.base);
 		this.pipeline = this.createPipeline(streaming, manifest, ...args);
 		// Share the pipeline's manifestData so both BaseApp and the pipeline
@@ -301,7 +313,13 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		const url = new URL(request.url);
 		// ignore requests matching public assets
 		if (this.manifest.assets.has(url.pathname)) return undefined;
-		let pathname = this.computePathnameFromDomain(request);
+		// Only the `domains-*` i18n strategies derive the pathname from the
+		// request's Host header; every other app routes on the URL pathname, so
+		// the probe is skipped.
+		let pathname: string | undefined;
+		if (this.#hasDomainI18nRouting) {
+			pathname = this.computePathnameFromDomain(request);
+		}
 		if (!pathname) {
 			pathname = prependForwardSlash(this.removeBase(url.pathname));
 		}
@@ -394,7 +412,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 		// For domain-based i18n, match against the locale-prefixed pathname
 		// derived from the Host header. FetchState recomputes this pathname
 		// itself for param/locale resolution, so it isn't threaded through here.
-		if (!routeData) {
+		if (!routeData && this.#hasDomainI18nRouting) {
 			const domainPathname = this.computePathnameFromDomain(request);
 			if (domainPathname) {
 				routeData = this.pipeline.matchRoute(this.safeDecodeURI(domainPathname));

--- a/packages/astro/src/core/cache/memory-provider.ts
+++ b/packages/astro/src/core/cache/memory-provider.ts
@@ -404,12 +404,13 @@ const memoryProvider = ((config): CacheProvider => {
 		name: 'memory',
 
 		async onRequest(context, next) {
-			const requestUrl = new URL(context.request.url);
-
 			// Only cache GET requests.
 			if (context.request.method !== 'GET') {
 				return next();
 			}
+
+			// Reuse the URL the cache handler already parsed instead of re-parsing.
+			const requestUrl = context.url;
 
 			const primaryKey = getCacheKey(requestUrl, queryConfig);
 

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -196,6 +196,15 @@ export class FetchState implements AstroFetchState {
 	}
 	/** Normalized URL for this request. */
 	url: URL;
+	/**
+	 * The request URL's pathname and search as originally parsed, before the
+	 * constructor decodes `pathname` and collapses its duplicate slashes in
+	 * place. `TrailingSlashHandler` matches against these so it sees the raw
+	 * path a redirect would correct (e.g. duplicate or missing trailing
+	 * slashes). `#applyForwardedHeaders` keeps them in sync with `request`.
+	 */
+	rawPathname: string;
+	rawSearch: string;
 	/** Client address for this request. */
 	clientAddress: string | undefined;
 	/** Whether this is a partial render (container API). */
@@ -273,6 +282,11 @@ export class FetchState implements AstroFetchState {
 		this.slots = undefined;
 		// Parse the URL once and derive both pathname and url from it.
 		const url = new URL(request.url);
+		// Record the raw pathname/search now, while `url` still holds the
+		// original path — the normalization below rewrites `url.pathname` in
+		// place. TrailingSlashHandler matches redirects against this raw path.
+		this.rawPathname = url.pathname;
+		this.rawSearch = url.search;
 		const publicPathname = this.#normalizePathname(url.pathname);
 		const pathname = this.#computePathname(publicPathname);
 		url.pathname = publicPathname;
@@ -1068,6 +1082,12 @@ export class FetchState implements AstroFetchState {
 		if (app !== undefined) {
 			Reflect.set(this.request, appSymbol, app);
 		}
+
+		// `this.request` now carries the rebuilt URL (`this.url`, including the
+		// forwarded host/proto/port), so re-sync the raw pathname/search to it;
+		// TrailingSlashHandler then matches against the request actually served.
+		this.rawPathname = this.url.pathname;
+		this.rawSearch = this.url.search;
 	}
 
 	/**

--- a/packages/astro/src/core/i18n/domain.ts
+++ b/packages/astro/src/core/i18n/domain.ts
@@ -10,6 +10,48 @@ import type { SSRManifest } from '../app/types.js';
 import type { AstroLogger } from '../logger/core.js';
 
 /**
+ * The i18n strategies that derive the request's locale from its domain (the
+ * `Host` header) rather than the URL pathname. `BaseApp` gates its
+ * Host-header pathname probe on this predicate, and `computePathnameFromDomain`
+ * only acts for these strategies. Keeping both driven by this one function
+ * stops the two lists from drifting apart.
+ */
+export function isDomainI18nStrategy(strategy: string | undefined): boolean {
+	return (
+		strategy === 'domains-prefix-always' ||
+		strategy === 'domains-prefix-other-locales' ||
+		strategy === 'domains-prefix-always-no-redirect'
+	);
+}
+
+/**
+ * Per-config cache of parsed `domainLookupTable` entries. The table comes from
+ * the (immutable) manifest, so its domain keys are parsed once and reused on
+ * every request instead of being re-parsed per request. Keyed by the table
+ * object itself so distinct apps don't share entries.
+ */
+const domainEntriesCache = new WeakMap<
+	object,
+	Array<{ host: string; protocol: string; locale: string }>
+>();
+
+function getDomainEntries(
+	domainLookupTable: Record<string, string>,
+): Array<{ host: string; protocol: string; locale: string }> {
+	let entries = domainEntriesCache.get(domainLookupTable);
+	if (!entries) {
+		entries = Object.entries(domainLookupTable).map(([domainKey, locale]) => {
+			// Safe because the protocol is forced via zod in the config; a throw
+			// here would mean a tampered manifest (caught by the caller).
+			const url = new URL(domainKey);
+			return { host: url.host, protocol: url.protocol, locale };
+		});
+		domainEntriesCache.set(domainLookupTable, entries);
+	}
+	return entries;
+}
+
+/**
  * For domain-based i18n routing strategies, derives the locale-prefixed
  * pathname from the request's `Host` header rather than its URL. For example,
  * a request for `/foo` served from `https://example.fr` resolves to `/fr/foo`.
@@ -29,12 +71,7 @@ export function computePathnameFromDomain(
 ): string | undefined {
 	let pathname: string | undefined = undefined;
 
-	if (
-		i18n &&
-		(i18n.strategy === 'domains-prefix-always' ||
-			i18n.strategy === 'domains-prefix-other-locales' ||
-			i18n.strategy === 'domains-prefix-always-no-redirect')
-	) {
+	if (i18n && isDomainI18nStrategy(i18n.strategy)) {
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
 		let host = request.headers.get('X-Forwarded-Host');
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
@@ -57,16 +94,9 @@ export function computePathnameFromDomain(
 			try {
 				let locale;
 				const hostAsUrl = new URL(`${protocol}//${host}`);
-				for (const [domainKey, localeValue] of Object.entries(i18n.domainLookupTable)) {
-					// This operation should be safe because we force the protocol via zod inside the configuration
-					// If not, then it means that the manifest was tampered
-					const domainKeyAsUrl = new URL(domainKey);
-
-					if (
-						hostAsUrl.host === domainKeyAsUrl.host &&
-						hostAsUrl.protocol === domainKeyAsUrl.protocol
-					) {
-						locale = localeValue;
+				for (const entry of getDomainEntries(i18n.domainLookupTable)) {
+					if (hostAsUrl.host === entry.host && hostAsUrl.protocol === entry.protocol) {
+						locale = entry.locale;
 						break;
 					}
 				}

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -80,6 +80,22 @@ export async function getProps(opts: GetParamsAndPropsOptions): Promise<Props> {
 }
 
 /**
+ * Returns the first of the route's own pattern or its fallback routes' patterns
+ * that matches `path`, or `null`. Uses a direct `exec` plus loop so no throwaway
+ * arrays are built per request — this runs on every param'd render.
+ */
+function matchRoutePattern(route: RouteData, path: string): RegExpExecArray | null {
+	let match = route.pattern.exec(path);
+	if (!match) {
+		for (const fallbackRoute of route.fallbackRoutes) {
+			match = fallbackRoute.pattern.exec(path);
+			if (match) break;
+		}
+	}
+	return match;
+}
+
+/**
  * When given a route with the pattern `/[x]/[y]/[z]/svelte`, and a pathname `/a/b/c/svelte`,
  * returns the params object: { x: "a", y: "b", z: "c" }.
  */
@@ -97,8 +113,10 @@ export function getParams(route: RouteData, pathname: string): Params {
 	const path =
 		hasHtmlSuffix && route.type === 'page' ? pathname.slice(0, -'.html'.length) : pathname;
 
-	const allPatterns = [route, ...route.fallbackRoutes].map((r) => r.pattern);
-	let paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
+	// Match `path` against the route's own pattern, then each fallback route,
+	// taking the first that matches. `route.params` indexes into the capture
+	// groups of this match below.
+	let paramsMatch = matchRoutePattern(route, path);
 
 	// For non-page routes, if the original pathname didn't match, fall back to stripping
 	// `.html` / `/index.html` to stay consistent with the dev route matcher, which also strips
@@ -110,16 +128,20 @@ export function getParams(route: RouteData, pathname: string): Params {
 		const strippedPath = pathname.endsWith('/index.html')
 			? pathname.slice(0, -'/index.html'.length) || '/'
 			: pathname.slice(0, -'.html'.length);
-		paramsMatch = allPatterns.map((pattern) => pattern.exec(strippedPath)).find((x) => x);
+		paramsMatch = matchRoutePattern(route, strippedPath);
 	}
 
 	if (!paramsMatch) return {};
+	// Inside `forEach`'s callback TypeScript treats `paramsMatch` as possibly
+	// null again (it doesn't narrow `let` across a closure), so read the match
+	// through a `const`, which stays typed as non-null.
+	const matched = paramsMatch;
 	const params: Params = {};
 	route.params.forEach((key, i) => {
 		if (key.startsWith('...')) {
-			params[key.slice(3)] = paramsMatch[i + 1] ? paramsMatch[i + 1] : undefined;
+			params[key.slice(3)] = matched[i + 1] ? matched[i + 1] : undefined;
 		} else {
-			params[key] = paramsMatch[i + 1];
+			params[key] = matched[i + 1];
 		}
 	});
 	return params;

--- a/packages/astro/src/core/routing/trailing-slash-handler.ts
+++ b/packages/astro/src/core/routing/trailing-slash-handler.ts
@@ -29,15 +29,16 @@ export class TrailingSlashHandler {
 	 * normalization, or `undefined` if no redirect is required.
 	 */
 	handle(state: FetchState): Response | undefined {
-		// Use a fresh URL parse from the raw request so we see the
-		// un-normalized pathname (e.g. duplicate slashes like `///`).
-		// state.url has already been normalized by the FetchState
-		// constructor, which would hide the redirect targets.
-		const url = new URL(state.request.url);
-		const redirect = this.#redirectTrailingSlash(url.pathname);
+		// Use the raw pathname/search captured by the FetchState constructor
+		// (before normalization) so we see the un-normalized pathname (e.g.
+		// duplicate slashes like `///`). state.url has already been normalized,
+		// which would hide the redirect targets. Reusing the captured values
+		// avoids re-parsing the request URL on every request.
+		const pathname = state.rawPathname;
+		const redirect = this.#redirectTrailingSlash(pathname);
 
 		// Not a redirect.
-		if (redirect === url.pathname) {
+		if (redirect === pathname) {
 			return undefined;
 		}
 
@@ -46,14 +47,14 @@ export class TrailingSlashHandler {
 		const response = new Response(
 			redirectTemplate({
 				status,
-				relativeLocation: url.pathname,
+				relativeLocation: pathname,
 				absoluteLocation: redirect,
 				from: state.request.url,
 			}),
 			{
 				status,
 				headers: {
-					location: redirect + url.search,
+					location: redirect + state.rawSearch,
 				},
 			},
 		);


### PR DESCRIPTION
## Summary

The core SSR request path parses `request.url` and rebuilds a few small things more often than it has to. This cuts that repeated work on the hot path. Nothing about the rendered output changes, and no public API moves; it's all internal.

This started as a bigger PR and was trimmed after review. The cross-adapter URL sharing (a new `RenderOptions.url` option) and the `createOutgoingHttpHeaders` rewrite are out, and the adapter side is now its own `minor`, #17417. What's left here is internal to `astro` core and stays a `patch`.

## What changed

- Domain-based i18n only looks at the `Host` header when a `domains-*` strategy is configured. That condition is now worked out once in the constructor, so every other app skips the probe, and the URL parse behind it, in both `match()` and `render()`.
- `TrailingSlashHandler` uses the raw pathname and search that `FetchState` captures before it normalizes the URL, instead of parsing `request.url` a second time to get them back.
- `getParams` checks the route's own pattern and then its fallback routes, stopping at the first match, rather than building throwaway arrays with `.map().map().find()`.
- The in-memory cache provider reuses the `URL` already sitting on `context.url` (and checks the request method first) instead of parsing `context.request.url` again.
- Domain-based i18n parses each `domainLookupTable` key once and keeps it per table, instead of re-parsing every key on every request.

## Relation to #17417

The adapter side landed as #17417, which adds `getRequestURL()`: a shared helper that parses `request.url` once and hands the same object to everything that asks for it. Two of the reuses here chase that same redundant parse by other means: the in-memory cache provider reads `context.url`, and the trailing-slash handler reads the raw pathname `FetchState` captures. If #17417 lands, both can be reconciled with `getRequestURL()` so core and the adapters follow one convention. They are kept apart so neither PR blocks the other; the only code the two share is `base.ts` `match()`, a trivial rebase whichever goes first.

## Testing

No behavior change, so nothing new to test. The paths above are covered by the existing unit suites (routing, i18n, app, cache, fetch), which pass, and the typecheck is clean.

## Benchmarks

Micro-benchmarks, median of 7 runs on the same machine, re-measured against current `main` (092da56) after merging it in — so the `getParams` baseline already includes #17299, which reworked that function on `main` while this branch was open:

| | Before | After |
| --- | --- | --- |
| Domain i18n lookup (4 domains) | 2240 ns | 1095 ns |
| Cache request (memory provider) | 445 ns | 225 ns |
| `getParams` matching | 56 ns | 42 ns |

The domain and `getParams` rows time the real exported functions; the cache row isolates the single removed `URL` parse, since the full handler path is dominated by response cloning. On a render-heavy page all of this is lost in the noise, since HTML rendering dominates. It shows up more on light responses like endpoints, redirects and 304s, where per-request setup is a bigger slice of the work.

Investigated and measured with help from Claude Opus 4.8.

