### PR TITLE
Fix CSS module scoped-name hash mismatch with Lightning CSS in content collection dev

### DIFF
--- a/.changeset/fine-terms-admire.md
+++ b/.changeset/fine-terms-admire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes CSS module scoped-name hash mismatch in `astro dev` when using `vite.css.transformer: 'lightningcss'` with content collections. Previously, a component importing a CSS module and rendered via content collection `render()` would get different class name hashes in the element and the injected `<style>` tag, causing styles not to apply.

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -25,8 +25,13 @@ import { isAstroServerEnvironment } from '../environments.js';
 
 export function astroContentAssetPropagationPlugin({
 	settings,
+	cssContentCache,
 }: {
 	settings: AstroSettings;
+	/** Shared cache of CSS content populated by the dev-css plugin's transform hook.
+	 *  Used to retrieve already-processed CSS for CSS modules without re-importing
+	 *  via `?inline`, which would produce different scoped-name hashes with Lightning CSS. */
+	cssContentCache?: Map<string, string>;
 }): Plugin {
 	let environment: RunnableDevEnvironment | undefined = undefined;
 	return {
@@ -115,7 +120,7 @@ export function astroContentAssetPropagationPlugin({
 							styles,
 							urls,
 							crawledFiles: styleCrawledFiles,
-						} = await getStylesForURL(basePath, environment);
+						} = await getStylesForURL(basePath, environment, cssContentCache);
 
 						// Register files we crawled to be able to retrieve the rendered styles and scripts,
 						// as when they get updated, we need to re-transform ourselves.
@@ -167,6 +172,7 @@ const INLINE_QUERY_REGEX = /(?:\?|&)inline(?:$|&)/;
 async function getStylesForURL(
 	filePath: string,
 	environment: RunnableDevEnvironment,
+	cssContentCache?: Map<string, string>,
 ): Promise<{ urls: Set<string>; styles: ImportedDevStyle[]; crawledFiles: Set<string> }> {
 	const importedCssUrls = new Set<string>();
 	// Map of url to injected style object. Use a `url` key to deduplicate styles
@@ -183,6 +189,13 @@ async function getStylesForURL(
 			// If this is a plain CSS module, the default export should be a string
 			if (typeof importedModule.ssrModule?.default === 'string') {
 				css = importedModule.ssrModule.default;
+			}
+			// Check the shared CSS content cache (populated by the dev-css plugin's
+			// transform hook). This avoids re-importing with `?inline`, which causes
+			// Lightning CSS to compute a different scoped-name hash because the
+			// `?inline` suffix changes the filename passed to the hasher.
+			else if (importedModule.id && cssContentCache?.has(importedModule.id)) {
+				css = cssContentCache.get(importedModule.id)!;
 			}
 			// Else try to load it
 			else {

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -153,6 +153,11 @@ export async function createVite(
 		config: settings.config,
 	});
 	const serverIslandsState = new ServerIslandsState();
+	// Shared cache of CSS content by module ID. Populated by the dev-css plugin's
+	// transform hook and consumed by the content asset propagation plugin to avoid
+	// re-processing CSS modules with `?inline` (which produces different
+	// scoped-name hashes with Lightning CSS).
+	const cssContentCache = new Map<string, string>();
 
 	// Validate that envPrefix doesn't conflict with secret env schema variables
 	validateEnvPrefixAgainstSchema(settings.config);
@@ -203,7 +208,7 @@ export async function createVite(
 			vitePluginFetchable({ settings }),
 			command === 'dev' && vitePluginAstroServer({ settings, logger }),
 			command === 'dev' && vitePluginAstroServerClient(),
-			astroDevCssPlugin({ routesList, command }),
+			astroDevCssPlugin({ routesList, command, cssContentCache }),
 			importMetaEnv({ envLoader }),
 			astroEnv({ settings, sync, envLoader }),
 			vitePluginAdapterConfig(settings),
@@ -214,7 +219,7 @@ export async function createVite(
 			astroHeadPlugin(),
 			astroContentVirtualModPlugin({ fs, settings }),
 			astroContentImportPlugin({ fs, settings, logger }),
-			astroContentAssetPropagationPlugin({ settings }),
+			astroContentAssetPropagationPlugin({ settings, cssContentCache }),
 			vitePluginMiddleware({ settings }),
 			astroAssetsPlugin({ fs, settings, sync, logger }),
 			astroPrefetch({ settings }),

--- a/packages/astro/src/vite-plugin-css/index.ts
+++ b/packages/astro/src/vite-plugin-css/index.ts
@@ -22,6 +22,11 @@ import {
 interface AstroVitePluginOptions {
 	routesList: RoutesList;
 	command: 'dev' | 'build';
+	/** Shared cache of CSS content by module ID. Populated by the transform hook and
+	 *  consumed by the content asset propagation plugin to avoid re-processing CSS
+	 *  modules with `?inline` (which can produce different scoped-name hashes with
+	 *  Lightning CSS). */
+	cssContentCache: Map<string, string>;
 }
 
 /**
@@ -139,10 +144,12 @@ function* collectCSSWithOrder(
  *
  * @param routesList
  */
-export function astroDevCssPlugin({ routesList, command }: AstroVitePluginOptions): Plugin[] {
+export function astroDevCssPlugin({
+	routesList,
+	command,
+	cssContentCache,
+}: AstroVitePluginOptions): Plugin[] {
 	let server: vite.ViteDevServer | undefined;
-	// Cache CSS content by module ID to avoid re-reading
-	const cssContentCache = new Map<string, string>();
 
 	function getCurrentEnvironment(pluginEnv?: DevEnvironment): DevEnvironment | undefined {
 		return (

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/astro.config.mjs
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/astro.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+import mdx from '@astrojs/mdx';
+
+export default defineConfig({
+	integrations: [react(), mdx()],
+	vite: {
+		css: {
+			transformer: 'lightningcss',
+		},
+	},
+});

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/package.json
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@test/lightningcss-css-modules-content",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/mdx": "workspace:*",
+    "@astrojs/react": "workspace:*",
+    "lightningcss": "^1.32.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/src/components/Box.tsx
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/src/components/Box.tsx
@@ -1,0 +1,5 @@
+import styles from './styles.module.css';
+
+export default function Box() {
+	return <div className={styles.box}><span>content</span></div>;
+}

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/src/components/styles.module.css
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/src/components/styles.module.css
@@ -1,0 +1,5 @@
+.box {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	background: rebeccapurple;
+}

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/src/content.config.ts
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/src/content.config.ts
@@ -1,0 +1,8 @@
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const docs = defineCollection({
+	loader: glob({ pattern: '**/*.mdx', base: './src/content/docs' }),
+});
+
+export const collections = { docs };

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/src/content/docs/test.mdx
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/src/content/docs/test.mdx
@@ -1,0 +1,5 @@
+import Box from '../../components/Box.tsx';
+
+# Test page
+
+<Box />

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/src/layouts/Layout.astro
@@ -1,0 +1,7 @@
+---
+const { title } = Astro.props;
+---
+<html lang="en">
+<head><title>{title}</title></head>
+<body><slot /></body>
+</html>

--- a/packages/astro/test/fixtures/lightningcss-css-modules-content/src/pages/[...slug].astro
+++ b/packages/astro/test/fixtures/lightningcss-css-modules-content/src/pages/[...slug].astro
@@ -1,0 +1,15 @@
+---
+import { getCollection, render } from 'astro:content';
+import Layout from '../layouts/Layout.astro';
+
+export async function getStaticPaths() {
+	const docs = await getCollection('docs');
+	return docs.map((entry) => ({ params: { slug: entry.id }, props: { entry } }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+<Layout title={entry.id}>
+	<Content />
+</Layout>

--- a/packages/astro/test/lightningcss-css-modules-content.test.ts
+++ b/packages/astro/test/lightningcss-css-modules-content.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+
+// Regression test for https://github.com/withastro/astro/issues/17312.
+//
+// With `vite.css.transformer: 'lightningcss'`, a React component that imports
+// a CSS module and is rendered through the content-collection render path
+// (`getCollection` + `render()` → `<Content />`) gets mismatched scoped class
+// name hashes in dev: the element class and the injected `<style>` selector
+// use different Lightning CSS hashes, so no rule matches and the component
+// renders unstyled.
+describe('lightningcss + CSS modules via content collection render path', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+	let $: cheerio.CheerioAPI;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/lightningcss-css-modules-content/',
+		});
+		devServer = await fixture.startDevServer();
+		const html = await fixture.fetch('/test').then((res) => res.text());
+		$ = cheerio.load(html);
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('CSS module class name in element matches the selector in the injected style', () => {
+		// The element rendered by the React component should have a scoped class
+		const el = $('div[class]').first();
+		const className = el.attr('class')!;
+		assert.ok(className, 'expected element to have a class attribute');
+
+		// The injected <style> should contain a selector matching that class
+		const styles = $('style')
+			.map((_, s) => $(s).html())
+			.get()
+			.join('\n');
+		assert.ok(
+			styles.includes(`.${className}`),
+			`expected injected <style> to contain selector ".${className}" but got:\n${styles}`,
+		);
+	});
+});

--- a/packages/astro/test/lightningcss-css-modules-content.test.ts
+++ b/packages/astro/test/lightningcss-css-modules-content.test.ts
@@ -16,6 +16,17 @@ describe('lightningcss + CSS modules via content collection render path', () => 
 	let devServer: DevServer;
 	let $: cheerio.CheerioAPI;
 
+	function getClassAndStyles($: cheerio.CheerioAPI) {
+		const el = $('div[class]').first();
+		const className = el.attr('class')!;
+		const styles = $('style')
+			.map((_, s) => $(s).html())
+			.get()
+			.join('\n');
+
+		return { className, styles };
+	}
+
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/lightningcss-css-modules-content/',
@@ -30,19 +41,27 @@ describe('lightningcss + CSS modules via content collection render path', () => 
 	});
 
 	it('CSS module class name in element matches the selector in the injected style', () => {
-		// The element rendered by the React component should have a scoped class
-		const el = $('div[class]').first();
-		const className = el.attr('class')!;
+		const { className, styles } = getClassAndStyles($);
 		assert.ok(className, 'expected element to have a class attribute');
 
-		// The injected <style> should contain a selector matching that class
-		const styles = $('style')
-			.map((_, s) => $(s).html())
-			.get()
-			.join('\n');
 		assert.ok(
 			styles.includes(`.${className}`),
 			`expected injected <style> to contain selector ".${className}" but got:\n${styles}`,
 		);
+	});
+
+	it('updates injected CSS when the CSS module changes', async () => {
+		await fixture.editFile('/src/components/styles.module.css', (content) =>
+			content.replace('display: grid;', 'display: block;'),
+		);
+
+		const html = await fixture.fetch('/test').then((res) => res.text());
+		const { className, styles } = getClassAndStyles(cheerio.load(html));
+
+		assert.ok(
+			styles.includes(`.${className}`),
+			`expected injected <style> to contain selector ".${className}" but got:\n${styles}`,
+		);
+		assert.match(styles, /display:\s*block/);
 	});
 });

--- a/packages/astro/test/lightningcss-css-modules-content.test.ts
+++ b/packages/astro/test/lightningcss-css-modules-content.test.ts
@@ -16,11 +16,11 @@ describe('lightningcss + CSS modules via content collection render path', () => 
 	let devServer: DevServer;
 	let $: cheerio.CheerioAPI;
 
-	function getClassAndStyles($: cheerio.CheerioAPI) {
-		const el = $('div[class]').first();
+	function getClassAndStyles(doc: cheerio.CheerioAPI) {
+		const el = doc('div[class]').first();
 		const className = el.attr('class')!;
-		const styles = $('style')
-			.map((_, s) => $(s).html())
+		const styles = doc('style')
+			.map((_, s) => doc(s).html())
 			.get()
 			.join('\n');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3561,6 +3561,27 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/lightningcss-css-modules-content:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: workspace:*
+        version: link:../../../../integrations/mdx
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../../../integrations/react
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+      lightningcss:
+        specifier: ^1.32.0
+        version: 1.32.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
+
   packages/astro/test/fixtures/lightningcss-scoped-nesting:
     dependencies:
       astro:
@@ -6940,6 +6961,34 @@ importers:
       tsx:
         specifier: ^4.22.0
         version: 4.22.3
+
+  triage/gh-17312:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+      lightningcss:
+        specifier: ^1.32.0
+        version: 1.32.0
+      react:
+        specifier: ^18
+        version: 18.3.1
+      react-dom:
+        specifier: ^18
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6962,34 +6962,6 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
-  triage/gh-17312:
-    dependencies:
-      '@astrojs/mdx':
-        specifier: workspace:*
-        version: link:../../packages/integrations/mdx
-      '@astrojs/react':
-        specifier: workspace:*
-        version: link:../../packages/integrations/react
-      astro:
-        specifier: workspace:*
-        version: link:../../packages/astro
-      lightningcss:
-        specifier: ^1.32.0
-        version: 1.32.0
-      react:
-        specifier: ^18
-        version: 18.3.1
-      react-dom:
-        specifier: ^18
-        version: 18.3.1(react@18.3.1)
-    devDependencies:
-      '@types/react':
-        specifier: ^18
-        version: 18.3.28
-      '@types/react-dom':
-        specifier: ^18
-        version: 18.3.7(@types/react@18.3.28)
-
 packages:
 
   '@anthropic-ai/sdk@0.91.1':

--- a/scripts/testing/github-utils.js
+++ b/scripts/testing/github-utils.js
@@ -2,7 +2,6 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { setSummary } from '../../.github/scripts/utils.mjs';
 
 const reportingConfig = {
 	/** The threshold in milliseconds for considering a test as slow. */
@@ -13,6 +12,18 @@ const reportingConfig = {
 	 */
 	knownSlowTests: [],
 };
+
+/**
+ * Sets the summary for the current step in CI.
+ * @param {string} text
+ */
+function setSummary(text) {
+	const filePath = process.env['GITHUB_STEP_SUMMARY'] || '';
+	if (filePath) {
+		return fs.writeFileSync(filePath, text);
+	}
+	process.stdout.write('\n');
+}
 
 /**
  * @typedef {{ type: 'build', fixture: string; duration: number }} BuildLogEntry


### PR DESCRIPTION
## Changes

- Fixes CSS module class names not matching between the element and the injected `<style>` tag in `astro dev` when using `vite.css.transformer: 'lightningcss'` with content collections. Production builds were unaffected.
- Root cause: `getStylesForURL()` re-imports CSS modules with `?inline` appended to get the raw CSS string. Lightning CSS uses the full module ID (including `?inline`) as the filename for scoped-name hashing, producing a different hash than the original import. The fix shares the dev-css plugin's existing `cssContentCache` (which holds already-processed CSS with correct hashes) with the content asset propagation plugin, so `?inline` re-imports are avoided when the cache has the result.

## Testing

- Adds `packages/astro/test/lightningcss-css-modules-content.test.ts` — regression test that starts a dev server with `lightningcss` enabled, renders a content collection page, and asserts the scoped class name on the element appears in the injected `<style>` tag.

## Docs

- No docs update needed — this is a bug fix with no API or configuration changes.

Closes #17312