### PR TITLE
fix(@astrojs/solid-js): detect Svelte 5 components using the $$renderer prop

### DIFF
--- a/.changeset/fix-solid-svelte5-renderer-prop-detection.md
+++ b/.changeset/fix-solid-svelte5-renderer-prop-detection.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/solid-js': patch
+---
+
+Fix `@astrojs/solid-js` incorrectly claiming Svelte 5 components compiled with the newer `$$renderer` prop (instead of the legacy `$$payload`). Projects mixing Solid and Svelte could see Svelte components silently rendered as empty strings by the Solid renderer.

--- a/packages/integrations/solid/src/server.ts
+++ b/packages/integrations/solid/src/server.ts
@@ -26,7 +26,9 @@ async function check(
 	// Svelte component renders fine by Solid as an empty string. The only way to detect
 	// if this isn't a Solid but Svelte component is to unfortunately copy the check
 	// implementation of the Svelte renderer.
-	if (Component.toString().includes('$$payload')) return false;
+	// `$$payload` is the legacy prop name; `$$renderer` is the name used since Svelte 5.x.
+	const componentStr = Component.toString();
+	if (componentStr.includes('$$payload') || componentStr.includes('$$renderer')) return false;
 
 	// There is nothing particularly special about Solid components. Basically they are just functions.
 	// In general, components from other frameworks (eg, MDX, React, etc.) tend to render as "undefined",


### PR DESCRIPTION
Svelte 5 renamed its internal SSR prop from $$payload to $$renderer starting in a newer patch (tracked in [fix(svelte): detect Svelte components with renamed renderer prop #14433](https://github.com/withastro/astro/pull/14433), which updated the Svelte renderer). That PR correctly updated @astrojs/svelte, but the Solid renderer has its own copy of the same Svelte-exclusion check and was not updated at the same time.

**Impact:** users who have both @astrojs/solid-js and @astrojs/svelte installed, and whose Svelte version compiles components with $$renderer, will see those Svelte components rendered as empty strings by the Solid renderer instead of being handed off to the Svelte renderer.

**Fix:** mirror the same two-prop check already used in @astrojs/svelte:
```ts
if (componentStr.includes('$$payload') || componentStr.includes('$$renderer')) return false; 