### PR TITLE
Fix astro dev --force not replacing a running dev server

### DIFF
--- a/.changeset/new-lamps-fly.md
+++ b/.changeset/new-lamps-fly.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+---
+
+Fixes `astro dev --force` not replacing an already-running dev server
+

--- a/packages/astro/src/cli/dev/background.ts
+++ b/packages/astro/src/cli/dev/background.ts
@@ -11,7 +11,7 @@ import {
 	readLockFile,
 	removeLockFile,
 	isProcessAlive,
-	GRACEFUL_SHUTDOWN_TIMEOUT,
+	killDevServer,
 	type LockFileData,
 } from '../../core/dev/lockfile.js';
 import { resolveRoot } from '../../core/config/config.js';
@@ -73,26 +73,7 @@ export async function background({
 
 	// If --force, kill the existing server first
 	if (existing && flags.force) {
-		try {
-			process.kill(existing.pid, 'SIGTERM');
-		} catch {
-			// Already dead
-		}
-		// Wait for graceful shutdown before escalating to SIGKILL
-		const deadline = Date.now() + GRACEFUL_SHUTDOWN_TIMEOUT;
-		while (Date.now() < deadline) {
-			if (!isProcessAlive(existing.pid)) break;
-			await new Promise((r) => setTimeout(r, 100));
-		}
-		// If still alive after timeout, force kill
-		if (isProcessAlive(existing.pid)) {
-			try {
-				process.kill(existing.pid, 'SIGKILL');
-			} catch {
-				// Already dead
-			}
-		}
-		removeLockFile(root);
+		await killDevServer(root, existing);
 	}
 
 	// Build the args for the child process: plain `astro dev` (no --background)

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -2,7 +2,12 @@ import { detectAgenticEnvironment } from 'am-i-vibing';
 import colors from 'piccolore';
 import devServer from '../../core/dev/index.js';
 import { pathToFileURL } from 'node:url';
-import { checkExistingServer, removeLockFile, writeLockFile } from '../../core/dev/lockfile.js';
+import {
+	checkExistingServer,
+	killDevServer,
+	removeLockFile,
+	writeLockFile,
+} from '../../core/dev/lockfile.js';
 import { resolveRoot } from '../../core/config/config.js';
 import { printHelp } from '../../core/messages/runtime.js';
 import { type Flags, createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
@@ -107,15 +112,20 @@ export async function dev({ flags }: DevOptions) {
 	const root = pathToFileURL(resolveRoot(flags.root) + '/');
 	const existingServer = checkExistingServer(root);
 	if (existingServer) {
-		const message = [
-			'Another astro dev server is already running.',
-			'',
-			`  URL:  ${existingServer.url}`,
-			`  PID:  ${existingServer.pid}`,
-			'',
-			`Run \`astro dev stop\` to stop it, or use \`astro dev --force\` to replace it.`,
-		].join('\n');
-		throw new Error(message);
+		if (flags.force) {
+			// --force: kill the existing server and replace it
+			await killDevServer(root, existingServer);
+		} else {
+			const message = [
+				'Another astro dev server is already running.',
+				'',
+				`  URL:  ${existingServer.url}`,
+				`  PID:  ${existingServer.pid}`,
+				'',
+				`Run \`astro dev stop\` to stop it, or use \`astro dev --force\` to replace it.`,
+			].join('\n');
+			throw new Error(message);
+		}
 	}
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);

--- a/packages/astro/src/cli/dev/stop.ts
+++ b/packages/astro/src/cli/dev/stop.ts
@@ -1,12 +1,7 @@
 import type { AstroLogger } from '../../core/logger/core.js';
 import type { Flags } from '../flags.js';
 import { pathToFileURL } from 'node:url';
-import {
-	checkExistingServer,
-	removeLockFile,
-	isProcessAlive,
-	GRACEFUL_SHUTDOWN_TIMEOUT,
-} from '../../core/dev/lockfile.js';
+import { checkExistingServer, killDevServer } from '../../core/dev/lockfile.js';
 import { resolveRoot } from '../../core/config/config.js';
 
 export interface StopResult {
@@ -34,30 +29,7 @@ export async function stop({
 		return;
 	}
 
-	try {
-		process.kill(existing.pid, 'SIGTERM');
-	} catch {
-		// Process may have already exited between check and kill
-	}
-
-	// Wait for graceful shutdown before escalating to SIGKILL
-	const deadline = Date.now() + GRACEFUL_SHUTDOWN_TIMEOUT;
-	while (Date.now() < deadline) {
-		if (!isProcessAlive(existing.pid)) break;
-		await new Promise((r) => setTimeout(r, 100));
-	}
-
-	// If still alive after timeout, force kill
-	if (isProcessAlive(existing.pid)) {
-		try {
-			process.kill(existing.pid, 'SIGKILL');
-		} catch {
-			// Already dead
-		}
-	}
-
-	// Clean up the lock file in case the process didn't remove it
-	removeLockFile(root);
+	await killDevServer(root, existing);
 
 	logger.info('SKIP_FORMAT', `Stopped dev server (pid ${existing.pid}).`);
 }

--- a/packages/astro/src/core/dev/lockfile.ts
+++ b/packages/astro/src/core/dev/lockfile.ts
@@ -152,6 +152,40 @@ export function evaluateExistingServer(
 }
 
 /**
+ * Kill the dev server identified by `data` and clean up its lock file.
+ *
+ * Sends SIGTERM and waits up to {@link GRACEFUL_SHUTDOWN_TIMEOUT} for the
+ * process to exit, escalating to SIGKILL if it is still alive. The lock file
+ * is always removed afterwards so a new server can start.
+ */
+export async function killDevServer(root: URL, data: LockFileData): Promise<void> {
+	try {
+		process.kill(data.pid, 'SIGTERM');
+	} catch {
+		// Process may have already exited between check and kill
+	}
+
+	// Wait for graceful shutdown before escalating to SIGKILL
+	const deadline = Date.now() + GRACEFUL_SHUTDOWN_TIMEOUT;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(data.pid)) break;
+		await new Promise((r) => setTimeout(r, 100));
+	}
+
+	// If still alive after timeout, force kill
+	if (isProcessAlive(data.pid)) {
+		try {
+			process.kill(data.pid, 'SIGKILL');
+		} catch {
+			// Already dead
+		}
+	}
+
+	// Clean up the lock file in case the process didn't remove it
+	removeLockFile(root);
+}
+
+/**
  * Check for an existing dev server by reading the lock file and checking process liveness.
  * Automatically cleans up stale lock files.
  * Returns the server info if a live server is found, null otherwise.

--- a/packages/astro/test/units/dev/lockfile.test.ts
+++ b/packages/astro/test/units/dev/lockfile.test.ts
@@ -1,9 +1,18 @@
 import * as assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { after, before, describe, it } from 'node:test';
 import {
 	parseLockFile,
 	serializeLockFile,
 	evaluateExistingServer,
+	killDevServer,
+	writeLockFile,
+	readLockFile,
+	isProcessAlive,
 	type LockFileData,
 } from '../../../dist/core/dev/lockfile.js';
 
@@ -176,6 +185,57 @@ describe('evaluateExistingServer', () => {
 		assert.notEqual(result, null);
 		assert.equal(result!.stale, true);
 		assert.deepEqual(result!.data, validData);
+	});
+});
+// #endregion
+
+// #region killDevServer
+describe('killDevServer', () => {
+	let tempDir: string;
+	let root: URL;
+
+	before(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'astro-lockfile-'));
+		root = pathToFileURL(tempDir + '/');
+	});
+
+	after(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('removes the lock file when the process is already dead', async () => {
+		// Use a PID that is very unlikely to be alive.
+		const data: LockFileData = {
+			...validData,
+			pid: 999_999,
+		};
+		writeLockFile(root, data);
+		assert.notEqual(readLockFile(root), null);
+
+		await killDevServer(root, data);
+
+		assert.equal(readLockFile(root), null);
+	});
+
+	it('kills a live process and removes the lock file', async () => {
+		// Spawn a long-running child process.
+		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+			stdio: 'ignore',
+		});
+		const pid = child.pid!;
+		// Wait until the child is confirmed alive.
+		assert.equal(isProcessAlive(pid), true);
+
+		const data: LockFileData = {
+			...validData,
+			pid,
+		};
+		writeLockFile(root, data);
+
+		await killDevServer(root, data);
+
+		assert.equal(isProcessAlive(pid), false);
+		assert.equal(readLockFile(root), null);
 	});
 });
 // #endregion


### PR DESCRIPTION
## Changes

- `astro dev --force` now actually replaces an already-running dev server instead of always erroring, matching the behavior already promised by the error message.
- Extracts the SIGTERM → wait → SIGKILL → remove-lock-file sequence into a shared `killDevServer` helper in `core/dev/lockfile.ts`, and reuses it in `stop.ts` and `background.ts` (previously duplicated in both).

## Testing

- Adds `killDevServer` unit tests in `test/units/dev/lockfile.test.ts`: killing a live spawned process and cleaning up the lock file, and cleaning up the lock file when the recorded PID is already dead.

## Docs

- No docs update needed — `--force` is already documented for `astro dev`; this fixes it to match existing documented behavior.