### PR TITLE
Treat backslash-prefixed paths as internal in trailing-slash handling

### DIFF
--- a/.changeset/node-backslash-trailing-slash.md
+++ b/.changeset/node-backslash-trailing-slash.md
@@ -1,0 +1,10 @@
+---
+'@astrojs/internal-helpers': patch
+'@astrojs/node': patch
+---
+
+Fixes trailing-slash handling for request paths that begin with a backslash
+
+With `trailingSlash: 'always'`, the standalone Node server could append a trailing slash to a request path that begins with a backslash (for example `/\example.com/foo`) and echo that path back in the `Location` header of a `301` response. Because browsers resolve a leading `\` the same way as `/`, the resulting `Location` could point off-site.
+
+Such paths are now recognized as internal paths, matching the existing handling for paths that begin with `//`, so they are no longer rewritten with a trailing slash.

--- a/packages/integrations/node/test/trailing-slash.test.ts
+++ b/packages/integrations/node/test/trailing-slash.test.ts
@@ -235,7 +235,7 @@ describe('Trailing slash', () => {
 				// (like `curl --path-as-is`) because URL parsers fold the
 				// backslash to a forward slash. It must not produce a 301 that
 				// echoes the backslash path back in the `Location` header.
-				const raw = await rawRequest(server.host, server.port, '/\\example.com/press');
+				const raw = await rawRequest(server.host ?? 'localhost', server.port, '/\\example.com/press');
 				assert.match(raw.statusLine, /404/);
 				assert.equal(/^location:/im.test(raw.head), false);
 			});

--- a/packages/integrations/node/test/trailing-slash.test.ts
+++ b/packages/integrations/node/test/trailing-slash.test.ts
@@ -1,8 +1,39 @@
 import * as assert from 'node:assert/strict';
+import net from 'node:net';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { type Fixture, loadFixture, waitServerListen, type AdapterServer } from './test-utils.ts';
+
+/**
+ * Sends a raw HTTP/1.1 request so the exact request-target (including
+ * characters like `\` that URL parsers would otherwise normalize) reaches
+ * the server unchanged, mirroring `curl --path-as-is`.
+ */
+function rawRequest(
+	host: string,
+	port: number,
+	requestTarget: string,
+): Promise<{ statusLine: string; head: string }> {
+	return new Promise((resolve, reject) => {
+		const socket = net.connect(port, host, () => {
+			socket.write(
+				`GET ${requestTarget} HTTP/1.1\r\nHost: ${host}:${port}\r\nConnection: close\r\n\r\n`,
+			);
+		});
+		let data = '';
+		socket.setEncoding('utf8');
+		socket.on('data', (chunk) => {
+			data += chunk;
+		});
+		socket.on('error', reject);
+		socket.on('end', () => {
+			const head = data.split('\r\n\r\n')[0] ?? '';
+			const statusLine = head.split('\r\n')[0] ?? '';
+			resolve({ statusLine, head });
+		});
+	});
+}
 
 describe('Trailing slash', () => {
 	let fixture: Fixture;
@@ -196,6 +227,17 @@ describe('Trailing slash', () => {
 					`http://${server.host}:${server.port}//example.com/es//astro.build/press`,
 				);
 				assert.equal(res.status, 404);
+			});
+
+			it('Does not append a trailing slash to a backslash-prefixed path', async () => {
+				// A path like `/\example.com/press` is treated by browsers as
+				// `//example.com/press`. It has to be sent as a raw request line
+				// (like `curl --path-as-is`) because URL parsers fold the
+				// backslash to a forward slash. It must not produce a 301 that
+				// echoes the backslash path back in the `Location` header.
+				const raw = await rawRequest(server.host, server.port, '/\\example.com/press');
+				assert.match(raw.statusLine, /404/);
+				assert.equal(/^location:/im.test(raw.head), false);
 			});
 		});
 	});

--- a/packages/internal-helpers/src/path.ts
+++ b/packages/internal-helpers/src/path.ts
@@ -83,7 +83,13 @@ const INTERNAL_PREFIXES = new Set(['/_', '/@', '/.', '//']);
 const JUST_SLASHES = /^\/{2,}$/;
 
 export function isInternalPath(path: string) {
-	return INTERNAL_PREFIXES.has(path.slice(0, 2)) && !JUST_SLASHES.test(path);
+	// Browsers follow the WHATWG URL spec and treat backslashes as forward
+	// slashes when resolving a path, so `/\host` behaves like `//host`. Fold
+	// backslashes to forward slashes before comparing the prefix so those
+	// paths are recognized as internal too, instead of being appended with a
+	// trailing slash and echoed back into a `Location` header.
+	const prefix = path.slice(0, 2).replace(/\\/g, '/');
+	return INTERNAL_PREFIXES.has(prefix) && !JUST_SLASHES.test(path);
 }
 
 export function joinPaths(...paths: (string | undefined)[]) {

--- a/packages/internal-helpers/test/path.test.ts
+++ b/packages/internal-helpers/test/path.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { isParentDirectory, isRemotePath, normalizePathname } from '../dist/path.js';
+import {
+	isInternalPath,
+	isParentDirectory,
+	isRemotePath,
+	normalizePathname,
+} from '../dist/path.js';
 
 describe('isRemotePath', () => {
 	const remotePaths = [
@@ -846,5 +851,30 @@ describe('normalizePathname', () => {
 			assert.equal(normalizePathname('/about/', 'preserve', 'always'), '/about/');
 			assert.equal(normalizePathname('/', 'preserve', 'ignore'), '/');
 		});
+	});
+});
+
+describe('isInternalPath', () => {
+	it('recognizes known internal prefixes', () => {
+		assert.equal(isInternalPath('/_astro/index.js'), true);
+		assert.equal(isInternalPath('/@vite/client'), true);
+		assert.equal(isInternalPath('/.well-known/foo'), true);
+		assert.equal(isInternalPath('//example.com/press'), true);
+	});
+
+	it('treats backslash-prefixed paths like their forward-slash equivalent', () => {
+		// Browsers fold `\` to `/`, so `/\host` resolves like `//host`.
+		assert.equal(isInternalPath('/\\example.com/press'), true);
+		assert.equal(isInternalPath('/\\'), true);
+	});
+
+	it('does not flag regular paths', () => {
+		assert.equal(isInternalPath('/about'), false);
+		assert.equal(isInternalPath('/one/two'), false);
+	});
+
+	it('does not flag paths that are only slashes', () => {
+		assert.equal(isInternalPath('//'), false);
+		assert.equal(isInternalPath('///'), false);
 	});
 });


### PR DESCRIPTION
## Summary

With `trailingSlash: 'always'`, the standalone `@astrojs/node` server could append a trailing slash to a request path beginning with a backslash (e.g. `/\example.com/foo`) and echo it back in the `Location` header of a `301`. Since browsers resolve a leading `\` like `/`, that `Location` could point off-site.

`isInternalPath` now folds backslashes to forward slashes before comparing the prefix, so `/\host` is recognized as an internal path just like `//host` and is no longer rewritten with a trailing slash (it falls through to a 404). The core trailing-slash handlers already normalized this via URL parsing; this brings the raw-request path in the Node adapter in line.

## Testing

- Unit tests for `isInternalPath` covering backslash prefixes.
- Integration test in the Node adapter using a raw request line (a literal backslash, which URL parsers would otherwise normalize) asserting a `404` with no `Location` header.
