### PR TITLE
Pre-bundle astro/components virtual module in Cloudflare adapter

### DIFF
--- a/.changeset/cloudflare-prebundle-astro-components.md
+++ b/.changeset/cloudflare-prebundle-astro-components.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Prebundles `astro/components` and the `<ClientRouter />` transition runtime modules in the dev server environment so pages using them no longer trigger a mid-session dep optimizer reload, which caused React "Invalid hook call" errors in islands on the first request after a cold cache

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -343,6 +343,11 @@ export default function createIntegration({
 													'astro/app/entrypoint/dev',
 													'astro/virtual-modules/middleware.js',
 													'astro/virtual-modules/transitions.js',
+													'astro/virtual-modules/transitions-events.js',
+													'astro/virtual-modules/transitions-router.js',
+													'astro/virtual-modules/transitions-swap-functions.js',
+													'astro/virtual-modules/transitions-types.js',
+													'astro/components',
 													...(isAstroPrismPackageInstalled ? prismFiles : []),
 													...(Array.isArray(userOptimizeDeps?.include)
 														? userOptimizeDeps.include


### PR DESCRIPTION
## Changes

Follow-up to #17187, which pre-bundled `astro/virtual-modules/transitions.js` in the Cloudflare adapter's server dev environment to stop a mid-request dep optimizer reload. The same class of bug (#17166 / #16853 / #16529) still fires for pages that use the `astro:components` virtual module (e.g. `import { Code } from "astro:components"`).

- The adapter's server `optimizeDeps` excludes `astro:*` virtual modules, so the real module behind that virtual, `astro/components`, is never in the boot-time include list.
- It is therefore discovered by the SSR dep optimizer only at first render. On the first request after a cold optimizer cache, that late discovery triggers `optimized dependencies changed. reloading` **mid-render**, which the workerd module runner does not survive cleanly: components resolve `react` from `node_modules` while `react-dom/server` comes from a freshly re-optimized `deps_ssr` chunk. Two copies of React in one render throw `Invalid hook call` / `Cannot read properties of null (reading 'useState')` in every island, and the page returns 200 with the islands empty.
- Fix: add `astro/components` to the server-environment `optimizeDeps.include` list, right after the existing `astro/virtual-modules/transitions.js` entry, so it is pre-bundled at boot and the mid-render reload never happens.

This is the same one-line shape as #17187, for a different late-discovered virtual-module target.

## Testing

Reproduced on a real Astro 7 + `@astrojs/cloudflare` 14.1.1 + `@astrojs/react` site (React 19) that renders `astro:components`:

- **Stock adapter (bug):** cold `astro dev` (`rm -rf node_modules/.vite`), then requesting routes across the reload window. The dev log shows `dependency optimized: astro/components` → `optimized dependencies changed. reloading` → repeated `Invalid hook call` and `TypeError: Cannot read properties of null (reading 'useState')`. Every route still returns 200 but React islands render empty.
- **Patched adapter (this PR):** identical cold-cache procedure. Zero optimizer reloads after startup, zero hook errors, all islands render, and warm-cache reboots stay clean.

I verified this by packing the patched adapter and pinning it into the site via a pnpm override; the bug reproduces reliably without the patch and disappears with it.

## Docs

No docs needed — this is an internal dev-server dependency-optimization detail with no user-facing API change.
