### PR TITLE
Fix static build crash for file-extension endpoint routes with `trailingSlash: "always"`

### DIFF
--- a/packages/astro/src/core/routing/params.ts
+++ b/packages/astro/src/core/routing/params.ts
@@ -1,3 +1,4 @@
+import { hasFileExtension } from '@astrojs/internal-helpers/path';
 import type { GetStaticPathsItem } from '../../types/public/common.js';
 import type { AstroConfig } from '../../types/public/index.js';
 import type { RouteData } from '../../types/public/internal.js';
@@ -15,6 +16,14 @@ export function stringifyParams(
 	route: RouteData,
 	trailingSlash: AstroConfig['trailingSlash'],
 ) {
+	// Endpoint routes with file extensions (e.g. [slug].png.ts) should never
+	// append a trailing slash, matching the pattern generated in create-manifest.ts
+	// by trailingSlashForPath(). Without this, the generated path (e.g. /og/foo.png/)
+	// won't match the route pattern (e.g. /^\/og\/(.*?)\.png$/) and getParams() fails.
+	if (route.type === 'endpoint' && hasFileExtension(route.route)) {
+		trailingSlash = 'never';
+	}
+
 	// validate parameter values then stringify each value
 	const validatedParams: Record<string, string> = {};
 	for (const [key, value] of Object.entries(params)) {

--- a/packages/astro/test/units/routing/get-params.test.ts
+++ b/packages/astro/test/units/routing/get-params.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import { getParams } from '../../../dist/core/render/params-and-props.js';
+import { stringifyParams } from '../../../dist/core/routing/params.js';
 import { dynamicPart, makeRoute, spreadPart, staticPart } from './test-helpers.ts';
 import { createTestApp, createPage } from '../mocks.ts';
 
@@ -164,6 +165,50 @@ describe('getParams', () => {
 			const params = getParams(route, '/other/something');
 			assert.deepEqual(params, {});
 		});
+	});
+});
+
+describe('stringifyParams', () => {
+	it('should not append trailing slash for file extension endpoint routes with trailingSlash always (issue #17306)', () => {
+		const route = makeRoute({
+			route: '/og/[...slug].png',
+			segments: [[staticPart('og')], [spreadPart('...slug'), staticPart('.png')]],
+			trailingSlash: 'never',
+			pathname: undefined,
+			type: 'endpoint',
+		});
+
+		const result = stringifyParams({ slug: '概率论/参数估计' }, route, 'always');
+		assert.equal(result, '/og/概率论/参数估计.png');
+		// Verify the generated path matches the route pattern
+		assert.ok(route.pattern.test(result), 'generated path should match route pattern');
+	});
+
+	it('should not append trailing slash for single dynamic file extension endpoint', () => {
+		const route = makeRoute({
+			route: '/api/[name].json',
+			segments: [[staticPart('api')], [dynamicPart('name'), staticPart('.json')]],
+			trailingSlash: 'never',
+			pathname: undefined,
+			type: 'endpoint',
+		});
+
+		const result = stringifyParams({ name: 'bar' }, route, 'always');
+		assert.equal(result, '/api/bar.json');
+		assert.ok(route.pattern.test(result), 'generated path should match route pattern');
+	});
+
+	it('should still append trailing slash for endpoints without file extensions', () => {
+		const route = makeRoute({
+			route: '/api/[name]',
+			segments: [[staticPart('api')], [dynamicPart('name')]],
+			trailingSlash: 'always',
+			pathname: undefined,
+			type: 'endpoint',
+		});
+
+		const result = stringifyParams({ name: 'bar' }, route, 'always');
+		assert.equal(result, '/api/bar/');
 	});
 });
 


### PR DESCRIPTION
## Changes

- Dynamic endpoint routes with a file extension (e.g. `[...slug].png.ts`) no longer fail with `NoMatchingStaticPathFound` during `astro build` when `trailingSlash: "always"` is set. `stringifyParams()` now mirrors the `trailingSlashForPath()` logic already used in route pattern generation: when a route is an endpoint with a file extension, trailing slash is forced to `'never'`, so generated paths (e.g. `/og/foo.png`) match the route pattern (e.g. `/^\/og\/(.*?)\.png$/`). The mismatch affected both ASCII and non-ASCII params.

Closes #17306

## Testing

- Added three unit tests in `packages/astro/test/units/routing/get-params.test.ts` covering:
  - Spread file-extension endpoint with non-ASCII params + `trailingSlash: 'always'` — path must not get a trailing slash and must match the route pattern.
  - Single dynamic file-extension endpoint (`[name].json`) with the same config.
  - Endpoint *without* a file extension still gets a trailing slash, confirming the fix is scoped correctly.

## Docs

- No docs update needed — this is a bug fix for existing static build behavior with no API surface change.