### PR TITLE
Fix styles silently dropped when `await` is used in .astro template markup

### DIFF
--- a/.changeset/humble-islands-trade.md
+++ b/.changeset/humble-islands-trade.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where `<style>` tags from components could vanish from the build output when `await` expressions were used in the template/markup section of an `.astro` file

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -419,6 +419,7 @@ export class FetchState implements AstroFetchState {
 				extraStyleHashes,
 				extraScriptHashes,
 				propagators: new Set(),
+				pendingSlotEvaluations: [],
 				templateDepth: 0,
 			},
 			cspDestination: manifest.csp?.cspDestination ?? (routeData.prerender ? 'meta' : 'header'),

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -33,6 +33,13 @@ export class AstroComponentInstance {
 			// prerender the slots eagerly to make collection entries propagate styles and scripts
 			let didRender = false;
 			let value = slots[name](result);
+			// When a slot function is async (e.g. it contains `await` in the template),
+			// the returned Promise must resolve before head content is buffered, otherwise
+			// propagating components (like Content with styles) inside the slot won't be
+			// registered in time and their styles will be lost.
+			if (isPromise(value)) {
+				result._metadata.pendingSlotEvaluations.push(value);
+			}
 			this.slotValues[name] = () => {
 				// use prerendered value only once
 				if (!didRender) {

--- a/packages/astro/src/runtime/server/render/head-propagation/runtime.ts
+++ b/packages/astro/src/runtime/server/render/head-propagation/runtime.ts
@@ -52,6 +52,12 @@ export function registerIfPropagating(
 }
 
 export async function bufferPropagatedHead(result: SSRResult): Promise<void> {
+	// Wait for any async slot pre-renders to finish so that propagating
+	// components inside those slots are registered before we collect head parts.
+	if (result._metadata.pendingSlotEvaluations.length > 0) {
+		await Promise.all(result._metadata.pendingSlotEvaluations);
+		result._metadata.pendingSlotEvaluations.length = 0;
+	}
 	// Initialize potential propagators, then append all emitted head parts.
 	const collected = await collectPropagatedHeadParts({
 		propagators: result._metadata.propagators,

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -305,6 +305,12 @@ export interface SSRMetadata {
 	extraScriptHashes: string[];
 	propagators: Set<AstroComponentInstance | ServerIslandComponent>;
 	/**
+	 * Promises from async slot pre-rendering that must resolve before
+	 * head content is buffered, so that propagating components inside
+	 * async slots are registered in time.
+	 */
+	pendingSlotEvaluations: Promise<unknown>[];
+	/**
 	 * Tracks nesting depth of HTML `<template>` elements during rendering.
 	 * Scripts rendered inside `<template>` tags should not be deduplicated,
 	 * because template content is inert and scripts inside don't execute.

--- a/packages/astro/test/units/render/head-propagation/runtime-adapters.test.ts
+++ b/packages/astro/test/units/render/head-propagation/runtime-adapters.test.ts
@@ -15,6 +15,7 @@ function createResult() {
 			hasRenderedHead: false,
 			headInTree: false,
 			propagators: new Set(),
+			pendingSlotEvaluations: [] as Promise<unknown>[],
 			extraHead: [] as string[],
 		},
 	};

--- a/packages/astro/test/units/render/head-propagation/runtime.test.ts
+++ b/packages/astro/test/units/render/head-propagation/runtime.test.ts
@@ -18,6 +18,7 @@ function createResult() {
 			hasRenderedHead: false,
 			headInTree: false,
 			propagators: new Set(),
+			pendingSlotEvaluations: [] as Promise<unknown>[],
 			extraHead: [] as string[],
 		},
 	};
@@ -54,6 +55,36 @@ describe('head propagation runtime facade', () => {
 
 		await bufferPropagatedHead(result as unknown as SSRResult);
 		assert.deepEqual(result._metadata.extraHead, ['<link rel="stylesheet" href="/one.css">']);
+	});
+
+	it('awaits pending async slot evaluations before collecting head parts', async () => {
+		const result = createResult();
+
+		// Simulate an async slot that registers a propagator after a delay,
+		// mimicking what happens when `await` appears in a template expression
+		// before a component with head content (e.g. styles).
+		result._metadata.pendingSlotEvaluations.push(
+			new Promise<void>((resolve) => {
+				setTimeout(() => {
+					result._metadata.propagators.add({
+						init() {
+							return {
+								[headAndContentSym]: true,
+								head: '<style>.my-red{background:red}</style>',
+							};
+						},
+					});
+					resolve();
+				}, 10);
+			}),
+		);
+
+		// Without the fix, bufferPropagatedHead would find 0 propagators
+		// because the async slot hasn't resolved yet.
+		await bufferPropagatedHead(result as unknown as SSRResult);
+		assert.deepEqual(result._metadata.extraHead, ['<style>.my-red{background:red}</style>']);
+		// Pending evaluations should be cleared after processing
+		assert.equal(result._metadata.pendingSlotEvaluations.length, 0);
 	});
 
 	it('exposes render state and evaluates instruction policy', () => {

--- a/packages/astro/test/units/server-islands/server-islands-render.test.ts
+++ b/packages/astro/test/units/server-islands/server-islands-render.test.ts
@@ -65,6 +65,7 @@ async function createStubResult(overrides: Partial<SSRResult> = {}): Promise<SSR
 			extraStyleHashes: [],
 			extraScriptHashes: [],
 			propagators: new Set(),
+			pendingSlotEvaluations: [],
 			templateDepth: 0,
 		},
 		cspDestination: 'header',


### PR DESCRIPTION
## Changes

- Fixes a race condition where `<style>` tags from propagating components (e.g. content collection `Content` with `propagation: 'self'`) were silently dropped from the build output when `await` appeared in the template/markup section of an `.astro` file. Moving the `await` to the frontmatter was the only workaround.
- The root cause: `AstroComponentInstance` pre-renders slots eagerly to trigger propagator registration, but when a slot function is async it returns a Promise. `bufferPropagatedHead` ran before the Promise resolved, collecting zero propagators and dropping their styles.
- Fix: async slot pre-render Promises are tracked on a new `pendingSlotEvaluations` field of `SSRMetadata`. `bufferPropagatedHead` awaits them all before collecting head parts.

Closes #17218

## Testing

- Added `'awaits pending async slot evaluations before collecting head parts'` to `packages/astro/test/units/render/head-propagation/runtime.test.ts`. It pushes a delayed Promise that registers a propagator, then verifies `bufferPropagatedHead` waits for it and collects the resulting style tag.
- Updated `runtime-adapters.test.ts` and `server-islands-render.test.ts` fixtures to include the new `pendingSlotEvaluations` field on `SSRMetadata`.

## Docs

No docs update needed — this is a bug fix restoring already-documented behavior (styles from components should always be collected regardless of where `await` appears).
