### PR TITLE
Fix/security patches

### DIFF
--- a/.changeset/nice-hairs-rush.md
+++ b/.changeset/nice-hairs-rush.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Blocks cross-origin POST requests regardless of Content-Type to prevent CSRF bypass

--- a/.changeset/open-rocks-clean.md
+++ b/.changeset/open-rocks-clean.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes prototype pollution in config merge by filtering `__proto__`, `constructor`, and `prototype` keys

--- a/.changeset/quiet-ligers-walk.md
+++ b/.changeset/quiet-ligers-walk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes XSS by escaping `</script>` and `</style>` sequences in raw string children of `<script>` and `<style>` elements

--- a/packages/astro/src/core/app/origin-check.ts
+++ b/packages/astro/src/core/app/origin-check.ts
@@ -48,11 +48,6 @@ export function isForbiddenCrossOriginRequest(
 	}
 	const isSameOrigin = request.headers.get('origin') === url.origin;
 
-	const hasContentType = request.headers.has('content-type');
-	if (hasContentType) {
-		const formLikeHeader = hasFormLikeHeader(request.headers.get('content-type'));
-		return formLikeHeader && !isSameOrigin;
-	}
 	return !isSameOrigin;
 }
 

--- a/packages/astro/src/core/config/merge.ts
+++ b/packages/astro/src/core/config/merge.ts
@@ -10,6 +10,10 @@ function mergeConfigRecursively(
 ) {
 	const merged: Record<string, any> = { ...defaults };
 	for (const key in overrides) {
+		// ponytail: __proto__/constructor/prototype filtered — sufficient for userland config merge; add a deep-freeze post-merge if defense-in-depth is ever required
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+			continue;
+		}
 		const value = overrides[key];
 		if (value == null) {
 			continue;

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -210,8 +210,9 @@ function prerenderElementChildren(tag: string, children: any) {
 	// For content within <style> and <script> tags that are plain strings, e.g. injected
 	// by remark/rehype plugins, or if a user explicitly does `<script>{'...'}</script>`,
 	// we mark it as an HTML string to prevent the content from being HTML-escaped.
+	// ponytail: replaceAll handles common </script>/</style> injection in raw strings; full JS/CSS tokenizer only if user-controlled multi-line content is ever passed here
 	if (typeof children === 'string' && (tag === 'style' || tag === 'script')) {
-		return markHTMLString(children);
+		return markHTMLString(children.replaceAll('</script', '<\\/script').replaceAll('</style', '<\\/style'));
 	} else {
 		return children;
 	}

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -198,7 +198,7 @@ export async function renderStreaming(
 			if (!isVoid && children != null && children !== '') {
 				// `<script>`/`<style>` string content is raw HTML, not escaped.
 				if (typeof children === 'string' && (type === 'style' || type === 'script')) {
-					stack.push(markHTMLString(children));
+					stack.push(markHTMLString(children.replaceAll('</script', '<\\/script').replaceAll('</style', '<\\/style')));
 				} else {
 					stack.push(children);
 				}

--- a/packages/astro/test/units/app/csrf.test.ts
+++ b/packages/astro/test/units/app/csrf.test.ts
@@ -185,22 +185,22 @@ describe('CSRF - createOriginCheckMiddleware', () => {
 		assert.equal(res.status, 403);
 	});
 
-	it('allows cross-origin POST with application/json', async () => {
+	it('blocks cross-origin POST with application/json', async () => {
 		const res = await callCSRF({
 			method: 'POST',
 			url: 'http://example.com/api/',
 			headers: { origin: 'http://evil.com', 'content-type': 'application/json' },
 		});
-		assert.equal(res.status, 200);
+		assert.equal(res.status, 403);
 	});
 
-	it('allows cross-origin POST with application/octet-stream', async () => {
+	it('blocks cross-origin POST with application/octet-stream', async () => {
 		const res = await callCSRF({
 			method: 'POST',
 			url: 'http://example.com/api/',
 			headers: { origin: 'http://evil.com', 'content-type': 'application/octet-stream' },
 		});
-		assert.equal(res.status, 200);
+		assert.equal(res.status, 403);
 	});
 
 	it('blocks cross-origin POST with uppercased form content-type', async () => {


### PR DESCRIPTION
Changes
- Prevents prototype pollution in config merge by filtering __proto__/constructor/prototype keys
- Fixes XSS in <script> and <style> elements by escaping </script> and </style> sequences in raw string children before marking as HTML-safe
- Blocks cross-origin POST regardless of Content-Type to prevent CSRF bypass (defense-in-depth; CORS preflight already protects fetch)

Testing
- Updated 2 CSRF test assertions to expect 403 instead of 200 for cross-origin JSON/octet-stream POSTs

Docs
- No docs update needed; all changes are internal hardening with no user-facing API changes