### PR TITLE
Fix dev server crash when .html-suffixed requests hit dynamic endpoint routes

### DIFF
--- a/.changeset/moody-stamps-care.md
+++ b/.changeset/moody-stamps-care.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a dev server crash when a `.html` or `/index.html` suffixed request (such as those `netlify dev` probes as pretty-URL fallbacks) matched a dynamic endpoint route, causing a `TypeError: Missing parameter` error

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -87,34 +87,30 @@ export function getParams(route: RouteData, pathname: string): Params {
 	if (!route.params.length) return {};
 	// The RegExp pattern expects a decoded string, but the pathname is encoded
 	// when the URL contains non-English characters.
-	// Strip `.html` from the pathname of page routes unless `.html` is a static part of the
-	// route definition itself (e.g. `[slug].html.astro`). Dynamic params like `[id]` would
-	// otherwise greedily capture the `.html` suffix that is either implied or injected
-	// for page routes (e.g. `id = '42.html'` instead of `id = '42'`).
-	// For non-page routes (endpoints), first try matching the original pathname. If that
-	// fails, fall back to stripping `.html` / `/index.html` to stay consistent with the
-	// dev route matcher which also strips these suffixes when retrying (see `dev.ts`).
-	// Without this fallback, requests like `/api/items/123/status.html` would match a
-	// dynamic endpoint route but fail to extract params, causing a "Missing parameter" error.
-	let path = pathname;
-	if (pathname.endsWith('.html') && !routeHasHtmlExtension(route)) {
-		if (route.type === 'page') {
-			path = pathname.slice(0, -5);
-		}
-	}
+	// A `.html` suffix is only meaningful to strip when it isn't a static part of the route
+	// definition itself (e.g. `[slug].html.astro`), otherwise dynamic params like `[id]` would
+	// greedily capture the `.html` that is implied or injected for page routes.
+	const hasHtmlSuffix = pathname.endsWith('.html') && !routeHasHtmlExtension(route);
+
+	// Page routes always strip `.html` up front (e.g. `id = '42'` instead of `id = '42.html'`).
+	// Non-page routes (endpoints) match the original pathname first — see the fallback below.
+	const path =
+		hasHtmlSuffix && route.type === 'page' ? pathname.slice(0, -'.html'.length) : pathname;
 
 	const allPatterns = [route, ...route.fallbackRoutes].map((r) => r.pattern);
 	let paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
 
-	// For non-page routes, if the original pathname didn't match, try stripping
-	// `.html` or `/index.html` as the dev router does when retrying.
-	if (!paramsMatch && route.type !== 'page' && !routeHasHtmlExtension(route)) {
-		if (pathname.endsWith('/index.html')) {
-			path = pathname.slice(0, -'/index.html'.length) || '/';
-		} else if (pathname.endsWith('.html')) {
-			path = pathname.slice(0, -'.html'.length);
-		}
-		paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
+	// For non-page routes, if the original pathname didn't match, fall back to stripping
+	// `.html` / `/index.html` to stay consistent with the dev route matcher, which also strips
+	// these suffixes when retrying (see `dev.ts`). Without this, requests like
+	// `/api/items/123/status.html` would match a dynamic endpoint route but fail to extract
+	// params, causing a "Missing parameter" error. Endpoints that genuinely capture `.html` in
+	// a param (e.g. `[path]` matching `/file.html`) already matched above, so never reach here.
+	if (!paramsMatch && hasHtmlSuffix && route.type !== 'page') {
+		const strippedPath = pathname.endsWith('/index.html')
+			? pathname.slice(0, -'/index.html'.length) || '/'
+			: pathname.slice(0, -'.html'.length);
+		paramsMatch = allPatterns.map((pattern) => pattern.exec(strippedPath)).find((x) => x);
 	}
 
 	if (!paramsMatch) return {};

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -91,15 +91,31 @@ export function getParams(route: RouteData, pathname: string): Params {
 	// route definition itself (e.g. `[slug].html.astro`). Dynamic params like `[id]` would
 	// otherwise greedily capture the `.html` suffix that is either implied or injected
 	// for page routes (e.g. `id = '42.html'` instead of `id = '42'`).
-	// Other route types do not enforce HTML generation nor modify the path, so any suffix
-	// was added by user code and their pattern matching should apply on the complete pathname.
-	const path =
-		pathname.endsWith('.html') && route.type === 'page' && !routeHasHtmlExtension(route)
-			? pathname.slice(0, -5)
-			: pathname;
+	// For non-page routes (endpoints), first try matching the original pathname. If that
+	// fails, fall back to stripping `.html` / `/index.html` to stay consistent with the
+	// dev route matcher which also strips these suffixes when retrying (see `dev.ts`).
+	// Without this fallback, requests like `/api/items/123/status.html` would match a
+	// dynamic endpoint route but fail to extract params, causing a "Missing parameter" error.
+	let path = pathname;
+	if (pathname.endsWith('.html') && !routeHasHtmlExtension(route)) {
+		if (route.type === 'page') {
+			path = pathname.slice(0, -5);
+		}
+	}
 
 	const allPatterns = [route, ...route.fallbackRoutes].map((r) => r.pattern);
-	const paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
+	let paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
+
+	// For non-page routes, if the original pathname didn't match, try stripping
+	// `.html` or `/index.html` as the dev router does when retrying.
+	if (!paramsMatch && route.type !== 'page' && !routeHasHtmlExtension(route)) {
+		if (pathname.endsWith('/index.html')) {
+			path = pathname.slice(0, -'/index.html'.length) || '/';
+		} else if (pathname.endsWith('.html')) {
+			path = pathname.slice(0, -'.html'.length);
+		}
+		paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
+	}
 
 	if (!paramsMatch) return {};
 	const params: Params = {};

--- a/packages/astro/test/units/routing/get-params.test.ts
+++ b/packages/astro/test/units/routing/get-params.test.ts
@@ -151,6 +151,55 @@ describe('getParams', () => {
 			const params = getParams(route, '/food.html');
 			assert.equal(params.category, 'food');
 		});
+
+		it('strips .html for endpoint routes when the pattern does not match otherwise', () => {
+			// Regression test for #17297: `.html`-suffixed requests to a dynamic endpoint
+			// (e.g. from `netlify dev` probing pretty-URL fallbacks) matched the route but
+			// failed to extract params, throwing "Missing parameter: id".
+			const route = makeRoute({
+				route: '/api/items/[id]/status',
+				segments: [
+					[staticPart('api')],
+					[staticPart('items')],
+					[dynamicPart('id')],
+					[staticPart('status')],
+				],
+				trailingSlash: 'ignore',
+				pathname: undefined,
+				type: 'endpoint',
+			});
+			assert.deepEqual(getParams(route, '/api/items/123/status'), { id: '123' });
+			assert.deepEqual(getParams(route, '/api/items/123/status.html'), { id: '123' });
+		});
+
+		it('strips /index.html for endpoint routes when the pattern does not match otherwise', () => {
+			const route = makeRoute({
+				route: '/api/items/[id]/status',
+				segments: [
+					[staticPart('api')],
+					[staticPart('items')],
+					[dynamicPart('id')],
+					[staticPart('status')],
+				],
+				trailingSlash: 'ignore',
+				pathname: undefined,
+				type: 'endpoint',
+			});
+			assert.deepEqual(getParams(route, '/api/items/123/status/index.html'), { id: '123' });
+		});
+
+		it('preserves .html captured by an endpoint param', () => {
+			// An endpoint whose param genuinely matches the `.html` pathname must keep the
+			// suffix — the fallback stripping only kicks in when the original pattern fails.
+			const route = makeRoute({
+				route: '/[path]',
+				segments: [[dynamicPart('path')]],
+				trailingSlash: 'ignore',
+				pathname: undefined,
+				type: 'endpoint',
+			});
+			assert.deepEqual(getParams(route, '/file.html'), { path: 'file.html' });
+		});
 	});
 
 	describe('no match', () => {


### PR DESCRIPTION
Closes #17297

## Changes

- A `.html` or `/index.html` suffixed request to a dynamic endpoint route (e.g. `GET /api/items/123/status.html` for `src/pages/api/items/[id]/status.ts`) no longer crashes dev with `TypeError: Missing parameter: id`.
- The dev route matcher strips `.html` / `/index.html` when retrying unmatched requests, but `getParams()` only stripped `.html` for `route.type === 'page'`. For a matched endpoint, params came back `{}` and `stringifyParams` threw. `getParams` now applies the same fallback for non-page routes: if the pattern doesn't match the original pathname, retry with the suffix stripped. Endpoints that legitimately capture `.html` in a param (e.g. `[path]` matching `/file.html`) match on the original pathname and are unaffected.
- Especially impactful under `netlify dev`, which probes `.html` / `/index.html` variants on any 404 — firing the crash for every dynamic API endpoint.

## Testing

- Added `getParams` unit tests covering `.html` and `/index.html` requests to a dynamic endpoint route, plus a guard asserting endpoints that capture `.html` in a param keep the suffix.

## Docs

No docs update needed — this restores the routing behavior users already expect.
