### PR TITLE
Fix syntax highlighting breaking after `@property` in `<style>` blocks

### DIFF
--- a/.changeset/fix-style-at-property-highlighting.md
+++ b/.changeset/fix-style-at-property-highlighting.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fixes syntax highlighting breaking when using CSS `@property` at-rules inside `<style>` blocks. The `</style>` closing tag and all subsequent blocks are now correctly recognized regardless of CSS content.

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "Astro",
   "scopeName": "source.astro",
-  "fileTypes": ["astro"],
+  "fileTypes": [
+    "astro"
+  ],
   "injections": {
     "L:(meta.script.astro) (meta.lang.json) - (meta.embedded.block source)": {
       "patterns": [
@@ -99,8 +101,19 @@
     "L:meta.style.astro meta.lang.stylus - (meta.embedded.block source)": {
       "patterns": [
         {
+          "begin": "(?<=>)(?=[^\\n]+</style[\\s>])",
+          "end": "(?=</style[\\s>])",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.stylus",
+          "patterns": [
+            {
+              "include": "source.stylus"
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)(?!</)",
-          "end": "(?=</)",
+          "while": "^(?!\\s*</style[\\s>])",
           "name": "meta.embedded.block.astro",
           "contentName": "source.stylus",
           "patterns": [
@@ -114,8 +127,19 @@
     "L:meta.style.astro meta.lang.sass - (meta.embedded.block source)": {
       "patterns": [
         {
+          "begin": "(?<=>)(?=[^\\n]+</style[\\s>])",
+          "end": "(?=</style[\\s>])",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.sass",
+          "patterns": [
+            {
+              "include": "source.sass"
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)(?!</)",
-          "end": "(?=</)",
+          "while": "^(?!\\s*</style[\\s>])",
           "name": "meta.embedded.block.astro",
           "contentName": "source.sass",
           "patterns": [
@@ -129,8 +153,19 @@
     "L:meta.style.astro meta.lang.css - (meta.embedded.block source)": {
       "patterns": [
         {
+          "begin": "(?<=>)(?=[^\\n]+</style[\\s>])",
+          "end": "(?=</style[\\s>])",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css",
+          "patterns": [
+            {
+              "include": "source.css"
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)(?!</)",
-          "end": "(?=</)",
+          "while": "^(?!\\s*</style[\\s>])",
           "name": "meta.embedded.block.astro",
           "contentName": "source.css",
           "patterns": [
@@ -144,8 +179,19 @@
     "L:meta.style.astro meta.lang.scss - (meta.embedded.block source)": {
       "patterns": [
         {
+          "begin": "(?<=>)(?=[^\\n]+</style[\\s>])",
+          "end": "(?=</style[\\s>])",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css.scss",
+          "patterns": [
+            {
+              "include": "source.css.scss"
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)(?!</)",
-          "end": "(?=</)",
+          "while": "^(?!\\s*</style[\\s>])",
           "name": "meta.embedded.block.astro",
           "contentName": "source.css.scss",
           "patterns": [
@@ -159,8 +205,19 @@
     "L:meta.style.astro meta.lang.less - (meta.embedded.block source)": {
       "patterns": [
         {
+          "begin": "(?<=>)(?=[^\\n]+</style[\\s>])",
+          "end": "(?=</style[\\s>])",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css.less",
+          "patterns": [
+            {
+              "include": "source.css.less"
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)(?!</)",
-          "end": "(?=</)",
+          "while": "^(?!\\s*</style[\\s>])",
           "name": "meta.embedded.block.astro",
           "contentName": "source.css.less",
           "patterns": [
@@ -174,8 +231,19 @@
     "L:meta.style.astro meta.lang.postcss - (meta.embedded.block source)": {
       "patterns": [
         {
+          "begin": "(?<=>)(?=[^\\n]+</style[\\s>])",
+          "end": "(?=</style[\\s>])",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css.postcss",
+          "patterns": [
+            {
+              "include": "source.css.postcss"
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)(?!</)",
-          "end": "(?=</)",
+          "while": "^(?!\\s*</style[\\s>])",
           "name": "meta.embedded.block.astro",
           "contentName": "source.css.postcss",
           "patterns": [
@@ -189,8 +257,19 @@
     "L:meta.style.astro - meta.lang - (meta.embedded.block source)": {
       "patterns": [
         {
+          "begin": "(?<=>)(?=[^\\n]+</style[\\s>])",
+          "end": "(?=</style[\\s>])",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css",
+          "patterns": [
+            {
+              "include": "source.css"
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)(?!</)",
-          "end": "(?=</)",
+          "while": "^(?!\\s*</style[\\s>])",
           "name": "meta.embedded.block.astro",
           "contentName": "source.css",
           "patterns": [

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -93,11 +93,17 @@ injections:
   # Style Languages
   # Stylus | 'stylus' | 'source.stylus'
   'L:meta.style.astro meta.lang.stylus - (meta.embedded.block source)':
-    patterns:
-      [
+    patterns: [
+        {
+          begin: '(?<=>)(?=[^\n]+</style[\s>])',
+          end: '(?=</style[\s>])',
+          name: meta.embedded.block.astro,
+          contentName: source.stylus,
+          patterns: [{ include: source.stylus }],
+        },
         {
           begin: '(?<=>)(?!</)',
-          end: '(?=</)',
+          while: '^(?!\s*</style[\s>])',
           name: meta.embedded.block.astro,
           contentName: source.stylus,
           patterns: [{ include: source.stylus }],
@@ -106,11 +112,17 @@ injections:
 
   # Sass | 'sass' | 'source.sass'
   'L:meta.style.astro meta.lang.sass - (meta.embedded.block source)':
-    patterns:
-      [
+    patterns: [
+        {
+          begin: '(?<=>)(?=[^\n]+</style[\s>])',
+          end: '(?=</style[\s>])',
+          name: meta.embedded.block.astro,
+          contentName: source.sass,
+          patterns: [{ include: source.sass }],
+        },
         {
           begin: '(?<=>)(?!</)',
-          end: '(?=</)',
+          while: '^(?!\s*</style[\s>])',
           name: meta.embedded.block.astro,
           contentName: source.sass,
           patterns: [{ include: source.sass }],
@@ -119,11 +131,17 @@ injections:
 
   # CSS | 'css' | 'source.css'
   'L:meta.style.astro meta.lang.css - (meta.embedded.block source)':
-    patterns:
-      [
+    patterns: [
+        {
+          begin: '(?<=>)(?=[^\n]+</style[\s>])',
+          end: '(?=</style[\s>])',
+          name: meta.embedded.block.astro,
+          contentName: source.css,
+          patterns: [{ include: source.css }],
+        },
         {
           begin: '(?<=>)(?!</)',
-          end: '(?=</)',
+          while: '^(?!\s*</style[\s>])',
           name: meta.embedded.block.astro,
           contentName: source.css,
           patterns: [{ include: source.css }],
@@ -132,11 +150,17 @@ injections:
 
   # SCSS | 'scss' | 'source.css.scss'
   'L:meta.style.astro meta.lang.scss - (meta.embedded.block source)':
-    patterns:
-      [
+    patterns: [
+        {
+          begin: '(?<=>)(?=[^\n]+</style[\s>])',
+          end: '(?=</style[\s>])',
+          name: meta.embedded.block.astro,
+          contentName: source.css.scss,
+          patterns: [{ include: source.css.scss }],
+        },
         {
           begin: '(?<=>)(?!</)',
-          end: '(?=</)',
+          while: '^(?!\s*</style[\s>])',
           name: meta.embedded.block.astro,
           contentName: source.css.scss,
           patterns: [{ include: source.css.scss }],
@@ -145,11 +169,17 @@ injections:
 
   # Less | 'less' | 'source.css.less'
   'L:meta.style.astro meta.lang.less - (meta.embedded.block source)':
-    patterns:
-      [
+    patterns: [
+        {
+          begin: '(?<=>)(?=[^\n]+</style[\s>])',
+          end: '(?=</style[\s>])',
+          name: meta.embedded.block.astro,
+          contentName: source.css.less,
+          patterns: [{ include: source.css.less }],
+        },
         {
           begin: '(?<=>)(?!</)',
-          end: '(?=</)',
+          while: '^(?!\s*</style[\s>])',
           name: meta.embedded.block.astro,
           contentName: source.css.less,
           patterns: [{ include: source.css.less }],
@@ -158,11 +188,17 @@ injections:
 
   # PostCSS | 'postcss' | 'source.css.postcss'
   'L:meta.style.astro meta.lang.postcss - (meta.embedded.block source)':
-    patterns:
-      [
+    patterns: [
+        {
+          begin: '(?<=>)(?=[^\n]+</style[\s>])',
+          end: '(?=</style[\s>])',
+          name: meta.embedded.block.astro,
+          contentName: source.css.postcss,
+          patterns: [{ include: source.css.postcss }],
+        },
         {
           begin: '(?<=>)(?!</)',
-          end: '(?=</)',
+          while: '^(?!\s*</style[\s>])',
           name: meta.embedded.block.astro,
           contentName: source.css.postcss,
           patterns: [{ include: source.css.postcss }],
@@ -171,11 +207,17 @@ injections:
 
   # Default (CSS)
   'L:meta.style.astro - meta.lang - (meta.embedded.block source)':
-    patterns:
-      [
+    patterns: [
+        {
+          begin: '(?<=>)(?=[^\n]+</style[\s>])',
+          end: '(?=</style[\s>])',
+          name: meta.embedded.block.astro,
+          contentName: source.css,
+          patterns: [{ include: source.css }],
+        },
         {
           begin: '(?<=>)(?!</)',
-          end: '(?=</)',
+          while: '^(?!\s*</style[\s>])',
           name: meta.embedded.block.astro,
           contentName: source.css,
           patterns: [{ include: source.css }],

--- a/packages/language-tools/vscode/test/grammar/dummy/css.tmLanguage-dummy.json
+++ b/packages/language-tools/vscode/test/grammar/dummy/css.tmLanguage-dummy.json
@@ -1,4 +1,21 @@
 {
-  "comment": "Dummy CSS TextMate grammar for use in testing",
-  "scopeName": "source.css"
+  "comment": "CSS TextMate grammar for testing. Includes a minimal selector pattern that simulates VS Code's real CSS grammar behavior where < in @property's syntax descriptor triggers a selector scope.",
+  "scopeName": "source.css",
+  "patterns": [
+    {
+      "name": "meta.selector.css",
+      "begin": "\\s*(?=[\\w.<])",
+      "end": "(?=\\{)",
+      "patterns": [
+        {
+          "name": "entity.name.tag.css",
+          "match": "[a-zA-Z][\\w-]*"
+        },
+        {
+          "name": "keyword.operator.combinator.css",
+          "match": "[>+~]"
+        }
+      ]
+    }
+  ]
 }

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/at-property.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/at-property.astro
@@ -1,0 +1,27 @@
+<script>
+  console.log(window);
+</script>
+
+<style>
+  @property --logo-color {
+    syntax: "<color>";
+    inherits: false;
+    initial-value: #c0ffee;
+  }
+</style>
+
+<style>
+  div {
+    background: red;
+  }
+</style>
+
+<script>
+  console.log(window);
+
+  function testFunc() {
+        console.log("test");
+    }
+
+    testFunc();
+</script>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/at-property.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/at-property.astro.snap
@@ -1,0 +1,91 @@
+><script>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  console.log(window);
+#^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.embedded.block.astro source.js
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  @property --logo-color {
+#^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+#   ^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#           ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#              ^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                        ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                         ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+>    syntax: "<color>";
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#    ^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#          ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#              ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                   ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css keyword.operator.combinator.css
+#                    ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+>    inherits: false;
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#    ^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#            ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#              ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                   ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+>    initial-value: #c0ffee;
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#    ^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                 ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                    ^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                          ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+>  }
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  div {
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#     ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#      ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+>    background: red;
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#    ^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#              ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                   ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+>  }
+#^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><script>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  console.log(window);
+#^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.embedded.block.astro source.js
+>
+>  function testFunc() {
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.embedded.block.astro source.js
+>        console.log("test");
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.embedded.block.astro source.js
+>    }
+#^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.embedded.block.astro source.js
+>
+>    testFunc();
+#^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.embedded.block.astro source.js
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/expression.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/expression.astro.snap
@@ -14,9 +14,18 @@
 #   ^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
 #        ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
 >    .gallery { display: grid; }
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+#^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#    ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#     ^^^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#            ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#             ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+#              ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#               ^^^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                      ^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                        ^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                            ^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
 >  </style>
-#^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+#^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro
 #  ^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
 #    ^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
 #         ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
@@ -30,9 +39,16 @@
 #                       ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
 #                        ^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
 #                             ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
-#                              ^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
-#                                                     ^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
-#                                                       ^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
-#                                                            ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
-#                                                             ^ source.astro punctuation.section.embedded.end.astro
+#                              ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                               ^^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                                     ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                                      ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+#                                       ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                                        ^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                                             ^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                                               ^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                                                  ^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#                                                       ^^^^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                                                            ^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css keyword.operator.combinator.css
+#                                                             ^^ source.astro meta.embedded.expression.astro source.tsx meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
 >

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/style.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/style.astro.snap
@@ -3,7 +3,11 @@
 # ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
 #      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
 >  .astro {}
-#^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#   ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#        ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#         ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
 ></style>
 #^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
 #  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro


### PR DESCRIPTION
## Changes

- Fixes VS Code syntax highlighting breaking when `@property` (or any CSS construct with angle brackets like `syntax: "<color>"`) is used inside a `<style>` block. Previously, the `</style>` closing tag and all subsequent `<style>` and `<script>` blocks would be incorrectly tokenized.
- Updates all 7 style injection patterns in `astro.tmLanguage.src.yaml` from a single `begin`/`end` approach to the same two-pattern `begin`/`end` (single-line) + `begin`/`while` (multi-line) approach already used by script injection patterns since PR #15109. The `while` pattern is evaluated at the start of each line before child patterns run, so `</style>` is always detected regardless of the embedded CSS grammar's internal state.

## Testing

- Adds `packages/language-tools/vscode/test/grammar/fixtures/style/at-property.astro` — a new grammar snapshot fixture verifying that all blocks are correctly scoped when `@property` with a `syntax: "<color>"` descriptor is present.
- Updates the dummy CSS grammar (`css.tmLanguage-dummy.json`) to include selector patterns that simulate VS Code's real CSS grammar behavior, making the existing snapshot tests more realistic.
- Updates `expression.astro.snap` and `style.astro.snap` snapshots to reflect that leading whitespace before `</style>` is no longer scoped as CSS content (matches the existing script behavior).

## Docs

No docs update needed — this is a VS Code extension grammar fix with no user-facing API changes.

Closes #16751