### PR TITLE
Fix dev request signal listener cleanup

### DIFF
--- a/.changeset/clean-dev-socket-listeners.md
+++ b/.changeset/clean-dev-socket-listeners.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Clean up dev server socket close listeners after request handling

--- a/packages/astro/src/vite-plugin-app/app.ts
+++ b/packages/astro/src/vite-plugin-app/app.ts
@@ -243,39 +243,50 @@ export class AstroServerApp extends BaseApp<RunnablePipeline> {
 						abortController.abort();
 					}
 				};
+				let removeSocketCloseListener = () => {};
 				if (socket.destroyed) {
 					onSocketClose();
 				} else {
 					socket.on('close', onSocketClose);
+					removeSocketCloseListener = () => {
+						socket.removeListener('close', onSocketClose);
+					};
+					abortController.signal.addEventListener('abort', removeSocketCloseListener, {
+						once: true,
+					});
 				}
 
-				const request = createRequest({
-					url,
-					headers: incomingRequest.headers,
-					method: incomingRequest.method,
-					body,
-					logger: self.logger,
-					isPrerendered: matchedRoute.routeData.prerender,
-					routePattern: matchedRoute.routeData.component,
-					init: { signal: abortController.signal },
-				});
+				try {
+					const request = createRequest({
+						url,
+						headers: incomingRequest.headers,
+						method: incomingRequest.method,
+						body,
+						logger: self.logger,
+						isPrerendered: matchedRoute.routeData.prerender,
+						routePattern: matchedRoute.routeData.component,
+						init: { signal: abortController.signal },
+					});
 
-				// This is required for adapters to set locals in dev mode. They use a dev server middleware to inject locals to the `http.IncomingRequest` object.
-				const locals = Reflect.get(incomingRequest, clientLocalsSymbol);
+					// This is required for adapters to set locals in dev mode. They use a dev server middleware to inject locals to the `http.IncomingRequest` object.
+					const locals = Reflect.get(incomingRequest, clientLocalsSymbol);
 
-				// Set user specified headers to response object.
-				for (const [name, value] of Object.entries(self.settings.config.server.headers ?? {})) {
-					if (value) incomingResponse.setHeader(name, value);
+					// Set user specified headers to response object.
+					for (const [name, value] of Object.entries(self.settings.config.server.headers ?? {})) {
+						if (value) incomingResponse.setHeader(name, value);
+					}
+					const clientAddress = incomingRequest.socket.remoteAddress;
+
+					const response = await self.render(request, {
+						locals,
+						routeData: matchedRoute.routeData,
+						clientAddress,
+					});
+
+					await writeSSRResult(request, response, incomingResponse);
+				} finally {
+					removeSocketCloseListener();
 				}
-				const clientAddress = incomingRequest.socket.remoteAddress;
-
-				const response = await self.render(request, {
-					locals,
-					routeData: matchedRoute.routeData,
-					clientAddress,
-				});
-
-				await writeSSRResult(request, response, incomingResponse);
 			},
 			onError(_err) {
 				const error = createSafeError(_err);

--- a/packages/astro/test/fixtures/request-signal/src/pages/dev-signal-test.ts
+++ b/packages/astro/test/fixtures/request-signal/src/pages/dev-signal-test.ts
@@ -2,14 +2,16 @@ import type { APIContext } from 'astro';
 
 export const prerender = false;
 
-export const GET = async ({ request }: APIContext) => {
+export const GET = async ({ request, url }: APIContext) => {
+	const timeoutMs = Number(url.searchParams.get('timeout') ?? 5000);
+
 	// Wait until the signal is aborted or 5 seconds pass
 	const aborted = await new Promise<boolean>((resolve) => {
 		if (request.signal.aborted) {
 			resolve(true);
 			return;
 		}
-		const timeout = setTimeout(() => resolve(false), 5000);
+		const timeout = setTimeout(() => resolve(false), timeoutMs);
 		request.signal.addEventListener(
 			'abort',
 			() => {

--- a/packages/astro/test/request-signal.test.ts
+++ b/packages/astro/test/request-signal.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events';
 import { after, before, describe, it } from 'node:test';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Agent } from 'undici';
 import { createRequestAndResponse } from './integration-test-helpers.ts';
 import { type DevServer, type Fixture, loadFixture, type RequestHandler } from './test-utils.ts';
 
@@ -166,5 +167,39 @@ describe('Dev server request abort signal', () => {
 		const normalRes = await fixture.fetch('/dev-signal-test');
 		const normalPayload = await normalRes.json();
 		assert.equal(normalPayload.aborted, false, 'non-aborted request should report aborted=false');
+	});
+
+	it('does not retain socket close listeners after successful requests', async () => {
+		const warnings: Error[] = [];
+		const onWarning = (warning: Error) => {
+			if (
+				warning.name === 'MaxListenersExceededWarning' &&
+				warning.message.includes('close listeners')
+			) {
+				warnings.push(warning);
+			}
+		};
+
+		process.on('warning', onWarning);
+		const dispatcher = new Agent({ connections: 1 });
+
+		try {
+			for (let i = 0; i < 12; i++) {
+				const response = await fixture.fetch('/dev-signal-test?timeout=1', {
+					dispatcher,
+				} as RequestInit);
+				assert.equal(response.status, 200);
+				await response.arrayBuffer();
+			}
+			await delay(50);
+		} finally {
+			process.off('warning', onWarning);
+			await dispatcher.close();
+		}
+
+		assert.deepEqual(
+			warnings.map((warning) => warning.message),
+			[],
+		);
 	});
 });


### PR DESCRIPTION
## Changes

- Removes the dev server socket close listener after request handling completes.
- Also removes the listener when the request signal aborts, preserving the disconnect behavior added in #17133 while avoiding listener buildup on reused sockets.
- Adds a regression test that sends repeated successful dev requests over one keep-alive dispatcher and asserts no MaxListenersExceededWarning is emitted for socket close listeners.

## Testing

- pnpm --filter @astrojs/node... run build:ci
- pnpm --filter astro run build:ci
- pnpm --filter astro exec astro-scripts test test/request-signal.test.ts --strip-types
- pnpm exec prettier --check packages/astro/src/vite-plugin-app/app.ts packages/astro/test/request-signal.test.ts packages/astro/test/fixtures/request-signal/src/pages/dev-signal-test.ts .changeset/clean-dev-socket-listeners.md

## Docs

No docs update needed. This is internal dev-server listener cleanup and does not change the public API.
