### PR TITLE
ci: add auto close workflow

### DIFF
--- a/.github/scripts/stale-issues.ts
+++ b/.github/scripts/stale-issues.ts
@@ -27,4 +27,5 @@ const stale = issues
 	.filter((issue) => new Date(issue.updatedAt) < cutoff)
 	.map((issue) => issue.number);
 
+// biome-ignore lint/suspicious/noConsole: valid for CI
 console.log(JSON.stringify(stale));

--- a/.github/scripts/stale-issues.ts
+++ b/.github/scripts/stale-issues.ts
@@ -1,0 +1,30 @@
+import { execSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+	options: {
+		token: { type: 'string' },
+	},
+});
+
+if (!values.token) {
+	console.error('Usage: node --experimental-strip-types stale-issues.ts --token <github-token>');
+	process.exit(1);
+}
+
+const DAYS_INACTIVE = 3;
+// Convert days to milliseconds: days * hours * minutes * seconds * ms
+const cutoff = new Date(Date.now() - DAYS_INACTIVE * 24 * 60 * 60 * 1000);
+
+const issues: { number: number; updatedAt: string }[] = JSON.parse(
+	execSync(
+		`gh issue list --label "triage: needs reproduction" --state open --json number,updatedAt --limit 500 --repo biomejs/biome`,
+		{ encoding: 'utf-8', env: { ...process.env, GH_TOKEN: values.token } },
+	),
+);
+
+const stale = issues
+	.filter((issue) => new Date(issue.updatedAt) < cutoff)
+	.map((issue) => issue.number);
+
+console.log(JSON.stringify(stale));

--- a/.github/scripts/stale-issues.ts
+++ b/.github/scripts/stale-issues.ts
@@ -18,7 +18,7 @@ const cutoff = new Date(Date.now() - DAYS_INACTIVE * 24 * 60 * 60 * 1000);
 
 const issues: { number: number; updatedAt: string }[] = JSON.parse(
 	execSync(
-		`gh issue list --label "triage: needs reproduction" --state open --json number,updatedAt --limit 500 --repo biomejs/biome`,
+		`gh issue list --label "triage: needs reproduction" --state open --json number,updatedAt --limit 500 --repo withastro/astro`,
 		{ encoding: 'utf-8', env: { ...process.env, GH_TOKEN: values.token } },
 	),
 );

--- a/.github/workflows/issue-state-issue.yml
+++ b/.github/workflows/issue-state-issue.yml
@@ -1,0 +1,35 @@
+name: Close issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    if: github.repository == 'withastro/astro'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.18.0
+
+      - name: Find stale issues
+        id: find-stale
+        run: echo "issues=$(node --experimental-strip-types .github/scripts/stale-issues.ts --token ${{ secrets.GITHUB_TOKEN }})" >> "$GITHUB_OUTPUT"
+
+      - name: Close stale issues
+        if: steps.find-stale.outputs.issues != '[]'
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+        run: |
+          echo '${{ steps.find-stale.outputs.issues }}' | jq -r '.[]' | while read -r issue; do
+            gh issue comment "$issue" --repo ${{ github.repository }} --body "This issue has been automatically closed because it has been inactive for more than 3 days and it does not have a minimal reproduction."
+            gh issue close "$issue" --repo ${{ github.repository }} --reason "not planned"
+            echo "Closed issue #$issue"
+          done

--- a/.github/workflows/issue-wontfix.yml
+++ b/.github/workflows/issue-wontfix.yml
@@ -1,29 +1,29 @@
-# Action taken down due to https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
-#name: "Issue: Wontfix"
-#
-#on:
-#  issues:
-#    types: [labeled]
-#
-#jobs:
-#  wontfix:
-#    if: github.event.label.name == 'wontfix'
-#    runs-on: ubuntu-latest
-#    permissions:
-#      issues: write
-#    steps:
-#      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-#        with:
-#          actions: "create-comment, close-issue"
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          issue-number: ${{ github.event.issue.number }}
-#          body: |
-#            Hello! 
-#
-#            This is an automated message to let you know that we've triaged this issue and unfortunately, we will be closing it as "not planned".
-#
-#            We sometimes have to close good ideas (even great ones!) because our limited resources simply do not allow us to pursue all possible features and improvements, and when fixing bugs we have to balance the impact of the bug against the effort required for the fix. Before closing this we considered several factors such as the amount of work involved, the severity of the problem, the number of people affected, whether a workaround is available, and the ongoing cost of maintenance.
-#
-#            If you're seeing this message and believe you can contribute to this issue, please consider submitting a PR yourself. Astro encourages [community contributions](https://docs.astro.build/en/contribute/)!
-#
-#            If you have more questions, come and say hi in the [Astro Discord](https://astro.build/chat).
+name: "Issue: Wontfix"
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  wontfix:
+    if: github.event.label.name == 'wontfix'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close issue
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          BODY: |
+            Hello!
+
+            This is an automated message to let you know that we've triaged this issue and unfortunately, we will be closing it as "not planned".
+
+            We sometimes have to close good ideas (even great ones!) because our limited resources simply do not allow us to pursue all possible features and improvements, and when fixing bugs we have to balance the impact of the bug against the effort required for the fix. Before closing this we considered several factors such as the amount of work involved, the severity of the problem, the number of people affected, whether a workaround is available, and the ongoing cost of maintenance.
+
+            If you're seeing this message and believe you can contribute to this issue, please consider submitting a PR yourself. Astro encourages [community contributions](https://docs.astro.build/en/contribute/)!
+
+            If you have more questions, come and say hi in the [Astro Discord](https://astro.build/chat).
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$BODY"
+          gh issue close "$ISSUE_NUMBER" --repo "$REPO" --reason "not planned"


### PR DESCRIPTION
## Changes

This PR restores two workflows:
- Automatic closure for missing reproduction. I adapted the script I created in the biome repository to the Astro repository. The script works in the other repo, so it's tested (with the secrets we have)
- Restore the "Wontfix" workflow using the `gh` CLI

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
