### PR TITLE
Fix `render()` type error when using live collections without a content config

### DIFF
--- a/.changeset/jolly-jobs-post.md
+++ b/.changeset/jolly-jobs-post.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes missing `render()` type overload for live collection entries. Previously, calling `render()` on a `LiveDataEntry` produced a TypeScript error when using only `live.config.ts` without a `content.config.ts`.

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -85,6 +85,10 @@ declare module 'astro:content' {
 		entry: DataEntryMap[C][string],
 	): Promise<RenderResult>;
 
+	export function render<C extends keyof LiveContentConfig['collections']>(
+		entry: import('astro').LiveDataEntry<LiveLoaderDataType<C>>,
+	): Promise<RenderResult>;
+
 	export function reference<
 		C extends
 			| keyof DataEntryMap


### PR DESCRIPTION
## Changes

- Adds a `render()` overload for `LiveDataEntry<LiveLoaderDataType<C>>` to `packages/astro/templates/content/types.d.ts`. Previously, the only overload covered entries from `DataEntryMap` (regular content collections). When a project only uses `live.config.ts`, `DataEntryMap` is empty, so `keyof DataEntryMap` resolves to `never` and `render()` rejects any live entry with a TypeScript error.
- The new overload mirrors the pattern already used by `getLiveEntry` and `getLiveCollection`. Projects with only `content.config.ts` are unaffected — `LiveContentConfig` resolves to `never` so the overload is inert.

Closes #16688

## Testing

- No new test added — the bug is in a `.d.ts` type template; integration-level verification (`astro sync` + `astro check`) is covered by the existing live loaders and content collection type test suites, all of which continue to pass.

## Docs

- No docs update needed. This fixes a missing type overload to match already-documented runtime behavior.
