### PR TITLE
chore(deps): remove `is-wsl` dependency

### DIFF
--- a/.changeset/giant-stamps-stop.md
+++ b/.changeset/giant-stamps-stop.md
@@ -2,4 +2,4 @@
 "@astrojs/telemetry": patch
 ---
 
-Removed `is-wsl` dependency
+Refactors internal WSL detection by removing the `is-wsl` dependency.

--- a/.changeset/giant-stamps-stop.md
+++ b/.changeset/giant-stamps-stop.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/telemetry": patch
+---
+
+Removed `is-wsl` dependency

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -28,7 +28,6 @@
     "ci-info": "^4.4.0",
     "dset": "^3.1.4",
     "is-docker": "^4.0.0",
-    "is-wsl": "^3.1.1",
     "package-manager-detector": "^1.6.0"
   },
   "devDependencies": {

--- a/packages/telemetry/src/system-info.ts
+++ b/packages/telemetry/src/system-info.ts
@@ -1,7 +1,6 @@
 import os from 'node:os';
 import { name as ciName, isCI } from 'ci-info';
 import isDocker from 'is-docker';
-import isWSL from 'is-wsl';
 
 /**
  * Astro Telemetry -- System Info
@@ -71,7 +70,7 @@ export function getSystemInfo(versions: { viteVersion: string; astroVersion: str
 		// Environment information
 		isDocker: isDocker(),
 		isTTY: process.stdout.isTTY,
-		isWSL,
+		isWSL: !!process.env.WSL_DISTRO_NAME,
 		isCI,
 		ciName,
 	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6872,9 +6872,6 @@ importers:
       is-docker:
         specifier: ^4.0.0
         version: 4.0.0
-      is-wsl:
-        specifier: ^3.1.1
-        version: 3.1.1
       package-manager-detector:
         specifier: ^1.6.0
         version: 1.6.0


### PR DESCRIPTION
## Changes

Replaces the `is-wsl` dependency with a `process.env.WSL_DISTRO_NAME` check

### Why it's safe to drop the dependency

Just checking for `process.env.WSL_DISTRO_NAME` is enough, [`WSL_DISTRO_NAME`](https://github.com/microsoft/WSL/blob/10a6ac3eee3bd8f109ae31de3388d85a953c4ecb/src/linux/init/util.h#L72) is [always set by WSL](https://github.com/microsoft/WSL/blob/10a6ac3eee3bd8f109ae31de3388d85a953c4ecb/src/linux/init/config.cpp#L841-L844) and is also what [`tinyclip`](https://github.com/tinylibs/tinyclip/blob/dd6e0030ebcad9bf2e1781f27978c54a7c793f9d/src/index.ts#L120) checks to detect the WSL environment



<!--
- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.
-->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Nothing to test, existing tests pass

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs needed
