### PR TITLE
Prevent inlining scripts with dynamic imports

### DIFF
--- a/.changeset/quiet-eagles-call.md
+++ b/.changeset/quiet-eagles-call.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a build regression that could leave unresolved preload markers in inlined scripts with external dynamic imports

--- a/packages/astro/src/core/build/plugins/plugin-scripts.ts
+++ b/packages/astro/src/core/build/plugins/plugin-scripts.ts
@@ -1,7 +1,50 @@
-import type { BuildOptions, Plugin as VitePlugin } from 'vite';
+import type { BuildOptions, Plugin as VitePlugin, Rollup } from 'vite';
 import type { BuildInternals } from '../internal.js';
 import { shouldInlineAsset } from './util.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../constants.js';
+
+type GetModuleInfo = (moduleId: string) => Rollup.ModuleInfo | null;
+
+export type ScriptChunkInfo = Pick<
+	Rollup.OutputChunk,
+	'code' | 'facadeModuleId' | 'fileName' | 'imports' | 'dynamicImports' | 'moduleIds'
+>;
+
+export function chunkHasDynamicImports(
+	output: Pick<ScriptChunkInfo, 'dynamicImports' | 'moduleIds'>,
+	getModuleInfo: GetModuleInfo,
+) {
+	return (
+		output.dynamicImports.length > 0 ||
+		output.moduleIds.some((id) => (getModuleInfo(id)?.dynamicallyImportedIds.length ?? 0) > 0)
+	);
+}
+
+export function shouldInlineScriptChunk(
+	output: ScriptChunkInfo,
+	{
+		discoveredScripts,
+		importedIds,
+		assetInlineLimit,
+		getModuleInfo,
+	}: {
+		discoveredScripts: Set<string>;
+		importedIds: Set<string>;
+		assetInlineLimit: NonNullable<BuildOptions['assetsInlineLimit']>;
+		getModuleInfo: GetModuleInfo;
+	},
+) {
+	const facadeModuleId = output.facadeModuleId;
+	if (facadeModuleId === null) return false;
+
+	return (
+		discoveredScripts.has(facadeModuleId) &&
+		!importedIds.has(output.fileName) &&
+		output.imports.length === 0 &&
+		!chunkHasDynamicImports(output, getModuleInfo) &&
+		shouldInlineAsset(output.code, output.fileName, assetInlineLimit)
+	);
+}
 
 /**
  * Inline scripts from Astro files directly into the HTML.
@@ -33,18 +76,19 @@ export function pluginScripts(internals: BuildInternals): VitePlugin {
 				}
 			}
 
+			const getModuleInfo = this.getModuleInfo.bind(this);
 			for (const output of outputs) {
 				// Try to inline scripts that don't import anything as is within the inline limit
 				if (
 					output.type === 'chunk' &&
-					output.facadeModuleId &&
-					internals.discoveredScripts.has(output.facadeModuleId) &&
-					!importedIds.has(output.fileName) &&
-					output.imports.length === 0 &&
-					output.dynamicImports.length === 0 &&
-					shouldInlineAsset(output.code, output.fileName, assetInlineLimit)
+					shouldInlineScriptChunk(output, {
+						discoveredScripts: internals.discoveredScripts,
+						importedIds,
+						assetInlineLimit,
+						getModuleInfo,
+					})
 				) {
-					internals.inlinedScripts.set(output.facadeModuleId, output.code.trim());
+					internals.inlinedScripts.set(output.facadeModuleId!, output.code.trim());
 					delete bundle[output.fileName];
 				}
 			}

--- a/packages/astro/test/units/build/plugin-scripts.test.ts
+++ b/packages/astro/test/units/build/plugin-scripts.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	chunkHasDynamicImports,
+	shouldInlineScriptChunk,
+	type ScriptChunkInfo,
+} from '../../../dist/core/build/plugins/plugin-scripts.js';
+
+const scriptModuleId = '/src/Component.astro?astro&type=script&index=0&lang.ts';
+
+function createChunk(overrides: Partial<ScriptChunkInfo> = {}): ScriptChunkInfo {
+	return {
+		code: 'console.log("hello");',
+		facadeModuleId: scriptModuleId,
+		fileName: '_astro/Component.js',
+		imports: [],
+		dynamicImports: [],
+		moduleIds: [scriptModuleId],
+		...overrides,
+	};
+}
+
+function createGetModuleInfo(dynamicImportsById: Record<string, string[]> = {}) {
+	return (id: string) => ({ dynamicallyImportedIds: dynamicImportsById[id] ?? [] }) as any;
+}
+
+describe('pluginScripts', () => {
+	it('detects external dynamic imports from module info when output dynamicImports is empty', () => {
+		const chunk = createChunk({
+			moduleIds: ['\0vite/preload-helper.js', scriptModuleId],
+		});
+
+		assert.equal(
+			chunkHasDynamicImports(chunk, createGetModuleInfo({ [scriptModuleId]: ['/test.js'] })),
+			true,
+		);
+	});
+
+	it('does not inline discovered script chunks with dynamic imports in module info', () => {
+		const chunk = createChunk({
+			moduleIds: ['\0vite/preload-helper.js', scriptModuleId],
+		});
+
+		assert.equal(
+			shouldInlineScriptChunk(chunk, {
+				discoveredScripts: new Set([scriptModuleId]),
+				importedIds: new Set(),
+				assetInlineLimit: 4096,
+				getModuleInfo: createGetModuleInfo({ [scriptModuleId]: ['/test.js'] }),
+			}),
+			false,
+		);
+	});
+
+	it('inlines discovered script chunks that are unimported and have no imports', () => {
+		assert.equal(
+			shouldInlineScriptChunk(createChunk(), {
+				discoveredScripts: new Set([scriptModuleId]),
+				importedIds: new Set(),
+				assetInlineLimit: 4096,
+				getModuleInfo: createGetModuleInfo(),
+			}),
+			true,
+		);
+	});
+});


### PR DESCRIPTION
Fixes #17265

## Changes

- Prevents Astro from inlining script chunks when module metadata reports dynamic imports, including external dynamic imports omitted from Rolldown chunk metadata.
- Extracts the script inlining decision into testable helpers.

## Testing

- Adds unit coverage for external dynamic imports reported through module info while `chunk.dynamicImports` is empty.

## Docs

- No docs update needed; this restores expected build output behavior.