### PR TITLE
Skip dev server setup in `configureServer` when running inside Vitest

### DIFF
--- a/.changeset/sweet-trains-follow.md
+++ b/.changeset/sweet-trains-follow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a crash when using Astro's `getViteConfig` with Vitest browser mode (e.g., Storybook vitest runner). The `astro:server` plugin's `configureServer` hook now skips dev server setup inside Vitest, preventing a `TypeError: Cannot read properties of undefined (reading 'wrapDynamicImport')` error.

--- a/.changeset/sweet-trains-follow.md
+++ b/.changeset/sweet-trains-follow.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a crash when using Astro's `getViteConfig` with Vitest browser mode (e.g., Storybook vitest runner). The `astro:server` plugin's `configureServer` hook now skips dev server setup inside Vitest, preventing a `TypeError: Cannot read properties of undefined (reading 'wrapDynamicImport')` error.
+Fixes a crash when using Astro's `getViteConfig` with Vitest browser mode (e.g., Storybook vitest runner). Astro now skips dev server setup inside Vitest, preventing errors.

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -35,6 +35,14 @@ export default function createVitePluginAstroServer({
 			return environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.ssr;
 		},
 		async configureServer(viteServer) {
+			// Skip Astro dev server setup when running inside Vitest. The dev server
+			// middleware (SSR handler, prerender handler, trailing-slash redirects, etc.)
+			// is only needed for `astro dev` and can crash in Vitest's browser server
+			// where the module evaluator may not support dynamic imports.
+			if (process.env.VITEST) {
+				return;
+			}
+
 			const ssrEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.ssr];
 			const prerenderEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.prerender];
 

--- a/packages/astro/test/units/vite-plugin-astro-server/vitest-guard.test.ts
+++ b/packages/astro/test/units/vite-plugin-astro-server/vitest-guard.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import createVitePluginAstroServer from '../../../dist/vite-plugin-astro-server/plugin.js';
+import { createBasicSettings } from '../test-utils.ts';
+import { defaultLogger } from '../test-utils.ts';
+
+describe('astro:server configureServer vitest guard', () => {
+	const originalVitest = process.env.VITEST;
+
+	afterEach(() => {
+		if (originalVitest !== undefined) {
+			process.env.VITEST = originalVitest;
+		} else {
+			delete process.env.VITEST;
+		}
+	});
+
+	it('skips server setup when process.env.VITEST is set', async () => {
+		process.env.VITEST = 'true';
+		const settings = await createBasicSettings({});
+		const plugin = createVitePluginAstroServer({ settings, logger: defaultLogger });
+
+		// configureServer should return early without throwing when VITEST is set,
+		// even with a fake viteServer that has no environments
+		const fakeViteServer = {} as any;
+		const result = await (plugin as any).configureServer(fakeViteServer);
+
+		// Early return produces undefined (no middleware callback)
+		assert.equal(result, undefined);
+	});
+
+	it('attempts server setup when process.env.VITEST is not set', async () => {
+		delete process.env.VITEST;
+		const settings = await createBasicSettings({});
+		const plugin = createVitePluginAstroServer({ settings, logger: defaultLogger });
+
+		// Without VITEST, configureServer should try to access viteServer.environments
+		// and fail because our fake server has none
+		const fakeViteServer = { environments: {} } as any;
+		// Should not throw — it will just have no runnable environments
+		const result = await (plugin as any).configureServer(fakeViteServer);
+
+		// When there are no runnable environments, it returns a middleware setup function
+		assert.equal(typeof result, 'function');
+	});
+});


### PR DESCRIPTION
Closes #16275

## Changes

- When `process.env.VITEST` is set, `configureServer` in `vite-plugin-astro-server` now returns early instead of setting up Astro's dev server middleware. Vitest's browser mode (used by the Storybook vitest runner) boots its own Vite server, which triggers this hook — but its module evaluator doesn't implement `wrapDynamicImport`, causing a `TypeError` when Astro's SSR runner tries to load `createAstroServerApp` via dynamic imports.
- The dev server middleware (SSR handler, prerender handler, trailing-slash redirects) is only meaningful for `astro dev`, so skipping it in Vitest contexts is safe.

## Testing

- Added `packages/astro/test/units/vite-plugin-astro-server/vitest-guard.test.ts` with two cases: one confirming the early return when `VITEST` is set (using a bare fake server with no environments), and one confirming normal execution proceeds when `VITEST` is absent.

## Docs

- No docs update needed — this is a bug fix with no user-facing API changes.
