### PR TITLE
chore: simpler package.json types

### DIFF
--- a/benchmark/packages/adapter/package.json
+++ b/benchmark/packages/adapter/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "keywords": [

--- a/benchmark/packages/timer/package.json
+++ b/benchmark/packages/timer/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "keywords": [

--- a/packages/astro-rss/package.json
+++ b/packages/astro-rss/package.json
@@ -3,7 +3,6 @@
   "description": "Add RSS feeds to your Astro projects",
   "version": "4.0.18",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -12,23 +12,6 @@
   },
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
-  "types": "./dist/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "app": [
-        "./dist/core/app/index"
-      ],
-      "app/*": [
-        "./dist/core/app/*"
-      ],
-      "hono": [
-        "./dist/core/hono/index"
-      ],
-      "middleware": [
-        "./dist/virtual-modules/middleware.d.ts"
-      ]
-    }
-  },
   "exports": {
     ".": "./dist/index.js",
     "./env": "./env.d.ts",

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -3,7 +3,6 @@
   "description": "Use Alpine within Astro",
   "version": "1.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -3,7 +3,6 @@
   "description": "Deploy your site to Cloudflare Workers",
   "version": "14.0.1",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -3,7 +3,6 @@
   "description": "Add support for Markdoc in your Astro site",
   "version": "2.0.1",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {
@@ -19,36 +18,14 @@
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/markdoc/",
   "exports": {
-    "./prism": {
-      "types": "./dist/extensions/prism.d.ts",
-      "default": "./dist/extensions/prism.js"
-    },
-    "./shiki": {
-      "types": "./dist/extensions/shiki.d.ts",
-      "default": "./dist/extensions/shiki.js"
-    },
-    "./config": {
-      "types": "./dist/config.d.ts",
-      "default": "./dist/config.js"
-    },
+    "./prism": "./dist/extensions/prism.js",
+    "./shiki": "./dist/extensions/shiki.js",
+    "./config": "./dist/config.js",
     ".": "./dist/index.js",
     "./components": "./components/index.ts",
     "./runtime": "./dist/runtime.js",
     "./runtime-assets-config": "./dist/runtime-assets-config.js",
     "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    "*": {
-      "config": [
-        "./dist/config.d.ts"
-      ],
-      "prism": [
-        "./dist/extensions/prism.d.ts"
-      ],
-      "shiki": [
-        "./dist/extensions/shiki.d.ts"
-      ]
-    }
   },
   "files": [
     "components",

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -3,7 +3,6 @@
   "description": "Add support for MDX pages in your Astro site",
   "version": "7.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -3,7 +3,6 @@
   "description": "Deploy your site to Netlify",
   "version": "8.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -3,7 +3,6 @@
   "description": "Deploy your site to a Node.js server",
   "version": "11.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -3,7 +3,6 @@
   "description": "Use Partytown to move scripts into a web worker in your Astro project",
   "version": "2.1.7",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -3,7 +3,6 @@
   "description": "Use Preact components within Astro",
   "version": "6.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -3,7 +3,6 @@
   "description": "Use React components within Astro",
   "version": "6.0.0",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -3,7 +3,6 @@
   "description": "Generate a sitemap for your Astro site",
   "version": "3.7.3",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -3,7 +3,6 @@
   "version": "7.0.0",
   "description": "Use Solid components within Astro",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -3,7 +3,6 @@
   "version": "9.0.0",
   "description": "Use Svelte components within Astro",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -26,16 +26,6 @@
     "./cache/provider": "./dist/cache/provider.js",
     "./package.json": "./package.json"
   },
-  "typesVersions": {
-    "*": {
-      "serverless": [
-        "dist/serverless/adapter.d.ts"
-      ],
-      "static": [
-        "dist/static/adapter.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "types.d.ts"

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -3,7 +3,6 @@
   "version": "7.0.0",
   "description": "Use Vue components within Astro",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {

--- a/packages/internal-helpers/package.json
+++ b/packages/internal-helpers/package.json
@@ -29,37 +29,6 @@
       "default": "./dist/shiki-engine-default.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "path": [
-        "./dist/path.d.ts"
-      ],
-      "remote": [
-        "./dist/remote.d.ts"
-      ],
-      "markdown": [
-        "./dist/markdown.d.ts"
-      ],
-      "frontmatter": [
-        "./dist/frontmatter.d.ts"
-      ],
-      "shiki": [
-        "./dist/shiki.d.ts"
-      ],
-      "fs": [
-        "./dist/fs.d.ts"
-      ],
-      "cli": [
-        "./dist/cli.d.ts"
-      ],
-      "create-filter": [
-        "./dist/create-filter.d.ts"
-      ],
-      "object": [
-        "./dist/object.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -2,7 +2,6 @@
   "name": "@astrojs/telemetry",
   "version": "3.3.2",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
   "license": "MIT",
   "repository": {
@@ -13,10 +12,7 @@
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
+    ".": "./dist/index.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/underscore-redirects/package.json
+++ b/packages/underscore-redirects/package.json
@@ -12,7 +12,6 @@
   },
   "bugs": "https://github.com/withastro/astro/issues",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"
   },


### PR DESCRIPTION
## Changes

- `typesVersions` is not used anymore
- Top level `types` is unecessary because we always define `exports.*`

## Testing

`pnpm publint` is green

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, I don't think this deserves a changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
