### PR TITLE
Fix false deprecation warning for markdown.gfm/smartypants in Container API

### DIFF
--- a/.changeset/eighty-items-check.md
+++ b/.changeset/eighty-items-check.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a false deprecation warning for `markdown.gfm` and `markdown.smartypants` when using the Container API

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -29,6 +29,11 @@ import type {
 import { ContainerPipeline } from './pipeline.js';
 import { createConsoleLogger } from '../core/logger/impls/console.js';
 
+// Strip deprecated `gfm` and `smartypants` from the defaults so the container
+// doesn't trigger the deprecation warning added for user-specified config.
+const { gfm: _, smartypants: __, ...containerMarkdownDefaults } = ASTRO_CONFIG_DEFAULTS.markdown;
+const CONTAINER_CONFIG_DEFAULTS = { ...ASTRO_CONFIG_DEFAULTS, markdown: containerMarkdownDefaults };
+
 /**
  * Public type, used for integrations to define a renderer for the container API
  * @deprecated Use `AstroRenderer` instead.
@@ -336,7 +341,7 @@ export class experimental_AstroContainer {
 		containerOptions: AstroContainerOptions = {},
 	): Promise<experimental_AstroContainer> {
 		const { streaming = false, manifest, renderers = [], resolve } = containerOptions;
-		const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
+		const astroConfig = await validateConfig(CONTAINER_CONFIG_DEFAULTS, process.cwd(), 'container');
 		return new experimental_AstroContainer({
 			streaming,
 			manifest,
@@ -439,7 +444,7 @@ export class experimental_AstroContainer {
 	private static async createFromManifest(
 		manifest: SSRManifest,
 	): Promise<experimental_AstroContainer> {
-		const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
+		const astroConfig = await validateConfig(CONTAINER_CONFIG_DEFAULTS, process.cwd(), 'container');
 		const container = new experimental_AstroContainer({
 			manifest,
 			astroConfig,

--- a/packages/astro/test/units/render/container-deprecation.test.ts
+++ b/packages/astro/test/units/render/container-deprecation.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+import { experimental_AstroContainer } from '../../../dist/container/index.js';
+
+describe('Container deprecation warnings', () => {
+	it('does not log markdown.gfm/smartypants deprecation warning with default config', async () => {
+		const warn = mock.method(console, 'warn', () => {});
+		try {
+			await experimental_AstroContainer.create();
+
+			const deprecationCalls = warn.mock.calls.filter((call) =>
+				String(call.arguments[0]).includes('markdown.gfm'),
+			);
+			assert.equal(
+				deprecationCalls.length,
+				0,
+				'Expected no deprecation warning for markdown.gfm/smartypants when using default config',
+			);
+		} finally {
+			warn.mock.restore();
+		}
+	});
+});


### PR DESCRIPTION
Closes #17206

## Changes

- The Container API no longer emits a false deprecation warning for `markdown.gfm` and `markdown.smartypants` when neither option was set by the user.
- Root cause: `AstroContainer.create()` and `createFromManifest()` passed `ASTRO_CONFIG_DEFAULTS` directly to `validateConfig()`. Because `ASTRO_CONFIG_DEFAULTS` includes `gfm: true` and `smartypants: true`, the `warnDeprecatedMarkdownOptions` check saw them as user-specified values. Normal builds pass raw user config (without defaults pre-applied), so the warning never fires there. The fix strips those two keys from the markdown defaults before passing to `validateConfig()`.

## Testing

- Added `packages/astro/test/units/render/container-deprecation.test.ts`: asserts that `AstroContainer.create()` with default config does not log the `markdown.gfm`/`smartypants` deprecation warning.

## Docs

- No docs update needed — this is a false-positive warning fix with no API or behavior change for users.