### PR TITLE
Match remotePatterns and domains metacharacters literally in Netlify Image CDN regex

### DIFF
--- a/.changeset/slow-steaks-exist.md
+++ b/.changeset/slow-steaks-exist.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes the generated Netlify Image CDN `remote_images` patterns so that regex metacharacters (such as `.`) in a `remotePatterns` `pathname` are matched literally instead of behaving like wildcards. This makes the generated patterns consistent with how Astro matches `remotePatterns` elsewhere.

--- a/.changeset/slow-steaks-exist.md
+++ b/.changeset/slow-steaks-exist.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-Fixes the generated Netlify Image CDN `remote_images` patterns so that regex metacharacters (such as `.`) in a `remotePatterns` `pathname` are matched literally instead of behaving like wildcards. This makes the generated patterns consistent with how Astro matches `remotePatterns` elsewhere.
+Fixes the generated Netlify Image CDN `remote_images` patterns so that regex metacharacters (such as `.`) in `image.remotePatterns` (`hostname`, `pathname`) and `image.domains` are matched literally instead of behaving like wildcards. This makes the generated patterns consistent with how Astro matches these values elsewhere.

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -34,6 +34,13 @@ export interface NetlifyLocals {
 type RemotePattern = AstroConfig['image']['remotePatterns'][number];
 
 /**
+ * Escape regex metacharacters in a literal string so it matches verbatim.
+ */
+function escapeRegex(literal: string): string {
+	return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Convert a remote pattern object to a regex string
  */
 export function remotePatternToRegex(
@@ -76,14 +83,15 @@ export function remotePatternToRegex(
 
 	if (pathname) {
 		if (pathname.endsWith('/**')) {
-			// Match any path.
-			regexStr += `(\\${pathname.replace('/**', '')}.*)`;
+			// Match any path. Escape the literal prefix so metacharacters
+			// (e.g. `.`) match verbatim instead of acting as wildcards.
+			regexStr += `(${escapeRegex(pathname.replace('/**', ''))}.*)`;
 		} else if (pathname.endsWith('/*')) {
 			// Match one level of path
-			regexStr += `(\\${pathname.replace('/*', '')}\/[^/?#]+)\/?`;
+			regexStr += `(${escapeRegex(pathname.replace('/*', ''))}\/[^/?#]+)\/?`;
 		} else {
 			// Exact match
-			regexStr += `(\\${pathname})`;
+			regexStr += `(${escapeRegex(pathname)})`;
 		}
 	} else {
 		// Default to matching any path

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -68,8 +68,8 @@ export function remotePatternToRegex(
 			regexStr += '([a-z0-9-]+\\.)';
 			hostname = hostname.substring(2); // Remove '*.' from the beginning
 		}
-		// Escape dots in the hostname
-		regexStr += hostname.replace(/\./g, '\\.');
+		// Escape metacharacters in the literal hostname so they match verbatim.
+		regexStr += escapeRegex(hostname);
 	} else {
 		regexStr += '[a-z0-9.-]+';
 	}
@@ -125,7 +125,7 @@ function remoteImagesFromAstroConfig(
 	const remoteImages: string[] = [];
 	// Domains get a simple regex match
 	remoteImages.push(
-		...config.image.domains.map((domain) => `https?:\/\/${domain.replaceAll('.', '\\.')}\/.*`),
+		...config.image.domains.map((domain) => `https?:\/\/${escapeRegex(domain)}\/.*`),
 	);
 	// Remote patterns need to be converted to regexes
 	remoteImages.push(

--- a/packages/integrations/netlify/test/functions/image-cdn.test.ts
+++ b/packages/integrations/netlify/test/functions/image-cdn.test.ts
@@ -116,6 +116,65 @@ describe('Image CDN', { timeout: 120000 }, () => {
 			);
 		});
 
+		it('treats metacharacters in a literal pathname as literals', async () => {
+			const spyLogger = new SpyLogger();
+			const logger = spyLogger.forkIntegrationLogger('test-spy');
+			const regexStr = remotePatternToRegex(
+				{
+					protocol: 'https',
+					hostname: 'cdn.example.com',
+					pathname: '/img/v1.0/file',
+				},
+				logger,
+			);
+			const regex = new RegExp(regexStr!);
+			assert.equal(
+				regex.test('https://cdn.example.com/img/v1.0/file'),
+				true,
+				'literal pathname should match',
+			);
+			assert.equal(
+				regex.test('https://cdn.example.com/img/v1X0/file'),
+				false,
+				'dot in pathname should not act as a wildcard',
+			);
+			assert.equal(
+				regex.test('https://cdn.example.com/img/v1/0/file'),
+				false,
+				'dot in pathname should not match a path separator',
+			);
+		});
+
+		it('treats metacharacters in a wildcard pathname prefix as literals', async () => {
+			const spyLogger = new SpyLogger();
+			const logger = spyLogger.forkIntegrationLogger('test-spy');
+			const oneLevel = new RegExp(
+				remotePatternToRegex(
+					{ protocol: 'https', hostname: 'cdn.example.com', pathname: '/v1.0/*' },
+					logger,
+				)!,
+			);
+			assert.equal(oneLevel.test('https://cdn.example.com/v1.0/file'), true);
+			assert.equal(
+				oneLevel.test('https://cdn.example.com/v1X0/file'),
+				false,
+				'dot in wildcard prefix should not act as a wildcard',
+			);
+
+			const anyPath = new RegExp(
+				remotePatternToRegex(
+					{ protocol: 'https', hostname: 'cdn.example.com', pathname: '/v1.0/**' },
+					logger,
+				)!,
+			);
+			assert.equal(anyPath.test('https://cdn.example.com/v1.0/a/b'), true);
+			assert.equal(
+				anyPath.test('https://cdn.example.com/v1X0/a/b'),
+				false,
+				'dot in wildcard prefix should not act as a wildcard',
+			);
+		});
+
 		it('warns when remotepatterns generates an invalid regex', async () => {
 			const spyLogger = new SpyLogger();
 			const logger = spyLogger.forkIntegrationLogger('test-spy');

--- a/packages/integrations/netlify/test/functions/image-cdn.test.ts
+++ b/packages/integrations/netlify/test/functions/image-cdn.test.ts
@@ -175,23 +175,24 @@ describe('Image CDN', { timeout: 120000 }, () => {
 			);
 		});
 
-		it('warns when remotepatterns generates an invalid regex', async () => {
+		it('treats metacharacters in the hostname as literals', async () => {
 			const spyLogger = new SpyLogger();
 			const logger = spyLogger.forkIntegrationLogger('test-spy');
-			const regex = remotePatternToRegex(
-				{
-					hostname: '*.examp[le.org',
-					pathname: '/images/*',
-				},
-				logger,
+			const regex = new RegExp(
+				remotePatternToRegex(
+					{ protocol: 'https', hostname: 'a+b.example.com', pathname: '/img.png' },
+					logger,
+				)!,
 			);
-			assert.strictEqual(regex, undefined);
-			assert.strictEqual(spyLogger.logs.length, 1);
-			const entry = spyLogger.logs[0];
-			assert.equal(entry.level, 'warn');
 			assert.equal(
-				entry.message,
-				'Could not generate a valid regex from the remotePattern "{"hostname":"*.examp[le.org","pathname":"/images/*"}". Please check the syntax.',
+				regex.test('https://a+b.example.com/img.png'),
+				true,
+				'literal hostname should match',
+			);
+			assert.equal(
+				regex.test('https://aaab.example.com/img.png'),
+				false,
+				'a metacharacter in the hostname should not act as a quantifier',
 			);
 		});
 	});


### PR DESCRIPTION
## Changes

- Escapes regex metacharacters in `image.remotePatterns` (`hostname`, `pathname`) and `image.domains` when generating Netlify Image CDN `remote_images` patterns, so characters like `.` match literally instead of as wildcards. Previously only `.` was escaped, and only in some positions. This makes the generated patterns consistent with how Astro matches these values elsewhere.

## Testing

- Adds cases covering metacharacters in literal and wildcard (`/*`, `/**`) pathnames and in the hostname.

## Docs

- No docs update needed; the documented `remotePatterns`/`domains` behavior is unchanged.