### PR TITLE
Restore proxy support in create-astro for corporate/firewall environments

### DIFF
--- a/.changeset/giant-guests-marry.md
+++ b/.changeset/giant-guests-marry.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes proxy support by respecting `HTTP_PROXY` and `HTTPS_PROXY` environment variables when downloading templates. On Node.js v22.21.0+ and v24.5.0+, `create-astro` now automatically enables the `--use-env-proxy` flag so that native `fetch()` routes requests through the configured proxy.

--- a/packages/create-astro/create-astro.mjs
+++ b/packages/create-astro/create-astro.mjs
@@ -12,4 +12,29 @@ if (requiredMajorVersion < minimumMajorVersion) {
 	process.exit(1);
 }
 
+// If proxy env vars are set but --use-env-proxy is not active, re-exec with it.
+// This makes Node.js native fetch() respect HTTP_PROXY/HTTPS_PROXY/NO_PROXY,
+// which is needed because @bluwy/giget-core uses native fetch() for template downloads.
+// --use-env-proxy is available in Node.js v22.21.0+ and v24.5.0+.
+const hasProxyEnv =
+	process.env.HTTP_PROXY ||
+	process.env.HTTPS_PROXY ||
+	process.env.http_proxy ||
+	process.env.https_proxy;
+
+if (hasProxyEnv && !process.execArgv.includes('--use-env-proxy')) {
+	const { execFileSync } = await import('node:child_process');
+	try {
+		execFileSync(process.execPath, ['--use-env-proxy', ...process.argv.slice(1)], {
+			stdio: 'inherit',
+		});
+		process.exit(0);
+	} catch (e) {
+		// If --use-env-proxy is not supported (Node.js < 22.21.0), fall through
+		// and run without proxy support. If the child exited with a non-zero status,
+		// propagate it.
+		if (e.status != null) process.exit(e.status);
+	}
+}
+
 void import('./dist/index.js').then(({ main }) => main());

--- a/packages/create-astro/test/units/proxy.test.ts
+++ b/packages/create-astro/test/units/proxy.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import path from 'node:path';
+
+const createAstroPath = path.resolve(fileURLToPath(import.meta.url), '../../../create-astro.mjs');
+
+describe('proxy support', () => {
+	it('respects HTTPS_PROXY when --use-env-proxy is available', () => {
+		// Set a non-existent proxy so fetch will fail with ECONNREFUSED if proxy is used.
+		// With the fix, create-astro re-execs with --use-env-proxy, so native fetch()
+		// routes through the proxy, causing a connection error to our fake proxy.
+		try {
+			execFileSync(
+				process.execPath,
+				[createAstroPath, '--template', 'minimal', '--yes', '--dry-run'],
+				{
+					env: {
+						...process.env,
+						HTTPS_PROXY: 'http://127.0.0.1:19999',
+						HTTP_PROXY: 'http://127.0.0.1:19999',
+					},
+					timeout: 15000,
+					stdio: 'pipe',
+				},
+			);
+			// If it succeeds, the proxy was ignored (bug not fixed)
+			assert.fail('Expected create-astro to fail when proxy is unreachable');
+		} catch (e: any) {
+			// The process should fail because the proxy is unreachable.
+			// This proves the proxy env var was respected.
+			const output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+			assert.ok(
+				output.includes('ECONNREFUSED') || output.includes('127.0.0.1:19999'),
+				`Expected proxy connection error, got: ${output.substring(0, 500)}`,
+			);
+		}
+	});
+
+	it('works normally without proxy env vars', () => {
+		// Without proxy vars, create-astro should not re-exec and should work normally
+		const result = execFileSync(
+			process.execPath,
+			[createAstroPath, '--template', 'minimal', '--yes', '--dry-run'],
+			{
+				env: {
+					...process.env,
+					HTTP_PROXY: '',
+					HTTPS_PROXY: '',
+					http_proxy: '',
+					https_proxy: '',
+				},
+				timeout: 15000,
+				stdio: 'pipe',
+			},
+		);
+		const output = result.toString();
+		assert.ok(
+			output.includes('Skipping template copying') || output.includes('Project initialized'),
+			`Expected normal dry-run output, got: ${output.substring(0, 500)}`,
+		);
+	});
+});


### PR DESCRIPTION
## Changes

- `create-astro` now respects `HTTP_PROXY`/`HTTPS_PROXY` environment variables when downloading templates. When proxy env vars are set, the CLI re-execs itself with Node.js's `--use-env-proxy` flag so that native `fetch()` (used by `@bluwy/giget-core`) routes requests through the configured proxy.
- Requires no new dependencies. Degrades gracefully on Node.js < v22.21.0 — older versions get the same behavior as before. The flag is available in Node.js v22.21.0+ and v24.5.0+.

Closes #13684

## Testing

- Added `packages/create-astro/test/units/proxy.test.ts` with two cases: one verifying that `HTTPS_PROXY` is respected (a non-existent proxy causes a connection error, proving the proxy was used), and one verifying normal operation is unaffected when no proxy env vars are set.

## Docs

- No docs update needed; this restores previously expected behavior with no new APIs or config options.
