### PR TITLE
feat: export AstroComponentLogger type

### DIFF
--- a/.changeset/export-logger.md
+++ b/.changeset/export-logger.md
@@ -2,5 +2,5 @@
 "astro": patch
 ---
 
-Fixes a bug where users couldn't properly type the logger functions at runtime. Now users can import `AstroRuntimeLogger`.
+Exposes the `AstroRuntimeLogger` interface to allow users to properly type the logger functions at runtime.
 

--- a/.changeset/export-logger.md
+++ b/.changeset/export-logger.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Export `AstroComponentLogger` public type for the runtime logger

--- a/.changeset/export-logger.md
+++ b/.changeset/export-logger.md
@@ -1,5 +1,6 @@
 ---
-"astro": minor
+"astro": patch
 ---
 
-Export `AstroComponentLogger` public type for the runtime logger
+Fixes a bug where users couldn't properly type the logger functions at runtime. Now users can import `AstroRuntimeLogger`.
+

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -599,7 +599,7 @@ export interface APIContext<
 	/**
 	 * It exposes utilities for logging messages.
 	 */
-	logger: AstroComponentLogger;
+	logger: AstroRuntimeLogger;
 
 	/**
 	 * The route currently rendered. It's stripped of the `srcDir` and the `pages` folder, and it doesn't contain the extension.

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -130,11 +130,11 @@ export interface AstroGlobal<
 }
 
 /**
- * The `AstroComponentLogger` exposes the logging functions available to Astro components, endpoints, and middleware.
+ * A type containing functions for logging messages.
  *
  * [Astro reference](https://docs.astro.build/en/reference/api-reference/#logger)
  */
-export interface AstroComponentLogger {
+export interface AstroRuntimeLogger {
 	/**
 	 * Logs a message with `info` level.
 	 */

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -130,6 +130,26 @@ export interface AstroGlobal<
 }
 
 /**
+ * The `AstroComponentLogger` exposes the logging functions available to Astro components, endpoints, and middleware.
+ *
+ * [Astro reference](https://docs.astro.build/en/reference/api-reference/#logger)
+ */
+export interface AstroComponentLogger {
+	/**
+	 * Logs a message with `info` level.
+	 */
+	info: (msg: string) => void;
+	/**
+	 * Logs a message with `warn` level.
+	 */
+	warn: (msg: string) => void;
+	/**
+	 * Logs a message with `error` level.
+	 */
+	error: (msg: string) => void;
+}
+
+/**
  * The `APIContext` is the object made available to endpoints and middleware.
  * It is a subset of the `Astro` global object available in pages.
  *
@@ -579,20 +599,7 @@ export interface APIContext<
 	/**
 	 * It exposes utilities for logging messages.
 	 */
-	logger: {
-		/**
-		 * Logs a message with `info` level.
-		 */
-		info: (msg: string) => void;
-		/**
-		 * Logs a message with `warn` level.
-		 */
-		warn: (msg: string) => void;
-		/**
-		 * Logs a message with `error` level.
-		 */
-		error: (msg: string) => void;
-	};
+	logger: AstroComponentLogger;
 
 	/**
 	 * The route currently rendered. It's stripped of the `srcDir` and the `pages` folder, and it doesn't contain the extension.


### PR DESCRIPTION
## Changes

- Extracts the `logger` type from `APIContext` to an exported `AstroComponentLogger` interface.
- This allows developers to easily type their custom middleware or integration functions that use the logger.
- Added a minor changeset.

## Testing

- The change is type-only and relies on TypeScript's compilation.
- Verified by running `pnpm run typecheck` and `pnpm run test:match "exports"`.
- No runtime behavioral changes were made.

## Docs

- Updated docs in PR withastro/docs#14203
