### PR TITLE
Respect integration-defined image services for Cloudflare build-time image generation

### DIFF
--- a/.changeset/cloudflare-integration-image-service.md
+++ b/.changeset/cloudflare-integration-image-service.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes build-time image optimization ignoring a custom image service registered by an integration
+
+Previously, when using `imageService: 'compile'` or `imageService: 'custom'`, a custom image service was only respected if it was set directly in the `image.service` option of `astro.config`. If an integration registered the service instead, images were silently optimized with the default Sharp service at build time. A custom image service now transforms your images at build time no matter how it was configured.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -20,7 +20,7 @@ import {
 	normalizeImageServiceConfig,
 	setImageConfig,
 } from './utils/image-config.js';
-import { createConfigPlugin } from './vite-plugin-config.js';
+import { createConfigPlugin, type CompileImageConfig } from './vite-plugin-config.js';
 import { createNodePrerenderPlugin } from './vite-plugin-dev-server-prerender-middleware.js';
 import {
 	cloudflareConfigCustomizer,
@@ -140,6 +140,7 @@ export default function createIntegration({
 	let _routes: IntegrationResolvedRoute[];
 	let cfPluginConfig: PluginConfig;
 	let hasUserBuildImageService = false;
+	let compileImageConfig: CompileImageConfig | null = null;
 
 	const { buildService, runtimeService } = normalizeImageServiceConfig(imageService);
 	const needsImagesBinding = runtimeService === 'cloudflare-binding';
@@ -155,7 +156,6 @@ export default function createIntegration({
 
 				let session = config.session;
 				const isCompile = buildService === 'compile';
-				hasUserBuildImageService = hasBuildImageService && hasUserImageService(config.image);
 
 				if (needsImagesBinding) {
 					logger.info(
@@ -392,19 +392,22 @@ export default function createIntegration({
 							},
 							createConfigPlugin({
 								sessionKVBindingName,
+								// `imageServiceEntrypoint` is finalized in `astro:config:done`:
+								// integrations may set `image.service` via `updateConfig()` after
+								// this hook runs (the adapter always runs first), so the service
+								// cannot be resolved yet. The plugin serializes this object lazily
+								// at load time, after the mutation below has happened.
 								compileImageConfig:
 									hasBuildImageService && command !== 'dev'
-										? {
+										? (compileImageConfig = {
 												base: config.base,
 												assetsPrefix:
 													typeof config.build.assetsPrefix === 'string'
 														? config.build.assetsPrefix
 														: undefined,
-												imageServiceEntrypoint: hasUserBuildImageService
-													? config.image.service.entrypoint
-													: '@astrojs/cloudflare/image-service-workerd',
+												imageServiceEntrypoint: '@astrojs/cloudflare/image-service-workerd',
 												buildAssets: config.build.assets ?? '_astro',
-											}
+											})
 										: null,
 								cacheProviderEnabled: needsWorkerCache,
 							}),
@@ -429,6 +432,15 @@ export default function createIntegration({
 				_config = config;
 				_buildOutput = buildOutput;
 				_originalClientDir = new URL(config.build.client.href);
+
+				// Resolve the custom image service against the FINAL config: the adapter's
+				// `astro:config:setup` runs before every user integration (Astro unshifts
+				// the adapter onto the integrations list), so a service registered by an
+				// integration via `updateConfig()` is only visible here.
+				hasUserBuildImageService = hasBuildImageService && hasUserImageService(config.image);
+				if (compileImageConfig && hasUserBuildImageService) {
+					compileImageConfig.imageServiceEntrypoint = config.image.service.entrypoint;
+				}
 
 				// When a base path is configured, nest the client output directory under
 				// the base so that on-disk paths match the URLs Astro writes into HTML.

--- a/packages/integrations/cloudflare/src/utils/image-config.ts
+++ b/packages/integrations/cloudflare/src/utils/image-config.ts
@@ -50,8 +50,14 @@ const WORKERD_IMAGE_SERVICE = { entrypoint: '@astrojs/cloudflare/image-service-w
 
 const SHARP_IMAGE_SERVICE = 'astro/assets/services/sharp';
 
+// Whether `image.service` was configured by the user or an integration, rather than being
+// Astro's default Sharp service or the workerd stub this adapter writes for `compile` mode.
 export function hasUserImageService(config: AstroConfig['image']): boolean {
-	return !!config.service?.entrypoint && config.service.entrypoint !== SHARP_IMAGE_SERVICE;
+	return (
+		!!config.service?.entrypoint &&
+		config.service.entrypoint !== SHARP_IMAGE_SERVICE &&
+		config.service.entrypoint !== WORKERD_IMAGE_SERVICE.entrypoint
+	);
 }
 
 export function setImageConfig(

--- a/packages/integrations/cloudflare/test/integration-defined-image-service.test.ts
+++ b/packages/integrations/cloudflare/test/integration-defined-image-service.test.ts
@@ -1,0 +1,93 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+// Same contract as the `compile-image-service.test.ts` Sharp-free matrix cells,
+// but the custom image service is registered by an INTEGRATION (via
+// `updateConfig` in `astro:config:setup`) instead of the top-level
+// `image.service` user config. Astro core unshifts the adapter to the front of
+// the integrations list, so the adapter's `astro:config:setup` runs before the
+// integration; the adapter must resolve the service against the final config
+// (`astro:config:done`) or the integration-defined service is invisible to the
+// build-time generation pass.
+const INTEGRATION_CONFIG = `import cloudflare from '@astrojs/cloudflare';
+import { defineConfig } from 'astro/config';
+
+const imageServiceIntegration = () => ({
+	name: 'image-service-integration',
+	hooks: {
+		'astro:config:setup': ({ updateConfig }) => {
+			updateConfig({
+				image: {
+					service: {
+						entrypoint: './src/image-service.ts',
+					},
+				},
+			});
+		},
+	},
+});
+
+export default defineConfig({
+	adapter: cloudflare({
+		imageService: 'MODE',
+	}),
+	output: 'static',
+	integrations: [imageServiceIntegration()],
+});
+`;
+
+async function buildFixture(mode: 'compile' | 'custom') {
+	const fixture = await loadFixture({
+		root: './fixtures/compile-custom-image-service/',
+		outDir: `./dist/integration-defined-image-service-${mode}/`,
+	});
+	const resetConfig = await fixture.editFile(
+		'astro.config.mjs',
+		() => INTEGRATION_CONFIG.replace("imageService: 'MODE'", `imageService: '${mode}'`),
+		false,
+	);
+
+	try {
+		await fixture.build();
+		return {
+			fixture,
+			html: await fixture.readFile('client/index.html'),
+		};
+	} finally {
+		resetConfig();
+	}
+}
+
+async function readGeneratedImage(fixture: Fixture, html: string) {
+	const src = cheerio.load(html)('img').attr('src');
+	assert.match(src ?? '', /^\/_astro\/.+/, 'expected a hashed asset in the markup');
+	return (await fixture.readFile(`client${src}`, null)) as unknown as Buffer;
+}
+
+describe('Image service defined by an integration', () => {
+	for (const mode of ['compile', 'custom'] as const) {
+		it(`imageService: '${mode}' - integration-defined service transform() runs at build time and markup is respected`, async () => {
+			const { fixture, html } = await buildFixture(mode);
+			const img = cheerio.load(html)('img');
+
+			// The integration-defined service should decorate the prerendered markup...
+			assert.equal(
+				img.attr('data-image-service'),
+				'custom',
+				'expected integration-defined getHTMLAttributes() to decorate prerendered markup',
+			);
+
+			// ...and its transform() should run during build-time asset generation,
+			// exactly as it does when the same service is set via `image.service`
+			// user config (covered by compile-image-service.test.ts).
+			const data = await readGeneratedImage(fixture, html);
+			assert.equal(
+				Buffer.from(data.subarray(0, 20)).toString('utf8'),
+				'CUSTOM_TRANSFORM_RAN',
+				'expected integration-defined transform() to have generated the asset',
+			);
+		});
+	}
+});


### PR DESCRIPTION
## Changes

Follow-up to #17099: a custom `image.service` was only respected during build-time image generation (`imageService: 'compile'` and `'custom'`) when set **directly** in the user config. A service registered by an **integration** via `updateConfig()` was silently replaced with Sharp, because the adapter's `astro:config:setup` runs before all integrations. The service is now resolved against the final config in `astro:config:done`.

## Testing

- New `integration-defined-image-service.test.ts` covers both modes with the service registered by an integration.
- Existing image service tests pass unchanged.

## Docs

Not required. Existing docs assumes this works.