### PR TITLE
fix: peer deps of packages

### DIFF
--- a/.changeset/loose-tables-work.md
+++ b/.changeset/loose-tables-work.md
@@ -1,0 +1,12 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/markdoc': patch
+'@astrojs/netlify': patch
+'@astrojs/svelte': patch
+'@astrojs/vercel': patch
+'@astrojs/node': patch
+'@astrojs/mdx': patch
+'@astrojs/vue': patch
+---
+
+Fixes an issue where the `peerDependencies` field used incorrect dependencies.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -51,7 +51,7 @@
     "vite": "^8.0.13"
   },
   "peerDependencies": {
-    "astro": "^7.0.0-alpha.2",
+    "astro": "^7.0.0",
     "wrangler": "^4.83.0"
   },
   "devDependencies": {

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -47,7 +47,7 @@
     "htmlparser2": "^10.1.0"
   },
   "peerDependencies": {
-    "astro": "^7.0.0-alpha.0"
+    "astro": "^7.0.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -50,8 +50,8 @@
     "vfile": "^6.0.3"
   },
   "peerDependencies": {
-    "@astrojs/markdown-satteri": "^0.3.1-alpha.0",
-    "astro": "^7.0.0-alpha.0"
+    "@astrojs/markdown-satteri": "^0.3.1",
+    "astro": "^7.0.0"
   },
   "peerDependenciesMeta": {
     "@astrojs/markdown-satteri": {

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -51,7 +51,7 @@
     "vite": "^8.0.13"
   },
   "peerDependencies": {
-    "astro": "^7.0.0-alpha.0"
+    "astro": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.6",

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -37,7 +37,7 @@
     "server-destroy": "^1.0.1"
   },
   "peerDependencies": {
-    "astro": "^7.0.0-alpha.2"
+    "astro": "^7.0.0"
   },
   "devDependencies": {
     "@fastify/middie": "^9.1.0",

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -51,7 +51,7 @@
     "svelte": "^5.54.1"
   },
   "peerDependencies": {
-    "astro": "^7.0.0-alpha.0",
+    "astro": "^7.0.0",
     "svelte": "^5.43.6",
     "typescript": "^5.3.3 || ^6.0.0"
   },

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -47,7 +47,7 @@
     "tinyglobby": "^0.2.15"
   },
   "peerDependencies": {
-    "astro": "^7.0.0-alpha.0"
+    "astro": "^7.0.0"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -52,7 +52,7 @@
     "vue": "^3.5.30"
   },
   "peerDependencies": {
-    "astro": "^7.0.0-alpha.0",
+    "astro": "^7.0.0",
     "vue": "^3.5.24"
   },
   "engines": {


### PR DESCRIPTION
## Changes

Our packages still had the alpha versions in their `peerDependencies` fields. This PR fixes the problem by using the non-alpha packages.

## Testing

Green CI.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
