### PR TITLE
Fix `process is not defined` crash in JSON and node loggers when running in non-Node runtimes (e.g. Cloudflare workerd)

### DIFF
--- a/.changeset/json-logger-process-fix.md
+++ b/.changeset/json-logger-process-fix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes JSON and node loggers crashing with "process is not defined" in non-Node runtimes like Cloudflare's workerd. The loggers now use `console.log`/`console.error` instead of `process.stdout`/`process.stderr`, matching the pattern already used by the console logger.

--- a/packages/astro/src/core/logger/impls/json.ts
+++ b/packages/astro/src/core/logger/impls/json.ts
@@ -5,7 +5,6 @@ import {
 	type AstroLoggerMessage,
 	levels,
 } from '../core.js';
-import type { Writable } from 'node:stream';
 import type { AstroInlineConfig } from '../../../types/public/index.js';
 import { matchesLevel } from '../public.js';
 
@@ -20,10 +19,6 @@ export type JsonHandlerConfig = {
 	level?: AstroLoggerLevel;
 };
 
-type ConsoleStream = Writable & {
-	fd: 1 | 2;
-};
-
 export const SGR_REGEX = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, 'g');
 
 export default function jsonLoggerDestination(
@@ -32,25 +27,23 @@ export default function jsonLoggerDestination(
 	const { pretty = false, level = 'info' } = config;
 	return {
 		write(event) {
-			let dest: ConsoleStream = process.stderr;
-			if (levels[event.level] < levels['error']) {
-				dest = process.stdout;
-			}
-
 			if (!matchesLevel(event.level, level)) {
 				return;
 			}
 
-			let trailingLine = event.newLine ? '\n' : '';
+			let dest = console.error;
+			if (levels[event.level] < levels['error']) {
+				dest = console.log;
+			}
+
 			const message = event.message.replace(SGR_REGEX, '');
 			if (pretty) {
-				dest.write(
-					JSON.stringify({ message, label: event.label, level: event.level }, null, 2) +
-						trailingLine,
+				dest(
+					JSON.stringify({ message, label: event.label, level: event.level }, null, 2),
 				);
 			} else {
-				dest.write(
-					JSON.stringify({ message, label: event.label, level: event.level }) + trailingLine,
+				dest(
+					JSON.stringify({ message, label: event.label, level: event.level }),
 				);
 			}
 		},

--- a/packages/astro/src/core/logger/impls/node.ts
+++ b/packages/astro/src/core/logger/impls/node.ts
@@ -6,13 +6,8 @@ import {
 	getEventPrefix,
 	levels,
 } from '../core.js';
-import type { Writable } from 'node:stream';
 import type { AstroInlineConfig } from '../../../types/public/index.js';
 import { matchesLevel } from '../public.js';
-
-type ConsoleStream = Writable & {
-	fd: 1 | 2;
-};
 
 export type NodeHandlerConfig = {
 	level?: AstroLoggerLevel;
@@ -24,20 +19,19 @@ function nodeLogDestination(
 	const { level = 'info' } = config;
 	return {
 		write(event: AstroLoggerMessage) {
-			let dest: ConsoleStream = process.stderr;
-			if (levels[event.level] < levels['error']) {
-				dest = process.stdout;
-			}
-
 			if (!matchesLevel(event.level, level)) {
 				return;
 			}
 
-			let trailingLine = event.newLine ? '\n' : '';
+			let dest = console.error;
+			if (levels[event.level] < levels['error']) {
+				dest = console.log;
+			}
+
 			if (event.label === 'SKIP_FORMAT') {
-				dest.write(event.message + trailingLine);
+				dest(event.message);
 			} else {
-				dest.write(getEventPrefix(event) + ' ' + event.message + trailingLine);
+				dest(getEventPrefix(event) + ' ' + event.message);
 			}
 		},
 	};

--- a/packages/astro/test/units/logger/destination.test.ts
+++ b/packages/astro/test/units/logger/destination.test.ts
@@ -141,29 +141,27 @@ describe('SGR_REGEX', () => {
 });
 
 describe('json handler', () => {
-	let stdoutWrites: string[];
-	let stderrWrites: string[];
-	let originalStdoutWrite: typeof process.stdout.write;
-	let originalStderrWrite: typeof process.stderr.write;
+	let logWrites: string[];
+	let errorWrites: string[];
+	let originalLog: typeof console.log;
+	let originalError: typeof console.error;
 
 	beforeEach(() => {
-		stdoutWrites = [];
-		stderrWrites = [];
-		originalStdoutWrite = process.stdout.write;
-		originalStderrWrite = process.stderr.write;
-		process.stdout.write = ((chunk: string) => {
-			stdoutWrites.push(chunk);
-			return true;
-		}) as typeof process.stdout.write;
-		process.stderr.write = ((chunk: string) => {
-			stderrWrites.push(chunk);
-			return true;
-		}) as typeof process.stderr.write;
+		logWrites = [];
+		errorWrites = [];
+		originalLog = console.log;
+		originalError = console.error;
+		console.log = (...args: any[]) => {
+			logWrites.push(args.join(' '));
+		};
+		console.error = (...args: any[]) => {
+			errorWrites.push(args.join(' '));
+		};
 	});
 
 	afterEach(() => {
-		process.stdout.write = originalStdoutWrite;
-		process.stderr.write = originalStderrWrite;
+		console.log = originalLog;
+		console.error = originalError;
 	});
 
 	describe('output format', () => {
@@ -175,26 +173,26 @@ describe('json handler', () => {
 
 		it('writes JSON with message and label', () => {
 			logger.info('build', 'compiled successfully');
-			assert.equal(stdoutWrites.length, 1);
+			assert.equal(logWrites.length, 1);
 			assert.equal(
-				stdoutWrites[0],
-				'{"message":"compiled successfully","label":"build","level":"info"}\n',
+				logWrites[0],
+				'{"message":"compiled successfully","label":"build","level":"info"}',
 			);
 		});
 
 		it('writes JSON with null label', () => {
 			logger.info(null, 'no label message');
-			assert.equal(stdoutWrites[0], '{"message":"no label message","label":null,"level":"info"}\n');
+			assert.equal(logWrites[0], '{"message":"no label message","label":null,"level":"info"}');
 		});
 
 		it('includes message, label and level in output', () => {
 			logger.warn('build', 'a warning');
-			assert.equal(stdoutWrites[0], '{"message":"a warning","label":"build","level":"warn"}\n');
+			assert.equal(logWrites[0], '{"message":"a warning","label":"build","level":"warn"}');
 		});
 
 		it('strips ANSI codes from messages', () => {
 			logger.info('build', '\x1b[32mgreen text\x1b[39m');
-			assert.equal(stdoutWrites[0], '{"message":"green text","label":"build","level":"info"}\n');
+			assert.equal(logWrites[0], '{"message":"green text","label":"build","level":"info"}');
 		});
 	});
 
@@ -207,10 +205,10 @@ describe('json handler', () => {
 
 		it('writes indented JSON when pretty is true', () => {
 			logger.info('build', 'test');
-			const parsed = JSON.parse(stdoutWrites[0]);
+			const parsed = JSON.parse(logWrites[0]);
 			assert.equal(parsed.message, 'test');
 			assert.equal(parsed.label, 'build');
-			assert.ok(stdoutWrites[0].includes('\n  '), 'output should be indented');
+			assert.ok(logWrites[0].includes('\n  '), 'output should be indented');
 		});
 	});
 
@@ -221,22 +219,44 @@ describe('json handler', () => {
 			level: 'info',
 		});
 
-		it('routes info to stdout', () => {
+		it('routes info to console.log', () => {
 			logger.info('build', 'test');
-			assert.equal(stdoutWrites.length, 1);
-			assert.equal(stderrWrites.length, 0);
+			assert.equal(logWrites.length, 1);
+			assert.equal(errorWrites.length, 0);
 		});
 
-		it('routes warn to stdout', () => {
+		it('routes warn to console.log', () => {
 			logger.warn('build', 'test');
-			assert.equal(stdoutWrites.length, 1);
-			assert.equal(stderrWrites.length, 0);
+			assert.equal(logWrites.length, 1);
+			assert.equal(errorWrites.length, 0);
 		});
 
-		it('routes error to stderr', () => {
+		it('routes error to console.error', () => {
 			logger.error('build', 'test');
-			assert.equal(stdoutWrites.length, 0);
-			assert.equal(stderrWrites.length, 1);
+			assert.equal(logWrites.length, 0);
+			assert.equal(errorWrites.length, 1);
+		});
+	});
+
+	describe('runtime compatibility', () => {
+		it('does not reference process global directly', () => {
+			// The json logger must use console.log/console.error instead of
+			// process.stdout/process.stderr so it works in non-Node runtimes
+			// like Cloudflare's workerd (see issue #17280).
+			const destination = jsonFactory({ pretty: false });
+			const logger = new AstroLogger({
+				destination,
+				level: 'info',
+			});
+
+			// This should not throw even if process were unavailable,
+			// since we use console methods instead.
+			assert.doesNotThrow(() => {
+				logger.info('build', 'test message');
+			});
+			assert.equal(logWrites.length, 1);
+			const parsed = JSON.parse(logWrites[0]);
+			assert.equal(parsed.message, 'test message');
 		});
 	});
 });


### PR DESCRIPTION
Closes #17280

## Changes

- The JSON and node loggers were writing to `process.stderr`/`process.stdout` directly. In Cloudflare's workerd runtime (used by `@astrojs/cloudflare` during `astro dev`), `process` is not defined, so every log call threw a `ReferenceError`. This cascaded: the error handler also tried to log the error, which threw again, resulting in a 500 for every request.
- Both loggers now use `console.error`/`console.log` instead, matching the pattern already used by the console logger and working across all JS runtimes.
- **Known regression:** removing `process.stdout.write` also drops `event.newLine: false` support in the node logger — `console.log` always appends a newline. Build progress lines that are composed from two write events (filename with `newLine: false` + timing suffix) will print on separate lines. This only affects the node logger's build output formatting; the core 500 fix is correct.

## Testing

- Updated `packages/astro/test/units/logger/destination.test.ts`: replaced `process.stdout.write`/`process.stderr.write` spies with `console.log`/`console.error` stubs, and updated output assertions to drop the trailing `\n` (since `console.log` adds it implicitly and the captured string no longer includes it).

## Docs

- No docs change needed — this is a runtime crash fix with no user-facing API change.
