### PR TITLE
chore: bump triagebot-action to v0.3.9

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm build
 
       - name: Run triagebot
-        uses: withastro/triagebot-action@978d7b674cac3e129703120da837fef40516e7d0 # v0.3.8
+        uses: withastro/triagebot-action@b16c8f2209da49daed89811cf6f9a50b0270168e # v0.3.9
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps `withastro/triagebot-action` from v0.3.8 to **v0.3.9** in the Issue Triage workflow.

v0.3.9 (withastro/triagebot-action#13) fixes a silent commit failure. The fix commit was built with a shell string `git commit -m ${JSON.stringify(message)}`, so backticks and `$()` in LLM-authored commit messages were interpreted by `/bin/sh` as command substitution and crashed the commit with a syntax error. The exit code wasn't checked and success was measured from the (force-)push, so the bot pushed an **empty fix branch** and posted a misleading "try this fix" comment + preview release containing none of the fix (e.g. #15440).

v0.3.9 commits via `execFile` with an argv array (no shell) and throws on a non-zero commit exit code so failures surface loudly.

- Pinned by full commit SHA `b16c8f2209da49daed89811cf6f9a50b0270168e` (= tag `v0.3.9`), matching the existing pinning convention.
- Only reference to the action in this repo: `.github/workflows/issue-triage.yml`.
