### PR TITLE
Fix `inferSize` for remote images in the `Picture` component

### DIFF
--- a/.changeset/neat-parrots-ring.md
+++ b/.changeset/neat-parrots-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where `<Picture inferSize>` with a remote image could fail with `FailedToFetchRemoteImageDimensions` when the image server rate-limits requests (e.g. HTTP 429). Remote dimensions are now resolved once per render instead of once per output format.

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -1,7 +1,7 @@
 ---
-import { getImage, imageConfig, type LocalImageProps, type RemoteImageProps } from 'astro:assets';
+import { getImage, imageConfig, inferRemoteSize, type LocalImageProps, type RemoteImageProps } from 'astro:assets';
 import * as mime from 'mrmime';
-import { isESMImportedImage, resolveSrc } from '../dist/assets/utils/imageKind.js';
+import { isESMImportedImage, isRemoteImage, resolveSrc } from '../dist/assets/utils/imageKind.js';
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
 import type {
 	GetImageResult,
@@ -62,6 +62,17 @@ for (const key in props) {
 }
 
 const originalSrc = await resolveSrc(props.src);
+
+// When inferSize is set for a remote image, resolve dimensions once and thread them through
+// to all getImage() calls. This avoids multiple redundant HTTP requests to the same URL,
+// which can trigger rate-limiting (HTTP 429) on servers like Wikimedia.
+if (props.inferSize && isRemoteImage(originalSrc)) {
+	const remoteSize = await inferRemoteSize(originalSrc);
+	delete props.inferSize;
+	props.width ??= remoteSize.width;
+	props.height ??= remoteSize.height;
+}
+
 const optimizedImages: GetImageResult[] = await Promise.all(
 	formats.map(
 		async (format) =>


### PR DESCRIPTION
## Changes

- `<Picture inferSize>` with remote URLs no longer fails with `FailedToFetchRemoteImageDimensions` on rate-limiting servers (e.g. Wikimedia HTTP 429). The `Picture` component calls `getImage()` once per output format, and each call was independently invoking `inferRemoteSize()` — firing 2–4 HTTP requests to the same URL in rapid succession.
- Fix: resolve remote dimensions once in `Picture.astro` before the `getImage()` loop, then pass explicit `width`/`height` (dropping `inferSize`) to each call. No global caches — the result is scoped to the single component render, matching the approach recommended by @matthewp.

Closes #17263

## Testing

- Covered by the existing `core-image-infersize.test.ts` suite, which includes a `Picture component works` case with `inferSize` in dev mode and passes without changes.
- The specific failure mode (HTTP 429 from a rate-limiting server) is not easily reproducible in CI without a live server, and was verified manually by the reporter.

## Docs

- No docs update needed — `inferSize` behavior on `<Picture>` is unchanged from the user's perspective; this fixes a reliability regression.
