### PR TITLE
Keep component scripts in place when rendered via Astro.slots.render()

### DIFF
--- a/.changeset/whole-regions-show.md
+++ b/.changeset/whole-regions-show.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression where a `<script>` inside a component rendered through `Astro.slots.render()` was hoisted out of its original position instead of staying next to its component content

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -149,12 +149,21 @@ function stringifyChunk(
 	} else if (isSlotString(chunk as string)) {
 		let out = '';
 		const c = chunk as SlotString;
+		// Position-independent instructions (head, hydration, etc.) are emitted first.
 		if (c.instructions) {
 			for (const instr of c.instructions) {
 				out += stringifyChunk(result, instr);
 			}
 		}
-		out += chunk.toString();
+		// Walk the ordered content stream so scripts render at their original
+		// position (and are deduplicated) instead of being hoisted to the front.
+		if (c.chunks.length) {
+			for (const part of c.chunks) {
+				out += typeof part === 'string' ? part : stringifyChunk(result, part);
+			}
+		} else {
+			out += chunk.toString();
+		}
 		return out;
 	}
 

--- a/packages/astro/src/runtime/server/render/instruction.ts
+++ b/packages/astro/src/runtime/server/render/instruction.ts
@@ -62,3 +62,7 @@ export function createRenderInstruction<T extends RenderInstruction>(instruction
 export function isRenderInstruction(chunk: any): chunk is RenderInstruction {
 	return chunk && typeof chunk === 'object' && chunk[RenderInstructionSymbol];
 }
+
+export function isScriptInstruction(chunk: any): chunk is RenderScriptInstruction {
+	return chunk && typeof chunk === 'object' && 'type' in chunk && chunk.type === 'script';
+}

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -145,18 +145,18 @@ export class ServerIslandComponent {
 		for (const name in this.slots) {
 			if (name !== 'fallback') {
 				const content = await renderSlotToString(this.result, this.slots[name]);
-				let slotHtml = content.toString();
-				// Append script instructions so that components passed as slots
-				// to server:defer components retain their scripts in the island response.
-				// renderSlotToString returns a SlotString (typed as string) that carries
-				// render instructions stripped from the HTML content.
+				// renderSlotToString returns a SlotString (typed as string) whose
+				// `chunks` hold the ordered content stream. Scripts live inline there,
+				// so walking it keeps them at their original position in the island
+				// response instead of being appended at the end.
 				const slotContent = content as unknown as SlotString;
-				if (Array.isArray(slotContent.instructions)) {
-					for (const instruction of slotContent.instructions) {
-						if (instruction.type === 'script') {
-							slotHtml += instruction.content;
-						}
+				let slotHtml = '';
+				if (slotContent.chunks?.length) {
+					for (const part of slotContent.chunks) {
+						slotHtml += typeof part === 'string' ? part : part.content;
 					}
+				} else {
+					slotHtml = content.toString();
 				}
 				renderedSlots[name] = slotHtml;
 			}

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -3,7 +3,7 @@ import { HTMLString, markHTMLString, unescapeHTML } from '../escape.js';
 import { renderChild } from './any.js';
 import { renderTemplate } from './astro/render-template.js';
 import { chunkToString, type RenderDestination, type RenderInstance } from './common.js';
-import type { RenderInstruction } from './instruction.js';
+import type { RenderInstruction, RenderScriptInstruction } from './instruction.js';
 
 type RenderTemplateResult = ReturnType<typeof renderTemplate>;
 export type ComponentSlots = Record<string, ComponentSlotValue>;
@@ -13,12 +13,31 @@ export type ComponentSlotValue = (
 
 const slotString = Symbol.for('astro:slot-string');
 
+/**
+ * A part of a slot's content stream: either already-stringified HTML or a
+ * position-sensitive script instruction that is resolved (and deduplicated)
+ * lazily when the slot is finally stringified.
+ */
+export type SlotStringChunk = string | RenderScriptInstruction;
+
 export class SlotString extends HTMLString {
 	public instructions: null | RenderInstruction[];
+	/**
+	 * The slot's content as an ordered stream. Unlike `instructions` (which holds
+	 * position-independent instructions like head/hydration content), scripts are
+	 * kept inline here so they render at their original position instead of being
+	 * hoisted to the start of the slot output.
+	 */
+	public chunks: SlotStringChunk[];
 	public [slotString]: boolean;
-	constructor(content: string, instructions: null | RenderInstruction[]) {
+	constructor(
+		content: string,
+		instructions: null | RenderInstruction[],
+		chunks: SlotStringChunk[] = [],
+	) {
 		super(content);
 		this.instructions = instructions;
+		this.chunks = chunks;
 		this[slotString] = true;
 	}
 }
@@ -64,26 +83,40 @@ export async function renderSlotToString(
 ): Promise<string> {
 	let content = '';
 	let instructions: null | RenderInstruction[] = null;
+	const chunks: SlotStringChunk[] = [];
 	const temporaryDestination: RenderDestination = {
 		write(chunk) {
 			// if the chunk is already a SlotString, we concatenate
 			if (chunk instanceof SlotString) {
 				content += chunk;
+				// Preserve nested content (including its scripts) in order.
+				if (chunk.chunks.length) {
+					chunks.push(...chunk.chunks);
+				}
 				instructions = mergeSlotInstructions(instructions, chunk);
 			} else if (chunk instanceof Response) return;
 			else if (typeof chunk === 'object' && 'type' in chunk && typeof chunk.type === 'string') {
-				if (instructions === null) {
-					instructions = [];
+				// Scripts are position-sensitive, so keep them inline in the content
+				// stream at their original location. Other instructions (head,
+				// hydration, etc.) are position-independent and bubble up separately.
+				if (chunk.type === 'script') {
+					chunks.push(chunk as RenderScriptInstruction);
+				} else {
+					if (instructions === null) {
+						instructions = [];
+					}
+					instructions.push(chunk);
 				}
-				instructions.push(chunk);
 			} else {
-				content += chunkToString(result, chunk);
+				const str = chunkToString(result, chunk);
+				content += str;
+				chunks.push(str);
 			}
 		},
 	};
 	const renderInstance = renderSlot(result, slotted, fallback);
 	await renderInstance.render(temporaryDestination);
-	return markHTMLString(new SlotString(content, instructions));
+	return markHTMLString(new SlotString(content, instructions, chunks));
 }
 
 interface RenderSlotsResult {
@@ -106,6 +139,19 @@ export async function renderSlots(
 							slotInstructions = [];
 						}
 						slotInstructions.push(...output.instructions);
+					}
+					// Framework/`.html` components inline slot content as an opaque
+					// string, so the inline scripts kept in `chunks` would be lost.
+					// Surface them here so they still render (deduplicated at output).
+					if (output.chunks) {
+						for (const part of output.chunks as SlotStringChunk[]) {
+							if (typeof part !== 'string') {
+								if (slotInstructions === null) {
+									slotInstructions = [];
+								}
+								slotInstructions.push(part);
+							}
+						}
 					}
 					children[key] = output;
 				}),

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -3,7 +3,11 @@ import { HTMLString, markHTMLString, unescapeHTML } from '../escape.js';
 import { renderChild } from './any.js';
 import { renderTemplate } from './astro/render-template.js';
 import { chunkToString, type RenderDestination, type RenderInstance } from './common.js';
-import type { RenderInstruction, RenderScriptInstruction } from './instruction.js';
+import {
+	isScriptInstruction,
+	type RenderInstruction,
+	type RenderScriptInstruction,
+} from './instruction.js';
 
 type RenderTemplateResult = ReturnType<typeof renderTemplate>;
 export type ComponentSlots = Record<string, ComponentSlotValue>;
@@ -99,8 +103,8 @@ export async function renderSlotToString(
 				// Scripts are position-sensitive, so keep them inline in the content
 				// stream at their original location. Other instructions (head,
 				// hydration, etc.) are position-independent and bubble up separately.
-				if (chunk.type === 'script') {
-					chunks.push(chunk as RenderScriptInstruction);
+				if (isScriptInstruction(chunk)) {
+					chunks.push(chunk);
 				} else {
 					if (instructions === null) {
 						instructions = [];

--- a/packages/astro/test/astro-scripts.test.ts
+++ b/packages/astro/test/astro-scripts.test.ts
@@ -80,6 +80,17 @@ describe('Scripts', () => {
 			assert.equal($('script').length, 1, 'script should be rendered');
 		});
 
+		it('Scripts rendered via Astro.slots.render() preserve their position', async () => {
+			let html = await fixture.readFile('/slot-render-script-position/index.html');
+			let $ = cheerio.load(html);
+
+			assert.equal($('script').length, 1, 'script should be rendered');
+			// The script should stay inside the <li> next to its component content,
+			// not be hoisted out of the <ol>.
+			assert.equal($('li script').length, 1, 'script should be inside the <li>');
+			assert.equal($('ol script').length, 1, 'script should be inside the <ol>');
+		});
+
 		describe('Inlining', () => {
 			// eslint-disable-next-line @typescript-eslint/no-shadow
 			let fixture: Fixture;

--- a/packages/astro/test/fixtures/astro-scripts/src/components/ScriptWithContent.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/ScriptWithContent.astro
@@ -1,0 +1,2 @@
+<p>Script Component Content</p>
+<script>console.log('hello from script component')</script>

--- a/packages/astro/test/fixtures/astro-scripts/src/components/SlotRenderWrapper.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/SlotRenderWrapper.astro
@@ -1,0 +1,4 @@
+---
+const html = await Astro.slots.render('default');
+---
+<div class="wrapper"><Fragment set:html={html} /></div>

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/slot-render-script-position.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/slot-render-script-position.astro
@@ -1,0 +1,18 @@
+---
+import SlotRenderWrapper from '../components/SlotRenderWrapper.astro'
+import ScriptWithContent from '../components/ScriptWithContent.astro'
+---
+<html lang="en">
+    <head>
+        <title>Script Position in Slot Render</title>
+    </head>
+    <body>
+        <SlotRenderWrapper>
+            <ol>
+                <li>Item before</li>
+                <li><ScriptWithContent /></li>
+                <li>Item after</li>
+            </ol>
+        </SlotRenderWrapper>
+    </body>
+</html>


### PR DESCRIPTION
Fixes #15627

## Changes

- A `<script>` inside a component rendered through `Astro.slots.render()` now stays at its original position instead of being hoisted to the start of the slot output (sometimes escaping its parent element entirely). This regressed in #15147 and broke Starlight components (withastro/starlight#3712) as well as any CSS relying on `:first-child`/sibling selectors.
- `SlotString` now keeps its content as an ordered `chunks` stream with scripts inline, resolved and deduplicated lazily at stringify time — matching how the main render path already handles instructions.

## Testing

- Adds "Scripts rendered via `Astro.slots.render()` preserve their position", asserting the script renders inside its `<li>`/`<ol>` rather than before them.
- Verified the existing #13847 test ("Scripts in Fragment slots are processed when another slot is unused") still passes alongside the new positional behavior.

## Docs

- No docs update needed; this restores previously documented `<script>` positioning behavior.
