### PR TITLE
Fix CSS missing when building from a symlinked directory

### DIFF
--- a/.changeset/quick-plums-argue.md
+++ b/.changeset/quick-plums-argue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes missing CSS when building from a symlinked or junction-linked directory

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -21,7 +21,15 @@ export function resolveRoot(cwd?: string | URL): string {
 	if (cwd instanceof URL) {
 		cwd = fileURLToPath(cwd);
 	}
-	return cwd ? path.resolve(cwd) : process.cwd();
+	const resolved = cwd ? path.resolve(cwd) : process.cwd();
+	// Resolve symlinks so that the root path matches Vite's resolved module IDs.
+	// Building from a symlinked directory otherwise causes path mismatches in the
+	// CSS pipeline, where `pagesByViteID` keys no longer match Rollup module graph IDs.
+	try {
+		return fs.realpathSync(resolved);
+	} catch {
+		return resolved;
+	}
 }
 
 // Config paths to search for.

--- a/packages/astro/test/fixtures/symlink-css-linked
+++ b/packages/astro/test/fixtures/symlink-css-linked
@@ -1,0 +1,1 @@
+symlink-css

--- a/packages/astro/test/fixtures/symlink-css/astro.config.mjs
+++ b/packages/astro/test/fixtures/symlink-css/astro.config.mjs
@@ -1,0 +1,2 @@
+import { defineConfig } from 'astro/config';
+export default defineConfig({});

--- a/packages/astro/test/fixtures/symlink-css/src/layouts/BaseLayout.astro
+++ b/packages/astro/test/fixtures/symlink-css/src/layouts/BaseLayout.astro
@@ -1,0 +1,10 @@
+---
+import '../styles/global.css';
+---
+<html>
+  <head><meta charset="utf-8" /><title>Test</title></head>
+  <body><slot /></body>
+</html>
+<style>
+  body { margin: 0; padding: 2rem; }
+</style>

--- a/packages/astro/test/fixtures/symlink-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/symlink-css/src/pages/index.astro
@@ -1,0 +1,6 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+<BaseLayout>
+  <h1>Hello World</h1>
+</BaseLayout>

--- a/packages/astro/test/fixtures/symlink-css/src/styles/global.css
+++ b/packages/astro/test/fixtures/symlink-css/src/styles/global.css
@@ -1,0 +1,4 @@
+body {
+  background-color: red;
+  color: white;
+}

--- a/packages/astro/test/symlink-css.test.ts
+++ b/packages/astro/test/symlink-css.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.ts';
+
+describe('Symlink CSS', () => {
+	let realHtml: string;
+	let linkedHtml: string;
+
+	before(
+		async () => {
+			// Build from real directory
+			const realFixture = await loadFixture({
+				root: './fixtures/symlink-css/',
+			});
+			await realFixture.build();
+			realHtml = await realFixture.readFile('/index.html');
+
+			// Build from symlinked directory
+			const linkedFixture = await loadFixture({
+				root: './fixtures/symlink-css-linked/',
+			});
+			await linkedFixture.build();
+			linkedHtml = await linkedFixture.readFile('/index.html');
+		},
+		{ timeout: 60000 },
+	);
+
+	it('should include CSS when building from a symlinked directory', () => {
+		const $linked = cheerio.load(linkedHtml);
+		const cssLinks = $linked('link[rel=stylesheet]').length;
+		const styles = $linked('style').length;
+		assert.ok(cssLinks > 0 || styles > 0, 'Should have CSS in symlinked build');
+	});
+
+	it('should have same CSS output as real directory build', () => {
+		const $real = cheerio.load(realHtml);
+		const $linked = cheerio.load(linkedHtml);
+		const realCssCount = $real('link[rel=stylesheet]').length + $real('style').length;
+		const linkedCssCount = $linked('link[rel=stylesheet]').length + $linked('style').length;
+		assert.equal(linkedCssCount, realCssCount, 'Should have same number of CSS references');
+	});
+});


### PR DESCRIPTION
## Changes

- Building from a symlinked (or junction-linked) directory dropped all CSS from the output. `resolveRoot()` used `path.resolve()`, which does not follow symlinks, so `config.root` kept the symlink path while Vite/Rollup resolve module IDs to the real path (`resolve.preserveSymlinks` is `false`). The `pagesByViteID` keys then never matched the Rollup module graph IDs, so `getPageDataByViteID()` returned `undefined` and CSS was never associated with any page.
- `resolveRoot()` now runs `fs.realpathSync()` on the resolved path so `config.root` matches Vite's resolved IDs, with a try/catch fallback for a root that doesn't exist yet.

Fixes #17319

## Testing

- Adds `test/symlink-css.test.ts`, which builds the same fixture from its real directory and from a symlink to it and asserts the symlinked build has the same CSS as the real one. It fails on `main` (the symlinked build has no CSS) and passes with the fix.

## Docs

- No docs needed — this restores the documented build behavior for symlinked roots.
