### PR TITLE
Fix route generator throwing on a dynamic param value of 0

### DIFF
--- a/.changeset/fix-route-generator-zero-param.md
+++ b/.changeset/fix-route-generator-zero-param.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes route generation throwing "Missing parameter" (or silently dropping the segment) when a dynamic param's value is `0`. The generator used truthy checks instead of checking for `undefined`, so `paginate(posts, { params: { categoryId: 0 } })` would crash even though `0` is a perfectly valid param value.

--- a/packages/astro/src/core/routing/generator.ts
+++ b/packages/astro/src/core/routing/generator.ts
@@ -20,11 +20,11 @@ function sanitizeParams(params: Record<string, string | number>): Record<string,
 
 function getParameter(part: RoutePart, params: Record<string, string | number>): string | number {
 	if (part.spread) {
-		return params[part.content.slice(3)] || '';
+		return params[part.content.slice(3)] ?? '';
 	}
 
 	if (part.dynamic) {
-		if (!params[part.content]) {
+		if (params[part.content] === undefined) {
 			throw new TypeError(`Missing parameter: ${part.content}`);
 		}
 

--- a/packages/astro/test/units/render/paginate.test.ts
+++ b/packages/astro/test/units/render/paginate.test.ts
@@ -133,6 +133,30 @@ describe('Pagination — multiple params (color + page)', () => {
 	});
 });
 
+describe('Pagination — param value of 0 (e.g. an "uncategorized" id)', () => {
+	const route = createRouteData({
+		route: '/posts/[categoryId]/[page]',
+		segments: [
+			[{ content: 'posts', dynamic: false, spread: false }],
+			[{ content: 'categoryId', dynamic: true, spread: false }],
+			[{ content: 'page', dynamic: true, spread: false }],
+		],
+	});
+	const paginate = generatePaginateFunction(route, '/blog', 'never');
+
+	it('does not throw when categoryId is 0', () => {
+		assert.doesNotThrow(() => paginate(items, { pageSize: 10, params: { categoryId: 0 } as any }));
+	});
+
+	it('generates a path containing /0/', () => {
+		const pages = paginate(items, { pageSize: 10, params: { categoryId: 0 } as any });
+		assert.ok(
+			pages[0].props.page.url.current.includes('/posts/0/'),
+			`expected /posts/0/, got ${pages[0].props.page.url.current}`,
+		);
+	});
+});
+
 describe('Pagination — root spread, correct prev URL — Migrated from astro-pagination-root-spread.test.js', () => {
 	// 4 items, pageSize 1 → 4 pages; root spread means page 1 has no number in URL.
 	const route = createRouteData({

--- a/packages/astro/test/units/routing/generator.test.ts
+++ b/packages/astro/test/units/routing/generator.test.ts
@@ -143,6 +143,24 @@ describe('routing - generator', () => {
 			params: { page: 1 },
 			path: '/fix/1',
 		},
+		{
+			routeData: [
+				[{ spread: false, content: 'products', dynamic: false }],
+				[{ spread: false, content: 'id', dynamic: true }],
+			],
+			trailingSlash: 'never',
+			params: { id: 0 },
+			path: '/products/0',
+		},
+		{
+			routeData: [
+				[{ spread: false, content: 'fix', dynamic: false }],
+				[{ spread: true, content: '...foo', dynamic: true }],
+			],
+			trailingSlash: 'never',
+			params: { foo: 0 },
+			path: '/fix/0',
+		},
 	];
 
 	cases.forEach(({ routeData, trailingSlash, params, path }) => {
@@ -158,5 +176,13 @@ describe('routing - generator', () => {
 			'never',
 		);
 		assert.throws(() => generator({}), TypeError);
+	});
+
+	it('should not throw when a dynamic parameter is 0', () => {
+		const generator = getRouteGenerator(
+			[[{ spread: false, content: 'foo', dynamic: true }]],
+			'never',
+		);
+		assert.equal(generator({ foo: 0 }), '/0');
 	});
 });


### PR DESCRIPTION
\`getParameter\` in the route generator was using truthy checks (\`!params[x]\`, \`|| ''\`) instead of checking for \`undefined\`. That means a param that's legitimately \`0\` — like a zero-indexed category id — either throws \`TypeError: Missing parameter\` or gets silently dropped from the generated path. It's reachable through the public API too: \`paginate(posts, { params: { categoryId: 0 } })\` throws.

Switched to \`=== undefined\` / \`??\` so falsy-but-valid values pass through correctly, and added tests for both the dynamic-segment and spread-segment branches.