### PR TITLE
Respect the astroConfig option in AstroContainer.create()

### DIFF
--- a/.changeset/mighty-donuts-fall.md
+++ b/.changeset/mighty-donuts-fall.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the `astroConfig` option of `AstroContainer.create()` was ignored. Configuration values such as `site` are now applied, making `Astro.site` available when rendering components with the Container API

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -136,6 +136,7 @@ function createManifest(
 	manifest?: AstroContainerManifest,
 	renderers?: SSRLoadedRenderer[],
 	middleware?: MiddlewareHandler,
+	astroConfig?: AstroConfig,
 ): SSRManifest {
 	function middlewareInstance(): AstroMiddlewareInstance {
 		return {
@@ -162,6 +163,7 @@ function createManifest(
 		entryModules: manifest?.entryModules ?? {},
 		routes: manifest?.routes ?? [],
 		adapterName: '',
+		site: manifest?.site ?? astroConfig?.site,
 		clientDirectives: manifest?.clientDirectives ?? getDefaultClientDirectives(),
 		renderers: renderers ?? manifest?.renderers ?? [],
 		base: manifest?.base ?? ASTRO_CONFIG_DEFAULTS.base,
@@ -264,6 +266,7 @@ type AstroContainerManifest = Pick<
 	| 'compressHTML'
 	| 'trailingSlash'
 	| 'buildFormat'
+	| 'site'
 	| 'i18n'
 	| 'srcDir'
 	| 'buildClientDir'
@@ -308,7 +311,7 @@ export class experimental_AstroContainer {
 	}: AstroContainerConstructor) {
 		this.#pipeline = ContainerPipeline.create({
 			logger: createConsoleLogger({ level: 'error' }),
-			manifest: createManifest(manifest, renderers),
+			manifest: createManifest(manifest, renderers, undefined, astroConfig),
 			streaming,
 			renderers: renderers ?? manifest?.renderers ?? [],
 			resolve: async (specifier: string) => {
@@ -341,7 +344,11 @@ export class experimental_AstroContainer {
 		containerOptions: AstroContainerOptions = {},
 	): Promise<experimental_AstroContainer> {
 		const { streaming = false, manifest, renderers = [], resolve } = containerOptions;
-		const astroConfig = await validateConfig(CONTAINER_CONFIG_DEFAULTS, process.cwd(), 'container');
+		const astroConfig = await validateConfig(
+			{ ...CONTAINER_CONFIG_DEFAULTS, ...containerOptions.astroConfig },
+			process.cwd(),
+			'container',
+		);
 		return new experimental_AstroContainer({
 			streaming,
 			manifest,

--- a/packages/astro/test/units/render/container.test.ts
+++ b/packages/astro/test/units/render/container.test.ts
@@ -276,4 +276,48 @@ describe('Container', () => {
 
 		assert.match(result, /Is open/);
 	});
+
+	it('provides Astro.site from astroConfig', async () => {
+		const $$Astro = createAstro('');
+		const Page = createComponent((result, props, slots) => {
+			type ResultCreateAstro = (
+				$$Astro: unknown,
+				props: Record<string, unknown>,
+				slots: Record<string, unknown> | null,
+			) => ReturnType<typeof result.createAstro>;
+			const resultCreateAstro: ResultCreateAstro =
+				result.createAstro as unknown as ResultCreateAstro;
+			const Astro = resultCreateAstro($$Astro, props, slots);
+			return render`${maybeRenderHead()}<div>site:${String(Astro.site)}</div>`;
+		});
+
+		const container = await experimental_AstroContainer.create({
+			astroConfig: {
+				site: 'http://example.com/',
+			},
+		});
+		const result = await container.renderToString(Page);
+
+		assert.match(result, /site:http:\/\/example\.com\//);
+	});
+
+	it('Astro.site is undefined when astroConfig.site is not set', async () => {
+		const $$Astro = createAstro('');
+		const Page = createComponent((result, props, slots) => {
+			type ResultCreateAstro = (
+				$$Astro: unknown,
+				props: Record<string, unknown>,
+				slots: Record<string, unknown> | null,
+			) => ReturnType<typeof result.createAstro>;
+			const resultCreateAstro: ResultCreateAstro =
+				result.createAstro as unknown as ResultCreateAstro;
+			const Astro = resultCreateAstro($$Astro, props, slots);
+			return render`${maybeRenderHead()}<div>site:${String(Astro.site)}</div>`;
+		});
+
+		const container = await experimental_AstroContainer.create();
+		const result = await container.renderToString(Page);
+
+		assert.match(result, /site:undefined/);
+	});
 });


### PR DESCRIPTION
## Changes

- `AstroContainer.create()` accepted a documented `astroConfig` option but never read it, silently ignoring all user-provided values. The option is now merged with the container defaults before validation.
- The resolved config's `site` is wired through `createManifest()` onto the SSRManifest, so `Astro.site` is available when rendering components with the Container API instead of always being `undefined`.

Fixes #16833

## Testing

- Adds two unit tests to `test/units/render/container.test.ts`: one verifying `Astro.site` reflects the URL passed via `astroConfig`, and one verifying it stays `undefined` when no `site` is configured.

## Docs

- No docs update needed — the `astroConfig` option is already documented; this makes it behave as documented.