### PR TITLE
Fix `astro preview --open` not opening a browser with the Cloudflare adapter

### DIFF
--- a/.changeset/dark-llamas-matter.md
+++ b/.changeset/dark-llamas-matter.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/cloudflare': patch
+---
+
+Fixes `astro preview --open` not opening a browser when using an adapter with a custom preview entrypoint, such as `@astrojs/cloudflare`

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -92,6 +92,7 @@ export default async function preview(inlineConfig: AstroInlineConfig): Promise<
 		logger: new AstroIntegrationLogger(logger.options, settings.adapter.name),
 		headers: settings.config.server.headers,
 		allowedHosts: settings.config.server.allowedHosts,
+		open: settings.config.server.open,
 		root: settings.config.root,
 	});
 

--- a/packages/astro/src/types/public/preview.ts
+++ b/packages/astro/src/types/public/preview.ts
@@ -23,6 +23,11 @@ export interface PreviewServerParams {
 	 * If the `Host` header doesn't match one of the allowed hosts, the server will return a 403 response.
 	 */
 	allowedHosts?: string[] | true;
+	/**
+	 * Controls whether the preview server should open in the browser on startup.
+	 * Pass a full URL string (e.g. "http://example.com") or a pathname (e.g. "/about") to specify the URL to open.
+	 */
+	open?: string | boolean;
 	root: URL;
 }
 

--- a/packages/integrations/cloudflare/src/entrypoints/preview.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/preview.ts
@@ -20,6 +20,7 @@ const createPreviewServer: CreatePreviewServer = async ({
 	headers,
 	port,
 	host,
+	open,
 	allowedHosts,
 	root,
 }) => {
@@ -45,7 +46,7 @@ const createPreviewServer: CreatePreviewServer = async ({
 				host,
 				port,
 				headers,
-				open: false,
+				open: open ?? false,
 				allowedHosts,
 			},
 			plugins: [


### PR DESCRIPTION
## Changes

- `astro preview --open` now correctly opens a browser when using adapters with a custom preview entrypoint (such as `@astrojs/cloudflare`). Previously, the `open` option was never forwarded from core preview to adapter preview entrypoints.
- Adds `open?: string | boolean` to the `PreviewServerParams` interface so adapters can receive and act on the value.
- Passes `settings.config.server.open` from `packages/astro/src/core/preview/index.ts` to the adapter's preview function, matching how `headers` and `allowedHosts` are already forwarded.
- Updates the Cloudflare adapter's preview entrypoint to use the received `open` value instead of hardcoding `false`.

## Testing

- No new automated tests — browser-opening behavior cannot be observed in a headless CI environment. TypeScript compilation validates the type contract. Confirmed working by the issue reporter (@kitschpatrol).

## Docs

- No docs update needed; `open` / `--open` is an existing CLI flag with no change in user-facing behavior or configuration surface.

Closes #17362
