### PR TITLE
Fix astro check failing to resolve dependencies when astro is in a virtual store

### DIFF
--- a/.changeset/kind-items-fall.md
+++ b/.changeset/kind-items-fall.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro check` failing to find `@astrojs/check` and `typescript` when astro is installed in a directory outside the project tree (e.g. pnpm virtual store)

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 import * as clack from '@clack/prompts';
 import ci from 'ci-info';
 import { detect, resolveCommand } from 'package-manager-detector';
@@ -24,8 +25,8 @@ export async function getPackage<T>(
 	try {
 		// Try to resolve with `createRequire` first to prevent ESM caching of the package
 		// if it errors and fails here
-		require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
-		const packageImport = await import(packageName);
+		const resolved = require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
+		const packageImport = await import(pathToFileURL(resolved).href);
 		return packageImport as T;
 	} catch {
 		if (options.optional) return undefined;
@@ -46,7 +47,8 @@ export async function getPackage<T>(
 		const result = await installPackage([packageName, ...otherDeps], options, logger);
 
 		if (result) {
-			const packageImport = await import(packageName);
+			const resolved = require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
+			const packageImport = await import(pathToFileURL(resolved).href);
 			return packageImport;
 		} else {
 			return undefined;

--- a/packages/astro/test/units/cli/install-package.test.ts
+++ b/packages/astro/test/units/cli/install-package.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getPackage } from '../../../dist/cli/install-package.js';
+import { defaultLogger } from '../test-utils.ts';
+
+describe('getPackage', () => {
+	it('resolves packages from the project cwd, not from astro install location', async () => {
+		// Create a temporary directory simulating a project with a fake package
+		const projectDir = join(tmpdir(), `astro-test-getpackage-${Date.now()}`);
+		const pkgDir = join(projectDir, 'node_modules', 'fake-test-pkg');
+
+		try {
+			await mkdir(pkgDir, { recursive: true });
+			await writeFile(
+				join(pkgDir, 'package.json'),
+				JSON.stringify({
+					name: 'fake-test-pkg',
+					version: '1.0.0',
+					main: 'index.js',
+					type: 'module',
+				}),
+			);
+			await writeFile(join(pkgDir, 'index.js'), 'export const loaded = true;\n');
+
+			// getPackage should resolve from the project cwd, finding the fake package
+			const result = await getPackage('fake-test-pkg', defaultLogger, {
+				cwd: projectDir,
+				optional: true,
+			});
+
+			assert.ok(result, 'Expected getPackage to find the package in the project cwd');
+			assert.equal(result.loaded, true, 'Expected the loaded export to be true');
+		} finally {
+			await rm(projectDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/astro/test/units/cli/install-package.test.ts
+++ b/packages/astro/test/units/cli/install-package.test.ts
@@ -26,7 +26,7 @@ describe('getPackage', () => {
 			await writeFile(join(pkgDir, 'index.js'), 'export const loaded = true;\n');
 
 			// getPackage should resolve from the project cwd, finding the fake package
-			const result = await getPackage('fake-test-pkg', defaultLogger, {
+			const result = await getPackage<{ loaded: boolean }>('fake-test-pkg', defaultLogger, {
 				cwd: projectDir,
 				optional: true,
 			});


### PR DESCRIPTION
Closes #17135

## Changes

- `getPackage` now imports packages using the absolute path returned by `require.resolve()` (converted to a file URL via `pathToFileURL`) instead of the bare package name. Previously, `require.resolve()` was correctly scoped to the project's `cwd`, but the subsequent `await import(packageName)` resolved from astro's own install location — causing `astro check` to fail when astro lives in a virtual store (e.g. pnpm) outside the project directory tree.
- Affects both import sites in `getPackage`: the initial load and the post-install load.

## Testing

- Added `packages/astro/test/units/cli/install-package.test.ts`: creates a temporary project directory with a fake package in its `node_modules`, then verifies `getPackage` can find and load it when passed that directory as `cwd`.

## Docs

- No docs update needed — this is an internal resolution fix with no user-facing API change.
