### PR TITLE
Validate attribute names on custom HTML elements during SSR

### DIFF
--- a/.changeset/quick-otters-attend.md
+++ b/.changeset/quick-otters-attend.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens `renderHTMLElement` to drop attribute names containing characters that are invalid per the HTML spec (`"`, `'`, `>`, `/`, `=`, whitespace), matching the guard already applied in `addAttribute`

--- a/.changeset/quick-otters-attend.md
+++ b/.changeset/quick-otters-attend.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Hardens `renderHTMLElement` to drop attribute names containing characters that are invalid per the HTML spec (`"`, `'`, `>`, `/`, `=`, whitespace), matching the guard already applied in `addAttribute`
+Fixes a security issue where invalid attribute names on custom HTML elements could produce unsafe HTML output when rendered server-side

--- a/.changeset/quick-otters-attend.md
+++ b/.changeset/quick-otters-attend.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a security issue where invalid attribute names on custom HTML elements could produce unsafe HTML output when rendered server-side
+Hardens the handling of attribute rendering when using with custom elements.

--- a/packages/astro/src/runtime/server/render/dom.ts
+++ b/packages/astro/src/runtime/server/render/dom.ts
@@ -1,7 +1,7 @@
 import type { SSRResult } from '../../../types/public/internal.js';
 import { markHTMLString } from '../escape.js';
 import { renderSlotToString } from './slot.js';
-import { toAttributeString } from './util.js';
+import { INVALID_ATTR_NAME_CHAR, toAttributeString } from './util.js';
 
 export function componentIsHTMLElement(Component: unknown) {
 	return typeof HTMLElement !== 'undefined' && HTMLElement.isPrototypeOf(Component as object);
@@ -18,6 +18,12 @@ export async function renderHTMLElement(
 	let attrHTML = '';
 
 	for (const attr in props) {
+		// Reject attribute names with characters that could break out of the attribute context.
+		// Without this guard, untrusted prop keys spread onto the element could inject arbitrary
+		// markup or event-handler attributes (XSS). Mirrors the guard in `addAttribute`.
+		if (INVALID_ATTR_NAME_CHAR.test(attr)) {
+			continue;
+		}
 		attrHTML += ` ${attr}="${toAttributeString(await props[attr])}"`;
 	}
 

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -15,7 +15,7 @@ const DOUBLE_QUOTE_REGEX = /"/g;
 const STATIC_DIRECTIVES = new Set(['set:html', 'set:text']);
 
 // Per the HTML spec, attribute names must not contain ASCII whitespace, ", ', >, /, or =.
-const INVALID_ATTR_NAME_CHAR = /[\s"'>/=]/;
+export const INVALID_ATTR_NAME_CHAR = /[\s"'>/=]/;
 
 // converts (most) arbitrary strings to valid JS identifiers
 const toIdent = (k: string) =>

--- a/packages/astro/test/units/render/html-primitives.test.ts
+++ b/packages/astro/test/units/render/html-primitives.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import {
 	addAttribute,
@@ -15,6 +15,7 @@ import {
 	Fragment,
 	render as renderTemplate,
 	renderComponent,
+	renderHTMLElement,
 	renderSlot,
 	unescapeHTML,
 } from '../../../dist/runtime/server/index.js';
@@ -260,6 +261,54 @@ describe('spreadAttributes rejects invalid attribute keys', () => {
 		assert.ok(result.includes('id="ok"'));
 		assert.ok(!result.includes('onclick'));
 		assert.ok(!result.includes('alert'));
+	});
+});
+
+describe('renderHTMLElement rejects invalid attribute keys', () => {
+	// renderHTMLElement resolves the tag name through customElements.getName().
+	// In a Node test environment this global doesn't exist, so we stub it.
+	const originalCustomElements = globalThis.customElements;
+	const result = {} as any;
+
+	before(() => {
+		globalThis.customElements = {
+			getName: () => 'my-el',
+		} as any;
+	});
+
+	after(() => {
+		globalThis.customElements = originalCustomElements;
+	});
+
+	it('drops malicious keys while keeping valid ones', async () => {
+		const html = await renderHTMLElement(
+			result,
+			class {} as any,
+			{
+				'onmouseover=alert(document.domain) x': 'y',
+				'x><script>alert(1)</script>': 'z',
+				'data-safe': 'ok',
+			},
+			{},
+		);
+		const output = String(html);
+		assert.ok(output.includes('data-safe="ok"'));
+		assert.ok(!output.includes('onmouseover'));
+		assert.ok(!output.includes('<script>'));
+		assert.ok(!output.includes('alert'));
+	});
+
+	it('preserves namespaced and normal attribute names', async () => {
+		const html = await renderHTMLElement(
+			result,
+			class {} as any,
+			{ 'id': 'a', 'data-foo': 'b', 'on:click': 'c' },
+			{},
+		);
+		const output = String(html);
+		assert.ok(output.includes('id="a"'));
+		assert.ok(output.includes('data-foo="b"'));
+		assert.ok(output.includes('on:click="c"'));
 	});
 });
 


### PR DESCRIPTION
## Changes

- Applies the existing attribute name validation to custom HTML element rendering during SSR. Attribute names containing characters invalid per the HTML spec (`" ' > / =` or whitespace) are now dropped instead of interpolated raw, preventing unsafe HTML output.

## Testing

- Adds `renderHTMLElement rejects invalid attribute keys` test suite covering malicious keys (event handler injection, script tag injection) and valid keys (namespaced, `data-*`).

## Docs

- No docs update needed — this is an internal hardening fix with no user-facing API change.