### PR TITLE
fix(transitions): preserve same-document history traversal

### DIFF
--- a/.changeset/thirty-doors-trade.md
+++ b/.changeset/thirty-doors-trade.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes browser back and forward traversal incorrectly triggering a page transition when a same-document history entry is rewritten with `history.replaceState()`.

--- a/packages/astro/e2e/view-transitions.test.ts
+++ b/packages/astro/e2e/view-transitions.test.ts
@@ -4,6 +4,7 @@ import { type DevServer, testFactory, waitForHydrate, warmupDevServer } from './
 declare global {
 	interface Window {
 		preloads: string[];
+		transitionCount: number;
 		clientSideRouterForTestsParkedHere?: (
 			url: string,
 			options?: { history?: 'auto' | 'replace' | 'push' },
@@ -445,6 +446,44 @@ test.describe('View Transitions', () => {
 		await page.goForward();
 		locator = page.locator('#click-one-again');
 		await expect(locator).toBeInViewport();
+	});
+
+	test('Rewritten fragment entries remain same-document history navigations', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/long-page'));
+		await page.evaluate(() => {
+			window.transitionCount = 0;
+			document.addEventListener('astro:before-preparation', () => {
+				window.transitionCount++;
+			});
+		});
+
+		await expect(page.locator('#click-one-again')).not.toBeInViewport();
+		await page.click('#click-scroll-down');
+		let locator = page.locator('#click-one-again');
+		await expect(locator).toBeInViewport();
+		await expect(page.locator('#click-scroll-down')).not.toBeInViewport();
+
+		await page.click('#click-scroll-up');
+		locator = page.locator('#click-scroll-down');
+		await expect(locator).toBeInViewport();
+
+		await page.evaluate(() => {
+			history.replaceState(history.state, '', location.pathname + location.search);
+		});
+		await expect(page).toHaveURL(astro.resolveUrl('/long-page'));
+
+		await page.goBack();
+		locator = page.locator('#click-one-again');
+		await expect(locator).toBeInViewport();
+
+		await page.goForward();
+		locator = page.locator('#click-scroll-down');
+		await expect(locator).toBeInViewport();
+
+		expect(await page.evaluate(() => window.transitionCount)).toBe(0);
 	});
 
 	test('View Transitions Rule', async ({ page, astro }) => {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -9,6 +9,8 @@ type State = {
 	index: number;
 	scrollX: number;
 	scrollY: number;
+	// Whether this entry was created from the preceding entry without swapping the document.
+	sameDocument?: boolean;
 };
 type Navigation = { controller: AbortController };
 type Transition = {
@@ -68,17 +70,19 @@ let parser: DOMParser;
 // you can figure it using an index. On pushState the index is incremented so you
 // can use that to determine popstate if going forward or back.
 let currentHistoryIndex = 0;
+let currentEntryIsSameDocument = false;
 
 if (inBrowser) {
 	if (history.state) {
 		// Here we reloaded a page with history state
 		// (e.g. history navigation from non-transition page or browser reload)
 		currentHistoryIndex = history.state.index;
+		currentEntryIsSameDocument = history.state.sameDocument ?? false;
 		scrollTo({ left: history.state.scrollX, top: history.state.scrollY });
 	} else if (transitionEnabledOnThisPage()) {
 		// This page is loaded from the browser address bar or via a link from extern,
 		// it needs a state in the history
-		history.replaceState({ index: currentHistoryIndex, scrollX, scrollY }, '');
+		history.replaceState({ index: currentHistoryIndex, scrollX, scrollY, sameDocument: false }, '');
 		history.scrollRestoration = 'manual';
 	}
 }
@@ -171,14 +175,20 @@ const moveToLocation = (
 	options: Options,
 	pageTitleForBrowserHistory: string,
 	historyState?: State,
+	sameDocumentNavigation = false,
 ) => {
 	const intraPage = samePage(from, to);
+	const changesLocation = to.href !== location.href && !historyState;
 
 	const targetPageTitle = document.title;
 	document.title = pageTitleForBrowserHistory;
 
 	let scrolledToTop = false;
-	if (to.href !== location.href && !historyState) {
+	if (changesLocation) {
+		const sameDocument =
+			sameDocumentNavigation && options.history === 'replace'
+				? currentEntryIsSameDocument
+				: sameDocumentNavigation;
 		if (options.history === 'replace') {
 			const current = history.state;
 			history.replaceState(
@@ -187,17 +197,27 @@ const moveToLocation = (
 					index: current.index,
 					scrollX: current.scrollX,
 					scrollY: current.scrollY,
+					sameDocument,
 				},
 				'',
 				to.href,
 			);
 		} else {
 			history.pushState(
-				{ ...options.state, index: ++currentHistoryIndex, scrollX: 0, scrollY: 0 },
+				{
+					...options.state,
+					index: ++currentHistoryIndex,
+					scrollX: 0,
+					scrollY: 0,
+					sameDocument,
+				},
 				'',
 				to.href,
 			);
 		}
+	}
+	if (historyState || changesLocation) {
+		currentEntryIsSameDocument = history.state.sameDocument ?? false;
 	}
 	document.title = targetPageTitle;
 	// now we are on the new page for non-history navigation!
@@ -365,8 +385,15 @@ async function transition(
 		updateScrollPosition({ scrollX, scrollY });
 	}
 	if (samePage(from, to) && !options.formData) {
-		if ((direction !== 'back' && to.hash) || (direction === 'back' && from.hash)) {
-			moveToLocation(to, from, options, document.title, historyState);
+		const traversesSameDocument =
+			navigationType === 'traverse' &&
+			(direction === 'back' ? currentEntryIsSameDocument : (historyState?.sameDocument ?? false));
+		if (
+			traversesSameDocument ||
+			(direction !== 'back' && to.hash) ||
+			(direction === 'back' && from.hash)
+		) {
+			moveToLocation(to, from, options, document.title, historyState, true);
 			if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
 			return;
 		}


### PR DESCRIPTION
When a navigate() was a sameDocument switch, prevent back/forward navigation from triggering a view transition.

This change enables users to replaceState after a navigate() if they want to remove an anchor from the URL without Astro triggering view transitions later, during back/forward navigation.


```typescript
await navigate("#top", {
  history: "push",
  ...
});
history.replaceState(
  history.state,
  "",
  window.location.pathname + window.location.search
);
```

## Testing

- My own site, after backporting to 6.4.8. It used the `navigate -> replaceState` trick above
- new e2e test

## Docs

Possibly needs to change https://docs.astro.build/en/reference/modules/astro-transitions/? but these history.replaceState tricks are not documented there to begin with.