### PR TITLE
Resolve extensionless imports in island component paths

### DIFF
--- a/.changeset/little-chicken-listen.md
+++ b/.changeset/little-chicken-listen.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes island component paths so that extensionless imports (e.g. `import { Counter } from '../components/Counter'`) resolve to the real file on disk, matching Vite's extension order and directory `index` resolution. This makes the `include`/`exclude` options of JSX renderer integrations (React, Preact, Solid) match components imported without a file extension, and removes the spurious React 19 "Invalid hook call" warning logged on every request in dev when `include` was set alongside another JSX renderer

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -142,6 +142,41 @@ export function resolveJsToTs(filePath: string) {
 	return filePath;
 }
 
+// Match Vite's default `resolve.extensions` order so that when multiple
+// candidate files exist, we pick the same module Vite will load.
+// https://vite.dev/config/shared-options.html#resolve-extensions
+const VITE_DEFAULT_RESOLVE_EXTENSIONS = ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'];
+
+/**
+ * Resolve a path that doesn't name a file on disk (e.g. produced by an
+ * extensionless import like `import { Counter } from './Counter'`) to the file
+ * Vite would load, by probing Vite's default extension order and directory
+ * `index` files. Returns the path unchanged when it already exists as a file
+ * or when no candidate is found.
+ */
+export function resolveExtensionlessPath(filePath: string): string {
+	const stat = fs.statSync(filePath, { throwIfNoEntry: false });
+	if (stat?.isFile()) {
+		return filePath;
+	}
+	for (const ext of VITE_DEFAULT_RESOLVE_EXTENSIONS) {
+		const tryPath = filePath + ext;
+		if (fs.existsSync(tryPath)) {
+			return tryPath;
+		}
+	}
+	// Directory import: resolve to its `index` module, like Vite does.
+	if (stat?.isDirectory()) {
+		for (const ext of VITE_DEFAULT_RESOLVE_EXTENSIONS) {
+			const tryPath = `${filePath}/index${ext}`;
+			if (fs.existsSync(tryPath)) {
+				return tryPath;
+			}
+		}
+	}
+	return filePath;
+}
+
 /**
  * Set a default NODE_ENV so Vite doesn't set an incorrect default when loading the Astro config
  */

--- a/packages/astro/src/core/viteUtils.ts
+++ b/packages/astro/src/core/viteUtils.ts
@@ -3,7 +3,13 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { prependForwardSlash, slash } from '../core/path.js';
 import type { ModuleLoader } from './module-loader/index.js';
-import { resolveJsToTs, unwrapId, VALID_ID_PREFIX, viteID } from './util.js';
+import {
+	resolveExtensionlessPath,
+	resolveJsToTs,
+	unwrapId,
+	VALID_ID_PREFIX,
+	viteID,
+} from './util.js';
 
 const isWindows = typeof process !== 'undefined' && process.platform === 'win32';
 
@@ -20,13 +26,16 @@ export function normalizePath(id: string) {
  * Examples:
  * - `./components/Button.jsx` from `/app/src/pages/index.astro`
  *   -> `/app/src/pages/components/Button.tsx` (when `.tsx` exists)
+ * - `../components/Counter` from `/app/src/pages/index.astro`
+ *   -> `/app/src/components/Counter.tsx` (extensionless imports probe Vite's
+ *   default extension order, then directory `index` files)
  * - `#components/react/Counter.tsx`
  *   -> `/app/src/components/react/Counter.tsx` via package `imports`
  */
 export function resolvePath(specifier: string, importer: string) {
 	if (specifier.startsWith('.')) {
 		const absoluteSpecifier = path.resolve(path.dirname(importer), specifier);
-		return resolveJsToTs(normalizePath(absoluteSpecifier));
+		return resolveExtensionlessPath(resolveJsToTs(normalizePath(absoluteSpecifier)));
 	} else if (specifier.startsWith('#')) {
 		// Support Node subpath imports (package.json#imports), so this resolves
 		// before we hand off to non-runnable dev pipelines.

--- a/packages/astro/test/fixtures/multiple-jsx-renderers/src/pages/client-load-extensionless.astro
+++ b/packages/astro/test/fixtures/multiple-jsx-renderers/src/pages/client-load-extensionless.astro
@@ -1,0 +1,16 @@
+---
+import WoofCounter from '../components/WoofCounter.woof';
+import MeowCounter from '../components/MeowCounter.meow';
+---
+
+<html>
+  <head><title>Client Load Extensionless Test</title></head>
+  <body>
+    <div id="woof-root">
+      <WoofCounter client:load />
+    </div>
+    <div id="meow-root">
+      <MeowCounter client:load />
+    </div>
+  </body>
+</html>

--- a/packages/astro/test/multiple-jsx-renderers.test.ts
+++ b/packages/astro/test/multiple-jsx-renderers.test.ts
@@ -81,6 +81,33 @@ describe('With include option', () => {
 			assert.ok(island.attr('renderer-url')?.includes('meow-client'));
 		});
 	});
+
+	describe('client:load with extensionless imports', () => {
+		// Extensionless imports (`../components/WoofCounter.woof`) must still
+		// produce a componentUrl with the real on-disk extension so that
+		// include globs written against the filename (`**/*.woof.jsx`) match.
+		it('WoofCounter matched by include filter and rendered by woof', async () => {
+			const html = await fixture.readFile('/client-load-extensionless/index.html');
+			const $ = cheerio.load(html);
+			const woofRoot = $('#woof-root');
+			const island = woofRoot.find('astro-island');
+			assert.equal(woofRoot.find('[data-renderer="woof"]').length, 1);
+			assert.ok(woofRoot.text().includes('Woof Counter'));
+			assert.ok(island.attr('component-url')?.includes('WoofCounter.woof'));
+			assert.ok(island.attr('renderer-url')?.includes('woof-client'));
+		});
+
+		it('MeowCounter matched by include filter and rendered by meow', async () => {
+			const html = await fixture.readFile('/client-load-extensionless/index.html');
+			const $ = cheerio.load(html);
+			const meowRoot = $('#meow-root');
+			const island = meowRoot.find('astro-island');
+			assert.equal(meowRoot.find('[data-renderer="meow"]').length, 1);
+			assert.ok(meowRoot.text().includes('Meow Counter'));
+			assert.ok(island.attr('component-url')?.includes('MeowCounter.meow'));
+			assert.ok(island.attr('renderer-url')?.includes('meow-client'));
+		});
+	});
 });
 
 describe('Without include option', () => {

--- a/packages/astro/test/units/util/resolve-path.test.ts
+++ b/packages/astro/test/units/util/resolve-path.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { resolvePath } from '../../../dist/core/viteUtils.js';
+
+describe('resolvePath', () => {
+	let root: string;
+	let importer: string;
+
+	/** Create an empty fixture file (and its parent dirs) inside the temp root. */
+	function touch(relativePath: string) {
+		const filePath = path.join(root, relativePath);
+		mkdirSync(path.dirname(filePath), { recursive: true });
+		writeFileSync(filePath, '');
+	}
+
+	/** Posix-normalized absolute path of a fixture, as `resolvePath` returns it. */
+	function abs(relativePath: string) {
+		return path.posix.normalize(path.join(root, relativePath).replace(/\\/g, '/'));
+	}
+
+	before(() => {
+		root = mkdtempSync(path.join(tmpdir(), 'astro-resolve-path-'));
+		importer = path.join(root, 'src/pages/index.astro');
+		touch('src/pages/index.astro');
+		touch('src/components/Counter.tsx');
+		touch('src/components/OnlyTs.ts');
+		touch('src/components/OnlyJsx.jsx');
+		touch('src/components/Module.mjs');
+		touch('src/components/ModuleTs.mts');
+		// Both candidates exist: Vite's default extension order (.js before .tsx) must win.
+		touch('src/components/Order.js');
+		touch('src/components/Order.tsx');
+		// Directory index import.
+		touch('src/components/widgets/index.ts');
+		// Both a directory with an index and a sibling file: extension probing wins over the index.
+		touch('src/components/Amb/index.ts');
+		touch('src/components/Amb.tsx');
+		// Extensionless file that exists as-is must not be probed.
+		touch('src/components/LICENSE');
+		touch('src/components/LICENSE.js');
+		// `.jsx` specifier for an on-disk `.tsx` file (resolveJsToTs remap).
+		touch('src/components/Remap.tsx');
+	});
+
+	after(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it('resolves an extensionless import to the on-disk .tsx file', () => {
+		assert.equal(resolvePath('../components/Counter', importer), abs('src/components/Counter.tsx'));
+	});
+
+	it('resolves extensionless imports to .ts, .jsx, .mjs and .mts files', () => {
+		assert.equal(resolvePath('../components/OnlyTs', importer), abs('src/components/OnlyTs.ts'));
+		assert.equal(resolvePath('../components/OnlyJsx', importer), abs('src/components/OnlyJsx.jsx'));
+		assert.equal(resolvePath('../components/Module', importer), abs('src/components/Module.mjs'));
+		assert.equal(
+			resolvePath('../components/ModuleTs', importer),
+			abs('src/components/ModuleTs.mts'),
+		);
+	});
+
+	it("respects Vite's default extension order when multiple candidates exist", () => {
+		// Both Order.js and Order.tsx exist; Vite tries `.js` before `.tsx`.
+		assert.equal(resolvePath('../components/Order', importer), abs('src/components/Order.js'));
+	});
+
+	it('resolves a directory import to its index module', () => {
+		assert.equal(
+			resolvePath('../components/widgets', importer),
+			abs('src/components/widgets/index.ts'),
+		);
+	});
+
+	it('prefers a sibling file over a directory index, like Vite', () => {
+		// Both `Amb/index.ts` and `Amb.tsx` exist; Vite probes extensions before index files.
+		assert.equal(resolvePath('../components/Amb', importer), abs('src/components/Amb.tsx'));
+	});
+
+	it('returns extension-ful specifiers unchanged', () => {
+		assert.equal(
+			resolvePath('../components/Counter.tsx', importer),
+			abs('src/components/Counter.tsx'),
+		);
+	});
+
+	it('does not probe extensions when the extensionless path exists as a file', () => {
+		// `LICENSE` exists on disk, so it must win over `LICENSE.js`.
+		assert.equal(resolvePath('../components/LICENSE', importer), abs('src/components/LICENSE'));
+	});
+
+	it('still remaps a .jsx specifier to an on-disk .tsx file', () => {
+		assert.equal(resolvePath('../components/Remap.jsx', importer), abs('src/components/Remap.tsx'));
+	});
+
+	it('returns a non-existent extensionless path unchanged', () => {
+		assert.equal(resolvePath('../components/Missing', importer), abs('src/components/Missing'));
+	});
+
+	it('leaves bare specifiers untouched', () => {
+		assert.equal(resolvePath('react', importer), 'react');
+		assert.equal(resolvePath('@astrojs/react/client.js', importer), '@astrojs/react/client.js');
+	});
+
+	it('leaves unresolvable # subpath specifiers untouched', () => {
+		assert.equal(resolvePath('#components/Counter', importer), '#components/Counter');
+	});
+});


### PR DESCRIPTION
## Changes

- Island component paths (`client:component-path` → `metadata.componentUrl`) now resolve extensionless relative imports (e.g. `import { Counter } from '../components/Counter'`) to the real file on disk, probing Vite's default extension order and then directory `index` files. Previously the path stayed extensionless, so the `include`/`exclude` globs of JSX renderer integrations (e.g. `react({ include: ['**/react/*.tsx'] })`) could never match it.
- This is what fixes the "Invalid hook call" warning. Because the extensionless path never matched the `include` glob, the React renderer declined the component, and Astro asked the MDX renderer next — which tests a candidate by calling it as a plain function, so any `useState` inside triggered React 19's warning. Now the glob matches, React claims the component, and MDX never probes it. (With multiple JSX frameworks configured, the same mismatch instead hard-failed with "Unable to render" — also fixed.)
- Fixes #16767

## Testing

- New `test/units/util/resolve-path.test.ts` covering extension probing in Vite's order, directory `index` resolution, the existing `.jsx`→`.tsx` remap, and pass-through of extension-ful, bare, and `#` subpath specifiers (all fail without the fix)
- New `multiple-jsx-renderers` fixture page using an extensionless import matched by an `include` glob — the build hard-fails on it without the fix

## Docs

- No docs update needed — this makes behavior match what the integration docs already show (`include` globs written with file extensions).

