### PR TITLE
Fix spacing bug in "Examples / Template" Pages.

### DIFF
--- a/.changeset/dark-taxis-create.md
+++ b/.changeset/dark-taxis-create.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixed spacing bug in two example/template pages under "Examples/..."

--- a/.changeset/dark-taxis-create.md
+++ b/.changeset/dark-taxis-create.md
@@ -1,5 +1,0 @@
----
-'create-astro': patch
----
-
-Fixed spacing bug in two example/template pages under "Examples/..."

--- a/examples/advanced-routing/src/pages/index.astro
+++ b/examples/advanced-routing/src/pages/index.astro
@@ -6,7 +6,7 @@ import Layout from '../layouts/Layout.astro';
 	<h1>Advanced Routing</h1>
 	<p>
 		This example uses <code>src/app.ts</code> to control the request pipeline with Hono. Individual feature
-		middleware from <code>astro/hono</code> and <code>astro/fetch</code>
+		middleware from <code>astro/hono</code> and <code>astro/fetch</code>{' '}
 		are composed together, with your own Hono middleware running between them.
 	</p>
 

--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -20,8 +20,8 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 				website, blog, or portfolio with Astro.
 			</p>
 			<p>
-				This template comes with a few integrations already configured in your
-				<code>astro.config.mjs</code> file. You can customize your setup with
+				This template comes with a few integrations already configured in your{' '}
+				<code>astro.config.mjs</code> file. You can customize your setup with{' '}
 				<a href="https://astro.build/integrations">Astro Integrations</a> to add tools like Tailwind,
 				React, or Vue to your project.
 			</p>
@@ -34,13 +34,13 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 				<li>Customize the blog post page layout in <code>src/layouts/BlogPost.astro</code></li>
 			</ul>
 			<p>
-				Have fun! If you get stuck, remember to
-				<a href="https://docs.astro.build/">read the docs</a>
+				Have fun! If you get stuck, remember to{' '}
+				<a href="https://docs.astro.build/">read the docs</a>{' '}
 				or <a href="https://astro.build/chat">join us on Discord</a> to ask questions.
 			</p>
 			<p>
-				Looking for a blog template with a bit more personality? Check out
-				<a href="https://github.com/Charca/astro-blog-template">astro-blog-template</a>
+				Looking for a blog template with a bit more personality? Check out{' '}
+				<a href="https://github.com/Charca/astro-blog-template">astro-blog-template</a>{' '}
 				by <a href="https://twitter.com/Charca">Maxi Ferreira</a>.
 			</p>
 		</main>


### PR DESCRIPTION
## Changes
Both "Advanced Routing" and "Blog" Example Template pages presented missing spaces between the HTML tags, the file locations are respectively `examples/advanced-routing/src/pages/index.astro` and `examples/blog/src/pages/index.astro`.

Image provided below for Before and After.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Testing was made by editing the files and opening the URL in both Firefox and Chromium-based browsers and seeing if:
1. The problem was present and persistent between different Browser engines.
2. The patch worked.  
  
Both showed to be true.
  
## Docs
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Unneeded, very small text changes.

## Images
`"‎examples/blog/src/pages/index.astro"`:
| Before | After | 
| -- | -- |
| <img width="1133" height="1146" alt="Blog Before" src="https://github.com/user-attachments/assets/822a0889-b8cb-4d27-80a4-36fb8ed047c8" /> | <img width="1133" height="1146" alt="Blog After" src="https://github.com/user-attachments/assets/b370399c-5d74-4968-936c-71ac7f9063f0" /> |


`"examples/advanced-routing/src/pages/index.astro"`:
| Before | After | 
| -- | -- |
| <img width="1135" height="649" alt="Routing Before" src="https://github.com/user-attachments/assets/a4b4a0fe-0e4b-432c-ba88-27c6e7a92abc" /> | <img width="1121" height="693" alt="Routing After" src="https://github.com/user-attachments/assets/201d568f-14e5-4b3e-8acb-df54537677e6" />|

