### PR TITLE
Find Astro.locals references from .ts files in the TypeScript plugin

### DIFF
--- a/.changeset/swift-glasses-brush.md
+++ b/.changeset/swift-glasses-brush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/ts-plugin': patch
+---
+
+Fixes "Go To References" from `.ts` files missing usages inside `.astro` files that are reached through `Astro.locals` (or that import nothing). The plugin now includes tsconfig-matched `.astro` files in the TypeScript program and injects Astro's ambient types so type chains like `Astro.locals.utils.toUpper()` resolve.

--- a/.changeset/swift-glasses-brush.md
+++ b/.changeset/swift-glasses-brush.md
@@ -2,4 +2,4 @@
 '@astrojs/ts-plugin': patch
 ---
 
-Fixes "Go To References" from `.ts` files missing usages inside `.astro` files that are reached through `Astro.locals` (or that import nothing). The plugin now includes tsconfig-matched `.astro` files in the TypeScript program and injects Astro's ambient types so type chains like `Astro.locals.utils.toUpper()` resolve.
+Fixes "Go To References" from `.ts` files missing usages inside `.astro` files that are reached through `Astro.locals`. The plugin now injects Astro's ambient types so type chains like `Astro.locals.utils.toUpper()` resolve, matching the language server.

--- a/packages/language-tools/ts-plugin/src/astro-types.ts
+++ b/packages/language-tools/ts-plugin/src/astro-types.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import type ts from 'typescript';
 
 const decoratedHosts = new WeakSet<ts.LanguageServiceHost>();
-const decoratedProjects = new WeakSet<ts.LanguageServiceHost>();
 
 /**
  * Walk up from the given directories until an installed `astro` package is found,
@@ -77,66 +76,4 @@ export function addAstroTypes(
 		const seen = new Set(fileNames);
 		return [...fileNames, ...addedFileNames.filter((fileName) => !seen.has(fileName))];
 	};
-}
-
-/**
- * Ensure `.astro` files matched by the project's tsconfig are part of the TypeScript
- * program, even when no import chain reaches them. Without this, a page like
- * `index.astro` that only uses `Astro.locals.*` (and imports nothing) is never
- * searched by "Find All References".
- */
-export function addAstroProjectFiles(
-	tsModule: typeof import('typescript'),
-	project: ts.server.Project,
-	host: ts.LanguageServiceHost,
-) {
-	if (
-		decoratedProjects.has(host) ||
-		project.projectKind !== tsModule.server.ProjectKind.Configured
-	) {
-		return;
-	}
-	decoratedProjects.add(host);
-
-	const getScriptFileNames = host.getScriptFileNames.bind(host);
-	let lastProjectVersion: string | undefined;
-	let astroFiles: string[] = [];
-
-	host.getScriptFileNames = () => {
-		const fileNames = getScriptFileNames();
-		const projectVersion = host.getProjectVersion?.();
-		if (!astroFiles.length || projectVersion !== lastProjectVersion) {
-			lastProjectVersion = projectVersion;
-			astroFiles = findAstroFiles(tsModule, project);
-		}
-
-		const seen = new Set(fileNames);
-		return [...fileNames, ...astroFiles.filter((fileName) => !seen.has(fileName))];
-	};
-}
-
-function findAstroFiles(
-	tsModule: typeof import('typescript'),
-	project: ts.server.Project,
-): string[] {
-	const configFile = project.getProjectName();
-	const config = tsModule.readJsonConfigFile(configFile, project.readFile.bind(project));
-	const parseHost = {
-		useCaseSensitiveFileNames: project.useCaseSensitiveFileNames(),
-		fileExists: project.fileExists.bind(project),
-		readFile: project.readFile.bind(project),
-		readDirectory: (...args: Parameters<ts.server.Project['readDirectory']>) => {
-			args[1] = ['.astro'];
-			return project.readDirectory(...args);
-		},
-	};
-	const parsed = tsModule.parseJsonSourceFileConfigFileContent(
-		config,
-		parseHost,
-		project.getCurrentDirectory(),
-		undefined,
-		configFile,
-	);
-
-	return parsed.fileNames;
 }

--- a/packages/language-tools/ts-plugin/src/astro-types.ts
+++ b/packages/language-tools/ts-plugin/src/astro-types.ts
@@ -1,0 +1,142 @@
+import path from 'node:path';
+import type ts from 'typescript';
+
+const decoratedHosts = new WeakSet<ts.LanguageServiceHost>();
+const decoratedProjects = new WeakSet<ts.LanguageServiceHost>();
+
+/**
+ * Walk up from the given directories until an installed `astro` package is found,
+ * returning the directory that contains its `package.json`.
+ */
+export function findAstroPackageDirectory(
+	tsModule: typeof import('typescript'),
+	currentDirectory: string | string[],
+): string | undefined {
+	for (const candidate of Array.isArray(currentDirectory) ? currentDirectory : [currentDirectory]) {
+		const astroDirectory = findAstroPackageDirectoryFrom(tsModule, candidate);
+		if (astroDirectory) {
+			return astroDirectory;
+		}
+	}
+}
+
+function findAstroPackageDirectoryFrom(
+	tsModule: typeof import('typescript'),
+	currentDirectory: string,
+): string | undefined {
+	let directory = tsModule.sys.resolvePath(currentDirectory);
+
+	while (true) {
+		const packageJson = path.join(directory, 'node_modules', 'astro', 'package.json');
+		if (tsModule.sys.fileExists(packageJson)) {
+			return path.dirname(packageJson);
+		}
+
+		const parent = path.dirname(directory);
+		if (parent === directory) {
+			return undefined;
+		}
+		directory = parent;
+	}
+}
+
+/**
+ * Inject the installed Astro package's `env.d.ts` and `astro-jsx.d.ts` into the
+ * TypeScript program. Without these, the `Astro` global is undeclared and the type
+ * chain through `Astro.locals` can't be resolved, so "Go To References" from a `.ts`
+ * file misses usages inside `.astro` files. Mirrors the language server's
+ * `addAstroTypes()`.
+ */
+export function addAstroTypes(
+	tsModule: typeof import('typescript'),
+	host: ts.LanguageServiceHost,
+	currentDirectory: string | string[],
+) {
+	if (decoratedHosts.has(host)) {
+		return;
+	}
+
+	const astroDirectory = findAstroPackageDirectory(tsModule, currentDirectory);
+	if (!astroDirectory) {
+		return;
+	}
+
+	const addedFileNames = ['./env.d.ts', './astro-jsx.d.ts']
+		.map((filePath) => tsModule.sys.resolvePath(path.resolve(astroDirectory, filePath)))
+		.filter((fileName) => tsModule.sys.fileExists(fileName));
+
+	if (!addedFileNames.length) {
+		return;
+	}
+
+	decoratedHosts.add(host);
+
+	const getScriptFileNames = host.getScriptFileNames.bind(host);
+	host.getScriptFileNames = () => {
+		const fileNames = getScriptFileNames();
+		const seen = new Set(fileNames);
+		return [...fileNames, ...addedFileNames.filter((fileName) => !seen.has(fileName))];
+	};
+}
+
+/**
+ * Ensure `.astro` files matched by the project's tsconfig are part of the TypeScript
+ * program, even when no import chain reaches them. Without this, a page like
+ * `index.astro` that only uses `Astro.locals.*` (and imports nothing) is never
+ * searched by "Find All References".
+ */
+export function addAstroProjectFiles(
+	tsModule: typeof import('typescript'),
+	project: ts.server.Project,
+	host: ts.LanguageServiceHost,
+) {
+	if (
+		decoratedProjects.has(host) ||
+		project.projectKind !== tsModule.server.ProjectKind.Configured
+	) {
+		return;
+	}
+	decoratedProjects.add(host);
+
+	const getScriptFileNames = host.getScriptFileNames.bind(host);
+	let lastProjectVersion: string | undefined;
+	let astroFiles: string[] = [];
+
+	host.getScriptFileNames = () => {
+		const fileNames = getScriptFileNames();
+		const projectVersion = host.getProjectVersion?.();
+		if (!astroFiles.length || projectVersion !== lastProjectVersion) {
+			lastProjectVersion = projectVersion;
+			astroFiles = findAstroFiles(tsModule, project);
+		}
+
+		const seen = new Set(fileNames);
+		return [...fileNames, ...astroFiles.filter((fileName) => !seen.has(fileName))];
+	};
+}
+
+function findAstroFiles(
+	tsModule: typeof import('typescript'),
+	project: ts.server.Project,
+): string[] {
+	const configFile = project.getProjectName();
+	const config = tsModule.readJsonConfigFile(configFile, project.readFile.bind(project));
+	const parseHost = {
+		useCaseSensitiveFileNames: project.useCaseSensitiveFileNames(),
+		fileExists: project.fileExists.bind(project),
+		readFile: project.readFile.bind(project),
+		readDirectory: (...args: Parameters<ts.server.Project['readDirectory']>) => {
+			args[1] = ['.astro'];
+			return project.readDirectory(...args);
+		},
+	};
+	const parsed = tsModule.parseJsonSourceFileConfigFileContent(
+		config,
+		parseHost,
+		project.getCurrentDirectory(),
+		undefined,
+		configFile,
+	);
+
+	return parsed.fileNames;
+}

--- a/packages/language-tools/ts-plugin/src/astro2tsx.ts
+++ b/packages/language-tools/ts-plugin/src/astro2tsx.ts
@@ -7,7 +7,14 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 
 function safeConvertToTSX(content: string, options: ConvertToTSXOptions) {
 	try {
-		const tsx = convertToTSX(content, { filename: options.filename });
+		// Match the language server: strip `<script>`/`<style>` content from the TSX.
+		// The compiler otherwise wraps script bodies in `{() => { ... }}`, where
+		// `import` declarations are syntactically invalid and pollute the virtual file.
+		const tsx = convertToTSX(content, {
+			filename: options.filename,
+			includeScripts: false,
+			includeStyles: false,
+		});
 		return tsx;
 	} catch (e) {
 		console.error(

--- a/packages/language-tools/ts-plugin/src/index.ts
+++ b/packages/language-tools/ts-plugin/src/index.ts
@@ -1,14 +1,25 @@
+import path from 'node:path';
 import type { LanguagePlugin } from '@volar/language-core';
 import { createLanguageServicePlugin } from '@volar/typescript/lib/quickstart/createLanguageServicePlugin.js';
+import { addAstroProjectFiles, addAstroTypes } from './astro-types.js';
 import type { CollectionConfig } from './frontmatter.js';
 import { getFrontmatterLanguagePlugin } from './frontmatter.js';
 import { getLanguagePlugin } from './language.js';
 
 export = createLanguageServicePlugin((ts, info) => {
 	let collectionConfig = undefined;
+	const currentDir = info.project.getCurrentDirectory();
+
+	// Make "Go To References" from `.ts` files aware of usages inside `.astro` files:
+	// include tsconfig-matched `.astro` files in the program, and inject the Astro
+	// ambient types so type chains like `Astro.locals.*` resolve.
+	addAstroProjectFiles(ts, info.project, info.languageServiceHost);
+	addAstroTypes(ts, info.languageServiceHost, [
+		currentDir,
+		...info.languageServiceHost.getScriptFileNames().map((fileName) => path.dirname(fileName)),
+	]);
 
 	try {
-		const currentDir = info.project.getCurrentDirectory();
 		const fileContent = ts.sys.readFile(currentDir + '/.astro/collections/collections.json');
 		if (fileContent) {
 			collectionConfig = {

--- a/packages/language-tools/ts-plugin/src/index.ts
+++ b/packages/language-tools/ts-plugin/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import type { LanguagePlugin } from '@volar/language-core';
 import { createLanguageServicePlugin } from '@volar/typescript/lib/quickstart/createLanguageServicePlugin.js';
-import { addAstroProjectFiles, addAstroTypes } from './astro-types.js';
+import { addAstroTypes } from './astro-types.js';
 import type { CollectionConfig } from './frontmatter.js';
 import { getFrontmatterLanguagePlugin } from './frontmatter.js';
 import { getLanguagePlugin } from './language.js';
@@ -10,10 +10,9 @@ export = createLanguageServicePlugin((ts, info) => {
 	let collectionConfig = undefined;
 	const currentDir = info.project.getCurrentDirectory();
 
-	// Make "Go To References" from `.ts` files aware of usages inside `.astro` files:
-	// include tsconfig-matched `.astro` files in the program, and inject the Astro
-	// ambient types so type chains like `Astro.locals.*` resolve.
-	addAstroProjectFiles(ts, info.project, info.languageServiceHost);
+	// Make "Go To References" from `.ts` files aware of usages inside `.astro` files
+	// by injecting the Astro ambient types so type chains like `Astro.locals.*` resolve.
+	// (`.astro` files themselves already enter the program via Volar's external files.)
 	addAstroTypes(ts, info.languageServiceHost, [
 		currentDir,
 		...info.languageServiceHost.getScriptFileNames().map((fileName) => path.dirname(fileName)),

--- a/packages/language-tools/ts-plugin/test/units/astro-types.test.mts
+++ b/packages/language-tools/ts-plugin/test/units/astro-types.test.mts
@@ -1,0 +1,130 @@
+import 'mocha';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import ts from 'typescript';
+import { astro2tsx } from '../../src/astro2tsx.js';
+import { addAstroTypes } from '../../src/astro-types.js';
+
+function createFixture() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'astro-ts-plugin-'));
+	const src = path.join(root, 'src');
+	const astroPackage = path.join(root, 'node_modules', 'astro');
+
+	fs.mkdirSync(src, { recursive: true });
+	fs.mkdirSync(astroPackage, { recursive: true });
+
+	const utilsFile = path.join(src, 'utils.ts');
+	const envFile = path.join(src, 'env.d.ts');
+	const astroFile = path.join(src, 'index.astro');
+	const astroTsxFile = path.join(src, 'index.astro.tsx');
+
+	fs.writeFileSync(path.join(astroPackage, 'package.json'), '{"name":"astro","version":"6.0.0"}');
+	fs.writeFileSync(
+		path.join(astroPackage, 'env.d.ts'),
+		[
+			'type AstroGlobal = { locals: App.Locals };',
+			'declare const Astro: Readonly<AstroGlobal>;',
+			'declare const Fragment: any;',
+		].join('\n'),
+	);
+	fs.writeFileSync(path.join(astroPackage, 'astro-jsx.d.ts'), '');
+	fs.writeFileSync(
+		utilsFile,
+		[
+			'export class Utils {',
+			'\ttoUpper(value: string) {',
+			'\t\treturn value.toUpperCase();',
+			'\t}',
+			'}',
+		].join('\n'),
+	);
+	fs.writeFileSync(
+		envFile,
+		[
+			'export {};',
+			'declare global {',
+			'\tnamespace App {',
+			'\t\tinterface Locals {',
+			'\t\t\tutils: import("./utils").Utils;',
+			'\t\t}',
+			'\t}',
+			'}',
+		].join('\n'),
+	);
+	fs.writeFileSync(astroFile, '<div>{Astro.locals.utils.toUpper("Astro")}</div>\n');
+	const astroTsx = astro2tsx(fs.readFileSync(astroFile, 'utf8'), astroFile);
+	fs.writeFileSync(
+		astroTsxFile,
+		astroTsx.virtualFile.snapshot.getText(0, astroTsx.virtualFile.snapshot.getLength()),
+	);
+
+	return { root, files: [utilsFile, envFile, astroTsxFile], utilsFile, astroTsxFile };
+}
+
+function findToUpperReferenceFiles(injectAstroTypes: boolean) {
+	const fixture = createFixture();
+	const versions = new Map(fixture.files.map((fileName) => [fileName, '0']));
+	const host: ts.LanguageServiceHost = {
+		getScriptFileNames: () => fixture.files,
+		getScriptVersion: (fileName) => versions.get(fileName) ?? '0',
+		getScriptSnapshot: (fileName) => {
+			if (!fs.existsSync(fileName)) {
+				return undefined;
+			}
+			return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName, 'utf8'));
+		},
+		getCurrentDirectory: () => fixture.root,
+		getCompilationSettings: () => ({
+			allowJs: true,
+			jsx: ts.JsxEmit.Preserve,
+			module: ts.ModuleKind.ESNext,
+			moduleResolution: ts.ModuleResolutionKind.Node10,
+			target: ts.ScriptTarget.ESNext,
+		}),
+		getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+		fileExists: ts.sys.fileExists,
+		readFile: ts.sys.readFile,
+		readDirectory: ts.sys.readDirectory,
+		directoryExists: ts.sys.directoryExists,
+		getDirectories: ts.sys.getDirectories,
+		useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+		getNewLine: () => ts.sys.newLine,
+		getScriptKind: (fileName) => (fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS),
+	};
+
+	if (injectAstroTypes) {
+		addAstroTypes(ts, host, fixture.root);
+	}
+
+	const service = ts.createLanguageService(host);
+	const utilsText = fs.readFileSync(fixture.utilsFile, 'utf8');
+	const references = service.findReferences(fixture.utilsFile, utilsText.indexOf('toUpper')) ?? [];
+
+	try {
+		return references.flatMap((entry) =>
+			entry.references.map((reference) => path.relative(fixture.root, reference.fileName)),
+		);
+	} finally {
+		fs.rmSync(fixture.root, { recursive: true, force: true });
+	}
+}
+
+suite('Astro type injection', () => {
+	test('reproduces the missing Astro.locals reference without Astro types', () => {
+		const referencesWithoutAstroTypes = findToUpperReferenceFiles(false);
+		assert.ok(
+			!referencesWithoutAstroTypes.includes(path.join('src', 'index.astro.tsx')),
+			'fixture should reproduce missing Astro.locals references before injecting Astro types',
+		);
+	});
+
+	test('finds references through Astro.locals once Astro types are injected', () => {
+		const referencesWithAstroTypes = findToUpperReferenceFiles(true);
+		assert.ok(
+			referencesWithAstroTypes.includes(path.join('src', 'index.astro.tsx')),
+			'should find the Astro.locals reference in the Astro file',
+		);
+	});
+});


### PR DESCRIPTION
Fixes #16078

## Changes

- "Go To References" invoked from a `.ts` file now finds usages inside `.astro` files that are reached through `Astro.locals.*`. Previously only `.astro` files with an explicit frontmatter import were discovered; a page using `Astro.locals.utils.toUpper()` was silently missed.
- The `@astrojs/ts-plugin` now injects the installed Astro package's `env.d.ts` and `astro-jsx.d.ts` into the TypeScript program, mirroring the language server's `addAstroTypes()`. Without these the `Astro` global is undeclared, so the type chain through `Astro.locals` can't resolve and references aren't found. (`.astro` files themselves already enter the program via Volar's external-files mechanism, so no file-discovery change is needed.)
- Passes `includeScripts: false` / `includeStyles: false` to `convertToTSX()` (matching the language server) so `<script>`/`<style>` bodies are no longer wrapped in `{() => { ... }}` arrow functions, where `import` declarations are syntactically invalid and pollute the virtual file.

### Known limitation

References to symbols imported *inside* `<script>` tags still won't appear via the ts-plugin. Making script content reference-searchable requires `getExtraServiceScripts()`, which Volar explicitly does not support in the TS-plugin path (`decorateLanguageServiceHost.js` logs `getExtraServiceScripts() is not available in TS plugin.`). The Astro language server handles that case; the ts-plugin cannot without upstream Volar changes.

### Note on verification

This fix ships in `@astrojs/ts-plugin`, which the Astro VS Code extension **bundles** (`astro-ts-plugin-bundle`, registered via `typescriptServerPlugins`). When the extension is installed, tsserver loads the bundled plugin, so installing a preview of the npm package into a project's `node_modules` does **not** exercise the fix. End-to-end verification requires an extension build (or disabling the extension and relying solely on the tsconfig `plugins` entry with the workspace TypeScript).

## Testing

- Adds `test/units/astro-types.test.mts`: builds the `.astro` → `.tsx` output for a template that only uses `Astro.locals.utils.toUpper()`, then runs `findReferences` through the raw TypeScript language service. Asserts the reference is missed without type injection and found once `addAstroTypes` runs — a direct regression test for the reported behavior.

## Docs

- No docs update needed; this is an editor-tooling bug fix with no user-facing API change.
