### PR TITLE
fix(satteri): route highlighted code blocks through MDX pre components

### DIFF
--- a/.changeset/satteri-mdx-highlight-pre.md
+++ b/.changeset/satteri-mdx-highlight-pre.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/markdown-satteri": patch
+"@astrojs/mdx": patch
+---
+
+Fixes custom `pre` components not applying to syntax-highlighted code blocks when using the Sätteri Markdown processor with MDX.

--- a/packages/integrations/mdx/src/satteri/index.ts
+++ b/packages/integrations/mdx/src/satteri/index.ts
@@ -11,6 +11,7 @@ import {
 import { createDefaultAstroMetadata } from 'astro/markdown';
 import {
 	mdxToJs,
+	type HastNode,
 	type HastPluginDefinition,
 	type MdastPluginDefinition,
 	type MdxCompileOptions,
@@ -21,7 +22,7 @@ import { shouldAddCharset } from './charset.js';
 import { type AstroMetadata, createAstroMetadataPlugin } from './hast-astro-metadata.js';
 import { createImageToComponentPlugin, type ImageImportInfo } from './hast-images-to-component.js';
 
-type HighlightFn = (code: string, lang: string, meta?: string) => Promise<string>;
+type HighlightFn = (code: string, lang: string, meta?: string) => Promise<HastNode>;
 
 export type { MdastPluginDefinition, HastPluginDefinition, MarkdownHeading };
 export type { AstroMetadata } from './hast-astro-metadata.js';
@@ -96,9 +97,7 @@ export function createMdxProcessor(
 
 			const hastPlugins: HastPluginDefinition[] = [];
 			if (highlightFn) {
-				// `mdx: true` wraps the highlighted HTML in a JSX `<Fragment set:html>` node
-				// rather than a raw HTML node, since the Sätteri pipeline is compiling to JSX.
-				hastPlugins.push(satteriHighlightPlugin(highlightFn, excludeLangs, { mdx: true }));
+				hastPlugins.push(satteriHighlightPlugin(highlightFn, excludeLangs));
 			}
 			if (satteriOptions.hastPlugins.length) {
 				hastPlugins.push(...satteriOptions.hastPlugins);

--- a/packages/integrations/mdx/src/satteri/jsx-utils.ts
+++ b/packages/integrations/mdx/src/satteri/jsx-utils.ts
@@ -1,8 +1,8 @@
 import type { MdxJsxAttributeNode, MdxJsxFlowElementHast, MdxJsxTextElementHast } from 'satteri';
 
 // JSX-specific helpers used by the MDX pipeline. Non-MDX equivalents (e.g.
-// `makeFragmentNode`, `collectHastText`) live in `@astrojs/markdown-satteri`
-// because they're shared with the markdown render pipeline.
+// `collectHastText`) live in `@astrojs/markdown-satteri` because they're shared
+// with the markdown render pipeline.
 
 // Sätteri hands plugin visitors readonly nodes; these helpers only read them.
 export type MdxJsxHastNode = Readonly<MdxJsxFlowElementHast | MdxJsxTextElementHast>;

--- a/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre-optimize/src/components/Preformatted.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre-optimize/src/components/Preformatted.astro
@@ -1,0 +1,5 @@
+---
+const { class: className, ...rest } = Astro.props;
+---
+
+<pre data-custom-pre="rendered" class={className} {...rest}><slot /></pre>

--- a/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre-optimize/src/pages/index.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre-optimize/src/pages/index.mdx
@@ -1,0 +1,9 @@
+import Preformatted from '../components/Preformatted.astro';
+
+export const components = { pre: Preformatted };
+
+# Highlighted code through components.pre
+
+```js
+console.log("Hello, world!");
+```

--- a/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre/src/components/Preformatted.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre/src/components/Preformatted.astro
@@ -1,0 +1,5 @@
+---
+const { class: className, ...rest } = Astro.props;
+---
+
+<pre data-custom-pre="rendered" class={className} {...rest}><slot /></pre>

--- a/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre/src/pages/index.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-satteri-highlight-pre/src/pages/index.mdx
@@ -1,0 +1,9 @@
+import Preformatted from '../components/Preformatted.astro';
+
+export const components = { pre: Preformatted };
+
+# Highlighted code through components.pre
+
+```js
+console.log("Hello, world!");
+```

--- a/packages/integrations/mdx/test/mdx-satteri.test.ts
+++ b/packages/integrations/mdx/test/mdx-satteri.test.ts
@@ -53,3 +53,53 @@ describe('MDX with the Sätteri processor', () => {
 		assert.equal(frontmatterByPage['./test-with-frontmatter.mdx'].title, 'The Frontmatter Title');
 	});
 });
+
+describe('MDX Sätteri highlighting routes through components.pre', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-satteri-highlight-pre/', import.meta.url),
+			integrations: [mdx()],
+			markdown: {
+				processor: satteri(),
+			},
+		});
+
+		await fixture.build();
+	});
+
+	it('renders highlighted code blocks through a custom `pre` component', async () => {
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		const pre = document.querySelector('pre');
+		assert.equal(pre?.getAttribute('data-custom-pre'), 'rendered');
+		assert.match(pre?.innerHTML ?? '', /style="color:/);
+	});
+});
+
+describe('MDX Sätteri highlighting routes through components.pre with optimize', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-satteri-highlight-pre-optimize/', import.meta.url),
+			integrations: [mdx({ optimize: true })],
+			markdown: {
+				processor: satteri(),
+			},
+		});
+
+		await fixture.build();
+	});
+
+	it('keeps highlighted blocks addressable by `components.pre` when optimized', async () => {
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		const pre = document.querySelector('pre');
+		assert.equal(pre?.getAttribute('data-custom-pre'), 'rendered');
+		assert.match(pre?.innerHTML ?? '', /style="color:/);
+	});
+});

--- a/packages/markdown/satteri/package.json
+++ b/packages/markdown/satteri/package.json
@@ -29,6 +29,7 @@
     "@astrojs/internal-helpers": "workspace:*",
     "@astrojs/prism": "workspace:*",
     "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
     "satteri": "^0.9.1"
   },
   "devDependencies": {

--- a/packages/markdown/satteri/src/index.ts
+++ b/packages/markdown/satteri/src/index.ts
@@ -7,7 +7,6 @@ export {
 	createHighlightPlugin as satteriShikiPlugin,
 	createHighlightFn as satteriCreateHighlightFn,
 	collectHastText as satteriCollectHastText,
-	makeFragmentNode as satteriMakeFragmentNode,
 	type SatteriAstroData,
 	createSatteriMarkdownProcessor,
 	type SatteriMarkdownProcessorOptions,

--- a/packages/markdown/satteri/src/satteri-processor.ts
+++ b/packages/markdown/satteri/src/satteri-processor.ts
@@ -13,7 +13,7 @@ import type {
 	MarkdownRenderer,
 } from '@astrojs/internal-helpers/markdown';
 
-type HighlightFn = (code: string, lang: string, meta?: string) => Promise<string>;
+type HighlightFn = (code: string, lang: string, meta?: string) => Promise<HastNode>;
 
 declare module 'satteri' {
 	interface DataMap {
@@ -106,15 +106,6 @@ export function collectHastText(
 	return text;
 }
 
-export function makeFragmentNode(html: string): HastNode {
-	return {
-		type: 'mdxJsxFlowElement',
-		name: 'Fragment',
-		attributes: [{ type: 'mdxJsxAttribute', name: 'set:html', value: html }],
-		children: [],
-	} as unknown as HastNode;
-}
-
 export function createHeadingIdsPlugin(): HastPluginDefinition {
 	const slugger = new Slugger();
 	// Collect headings in a separate array so we can make this idempotent
@@ -140,10 +131,6 @@ export function createHeadingIdsPlugin(): HastPluginDefinition {
 			},
 		},
 	};
-}
-
-function makeRawNode(html: string): HastNode {
-	return { type: 'raw', value: html } as unknown as HastNode;
 }
 
 const HAST_PRESERVED_PROPERTIES = new Set(['className', 'htmlFor']);
@@ -190,14 +177,12 @@ export function createImageMarkerPlugin(): HastPluginDefinition {
 export function createHighlightPlugin(
 	highlight: HighlightFn,
 	excludeLangs: string[] | undefined,
-	options?: { mdx?: boolean },
 ): HastPluginDefinition {
-	const wrapResult = options?.mdx ? makeFragmentNode : makeRawNode;
 	return {
 		name: 'highlight',
 		element: {
 			filter: ['pre'],
-			async visit(node, ctx) {
+			visit(node, ctx) {
 				const codeChild = node.children?.find(
 					(c: HastNode) => c.type === 'element' && c.tagName === 'code',
 				) as HastNode | undefined;
@@ -214,8 +199,7 @@ export function createHighlightPlugin(
 				}
 
 				const code = ctx.textContent(codeChild).replace(/\n$/, '');
-				const html = await highlight(code, lang, meta);
-				return wrapResult(html);
+				return highlight(code, lang, meta);
 			},
 		},
 	};
@@ -230,7 +214,9 @@ export interface SatteriMarkdownProcessorOptions extends AstroMarkdownOptions {
 /**
  * Build the highlighter for the Sätteri pipeline, or `undefined` when syntax
  * highlighting is disabled. Shiki and Prism both resolve to a `HighlightFn`
- * that turns a code block into a complete `<pre>` HTML string.
+ * that turns a code block into a `<pre>` hast element. Returning real hast
+ * (rather than a raw HTML string) keeps the `<pre>` addressable by the MDX
+ * pipeline, so `components.pre` overrides still apply to highlighted blocks.
  */
 export async function createHighlightFn(
 	syntaxHighlight: AstroMarkdownOptions['syntaxHighlight'],
@@ -251,19 +237,23 @@ export async function createHighlightFn(
 			langAlias: shikiConfig?.langAlias,
 		});
 		return (code, lang, meta) =>
-			hl.codeToHtml(code, lang, {
-				meta,
-				wrap: shikiConfig?.wrap,
-				defaultColor: shikiConfig?.defaultColor,
-				transformers: shikiConfig?.transformers,
-			});
+			hl
+				.codeToHast(code, lang, {
+					meta,
+					wrap: shikiConfig?.wrap,
+					defaultColor: shikiConfig?.defaultColor,
+					transformers: shikiConfig?.transformers,
+				})
+				.then((root) => root.children[0] as HastNode);
 	}
 
 	if (syntaxHighlightType === 'prism') {
 		const { runHighlighterWithAstro } = await import('@astrojs/prism/dist/highlighter');
+		const { fromHtml } = await import('hast-util-from-html');
 		return async (code, lang) => {
 			const { html, classLanguage } = await runHighlighterWithAstro(lang, code);
-			return `<pre class="${classLanguage}" data-language="${lang}"><code class="${classLanguage}">${html}</code></pre>`;
+			const pre = `<pre class="${classLanguage}" data-language="${lang}"><code class="${classLanguage}">${html}</code></pre>`;
+			return fromHtml(pre, { fragment: true }).children[0] as HastNode;
 		};
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6877,6 +6877,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      hast-util-from-html:
+        specifier: ^2.0.3
+        version: 2.0.3
       satteri:
         specifier: ^0.9.1
         version: 0.9.1


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/astro/issues/17340

This PR makes it so the Sätteri processor uses HAST for code blocks like the Unified pipeline does, leading the final MDX to render it using normal components instead of raw strings.

## Testing

Added new tests and current ones should pass

## Docs

N/A
