### PR TITLE
Fix prefetch not triggering for links inside server:defer components

### DIFF
--- a/.changeset/thin-poems-turn.md
+++ b/.changeset/thin-poems-turn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes prefetch not working for links inside `server:defer` components

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -306,7 +306,8 @@ function isSlowConnection() {
 }
 
 /**
- * Listen to page loads and handle Astro's View Transition specific events
+ * Listen to page loads and handle Astro's View Transition specific events.
+ * Also observes DOM mutations for dynamically added anchors (e.g. from server islands).
  */
 function onPageLoad(cb: () => void) {
 	cb();
@@ -320,6 +321,21 @@ function onPageLoad(cb: () => void) {
 		}
 		cb();
 	});
+
+	// Watch for dynamically added anchors (e.g. from server islands)
+	new MutationObserver((mutations) => {
+		for (const mutation of mutations) {
+			for (const node of mutation.addedNodes) {
+				if (
+					node instanceof Element &&
+					(node.tagName === 'A' || node.querySelector?.('a'))
+				) {
+					cb();
+					return;
+				}
+			}
+		}
+	}).observe(document.body, { childList: true, subtree: true });
 }
 
 /**


### PR DESCRIPTION
## Changes

- Prefetch hover listeners now attach to links injected by `server:defer` components. Previously, `onPageLoad()` scanned for `<a>` tags once on page load, but server islands resolve asynchronously after that scan completes — so their links were never registered.
- Adds a `MutationObserver` inside `onPageLoad()` that watches for dynamically added DOM nodes. When a new anchor (or element containing one) is detected, the prefetch callback re-runs. The existing `listenedAnchors` WeakSet prevents duplicate listener attachment.

Closes #13297

## Testing

- No automated tests added — the prefetch module is entirely client-side browser code (`document`, `MutationObserver`, event listeners) with no existing test infrastructure in the repo. Fix was verified manually and confirmed by the reporter.

## Docs

- No docs update needed; this is a bug fix restoring expected behavior for an existing feature combination.
