### PR TITLE
Fix /_image 500 when catch-all prerendered route is combined with prerenderEnvironment: 'node'

### DIFF
--- a/.changeset/shiny-llamas-repair.md
+++ b/.changeset/shiny-llamas-repair.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where requests handled by the dev prerender environment (e.g. `/_image` with `@astrojs/cloudflare`'s `prerenderEnvironment: 'node'`) returned a 500 when a prerendered catch-all route existed, because non-prerendered route modules were imported in an environment where their runtime-specific APIs are unavailable

--- a/packages/astro/src/core/routing/dev.ts
+++ b/packages/astro/src/core/routing/dev.ts
@@ -86,7 +86,7 @@ export async function matchRoute(
 	const altPathname = pathname.replace(/\/index\.html$/, '/').replace(/\.html$/, '');
 
 	if (altPathname !== pathname) {
-		return await matchRoute(altPathname, routesList, pipeline, manifest);
+		return await matchRoute(altPathname, routesList, pipeline, manifest, { prerenderOnly });
 	}
 
 	if (matches.length) {

--- a/packages/astro/src/core/routing/dev.ts
+++ b/packages/astro/src/core/routing/dev.ts
@@ -24,6 +24,7 @@ export async function matchRoute(
 	routesList: RoutesList,
 	pipeline: RunnablePipeline,
 	manifest: SSRManifest,
+	{ prerenderOnly }: { prerenderOnly?: boolean } = {},
 ): Promise<MatchedRoute | undefined> {
 	const { logger, routeCache } = pipeline;
 	const matches = matchAllRoutes(pathname, routesList);
@@ -35,6 +36,13 @@ export async function matchRoute(
 
 	let firstError: unknown = null;
 	for await (const { route: maybeRoute, filePath } of preloadedMatches) {
+		// When running as the prerender handler, skip non-prerendered routes
+		// before importing their components. Their modules may use runtime-
+		// specific APIs (e.g. cloudflare:workers) unavailable in the prerender
+		// environment.
+		if (prerenderOnly && !maybeRoute.prerender) {
+			continue;
+		}
 		// attempt to get static paths
 		// if this fails, we have a bad URL match!
 		try {

--- a/packages/astro/src/core/routing/dev.ts
+++ b/packages/astro/src/core/routing/dev.ts
@@ -35,12 +35,14 @@ export async function matchRoute(
 	});
 
 	let firstError: unknown = null;
+	let skippedPrerenderOnly = false;
 	for await (const { route: maybeRoute, filePath } of preloadedMatches) {
 		// When running as the prerender handler, skip non-prerendered routes
 		// before importing their components. Their modules may use runtime-
 		// specific APIs (e.g. cloudflare:workers) unavailable in the prerender
 		// environment.
 		if (prerenderOnly && !maybeRoute.prerender) {
+			skippedPrerenderOnly = true;
 			continue;
 		}
 		// attempt to get static paths
@@ -87,6 +89,14 @@ export async function matchRoute(
 
 	if (altPathname !== pathname) {
 		return await matchRoute(altPathname, routesList, pipeline, manifest, { prerenderOnly });
+	}
+
+	// A non-prerendered route matched but was skipped above. Don't warn or fall
+	// back to the 404 route (which may be prerendered and would shadow the SSR
+	// route): returning undefined lets the caller mark the request as not
+	// handled, so it falls through to the SSR handler and its own full matching.
+	if (skippedPrerenderOnly) {
+		return undefined;
 	}
 
 	if (matches.length) {

--- a/packages/astro/src/vite-plugin-app/app.ts
+++ b/packages/astro/src/vite-plugin-app/app.ts
@@ -98,12 +98,16 @@ export class AstroServerApp extends BaseApp<RunnablePipeline> {
 		this.pipeline.clearActions();
 	}
 
-	async devMatch(pathname: string): Promise<DevMatch | undefined> {
+	async devMatch(
+		pathname: string,
+		{ prerenderOnly }: { prerenderOnly?: boolean } = {},
+	): Promise<DevMatch | undefined> {
 		const matchedRoute = await matchRoute(
 			pathname,
 			this.manifestData,
 			this.pipeline as unknown as RunnablePipeline,
 			this.manifest,
+			{ prerenderOnly },
 		);
 		if (!matchedRoute) {
 			return undefined;
@@ -200,7 +204,7 @@ export class AstroServerApp extends BaseApp<RunnablePipeline> {
 			controller,
 			pathname,
 			async run() {
-				const matchedRoute = await self.devMatch(pathname);
+				const matchedRoute = await self.devMatch(pathname, { prerenderOnly });
 				if (!matchedRoute) {
 					if (prerenderOnly) {
 						// In prerender-only mode, signal that we didn't handle this

--- a/packages/astro/test/units/routing/prerender-only-match.test.ts
+++ b/packages/astro/test/units/routing/prerender-only-match.test.ts
@@ -16,7 +16,10 @@ import type { SSRManifest } from '../../../dist/core/app/types.js';
  * imported in the current environment (e.g. `cloudflare:workers` in Node).
  * `loadedComponents` records every component whose module was requested.
  */
-function createMockPipelineAndManifest(componentLoaders: Record<string, () => any>) {
+function createMockPipelineAndManifest(
+	componentLoaders: Record<string, () => any>,
+	logger = defaultLogger,
+) {
 	const loadedComponents: string[] = [];
 	const routeCache = new RouteCache(defaultLogger);
 	const manifest = {
@@ -29,7 +32,7 @@ function createMockPipelineAndManifest(componentLoaders: Record<string, () => an
 		outDir: new URL('file:///fake/'),
 	} as unknown as SSRManifest;
 	const pipeline = {
-		logger: defaultLogger,
+		logger,
 		routeCache,
 		manifest,
 		getComponentByRoute(route: RouteData) {
@@ -61,6 +64,15 @@ const prerenderedCatchAll = makeRoute({
 	route: '/[...slug]',
 	pathname: undefined,
 	component: 'src/pages/[...slug].astro',
+	prerender: true,
+});
+
+const prerendered404 = makeRoute({
+	segments: [[staticPart('404')]],
+	trailingSlash,
+	route: '/404',
+	pathname: '/404',
+	component: 'src/pages/404.astro',
 	prerender: true,
 });
 
@@ -137,6 +149,72 @@ describe('matchRoute with prerenderOnly', () => {
 			!loadedComponents.includes('src/pages/foo.ts'),
 			'Expected the non-prerendered component to never be imported on the retry',
 		);
+	});
+
+	// A prerendered custom 404 must not shadow the skipped SSR route: the
+	// prerender handler would render a 404 for /_image instead of letting the
+	// SSR handler serve it.
+	it('does not fall back to a prerendered 404 when candidates were skipped', async () => {
+		const { pipeline, manifest, loadedComponents } = createMockPipelineAndManifest({
+			'@astrojs/cloudflare/image-transform-endpoint': runtimeOnlyModule,
+			'src/pages/[...slug].astro': () => ({
+				getStaticPaths: () => [{ params: { slug: 'blog' } }],
+			}),
+		});
+
+		const routesList = { routes: [ssrImageEndpoint, prerenderedCatchAll, prerendered404] };
+		const result = await matchRoute('/_image', routesList, pipeline, manifest, {
+			prerenderOnly: true,
+		});
+
+		assert.equal(result, undefined, 'Expected no match so the SSR handler takes over');
+		assert.ok(
+			!loadedComponents.includes('@astrojs/cloudflare/image-transform-endpoint'),
+			'Expected the non-prerendered component to never be imported',
+		);
+	});
+
+	it('still falls back to the 404 when nothing was skipped', async () => {
+		const { pipeline, manifest } = createMockPipelineAndManifest({
+			'@astrojs/cloudflare/image-transform-endpoint': runtimeOnlyModule,
+		});
+
+		const routesList = { routes: [ssrImageEndpoint, prerendered404] };
+		const result = await matchRoute('/nope', routesList, pipeline, manifest, {
+			prerenderOnly: true,
+		});
+
+		assert.ok(result, 'Expected the 404 fallback for a genuinely unmatched path');
+		assert.equal(result.route.route, '/404');
+	});
+
+	it('does not log NoMatchingStaticPathFound when candidates were skipped', async () => {
+		const warnings: string[] = [];
+		const spyLogger = {
+			warn: (_label: string | null, message: string) => {
+				warnings.push(message);
+			},
+			error: () => {},
+			info: () => {},
+			debug: () => {},
+		} as unknown as typeof defaultLogger;
+
+		const { pipeline, manifest } = createMockPipelineAndManifest(
+			{
+				'@astrojs/cloudflare/image-transform-endpoint': runtimeOnlyModule,
+				'src/pages/[...slug].astro': () => ({
+					getStaticPaths: () => [{ params: { slug: 'blog' } }],
+				}),
+			},
+			spyLogger,
+		);
+
+		const routesList = { routes: [ssrImageEndpoint, prerenderedCatchAll] };
+		await matchRoute('/_image', routesList, pipeline, manifest, {
+			prerenderOnly: true,
+		});
+
+		assert.deepEqual(warnings, [], 'Expected no router warning for skipped SSR candidates');
 	});
 
 	it('returns prerendered matches as usual', async () => {

--- a/packages/astro/test/units/routing/prerender-only-match.test.ts
+++ b/packages/astro/test/units/routing/prerender-only-match.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { matchRoute } from '../../../dist/core/routing/dev.js';
+import { makeRoute, spreadPart, staticPart } from './test-helpers.ts';
+import { defaultLogger } from '../test-utils.ts';
+import { RouteCache } from '../../../dist/core/render/route-cache.js';
+
+import type { RunnablePipeline } from '../../../dist/vite-plugin-app/pipeline.js';
+import type { RouteData } from '../../../dist/types/public/index.js';
+import type { SSRManifest } from '../../../dist/core/app/types.js';
+
+/**
+ * Creates a minimal mock pipeline and manifest for testing matchRoute.
+ * `componentLoaders` maps route component paths to functions producing their
+ * module exports; a loader that throws simulates a module that cannot be
+ * imported in the current environment (e.g. `cloudflare:workers` in Node).
+ * `loadedComponents` records every component whose module was requested.
+ */
+function createMockPipelineAndManifest(componentLoaders: Record<string, () => any>) {
+	const loadedComponents: string[] = [];
+	const routeCache = new RouteCache(defaultLogger);
+	const manifest = {
+		serverLike: false,
+		base: '/',
+		trailingSlash: 'ignore',
+		rootDir: new URL('file:///fake/'),
+		routes: [],
+		buildClientDir: new URL('file:///fake/client/'),
+		outDir: new URL('file:///fake/'),
+	} as unknown as SSRManifest;
+	const pipeline = {
+		logger: defaultLogger,
+		routeCache,
+		manifest,
+		getComponentByRoute(route: RouteData) {
+			loadedComponents.push(route.component);
+			return componentLoaders[route.component]();
+		},
+	} as unknown as RunnablePipeline;
+	return { pipeline, manifest, loadedComponents };
+}
+
+const trailingSlash = 'ignore';
+
+// A non-prerendered endpoint whose module only loads in a specific runtime,
+// like @astrojs/cloudflare's /_image endpoint importing `cloudflare:workers`.
+const ssrImageEndpoint = makeRoute({
+	segments: [[staticPart('_image')]],
+	trailingSlash,
+	route: '/_image',
+	pathname: '/_image',
+	type: 'endpoint',
+	component: '@astrojs/cloudflare/image-transform-endpoint',
+	prerender: false,
+	origin: 'external',
+});
+
+const prerenderedCatchAll = makeRoute({
+	segments: [[spreadPart('...slug')]],
+	trailingSlash,
+	route: '/[...slug]',
+	pathname: undefined,
+	component: 'src/pages/[...slug].astro',
+	prerender: true,
+});
+
+const runtimeOnlyModule = () => {
+	throw new Error("Cannot import 'cloudflare:workers' outside the workerd runtime");
+};
+
+describe('matchRoute with prerenderOnly', () => {
+	// Regression test for #17348: a prerendered catch-all makes the dev
+	// prerender gate route /_image through the Node prerender handler, which
+	// previously imported the endpoint's module there and crashed.
+	it('skips non-prerendered routes without importing their components', async () => {
+		const { pipeline, manifest, loadedComponents } = createMockPipelineAndManifest({
+			'@astrojs/cloudflare/image-transform-endpoint': runtimeOnlyModule,
+			'src/pages/[...slug].astro': () => ({
+				getStaticPaths: () => [{ params: { slug: 'blog' } }],
+			}),
+		});
+
+		const routesList = { routes: [ssrImageEndpoint, prerenderedCatchAll] };
+		const result = await matchRoute('/_image', routesList, pipeline, manifest, {
+			prerenderOnly: true,
+		});
+
+		assert.equal(result, undefined, 'Expected no match so the SSR handler takes over');
+		assert.ok(
+			!loadedComponents.includes('@astrojs/cloudflare/image-transform-endpoint'),
+			'Expected the non-prerendered component to never be imported',
+		);
+	});
+
+	it('still imports non-prerendered components without prerenderOnly', async () => {
+		const { pipeline, manifest } = createMockPipelineAndManifest({
+			'@astrojs/cloudflare/image-transform-endpoint': runtimeOnlyModule,
+			'src/pages/[...slug].astro': () => ({
+				getStaticPaths: () => [{ params: { slug: 'blog' } }],
+			}),
+		});
+
+		const routesList = { routes: [ssrImageEndpoint, prerenderedCatchAll] };
+		await assert.rejects(
+			() => matchRoute('/_image', routesList, pipeline, manifest),
+			/cloudflare:workers/,
+		);
+	});
+
+	it('keeps filtering through the .html alt-pathname retry', async () => {
+		const ssrEndpoint = makeRoute({
+			segments: [[staticPart('foo')]],
+			trailingSlash,
+			route: '/foo',
+			pathname: '/foo',
+			type: 'endpoint',
+			component: 'src/pages/foo.ts',
+			prerender: false,
+		});
+
+		const { pipeline, manifest, loadedComponents } = createMockPipelineAndManifest({
+			'src/pages/foo.ts': runtimeOnlyModule,
+			'src/pages/[...slug].astro': () => ({
+				getStaticPaths: () => [{ params: { slug: 'bar' } }],
+			}),
+		});
+
+		// '/foo.html' matches no candidate, so matchRoute retries with '/foo',
+		// which must keep skipping the non-prerendered endpoint.
+		const routesList = { routes: [ssrEndpoint, prerenderedCatchAll] };
+		const result = await matchRoute('/foo.html', routesList, pipeline, manifest, {
+			prerenderOnly: true,
+		});
+
+		assert.equal(result, undefined, 'Expected no match so the SSR handler takes over');
+		assert.ok(
+			!loadedComponents.includes('src/pages/foo.ts'),
+			'Expected the non-prerendered component to never be imported on the retry',
+		);
+	});
+
+	it('returns prerendered matches as usual', async () => {
+		const { pipeline, manifest } = createMockPipelineAndManifest({
+			'@astrojs/cloudflare/image-transform-endpoint': runtimeOnlyModule,
+			'src/pages/[...slug].astro': () => ({
+				getStaticPaths: () => [{ params: { slug: 'blog' } }],
+			}),
+		});
+
+		const routesList = { routes: [ssrImageEndpoint, prerenderedCatchAll] };
+		const result = await matchRoute('/blog', routesList, pipeline, manifest, {
+			prerenderOnly: true,
+		});
+
+		assert.ok(result, 'Expected the prerendered catch-all to match');
+		assert.equal(result.route.component, 'src/pages/[...slug].astro');
+	});
+});

--- a/packages/integrations/cloudflare/test/dev-image-endpoint.test.ts
+++ b/packages/integrations/cloudflare/test/dev-image-endpoint.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import cloudflare from '../dist/index.js';
 import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
 
 describe('Dev image endpoint', () => {
@@ -49,5 +50,38 @@ describe('Dev image endpoint', () => {
 		const res = await fixture.fetch('/_image?href=/placeholder.jpg&f=avif&w=100');
 		assert.equal(res.status, 200);
 		assert.equal(res.headers.get('content-type'), 'image/avif');
+	});
+});
+
+describe('Dev image endpoint with prerenderEnvironment: node', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/dev-image-endpoint/',
+			adapter: cloudflare({ prerenderEnvironment: 'node' }),
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	// Regression test for #17348: the prerendered catch-all route makes the
+	// dev prerender gate send /_image through the Node prerender handler,
+	// which previously imported the image endpoint (and its top-level
+	// `cloudflare:workers` import) in Node and returned a 500.
+	it('transforms local images when a prerendered catch-all route exists', async () => {
+		const res = await fixture.fetch('/_image?href=/placeholder.jpg&f=png&w=100');
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('content-type'), 'image/png');
+	});
+
+	it('renders the prerendered catch-all page', async () => {
+		const res = await fixture.fetch('/catch-all-page');
+		assert.equal(res.status, 200);
+		const html = await res.text();
+		assert.ok(html.includes('id="catch-all"'), 'Expected the catch-all page content');
 	});
 });

--- a/packages/integrations/cloudflare/test/fixtures/dev-image-endpoint/src/pages/[...slug].astro
+++ b/packages/integrations/cloudflare/test/fixtures/dev-image-endpoint/src/pages/[...slug].astro
@@ -1,0 +1,17 @@
+---
+export const prerender = true;
+
+export function getStaticPaths() {
+	return [{ params: { slug: 'catch-all-page' } }];
+}
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Catch-all Page</title>
+	</head>
+	<body>
+		<h1 id="catch-all">Catch-all page</h1>
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7119,15 +7119,6 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
-  triage/repro-17348:
-    dependencies:
-      '@astrojs/cloudflare':
-        specifier: workspace:*
-        version: link:../../packages/integrations/cloudflare
-      astro:
-        specifier: workspace:*
-        version: link:../../packages/astro
-
 packages:
 
   '@anthropic-ai/sdk@0.91.1':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7119,6 +7119,15 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
+  triage/repro-17348:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/integrations/cloudflare
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+
 packages:
 
   '@anthropic-ai/sdk@0.91.1':


### PR DESCRIPTION
Closes #17348

## Changes

- When the prerender handler processes a request (e.g. `/_image`), `matchRoute` now skips routes with `prerender: false` before importing their component modules. Previously, `/_image`'s component (`@astrojs/cloudflare/image-transform-endpoint`) was eagerly imported in the Node prerender environment, where its top-level `import { env } from 'cloudflare:workers'` fails. A prerendered catch-all like `[...slug].astro` was enough to trigger this path because `matchAllRoutes` returns it as a candidate for `/_image`, causing the broad prerender gate in `plugin.ts` to invoke the prerender handler for the request.
- Threads the existing `prerenderOnly` flag from `handleRequest` through `devMatch` into `matchRoute` to carry the filtering down to the right place.

## Testing

- No new test added — a dedicated fixture would need to combine `prerenderEnvironment: 'node'`, a catch-all prerendered route, and the Cloudflare image endpoint together. Existing tests (`dev-image-endpoint.test.ts`, `prerender-node-env.test.ts`) continue to pass. The fix was verified manually by the issue reporter.

## Docs

- No docs update needed; this restores documented behavior with no API changes.
