### PR TITLE
fix(markdown-satteri): clarify smartPunctuation default

### DIFF
--- a/.changeset/satteri-smart-punctuation-default-jsdoc.md
+++ b/.changeset/satteri-smart-punctuation-default-jsdoc.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-satteri': patch
+---
+
+Fixes the editor tooltip for `smartPunctuation` claiming it defaults to `false` when Astro enables it by default.

--- a/packages/markdown/satteri/src/index.ts
+++ b/packages/markdown/satteri/src/index.ts
@@ -15,6 +15,7 @@ export {
 export {
 	isSatteriProcessor,
 	satteri,
+	type SatteriFeatures,
 	type SatteriProcessorOptions,
 	type SatteriResolvedOptions,
 } from './processor.js';

--- a/packages/markdown/satteri/src/index.ts
+++ b/packages/markdown/satteri/src/index.ts
@@ -14,6 +14,7 @@ export {
 export {
 	isSatteriProcessor,
 	satteri,
+	type SatteriFeatures,
 	type SatteriProcessorOptions,
 	type SatteriResolvedOptions,
 } from './processor.js';

--- a/packages/markdown/satteri/src/processor.ts
+++ b/packages/markdown/satteri/src/processor.ts
@@ -14,7 +14,7 @@ export interface SatteriFeatures extends Omit<Features, 'smartPunctuation'> {
 	 *
 	 * Default: `true` in Astro.
 	 */
-	smartPunctuation?: boolean;
+	smartPunctuation?: Features['smartPunctuation'];
 }
 
 export interface SatteriProcessorOptions {

--- a/packages/markdown/satteri/src/processor.ts
+++ b/packages/markdown/satteri/src/processor.ts
@@ -8,10 +8,19 @@ import type {
 } from 'satteri';
 import { createSatteriMarkdownProcessor } from './satteri-processor.js';
 
+export interface SatteriFeatures extends Omit<Features, 'smartPunctuation'> {
+	/**
+	 * Smart punctuation à la SmartyPants.
+	 *
+	 * Default: `true` in Astro.
+	 */
+	smartPunctuation?: boolean;
+}
+
 export interface SatteriProcessorOptions {
 	mdastPlugins?: MdastPluginList;
 	hastPlugins?: HastPluginList;
-	features?: Features;
+	features?: SatteriFeatures;
 }
 
 /**
@@ -21,7 +30,7 @@ export interface SatteriProcessorOptions {
 export interface SatteriResolvedOptions {
 	mdastPlugins: MdastPluginEntry[];
 	hastPlugins: HastPluginEntry[];
-	features: Features;
+	features: SatteriFeatures;
 }
 
 /**

--- a/packages/markdown/satteri/src/processor.ts
+++ b/packages/markdown/satteri/src/processor.ts
@@ -2,10 +2,19 @@ import type { MarkdownProcessor } from '@astrojs/internal-helpers/markdown';
 import type { Features, HastPluginDefinition, MdastPluginDefinition } from 'satteri';
 import { createSatteriMarkdownProcessor } from './satteri-processor.js';
 
+export interface SatteriFeatures extends Omit<Features, 'smartPunctuation'> {
+	/**
+	 * Smart punctuation à la SmartyPants.
+	 *
+	 * Default: `true` in Astro.
+	 */
+	smartPunctuation?: boolean;
+}
+
 export interface SatteriProcessorOptions {
 	mdastPlugins?: MdastPluginDefinition[];
 	hastPlugins?: HastPluginDefinition[];
-	features?: Features;
+	features?: SatteriFeatures;
 }
 
 /**
@@ -15,7 +24,7 @@ export interface SatteriProcessorOptions {
 export interface SatteriResolvedOptions {
 	mdastPlugins: MdastPluginDefinition[];
 	hastPlugins: HastPluginDefinition[];
-	features: Features;
+	features: SatteriFeatures;
 }
 
 /**

--- a/packages/markdown/satteri/test/markdown.test.ts
+++ b/packages/markdown/satteri/test/markdown.test.ts
@@ -50,6 +50,15 @@ describe('satteri markdown', () => {
 		assert.ok(code.includes('"hello"'));
 	});
 
+	it('accepts a granular options object for `smartPunctuation`', async () => {
+		const renderer = await satteri({
+			features: { smartPunctuation: { dashes: false } },
+		}).createRenderer({});
+		const { code } = await renderer.render('He said "hello" -- really');
+		assert.match(code, /“hello”/);
+		assert.ok(code.includes('--'));
+	});
+
 	it('collects local image paths into metadata', async () => {
 		const processor = await createSatteriMarkdownProcessor();
 		const { metadata } = await processor.render('![alt](./local.png)');


### PR DESCRIPTION
## Summary

- add an Astro-specific `SatteriFeatures` type that overrides the upstream `smartPunctuation` JSDoc
- export the type so consumers see the corrected default in `satteri({ features })`

Fixes #17305.

## Testing

- `corepack pnpm --filter @astrojs/prism build`
- `corepack pnpm --filter @astrojs/internal-helpers build`
- `corepack pnpm --filter @astrojs/markdown-satteri build`
- `corepack pnpm --filter @astrojs/markdown-satteri test`
- `corepack pnpm exec prettier packages/markdown/satteri/src/processor.ts packages/markdown/satteri/src/index.ts --check`
- `git diff --check`

## Notes

AI-assisted. I manually reviewed the final diff and verification output.
