### PR TITLE
Add `edgeFunctions` to Netlify adapter `devFeatures` to allow disabling edge function emulation

### DIFF
--- a/.changeset/shiny-mugs-care.md
+++ b/.changeset/shiny-mugs-care.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/netlify': patch
+'@astrojs/netlify': minor
 ---
 
 Adds `edgeFunctions` to the `devFeatures` adapter option, allowing users to disable Netlify Edge Function emulation during `astro dev`

--- a/.changeset/shiny-mugs-care.md
+++ b/.changeset/shiny-mugs-care.md
@@ -1,0 +1,22 @@
+---
+'@astrojs/netlify': patch
+---
+
+Adds `edgeFunctions` to the `devFeatures` adapter option, allowing users to disable Netlify Edge Function emulation during `astro dev`
+
+Some npm packages that access the filesystem at initialization (e.g. `node-html-parser`) fail inside the edge function sandbox with "Reading or writing files with Edge Functions is not supported yet." You can now disable edge function emulation to avoid this error:
+
+```js
+import netlify from "@astrojs/netlify";
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  adapter: netlify({
+    devFeatures: {
+      edgeFunctions: false,
+    },
+  }),
+});
+```
+
+Edge functions will still work in production builds and via `netlify dev`.

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -281,10 +281,11 @@ export interface NetlifyIntegrationConfig {
 	 *
 	 * - `images`: Enables the Netlify Image CDN in local development. Default: true
 	 * - `environmentVariables`: If your site is linked to a Netlify site, this will automatically load the environment variables from the Netlify site or team. Default: false
+	 * - `edgeFunctions`: Enables emulation of Netlify Edge Functions defined in your project's `netlify/edge-functions` directory. Some npm packages that access the filesystem may not work in the edge function sandbox. If you encounter errors, disable this and use `netlify dev` instead. Default: true
 	 *
-	 * @default {{ environmentVariables: false, images: true }}
+	 * @default {{ environmentVariables: false, images: true, edgeFunctions: true }}
 	 */
-	devFeatures?: { environmentVariables: boolean; images: boolean } | boolean;
+	devFeatures?: { environmentVariables: boolean; images: boolean; edgeFunctions: boolean } | boolean;
 }
 
 export default function netlifyIntegration(
@@ -631,10 +632,12 @@ export default function netlifyIntegration(
 						? {
 								images: integrationConfig.devFeatures,
 								environmentVariables: integrationConfig.devFeatures,
+								edgeFunctions: integrationConfig.devFeatures,
 							}
 						: {
 								images: integrationConfig?.devFeatures?.images ?? true,
 								environmentVariables: integrationConfig?.devFeatures?.environmentVariables ?? false,
+								edgeFunctions: integrationConfig?.devFeatures?.edgeFunctions ?? true,
 							};
 
 				const vitePluginOptions: NetlifyPluginOptions = {
@@ -648,6 +651,9 @@ export default function netlifyIntegration(
 						// If features is an object, use the `environmentVariables` property
 						// Otherwise, use the boolean value of `features`, defaulting to false
 						enabled: features.environmentVariables,
+					},
+					edgeFunctions: {
+						enabled: features.edgeFunctions,
 					},
 				};
 


### PR DESCRIPTION
## Changes

- Adds `edgeFunctions` to the `devFeatures` adapter option so users can disable Netlify Edge Function emulation during `astro dev`. Some npm packages (e.g. `node-html-parser`) access the filesystem at initialization and fail inside the Deno sandbox with "Reading or writing files with Edge Functions is not supported yet." Setting `devFeatures: { edgeFunctions: false }` works around this — edge functions still work in production and via `netlify dev`.
- The new option defaults to `true` to preserve existing behavior.

Closes #17244

## Testing

- No new tests added. The fix is a config passthrough to `@netlify/vite-plugin`'s existing `edgeFunctions.enabled` option; existing integration tests already cover edge function emulation when enabled. Fix was verified against the reporter's reproduction repo.

## Docs

- No docs update needed; the new option is documented in the JSDoc on `NetlifyIntegrationConfig` and in the changeset.
