### PR TITLE
fix(language-server): don't report unused variable hints when noUnusedLocals/noUnusedParameters are disabled

### DIFF
--- a/.changeset/brave-hornets-decide.md
+++ b/.changeset/brave-hornets-decide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixes `astro check` reporting unused variable hints (`ts(6133)`, `ts(6196)`, etc.) even when `noUnusedLocals` / `noUnusedParameters` are disabled in the project's tsconfig. When these options are enabled, unused declarations are still reported as errors, matching `tsc`'s behavior.

--- a/packages/language-tools/astro-check/test/bin.test.ts
+++ b/packages/language-tools/astro-check/test/bin.test.ts
@@ -18,6 +18,8 @@ describe('astro-check - binary', async () => {
 		assert.ok(childProcess.stdout.toString().includes('Getting diagnostics for Astro files in'));
 		assert.ok(childProcess.stdout.toString().includes('1 error'));
 		assert.ok(childProcess.stdout.toString().includes('1 warning'));
-		assert.ok(childProcess.stdout.toString().includes('1 hint'));
+		// The unused variable hint in fileWithHints.astro is not reported since
+		// noUnusedLocals is not enabled in the fixture's tsconfig
+		assert.ok(childProcess.stdout.toString().includes('0 hints'));
 	});
 });

--- a/packages/language-tools/language-server/src/check.ts
+++ b/packages/language-tools/language-server/src/check.ts
@@ -16,6 +16,23 @@ import { getAstroInstall } from './utils.js';
 // Export those for downstream consumers
 export { Diagnostic, DiagnosticSeverity };
 
+// TypeScript's language service always reports unused declarations as hint-level suggestion
+// diagnostics, no matter if `noUnusedLocals` / `noUnusedParameters` are enabled or not. When
+// they are enabled, the same diagnostics are reported as errors through semantic diagnostics
+// instead, so hint-level ones only ever show up when the user did not enable those options.
+// `tsc` never reports them in that case, so we filter them out to match its behavior. Editors
+// are unaffected by this and still use these hints to show unused code as faded.
+// https://github.com/withastro/astro/issues/17330
+const unusedDiagnosticCodes = new Set([
+	6133, // '{0}' is declared but its value is never read.
+	6138, // Property '{0}' is declared but its value is never read.
+	6192, // All imports in import declaration are unused.
+	6196, // '{0}' is declared but never used.
+	6198, // All destructured elements are unused.
+	6199, // All variables are unused.
+	6205, // All type parameters are unused.
+]);
+
 export interface CheckResult {
 	status: 'completed' | 'cancelled' | undefined;
 	fileChecked: number;
@@ -88,7 +105,14 @@ export class AstroCheck {
 				result.status = 'cancelled';
 				return result;
 			}
-			const fileDiagnostics = await this.linter.check(file);
+			const fileDiagnostics = (await this.linter.check(file)).filter(
+				(diag) =>
+					!(
+						diag.severity === DiagnosticSeverity.Hint &&
+						typeof diag.code === 'number' &&
+						unusedDiagnosticCodes.has(diag.code)
+					),
+			);
 
 			// Filter diagnostics based on the logErrors level
 			const fileDiagnosticsToPrint = fileDiagnostics.filter((diag) => {

--- a/packages/language-tools/language-server/test/check/check.test.ts
+++ b/packages/language-tools/language-server/test/check/check.test.ts
@@ -27,7 +27,9 @@ describe('AstroCheck', async () => {
 
 	it('Can check files and return errors', async () => {
 		assert.notStrictEqual(result, undefined);
-		assert.strictEqual(result.fileResult.length, 4);
+		// fileWithHints.astro only contains an unused variable, which is not reported
+		// since noUnusedLocals is not enabled in the fixture's tsconfig
+		assert.strictEqual(result.fileResult.length, 3);
 	});
 
 	it("Returns the file's URL", async () => {
@@ -46,7 +48,9 @@ describe('AstroCheck', async () => {
 	it('Can return the total amount of errors, warnings and hints', async () => {
 		assert.strictEqual(result.errors, 2);
 		assert.strictEqual(result.warnings, 1);
-		assert.strictEqual(result.hints, 1);
+		// Unused variable hints are filtered out when noUnusedLocals/noUnusedParameters
+		// are not enabled, to match tsc's behavior
+		assert.strictEqual(result.hints, 0);
 	});
 
 	it('Can return the total amount of files checked', async () => {
@@ -55,5 +59,28 @@ describe('AstroCheck', async () => {
 
 	it('Can return the status of the check', async () => {
 		assert.strictEqual(result.status, 'completed');
+	});
+});
+
+describe('AstroCheck with noUnusedLocals and noUnusedParameters enabled', async () => {
+	let checker: AstroCheck;
+	let result: CheckResult;
+
+	before(async () => {
+		checker = new AstroCheck(
+			path.resolve(__dirname, 'unusedFixture'),
+			require.resolve('typescript/lib/typescript.js'),
+			undefined,
+		);
+		result = await checker.lint({});
+	});
+
+	it('Reports unused declarations as errors', async () => {
+		assert.strictEqual(result.errors, 3);
+		assert.strictEqual(result.warnings, 0);
+	});
+
+	it('Does not report duplicate hints for unused declarations', async () => {
+		assert.strictEqual(result.hints, 0);
 	});
 });

--- a/packages/language-tools/language-server/test/check/unusedFixture/fileWithUnused.astro
+++ b/packages/language-tools/language-server/test/check/unusedFixture/fileWithUnused.astro
@@ -1,0 +1,13 @@
+---
+interface UnusedInterface {
+	name: string;
+}
+
+const unusedVar = 'never read';
+
+function greet(unusedParam: string) {
+	return 'hello';
+}
+
+greet('hi');
+---

--- a/packages/language-tools/language-server/test/check/unusedFixture/tsconfig.json
+++ b/packages/language-tools/language-server/test/check/unusedFixture/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"noUnusedLocals": true,
+		"noUnusedParameters": true
+	}
+}


### PR DESCRIPTION
## Changes

Fixes #17330

`astro check` reported unused variable diagnostics (`ts(6133)`, `ts(6196)`, ...) as hints even when `noUnusedLocals` / `noUnusedParameters` were explicitly disabled (or simply not enabled) in the project's tsconfig, and `@ts-ignore` couldn't suppress them either. `tsc` never reports these in that situation.

**Root cause:** the TypeScript language service's `getSuggestionDiagnostics()` (called through `volar-service-typescript` alongside syntactic diagnostics) unconditionally returns unused declaration diagnostics as suggestion-level (hint) diagnostics, regardless of the compiler options. `tsc` only ever reports unused declarations through semantic diagnostics, as errors, and only when the corresponding option is enabled.

**Fix:** `AstroCheck.lint()` in `@astrojs/language-server` now filters out hint-level unused declaration diagnostics. Since TypeScript routes these to *either* suggestions (options disabled) *or* semantic errors (options enabled), this is exactly equivalent to respecting the compiler options:

- `noUnusedLocals` / `noUnusedParameters` disabled → no unused diagnostics, matching `tsc`
- enabled → unused declarations are still reported as errors, matching `tsc`

Only the CLI/API check path is affected; the language server is untouched, so editors keep showing unused code as faded text.

- Added a changeset (patch for `@astrojs/language-server`).

## Testing

- Updated the existing `AstroCheck` tests (`fileWithHints.astro` only contained an unused variable, so its hint is no longer reported).
- Added a new fixture with `noUnusedLocals` / `noUnusedParameters` enabled, asserting unused locals, parameters, and types are still reported as errors, with no duplicate hints.
- Updated the `@astrojs/check` bin test accordingly.
- Full `@astrojs/language-server` suite passes (86 pass, 1 skipped), `@astrojs/check` suite passes (6 pass).
- Manually verified with the issue's reproduction: `noUnusedLocals: false` → 0 hints; `noUnusedLocals: true` → errors reported, 0 hints.

## Docs

No docs changes needed: this makes `astro check` match the documented behavior of the TypeScript compiler options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
