### PR TITLE
Fix styles dropped when an await precedes a propagating component in slot markup

### DIFF
--- a/.changeset/proud-pugs-jump.md
+++ b/.changeset/proud-pugs-jump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where `<style>` tags from components such as a content collection's `Content` could be silently dropped from the output when an `await` appeared before the component in an `.astro` file's markup.

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -419,6 +419,8 @@ export class FetchState implements AstroFetchState {
 				extraStyleHashes,
 				extraScriptHashes,
 				propagators: new Set(),
+				routeHasPropagation: false,
+				pendingSlotEvaluations: [],
 				templateDepth: 0,
 			},
 			cspDestination: manifest.csp?.cspDestination ?? (routeData.prerender ? 'meta' : 'header'),

--- a/packages/astro/src/core/head-propagation/buffer.ts
+++ b/packages/astro/src/core/head-propagation/buffer.ts
@@ -5,17 +5,21 @@ export interface HeadPropagator {
 }
 
 /**
- * Runs all registered propagators and collects emitted head HTML strings.
+ * Runs all registered propagators and collects the head HTML they emit.
  *
- * Discovery is a fixpoint: initializing one propagator can register more (the
- * `in-tree` -> `self` chain), and resolving a pending async slot pre-render can
- * register propagators that live behind an `await` in slot markup. We keep
- * draining both until neither produces new work — i.e. "wait until there are no
- * more propagators".
+ * Components with head content are discovered as we go. Initializing one
+ * propagator can register more of them: a component marked `in-tree` renders
+ * its children, and one of those children may be a `self` component that emits
+ * styles. Slots add a second way to find them — a slot whose markup contains an
+ * `await` only reaches the components after that `await` once it resolves, so
+ * we also wait for those pending slot pre-renders. We keep initializing
+ * propagators and waiting on slots until no new ones appear.
  *
- * A `seen` set is used instead of a single live `Set` iterator because a
- * propagator can be registered *after* an `await` boundary, at which point a
- * `Set` iterator that has already reported `done` would never observe it.
+ * Propagators are tracked in a `seen` set rather than read through a single
+ * live `Set` iterator. A propagator can be registered after we have already
+ * iterated to the end of the set (e.g. once a slot's `await` resolves), and a
+ * `Set` iterator that has reported `done` would never report those late
+ * additions.
  *
  * @example
  * If a layout initializes and discovers a nested component that also emits
@@ -53,8 +57,11 @@ export async function collectPropagatedHeadParts(input: {
 			if (input.isHeadAndContent(returnValue) && returnValue.head) {
 				collectedHeadParts.push(returnValue.head);
 			}
-			// Restart the loop so any work queued during `init()` is drained
-			// before advancing.
+			// Only initialize one propagator per `for` pass, then break back to
+			// the `while`. This is not the same as letting the `for` run to its
+			// end: `init()` above may have queued new slot pre-renders, and
+			// breaking returns to step 1 so those are drained before the next
+			// propagator is initialized.
 			break;
 		}
 

--- a/packages/astro/src/core/head-propagation/buffer.ts
+++ b/packages/astro/src/core/head-propagation/buffer.ts
@@ -7,8 +7,15 @@ export interface HeadPropagator {
 /**
  * Runs all registered propagators and collects emitted head HTML strings.
  *
- * This iterates the live `Set`, so propagators discovered during iteration
- * are also processed in the same pass.
+ * Discovery is a fixpoint: initializing one propagator can register more (the
+ * `in-tree` -> `self` chain), and resolving a pending async slot pre-render can
+ * register propagators that live behind an `await` in slot markup. We keep
+ * draining both until neither produces new work — i.e. "wait until there are no
+ * more propagators".
+ *
+ * A `seen` set is used instead of a single live `Set` iterator because a
+ * propagator can be registered *after* an `await` boundary, at which point a
+ * `Set` iterator that has already reported `done` would never observe it.
  *
  * @example
  * If a layout initializes and discovers a nested component that also emits
@@ -20,20 +27,38 @@ export async function collectPropagatedHeadParts(input: {
 	isHeadAndContent: (value: unknown) => value is { head: string };
 }): Promise<string[]> {
 	const collectedHeadParts: string[] = [];
+	const seen = new Set<HeadPropagator>();
+	// Populated (only on propagation routes) by eager async slot pre-renders.
+	const pendingSlotEvaluations = input.result._metadata?.pendingSlotEvaluations ?? [];
 
-	// Keep the iterator live so newly-added propagators are seen.
-	const iterator = input.propagators.values();
 	while (true) {
-		const { value, done } = iterator.next();
-		if (done) {
+		// 1. Drain async slot pre-renders first. Resolving them runs the slot
+		//    markup past its `await`s, registering any propagators inside.
+		if (pendingSlotEvaluations.length > 0) {
+			const batch = pendingSlotEvaluations.splice(0, pendingSlotEvaluations.length);
+			await Promise.all(batch);
+			continue;
+		}
+
+		// 2. Initialize the next not-yet-seen propagator. `init()` may register
+		//    further propagators or queue more slot evaluations.
+		let progressed = false;
+		for (const propagator of input.propagators) {
+			if (seen.has(propagator)) continue;
+			seen.add(propagator);
+			progressed = true;
+
+			const returnValue = await propagator.init(input.result);
+			// Only collect explicit head-bearing return values.
+			if (input.isHeadAndContent(returnValue) && returnValue.head) {
+				collectedHeadParts.push(returnValue.head);
+			}
+			// Restart the loop so any work queued during `init()` is drained
+			// before advancing.
 			break;
 		}
 
-		const returnValue = await value.init(input.result);
-		// Only collect explicit head-bearing return values.
-		if (input.isHeadAndContent(returnValue) && returnValue.head) {
-			collectedHeadParts.push(returnValue.head);
-		}
+		if (!progressed) break;
 	}
 
 	return collectedHeadParts;

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -33,6 +33,15 @@ export class AstroComponentInstance {
 			// prerender the slots eagerly to make collection entries propagate styles and scripts
 			let didRender = false;
 			let value = slots[name](result);
+			// When a slot is async (contains `await` in its markup), the eager
+			// pre-render above only runs up to the first `await`, so any propagating
+			// component sequenced after it (e.g. a content collection `Content` with
+			// styles) is not registered yet. On propagation routes, track the pending
+			// pre-render so head buffering can await it and discover those propagators
+			// before flushing the head. See `collectPropagatedHeadParts`.
+			if (result._metadata.routeHasPropagation && isPromise(value)) {
+				result._metadata.pendingSlotEvaluations.push(value);
+			}
 			this.slotValues[name] = () => {
 				// use prerendered value only once
 				if (!didRender) {

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -1,5 +1,6 @@
 import type { RouteData, SSRResult } from '../../../types/public/internal.js';
 import { isRoute404, isRoute500 } from '../../../core/routing/internal/route-errors.js';
+import { isPropagatingHint } from '../../../core/head-propagation/resolver.js';
 import { renderToAsyncIterable, renderToReadableStream, renderToString } from './astro/render.js';
 import { encoder } from './common.js';
 import { type NonAstroPageComponent, renderComponentToString } from './component.js';
@@ -17,8 +18,9 @@ export async function renderPage(
 	route?: RouteData,
 ): Promise<Response> {
 	if (!isAstroComponentFactory(componentFactory)) {
-		result._metadata.headInTree =
-			result.componentMetadata.get((componentFactory as any).moduleId)?.containsHead ?? false;
+		const nonAstroMeta = result.componentMetadata.get((componentFactory as any).moduleId);
+		result._metadata.headInTree = nonAstroMeta?.containsHead ?? false;
+		result._metadata.routeHasPropagation = isPropagatingHint(nonAstroMeta?.propagation ?? 'none');
 
 		const pageProps: Record<string, any> = { ...(props ?? {}), 'server:root': true };
 
@@ -58,8 +60,12 @@ export async function renderPage(
 
 	// Mark if this page component contains a <head> within its tree. If it does
 	// We avoid implicit head injection entirely.
-	result._metadata.headInTree =
-		result.componentMetadata.get(componentFactory.moduleId!)?.containsHead ?? false;
+	const pageMeta = result.componentMetadata.get(componentFactory.moduleId!);
+	result._metadata.headInTree = pageMeta?.containsHead ?? false;
+	// Only routes on a propagation path need to await async slot pre-renders
+	// before flushing the head (see `collectPropagatedHeadParts`). Other routes
+	// keep streaming without blocking the head on unrelated markup `await`s.
+	result._metadata.routeHasPropagation = isPropagatingHint(pageMeta?.propagation ?? 'none');
 
 	let body: BodyInit | Response;
 	if (streaming) {

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -305,6 +305,20 @@ export interface SSRMetadata {
 	extraScriptHashes: string[];
 	propagators: Set<AstroComponentInstance | ServerIslandComponent>;
 	/**
+	 * `true` when the page being rendered is on a head-propagation path (its
+	 * component metadata hint is `in-tree`/`self`). Only then do we await async
+	 * slot pre-renders before collecting head content, so that propagating
+	 * components hidden behind an `await` in slot markup are discovered in time.
+	 * Pages with no propagation keep streaming without paying that cost.
+	 */
+	routeHasPropagation: boolean;
+	/**
+	 * Promises from async slot pre-renders that may still need to register
+	 * propagating components. Drained by `collectPropagatedHeadParts` before
+	 * head content is flushed. Only populated when `routeHasPropagation` is true.
+	 */
+	pendingSlotEvaluations: Promise<unknown>[];
+	/**
 	 * Tracks nesting depth of HTML `<template>` elements during rendering.
 	 * Scripts rendered inside `<template>` tags should not be deduplicated,
 	 * because template content is inert and scripts inside don't execute.

--- a/packages/astro/test/content-collections.test.ts
+++ b/packages/astro/test/content-collections.test.ts
@@ -404,6 +404,26 @@ describe('Content Collections', () => {
 			const $ = cheerio.load(html);
 			assert.equal($('script').attr('src')!.startsWith('/docs'), true);
 		});
+
+		// Regression test for https://github.com/withastro/astro/issues/17218
+		// An `await` in the slot markup before <Content /> used to defer the
+		// propagating component's registration past head buffering, silently
+		// dropping its styles from the build output.
+		it('keeps propagated styles when an await precedes <Content /> in slot markup', async () => {
+			const html = await fixture.readFile('/async-slot/index.html');
+			const $ = cheerio.load(html);
+			const href = $('head link[rel="stylesheet"]').attr('href');
+			assert.ok(href, 'Expected the propagated stylesheet link to survive in the head');
+
+			// Read the emitted CSS (href is base-prefixed with `/docs`) and confirm
+			// it contains the content component's rule.
+			const css = await fixture.readFile(href.replace(/^\/docs/, ''));
+			assert.equal(
+				css.includes('color:'),
+				true,
+				'Expected the style from the content component to be present',
+			);
+		});
 	});
 
 	describe('Mutation', () => {

--- a/packages/astro/test/fixtures/content-collections-base/src/components/SlotLayout.astro
+++ b/packages/astro/test/fixtures/content-collections-base/src/components/SlotLayout.astro
@@ -1,0 +1,11 @@
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Async slot</title>
+  </head>
+  <body>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/packages/astro/test/fixtures/content-collections-base/src/pages/async-slot.astro
+++ b/packages/astro/test/fixtures/content-collections-base/src/pages/async-slot.astro
@@ -1,0 +1,15 @@
+---
+import { getEntry, render } from 'astro:content';
+import SlotLayout from '../components/SlotLayout.astro';
+const entry = await getEntry('docs', 'one');
+const { Content } = await render(entry);
+---
+<SlotLayout>
+  <!--
+    Regression for #17218: an `await` in the slot markup before <Content />
+    used to defer the propagating component's registration past head buffering,
+    silently dropping its styles.
+  -->
+  <p>{await new Promise((resolve) => setTimeout(() => resolve('ready'), 50))}</p>
+  <Content />
+</SlotLayout>

--- a/packages/astro/test/units/render/head-propagation/buffer.test.ts
+++ b/packages/astro/test/units/render/head-propagation/buffer.test.ts
@@ -17,8 +17,12 @@ function isHeadAndContent(value: unknown): value is { head: string } {
 	return typeof value === 'object' && value !== null && headAndContentSym in value;
 }
 
-function createResult(): SSRResult {
-	return {} as SSRResult;
+function createResult(pendingSlotEvaluations: Promise<unknown>[] = []): SSRResult {
+	return { _metadata: { pendingSlotEvaluations } } as unknown as SSRResult;
+}
+
+function tick(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('head propagation buffer', () => {
@@ -88,5 +92,48 @@ describe('head propagation buffer', () => {
 			'<link rel="stylesheet" href="/early.css">',
 			'<link rel="stylesheet" href="/late.css">',
 		]);
+	});
+
+	it('drains async slot pre-renders that register propagators after an await', async () => {
+		const propagators = new Set<HeadPropagator>();
+		// Mimics an async slot whose markup registers a propagating component
+		// (e.g. content `Content` with styles) only after an `await` resolves.
+		const slotEvaluation = tick().then(() => {
+			propagators.add({
+				init: () => createHeadAndContentLike('<style>.from-async-slot{color:red}</style>'),
+			});
+		});
+
+		const result = createResult([slotEvaluation]);
+		const collected = await collectPropagatedHeadParts({ propagators, result, isHeadAndContent });
+
+		assert.deepEqual(collected, ['<style>.from-async-slot{color:red}</style>']);
+		// The queue is fully drained.
+		assert.equal(result._metadata.pendingSlotEvaluations.length, 0);
+	});
+
+	it('drains nested async slot pre-renders queued while collecting', async () => {
+		const propagators = new Set<HeadPropagator>();
+		const result = createResult();
+
+		// Outer async slot resolves, registers a propagator AND queues a deeper
+		// async slot pre-render — the case a one-shot `Promise.all` would miss.
+		const outer = tick().then(() => {
+			propagators.add({
+				init: () => createHeadAndContentLike('<style>.outer{}</style>'),
+			});
+			const inner = tick().then(() => {
+				propagators.add({
+					init: () => createHeadAndContentLike('<style>.inner{}</style>'),
+				});
+			});
+			result._metadata.pendingSlotEvaluations.push(inner);
+		});
+		result._metadata.pendingSlotEvaluations.push(outer);
+
+		const collected = await collectPropagatedHeadParts({ propagators, result, isHeadAndContent });
+
+		assert.deepEqual(collected, ['<style>.outer{}</style>', '<style>.inner{}</style>']);
+		assert.equal(result._metadata.pendingSlotEvaluations.length, 0);
 	});
 });

--- a/packages/astro/test/units/server-islands/server-islands-render.test.ts
+++ b/packages/astro/test/units/server-islands/server-islands-render.test.ts
@@ -65,6 +65,8 @@ async function createStubResult(overrides: Partial<SSRResult> = {}): Promise<SSR
 			extraStyleHashes: [],
 			extraScriptHashes: [],
 			propagators: new Set(),
+			routeHasPropagation: false,
+			pendingSlotEvaluations: [],
 			templateDepth: 0,
 		},
 		cspDestination: 'header',


### PR DESCRIPTION
## Changes

- Fixes `<style>` tags from propagating components (e.g. a content collection's `Content`) being silently dropped when an `await` appears before the component in slot markup.
- Head propagation discovers these components by eagerly pre-rendering slots. An `await` in the slot suspended that pre-render before the component was reached, so it registered too late and its styles were never collected. Astro now awaits pending async slot pre-renders while collecting head content on routes that use propagation. Routes without propagation are unaffected and keep streaming.

## Testing

- Adds a content-collections integration test: a `Content` rendered after an `await` in slot markup, asserting its propagated stylesheet survives.
- Adds unit tests for the head-collection loop covering an async slot that registers a propagator after an `await`, including a nested case.

## Docs

- No docs update needed — restores expected behavior that component styles are collected regardless of where `await` appears.

Closes #17218
