### PR TITLE
fix(language-server): fail with a clear error when TypeScript 7 native compiler is used

### DIFF
--- a/.changeset/tsgo-check-guard.md
+++ b/.changeset/tsgo-check-guard.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fixes an opaque `Cannot read properties of undefined (reading 'fileExists')` crash when `astro check` runs against the TypeScript 7 native compiler. The native compiler does not ship the programmatic API the checker relies on yet, so `astro check` now fails early with a clear message pointing to the tracking issue instead.

--- a/packages/language-tools/language-server/src/check.ts
+++ b/packages/language-tools/language-server/src/check.ts
@@ -140,6 +140,7 @@ export class AstroCheck {
 
 	private initialize() {
 		this.ts = this.typescriptPath ? require(this.typescriptPath) : require('typescript');
+		this.assertCompatibleTypeScript();
 		const tsconfigPath = this.getTsconfig();
 
 		const languagePlugins = [
@@ -191,6 +192,25 @@ export class AstroCheck {
 						languageServiceHost,
 					);
 				},
+			);
+		}
+	}
+
+	/**
+	 * The checker is built on Volar and TypeScript's programmatic Language Service API
+	 * (`ts.sys`, `ts.findConfigFile`, `LanguageServiceHost`, etc.). TypeScript's native
+	 * compiler does not ship that API yet — `require('typescript')` only exposes `version`
+	 * and `versionMajorMinor` — so continuing would crash later with an opaque
+	 * `Cannot read properties of undefined` error. Fail early with an actionable message.
+	 */
+	private assertCompatibleTypeScript() {
+		if (typeof this.ts.findConfigFile !== 'function' || this.ts.sys === undefined) {
+			const version = this.ts.version ? ` (found ${this.ts.version})` : '';
+			throw new Error(
+				`The TypeScript module loaded${version} does not expose the programmatic API that \`astro check\` relies on. ` +
+					`TypeScript's native compiler (7.0 and later) does not ship this API yet. ` +
+					`Until it does, run \`astro check\` with a TypeScript version that still provides it (6.x). ` +
+					`See https://github.com/withastro/roadmap/discussions/1321 to track support.`,
 			);
 		}
 	}

--- a/packages/language-tools/language-server/test/check/check.test.ts
+++ b/packages/language-tools/language-server/test/check/check.test.ts
@@ -57,3 +57,22 @@ describe('AstroCheck', async () => {
 		assert.strictEqual(result.status, 'completed');
 	});
 });
+
+describe('AstroCheck with an incompatible TypeScript', () => {
+	it('Fails with an actionable error when the TypeScript module lacks the programmatic API', () => {
+		// The TypeScript 7 native compiler only exposes `version`/`versionMajorMinor`,
+		// not `ts.sys` / `ts.findConfigFile`. Without the guard this crashes later with
+		// an opaque `Cannot read properties of undefined (reading 'fileExists')`.
+		const ts7StubPath = require.resolve('./ts7-native-stub.cjs');
+
+		assert.throws(
+			() => new AstroCheck(checkFixtureDir, ts7StubPath, undefined),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.match(error.message, /does not expose the programmatic API/);
+				assert.match(error.message, /found 7\.0\.2/);
+				return true;
+			},
+		);
+	});
+});

--- a/packages/language-tools/language-server/test/check/ts7-native-stub.cjs
+++ b/packages/language-tools/language-server/test/check/ts7-native-stub.cjs
@@ -1,0 +1,8 @@
+// Mimics the TypeScript 7 native compiler, which only exposes `version` and
+// `versionMajorMinor` and none of the programmatic Language Service API
+// (`ts.sys`, `ts.findConfigFile`, …) that `astro check` relies on.
+// Used to exercise the guard in `AstroCheck` without installing TypeScript 7.
+module.exports = {
+	version: '7.0.2',
+	versionMajorMinor: '7.0',
+};


### PR DESCRIPTION
### Changes

Running `astro check` (or the `@astrojs/language-server` CLI checker) against the **TypeScript 7 native compiler** currently crashes with an opaque error:

```
Cannot read properties of undefined (reading 'fileExists')
  at AstroCheck.getTsconfig (.../@astrojs/language-server/dist/check.js)
```

Root cause: the checker is built on Volar and TypeScript's programmatic Language Service API (`ts.sys`, `ts.findConfigFile`, `LanguageServiceHost`, …). The TypeScript 7 native compiler doesn't ship that API yet — `require('typescript')` resolves to a module that only exposes `version` and `versionMajorMinor`:

```js
const ts = require('typescript'); // typescript@7.0.2
Object.keys(ts); // -> ['version', 'versionMajorMinor']
ts.sys;          // -> undefined
ts.findConfigFile; // -> undefined
```

So `getTsconfig()` dereferences `this.ts.sys.fileExists` on `undefined` and throws before the user gets any hint about what went wrong.

This PR adds an early guard in `AstroCheck.initialize()` that detects a TypeScript build lacking the programmatic API and throws an actionable error instead:

> The TypeScript module loaded (found 7.0.2) does not expose the programmatic API that `astro check` relies on. This is expected with the TypeScript 7 native compiler, which does not ship that API yet. Use TypeScript 6.x for `astro check` for now — see https://github.com/withastro/roadmap/discussions/1321 for the tracking issue.

This does not add TypeScript 7 support (that's blocked on TypeScript's new API, tracked in withastro/roadmap#1321) — it just turns a confusing crash into a clear, actionable message.

### Testing

- With a TS7-shaped module (`{ version, versionMajorMinor }`): the new error is thrown instead of the `fileExists` crash.
- With a real TypeScript (`ts.sys` / `ts.findConfigFile` present): the guard is a no-op and existing behavior is unchanged.
- `pnpm --filter @astrojs/language-server build` passes; the file matches Prettier config.

### Docs

Not needed — no public API or documented behavior changes; only the failure message for an already-unsupported configuration.
