### PR TITLE
Improve rendering performance for pages with many components

### DIFF
--- a/.changeset/tidy-heads-run.md
+++ b/.changeset/tidy-heads-run.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves rendering performance for pages with many component instances, such as repeated MDX `<Content />` components.

--- a/benchmark/bench/rendering-perf.bench.js
+++ b/benchmark/bench/rendering-perf.bench.js
@@ -12,6 +12,12 @@ import { beforeAll, bench, describe } from 'vitest';
  * - many-slots:         #9 eager slot prerendering
  * - large-array:        #8 BufferedRenderer per array child
  * - static-heavy:       #1 markHTMLString baseline, #11/#12 future comparison
+ * - head-propagation-*: propagator collection in collectPropagatedHeadParts
+ *
+ * The head-propagation pages run at two sizes (1000 and 2000 propagating
+ * <Content /> instances) so complexity-class regressions are visible: with
+ * linear collection the 2000-page costs ~2x the 1000-page, while a quadratic
+ * scan over the propagator set pushes that ratio toward 4x.
  *
  * Requires: pnpm run build:bench
  */
@@ -67,6 +73,16 @@ describe('Rendering perf (non-streaming)', () => {
 		const request = new Request(new URL('http://example.com/static-heavy'));
 		await nonStreamingApp.render(request);
 	});
+
+	bench('head-propagation-1000 (propagator collection)', async () => {
+		const request = new Request(new URL('http://example.com/head-propagation-1000'));
+		await nonStreamingApp.render(request);
+	});
+
+	bench('head-propagation-2000 (propagator collection, 2x scale)', async () => {
+		const request = new Request(new URL('http://example.com/head-propagation-2000'));
+		await nonStreamingApp.render(request);
+	});
 });
 
 // Streaming path — included for comparison. Optimizations to the sync path
@@ -85,6 +101,11 @@ describe('Rendering perf (streaming)', () => {
 
 	bench('large-array [streaming]', async () => {
 		const request = new Request(new URL('http://example.com/large-array'));
+		await streamingApp.render(request);
+	});
+
+	bench('head-propagation-2000 [streaming]', async () => {
+		const request = new Request(new URL('http://example.com/head-propagation-2000'));
 		await streamingApp.render(request);
 	});
 });

--- a/benchmark/make-project/rendering-perf.js
+++ b/benchmark/make-project/rendering-perf.js
@@ -91,6 +91,58 @@ const className = \`styled-\${id}\`;
 };
 
 // ---------------------------------------------------------------------------
+// Content collection (used by the head-propagation pages)
+// ---------------------------------------------------------------------------
+
+// A single tiny MDX entry. MDX opts into content propagation
+// (`handlePropagation: true`), so the route is marked as a propagation route
+// and every rendered `<Content />` instance registers a head propagator. Plain
+// data-store markdown does NOT take this path, which is why the entry must be
+// MDX. Kept minimal so the pages below measure the propagator collection
+// machinery, not MDX rendering.
+const contentConfig = `\
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const notes = defineCollection({
+	loader: glob({ pattern: '*', base: './data/notes' }),
+});
+
+export const collections = { notes };
+`;
+
+const noteEntry = `\
+---
+title: Note
+---
+
+A tiny entry rendered thousands of times per page.
+`;
+
+// Head-propagation scaling: every <Content /> instance registers a head
+// propagator, so these pages put N entries in the propagator set that
+// `collectPropagatedHeadParts` iterates before the head is flushed. Generated
+// at two sizes so the scaling *shape* is visible, not just a point cost:
+// linear collection keeps the 2000-page near 2x the 1000-page, while a
+// quadratic rescan (the regression this guards against) pushes it toward 4x.
+const headPropagationPage = (n) => `\
+---
+import { getEntry, render } from 'astro:content';
+
+const entry = await getEntry('notes', 'note');
+const { Content } = await render(entry);
+const items = Array.from({ length: ${n} });
+---
+<html>
+  <head><title>Head Propagation ${n}</title></head>
+  <body>
+    <h1>${n} propagating Content instances</h1>
+    {items.map(() => <Content />)}
+  </body>
+</html>
+`;
+
+// ---------------------------------------------------------------------------
 // Pages
 // ---------------------------------------------------------------------------
 
@@ -244,6 +296,10 @@ const title = "Static Heavy Page";
   </body>
 </html>
 `,
+
+	// Head-propagation propagator collection at N and 2N (see headPropagationPage).
+	'pages/head-propagation-1000.astro': headPropagationPage(1000),
+	'pages/head-propagation-2000.astro': headPropagationPage(2000),
 };
 
 // ---------------------------------------------------------------------------
@@ -261,8 +317,9 @@ export async function run(projectDir) {
 	await fs.rm(projectDir, { recursive: true, force: true });
 	await fs.mkdir(new URL('./src/pages', projectDir), { recursive: true });
 	await fs.mkdir(new URL('./src/components', projectDir), { recursive: true });
+	await fs.mkdir(new URL('./data/notes', projectDir), { recursive: true });
 
-	const allFiles = { ...components, ...pages };
+	const allFiles = { ...components, ...pages, 'content.config.ts': contentConfig };
 
 	await Promise.all(
 		Object.entries(allFiles).map(([name, content]) => {
@@ -270,15 +327,19 @@ export async function run(projectDir) {
 		}),
 	);
 
+	await fs.writeFile(new URL('./data/notes/note.mdx', projectDir), noteEntry, 'utf-8');
+
 	await fs.writeFile(
 		new URL('./astro.config.js', projectDir),
 		`\
+import mdx from '@astrojs/mdx';
 import { defineConfig } from 'astro/config';
 import adapter from '@benchmark/adapter';
 
 export default defineConfig({
 	output: 'server',
 	adapter: adapter(),
+	integrations: [mdx()],
 });`,
 		'utf-8',
 	);

--- a/packages/astro/src/core/head-propagation/buffer.ts
+++ b/packages/astro/src/core/head-propagation/buffer.ts
@@ -12,14 +12,13 @@ export interface HeadPropagator {
  * its children, and one of those children may be a `self` component that emits
  * styles. Slots add a second way to find them — a slot whose markup contains an
  * `await` only reaches the components after that `await` once it resolves, so
- * we also wait for those pending slot pre-renders. We keep initializing
- * propagators and waiting on slots until no new ones appear.
+ * the pending slot pre-renders are fully drained before moving on to the next
+ * propagator.
  *
- * Propagators are tracked in a `seen` set rather than read through a single
- * live `Set` iterator. A propagator can be registered after we have already
- * iterated to the end of the set (e.g. once a slot's `await` resolves), and a
- * `Set` iterator that has reported `done` would never report those late
- * additions.
+ * A single pass over the live `Set` reaches every late registration: a `Set`
+ * iterator visits entries added during iteration (in insertion order), and
+ * because slots are drained before the iterator advances, nothing can register
+ * a propagator after the iterator has reported `done`.
  *
  * @example
  * If a layout initializes and discovers a nested component that also emits
@@ -31,41 +30,33 @@ export async function collectPropagatedHeadParts(input: {
 	isHeadAndContent: (value: unknown) => value is { head: string };
 }): Promise<string[]> {
 	const collectedHeadParts: string[] = [];
-	const seen = new Set<HeadPropagator>();
 	// Populated (only on propagation routes) by eager async slot pre-renders.
 	const pendingSlotEvaluations = input.result._metadata?.pendingSlotEvaluations ?? [];
 
-	while (true) {
-		// 1. Drain async slot pre-renders first. Resolving them runs the slot
-		//    markup past its `await`s, registering any propagators inside.
-		if (pendingSlotEvaluations.length > 0) {
+	// Resolving a pending slot pre-render runs the slot markup past its
+	// `await`s, registering any propagators inside — and possibly queueing
+	// deeper slot pre-renders, hence the loop.
+	const drainPendingSlots = async () => {
+		while (pendingSlotEvaluations.length > 0) {
 			const batch = pendingSlotEvaluations.splice(0, pendingSlotEvaluations.length);
 			await Promise.all(batch);
-			continue;
 		}
+	};
 
-		// 2. Initialize the next not-yet-seen propagator. `init()` may register
-		//    further propagators or queue more slot evaluations.
-		let progressed = false;
-		for (const propagator of input.propagators) {
-			if (seen.has(propagator)) continue;
-			seen.add(propagator);
-			progressed = true;
-
-			const returnValue = await propagator.init(input.result);
-			// Only collect explicit head-bearing return values.
-			if (input.isHeadAndContent(returnValue) && returnValue.head) {
-				collectedHeadParts.push(returnValue.head);
-			}
-			// Only initialize one propagator per `for` pass, then break back to
-			// the `while`. This is not the same as letting the `for` run to its
-			// end: `init()` above may have queued new slot pre-renders, and
-			// breaking returns to step 1 so those are drained before the next
-			// propagator is initialized.
-			break;
+	// Keep this as a single pass over the live `Set` so collection stays O(N).
+	// Draining pending slots before the iterator advances lets it discover
+	// propagators registered by async slot evaluations.
+	await drainPendingSlots();
+	for (const propagator of input.propagators) {
+		const returnValue = await propagator.init(input.result);
+		// Only collect explicit head-bearing return values.
+		if (input.isHeadAndContent(returnValue) && returnValue.head) {
+			collectedHeadParts.push(returnValue.head);
 		}
-
-		if (!progressed) break;
+		// `init()` may have queued new slot pre-renders. Drain them before the
+		// iterator advances so any propagators they register are appended while
+		// the iterator is still active.
+		await drainPendingSlots();
 	}
 
 	return collectedHeadParts;

--- a/packages/astro/test/units/render/head-propagation/buffer.test.ts
+++ b/packages/astro/test/units/render/head-propagation/buffer.test.ts
@@ -136,4 +136,68 @@ describe('head propagation buffer', () => {
 		assert.deepEqual(collected, ['<style>.outer{}</style>', '<style>.inner{}</style>']);
 		assert.equal(result._metadata.pendingSlotEvaluations.length, 0);
 	});
+
+	it('drains async slot pre-renders queued by a propagator before advancing', async () => {
+		const propagators = new Set<HeadPropagator>();
+		const result = createResult();
+		propagators.add({
+			init() {
+				result._metadata.pendingSlotEvaluations.push(
+					tick().then(() => {
+						propagators.add({
+							init: () => createHeadAndContentLike('<style>.from-async-slot{}</style>'),
+						});
+					}),
+				);
+				return createHeadAndContentLike('<style>.initial{}</style>');
+			},
+		});
+
+		const collected = await collectPropagatedHeadParts({ propagators, result, isHeadAndContent });
+
+		assert.deepEqual(collected, ['<style>.initial{}</style>', '<style>.from-async-slot{}</style>']);
+		assert.equal(result._metadata.pendingSlotEvaluations.length, 0);
+	});
+
+	it('iterates the propagator set linearly, not quadratically', async () => {
+		// Pages can render thousands of propagating component instances (e.g.
+		// MDX `<Content />` repeated in a loop). A collection strategy that
+		// restarts its scan of the set per propagator is O(N²) in iteration
+		// steps and dominates render time at that scale.
+		let steps = 0;
+		class CountingSet<T> extends Set<T> {
+			[Symbol.iterator](): SetIterator<T> {
+				const iterator = super[Symbol.iterator]();
+				const counting = {
+					[Symbol.iterator]() {
+						return counting;
+					},
+					next() {
+						steps++;
+						return iterator.next();
+					},
+				};
+				return counting as SetIterator<T>;
+			}
+		}
+
+		const count = 100;
+		const propagators = new CountingSet<HeadPropagator>();
+		for (let i = 0; i < count; i++) {
+			propagators.add({ init: () => createHeadAndContentLike(`<style>.s${i}{}</style>`) });
+		}
+
+		const collected = await collectPropagatedHeadParts({
+			propagators,
+			result: createResult(),
+			isHeadAndContent,
+		});
+
+		assert.equal(collected.length, count);
+		// A restart-per-propagator scan takes ~N²/2 steps (~5,000 for N=100).
+		assert.ok(
+			steps <= count * 3,
+			`expected linear iteration over ${count} propagators, took ${steps} steps`,
+		);
+	});
 });


### PR DESCRIPTION
## Changes

- Replaces the restart-per-propagator head collection scan with a single traversal of the live `Set`, restoring linear rendering performance on pages with many component instances.
- Fully drains pending async slot evaluations before advancing the iterator, preserving discovery order and ensuring propagators registered after an `await` are still collected.

## Testing

- Adds a unit test that counts `Set` iterator steps and fails if collection returns to the previous quadratic scan pattern.
- Adds a unit test covering async slot work queued during `init()`, including the late propagator registration and complete queue drain.

## Docs

- No documentation update is needed because this restores expected rendering performance without changing public APIs or behavior.

Closes #17343