### PR TITLE
Fix `inferSize` failing on `Picture` component with rate-limited remote image URLs

### DIFF
--- a/.changeset/fix-picture-infer-size-rate-limit.md
+++ b/.changeset/fix-picture-infer-size-rate-limit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `inferSize` failing on the `Picture` component with certain remote image URLs due to redundant HTTP requests triggering rate limiting (HTTP 429). Remote image probe results are now cached by URL, so the same image is only fetched once regardless of how many format variants the `Picture` component generates.

--- a/packages/astro/src/assets/utils/remoteProbe.ts
+++ b/packages/astro/src/assets/utils/remoteProbe.ts
@@ -7,6 +7,12 @@ import { fetchWithRedirects } from './redirectValidation.js';
 
 type RemoteImageConfig = Pick<AstroConfig['image'], 'domains' | 'remotePatterns'>;
 
+// Cache probe results by URL to avoid redundant fetches.
+// The Picture component calls getImage() multiple times (once per format),
+// each triggering inferRemoteSize(). Without caching, servers may rate-limit
+// the repeated requests (e.g. HTTP 429).
+const probeCache = new Map<string, Promise<Omit<ImageMetadata, 'src' | 'fsPath'>>>();
+
 /**
  * Infers the dimensions of a remote image by streaming its data and analyzing it progressively until sufficient metadata is available.
  *
@@ -16,6 +22,24 @@ type RemoteImageConfig = Pick<AstroConfig['image'], 'domains' | 'remotePatterns'
  * @throws {AstroError} Thrown when the fetching fails or metadata cannot be extracted.
  */
 export async function inferRemoteSize(
+	url: string,
+	imageConfig?: RemoteImageConfig,
+): Promise<Omit<ImageMetadata, 'src' | 'fsPath'>> {
+	const cached = probeCache.get(url);
+	if (cached) return cached;
+
+	const promise = inferRemoteSizeUncached(url, imageConfig);
+	probeCache.set(url, promise);
+
+	// Remove from cache on failure so retries can try again
+	promise.catch(() => {
+		probeCache.delete(url);
+	});
+
+	return promise;
+}
+
+async function inferRemoteSizeUncached(
 	url: string,
 	imageConfig?: RemoteImageConfig,
 ): Promise<Omit<ImageMetadata, 'src' | 'fsPath'>> {

--- a/packages/astro/test/units/assets/remote-probe.test.ts
+++ b/packages/astro/test/units/assets/remote-probe.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { inferRemoteSize } from '../../../dist/assets/utils/remoteProbe.js';
+
+// Minimal valid JPEG header (enough for image-size to detect dimensions)
+// This is a 1x1 JPEG
+const JPEG_1x1 = new Uint8Array([
+	0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+	0x00, 0x01, 0x00, 0x00, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11,
+	0x00, 0xff, 0xd9,
+]);
+
+function createMockFetch(callTracker: { count: number }) {
+	return async (_req: Request | string, _init?: RequestInit) => {
+		callTracker.count++;
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(JPEG_1x1);
+				controller.close();
+			},
+		});
+		return new Response(stream, {
+			status: 200,
+			headers: { 'Content-Type': 'image/jpeg' },
+		});
+	};
+}
+
+// The probeCache is module-level state, so we need unique URLs per test.
+let testCounter = 0;
+function uniqueUrl() {
+	return `https://example.com/test-image-${++testCounter}.jpg`;
+}
+
+describe('inferRemoteSize', () => {
+	it('caches results for the same URL to avoid redundant fetches', async () => {
+		const tracker = { count: 0 };
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = createMockFetch(tracker) as typeof fetch;
+
+		try {
+			const url = uniqueUrl();
+
+			// Call inferRemoteSize multiple times concurrently (simulates Picture component)
+			const [result1, result2, result3] = await Promise.all([
+				inferRemoteSize(url),
+				inferRemoteSize(url),
+				inferRemoteSize(url),
+			]);
+
+			// All results should be identical
+			assert.equal(result1.width, 1);
+			assert.equal(result1.height, 1);
+			assert.deepEqual(result1, result2);
+			assert.deepEqual(result1, result3);
+
+			// Only one fetch should have been made
+			assert.equal(tracker.count, 1, 'Expected only 1 fetch call, but got ' + tracker.count);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it('caches results for sequential calls to the same URL', async () => {
+		const tracker = { count: 0 };
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = createMockFetch(tracker) as typeof fetch;
+
+		try {
+			const url = uniqueUrl();
+
+			const result1 = await inferRemoteSize(url);
+			const result2 = await inferRemoteSize(url);
+
+			assert.deepEqual(result1, result2);
+			assert.equal(tracker.count, 1, 'Expected only 1 fetch call for sequential calls');
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it('makes separate fetches for different URLs', async () => {
+		const tracker = { count: 0 };
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = createMockFetch(tracker) as typeof fetch;
+
+		try {
+			const url1 = uniqueUrl();
+			const url2 = uniqueUrl();
+
+			const [result1, result2] = await Promise.all([inferRemoteSize(url1), inferRemoteSize(url2)]);
+
+			assert.equal(result1.width, 1);
+			assert.equal(result2.width, 1);
+			assert.equal(tracker.count, 2, 'Expected 2 fetch calls for different URLs');
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});


### PR DESCRIPTION
Closes #17263

## Changes

- Fixes `inferSize` failing on the `Picture` component when using remote URLs from servers that rate-limit repeated requests (e.g. Wikimedia returns HTTP 429). The `Picture` component calls `getImage()` once per output format, and each call independently invoked `inferRemoteSize()` with no caching — firing 3–4 HTTP requests for the same URL in rapid succession.
- Adds a promise-based cache (`probeCache`) to `inferRemoteSize()` in `remoteProbe.ts`, keyed by URL. The first request fetches normally; concurrent or sequential calls for the same URL share the same promise. Failed probes are evicted from the cache so retries can try again.

## Testing

- Adds `packages/astro/test/units/assets/remote-probe.test.ts` with 3 tests: concurrent calls to the same URL result in a single fetch, sequential calls to the same URL result in a single fetch, and different URLs each get their own fetch.

## Docs

- No docs update needed — this is an internal bug fix with no API changes.