### PR TITLE
Revert async-slot head propagation fix from #17228

### DIFF
--- a/.changeset/humble-islands-trade.md
+++ b/.changeset/humble-islands-trade.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Fixes a bug where `<style>` tags from components could vanish from the build output when `await` expressions were used in the template/markup section of an `.astro` file

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -419,7 +419,6 @@ export class FetchState implements AstroFetchState {
 				extraStyleHashes,
 				extraScriptHashes,
 				propagators: new Set(),
-				pendingSlotEvaluations: [],
 				templateDepth: 0,
 			},
 			cspDestination: manifest.csp?.cspDestination ?? (routeData.prerender ? 'meta' : 'header'),

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -33,13 +33,6 @@ export class AstroComponentInstance {
 			// prerender the slots eagerly to make collection entries propagate styles and scripts
 			let didRender = false;
 			let value = slots[name](result);
-			// When a slot function is async (e.g. it contains `await` in the template),
-			// the returned Promise must resolve before head content is buffered, otherwise
-			// propagating components (like Content with styles) inside the slot won't be
-			// registered in time and their styles will be lost.
-			if (isPromise(value)) {
-				result._metadata.pendingSlotEvaluations.push(value);
-			}
 			this.slotValues[name] = () => {
 				// use prerendered value only once
 				if (!didRender) {

--- a/packages/astro/src/runtime/server/render/head-propagation/runtime.ts
+++ b/packages/astro/src/runtime/server/render/head-propagation/runtime.ts
@@ -52,12 +52,6 @@ export function registerIfPropagating(
 }
 
 export async function bufferPropagatedHead(result: SSRResult): Promise<void> {
-	// Wait for any async slot pre-renders to finish so that propagating
-	// components inside those slots are registered before we collect head parts.
-	if (result._metadata.pendingSlotEvaluations.length > 0) {
-		await Promise.all(result._metadata.pendingSlotEvaluations);
-		result._metadata.pendingSlotEvaluations.length = 0;
-	}
 	// Initialize potential propagators, then append all emitted head parts.
 	const collected = await collectPropagatedHeadParts({
 		propagators: result._metadata.propagators,

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -305,12 +305,6 @@ export interface SSRMetadata {
 	extraScriptHashes: string[];
 	propagators: Set<AstroComponentInstance | ServerIslandComponent>;
 	/**
-	 * Promises from async slot pre-rendering that must resolve before
-	 * head content is buffered, so that propagating components inside
-	 * async slots are registered in time.
-	 */
-	pendingSlotEvaluations: Promise<unknown>[];
-	/**
 	 * Tracks nesting depth of HTML `<template>` elements during rendering.
 	 * Scripts rendered inside `<template>` tags should not be deduplicated,
 	 * because template content is inert and scripts inside don't execute.

--- a/packages/astro/test/units/render/head-propagation/runtime-adapters.test.ts
+++ b/packages/astro/test/units/render/head-propagation/runtime-adapters.test.ts
@@ -15,7 +15,6 @@ function createResult() {
 			hasRenderedHead: false,
 			headInTree: false,
 			propagators: new Set(),
-			pendingSlotEvaluations: [] as Promise<unknown>[],
 			extraHead: [] as string[],
 		},
 	};

--- a/packages/astro/test/units/render/head-propagation/runtime.test.ts
+++ b/packages/astro/test/units/render/head-propagation/runtime.test.ts
@@ -18,7 +18,6 @@ function createResult() {
 			hasRenderedHead: false,
 			headInTree: false,
 			propagators: new Set(),
-			pendingSlotEvaluations: [] as Promise<unknown>[],
 			extraHead: [] as string[],
 		},
 	};
@@ -55,36 +54,6 @@ describe('head propagation runtime facade', () => {
 
 		await bufferPropagatedHead(result as unknown as SSRResult);
 		assert.deepEqual(result._metadata.extraHead, ['<link rel="stylesheet" href="/one.css">']);
-	});
-
-	it('awaits pending async slot evaluations before collecting head parts', async () => {
-		const result = createResult();
-
-		// Simulate an async slot that registers a propagator after a delay,
-		// mimicking what happens when `await` appears in a template expression
-		// before a component with head content (e.g. styles).
-		result._metadata.pendingSlotEvaluations.push(
-			new Promise<void>((resolve) => {
-				setTimeout(() => {
-					result._metadata.propagators.add({
-						init() {
-							return {
-								[headAndContentSym]: true,
-								head: '<style>.my-red{background:red}</style>',
-							};
-						},
-					});
-					resolve();
-				}, 10);
-			}),
-		);
-
-		// Without the fix, bufferPropagatedHead would find 0 propagators
-		// because the async slot hasn't resolved yet.
-		await bufferPropagatedHead(result as unknown as SSRResult);
-		assert.deepEqual(result._metadata.extraHead, ['<style>.my-red{background:red}</style>']);
-		// Pending evaluations should be cleared after processing
-		assert.equal(result._metadata.pendingSlotEvaluations.length, 0);
 	});
 
 	it('exposes render state and evaluates instruction policy', () => {

--- a/packages/astro/test/units/server-islands/server-islands-render.test.ts
+++ b/packages/astro/test/units/server-islands/server-islands-render.test.ts
@@ -65,7 +65,6 @@ async function createStubResult(overrides: Partial<SSRResult> = {}): Promise<SSR
 			extraStyleHashes: [],
 			extraScriptHashes: [],
 			propagators: new Set(),
-			pendingSlotEvaluations: [],
 			templateDepth: 0,
 		},
 		cspDestination: 'header',


### PR DESCRIPTION
Reverts #17228. I have a better fix for #17218 coming in a follow-up.