### PR TITLE
Fix empty style tags for virtual CSS modules in dev mode when JS is disabled

### DIFF
--- a/.changeset/funky-houses-smell.md
+++ b/.changeset/funky-houses-smell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes missing CSS for virtual style modules (e.g., responsive image layout styles) in dev mode when JavaScript is disabled

--- a/packages/astro/src/vite-plugin-css/index.ts
+++ b/packages/astro/src/vite-plugin-css/index.ts
@@ -233,8 +233,11 @@ export function astroDevCssPlugin({ routesList, command }: AstroVitePluginOption
 						for (const collected of collectCSSWithOrder(componentPageId, mod)) {
 							// Use the CSS file ID as the key to deduplicate while keeping best ordering
 							if (!cssWithOrder.has(collected.idKey)) {
-								// Look up actual content from cache if available
-								const content = cssContentCache.get(collected.id) || collected.content;
+								// Look up actual content from cache if available.
+								// Use `idKey` (the raw module ID) for cache lookup because that matches the key
+								// used by the transform hook. `collected.id` is wrapped via `wrapId()` which
+								// transforms the `\0` prefix of virtual modules, causing a cache miss.
+								const content = cssContentCache.get(collected.idKey) || collected.content;
 								cssWithOrder.set(collected.idKey, { ...collected, content });
 							}
 						}

--- a/packages/astro/test/units/dev/dev-css-virtual-modules.test.ts
+++ b/packages/astro/test/units/dev/dev-css-virtual-modules.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { wrapId } from '../../../dist/core/util.js';
+
+/**
+ * Tests for the cache key alignment in the dev CSS collection pipeline.
+ *
+ * The `cssContentCache` in vite-plugin-css stores CSS content keyed by the raw
+ * module ID from the transform hook. The load handler must use the same raw ID
+ * (not the `wrapId()`-transformed version) when looking up cached content.
+ *
+ * Virtual modules (prefixed with `\0`) are affected because `wrapId()` transforms
+ * the `\0` prefix to `/@id/__x00__`, creating a cache key mismatch if used for lookup.
+ *
+ * See: https://github.com/withastro/astro/issues/17267
+ */
+describe('dev CSS cache key alignment for virtual modules', () => {
+	it('wrapId transforms null-byte prefix of virtual module IDs', () => {
+		const virtualId = '\0virtual:astro:image-styles.css';
+		const wrapped = wrapId(virtualId);
+
+		// wrapId replaces \0 with /@id/__x00__
+		assert.notEqual(wrapped, virtualId);
+		assert.equal(wrapped, '/@id/__x00__virtual:astro:image-styles.css');
+	});
+
+	it('wrapId is a no-op for filesystem path IDs', () => {
+		const fsId = '/home/user/project/src/pages/index.astro?astro&type=style&index=0&lang.css';
+		const wrapped = wrapId(fsId);
+
+		// Filesystem paths don't start with \0, so wrapId is identity
+		assert.equal(wrapped, fsId);
+	});
+
+	it('cache lookup must use raw ID, not wrapped ID, for virtual modules', () => {
+		// Simulates the cssContentCache behavior
+		const cache = new Map<string, string>();
+		const rawId = '\0virtual:astro:image-styles.css';
+		const cssContent = '@layer astro.images { :where([data-astro-image]) { height: auto; } }';
+
+		// Transform hook stores with raw ID
+		cache.set(rawId, cssContent);
+
+		// Load handler must look up with raw ID (idKey), not wrapId(rawId) (id)
+		const wrappedId = wrapId(rawId);
+
+		// Bug: using wrapped ID causes cache miss
+		assert.equal(cache.get(wrappedId), undefined);
+
+		// Fix: using raw ID finds the cached content
+		assert.equal(cache.get(rawId), cssContent);
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes `Image` and `Picture` component layout styles being missing in `astro dev` when JavaScript is disabled. The dev CSS pipeline was caching content by raw module ID (with `\0` prefix) in the `transform` hook, but looking it up via `collected.id` — the `wrapId()`-transformed version (`/@id/__x00__...`) — causing a cache miss for virtual CSS modules and producing empty `<style>` tags. Switching the lookup to `collected.idKey` (the raw ID) aligns both sides of the cache.

## Testing

- Adds `packages/astro/test/units/dev/dev-css-virtual-modules.test.ts` with three unit tests covering: `wrapId()` transformation behavior for virtual module IDs, the no-op behavior for filesystem paths, and the cache key mismatch that the fix resolves.

## Docs

- No docs update needed — this is a dev-mode bug fix with no API surface change.

Closes #17267