### PR TITLE
fix(astro-island): use query param for hydration import retry so recovery works in dev

### DIFF
--- a/.changeset/island-retry-query-param.md
+++ b/.changeset/island-retry-query-param.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where a client island could permanently fail to hydrate if the first attempt to load its component failed. Islands now reliably recover from transient import failures, which previously did not work for React components during `astro dev`.

--- a/packages/astro/e2e/astro-island-hydration-error.test.ts
+++ b/packages/astro/e2e/astro-island-hydration-error.test.ts
@@ -14,8 +14,23 @@ const test = testFactory(import.meta.url, {
 test.describe('astro-island hydration error handling', () => {
 	let devServer: DevServer;
 
-	test.beforeAll(async ({ astro }) => {
+	test.beforeAll(async ({ astro, browser }) => {
 		devServer = await astro.startDevServer();
+		// Vite buffers HMR messages sent before any client connects (e.g. the full-reload
+		// emitted while invalidating the content data store at startup) and flushes them to
+		// the first client. Drain them with a throwaway page so a stray full-reload cannot
+		// mask a broken island retry by recovering the page for us.
+		const warmup = await browser.newPage();
+		const connected = warmup
+			.waitForEvent('console', {
+				predicate: (message) => message.text().includes('[vite] connected'),
+				timeout: 10_000,
+			})
+			.catch(() => {});
+		await warmup.goto(astro.resolveUrl('/'));
+		await connected;
+		await warmup.waitForTimeout(500);
+		await warmup.close();
 	});
 
 	test.afterAll(async () => {
@@ -26,6 +41,13 @@ test.describe('astro-island hydration error handling', () => {
 		const pageUrl = astro.resolveUrl('/');
 		const html = await (await page.request.get(pageUrl)).text();
 		const componentUrl = getIslandComponentUrl(html);
+
+		// Recovery must come from the island's own import retry, not from a page reload
+		// (such as the full-reload a dev server may send to a newly connected client).
+		let navigations = 0;
+		page.on('framenavigated', (frame) => {
+			if (frame === page.mainFrame()) navigations++;
+		});
 
 		let attempts = 0;
 		await page.route(`**${componentUrl.split('?')[0]}*`, async (route) => {
@@ -45,6 +67,7 @@ test.describe('astro-island hydration error handling', () => {
 		await incrementButton.click();
 		await expect(count).toHaveText('1');
 		expect(attempts).toBe(2);
+		expect(navigations, 'expected hydration to recover without a page reload').toBe(1);
 	});
 
 	test('dispatches astro:hydration-error and avoids unhandled rejections on persistent failure', async ({

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -102,9 +102,7 @@ declare const Astro: {
 
 		private getRetryImportUrl(url: string) {
 			const parsed = new URL(url, document.baseURI);
-			const retryToken = `astro-retry=${Date.now()}`;
-			const currentHash = parsed.hash.replace(/^#/, '');
-			parsed.hash = currentHash ? `${currentHash}&${retryToken}` : retryToken;
+			parsed.searchParams.set('astro-retry', Date.now().toString());
 			return parsed.toString();
 		}
 
@@ -112,8 +110,10 @@ declare const Astro: {
 			try {
 				return await import(url);
 			} catch {
-				// Use a hash-based retry URL so we bypass failed module-cache state in the browser
-				// while keeping the same network request URL (hash is not sent to the server).
+				// Use a query-based retry URL rather than a hash: the browser caches the failed
+				// fetch in its module map keyed by URL, and in dev the module graph can reference
+				// the original URL again (e.g. @vitejs/plugin-react emits a self-import), so only
+				// a cache buster that the server sees propagates to every affected module key.
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 				return import(this.getRetryImportUrl(url));
 			}


### PR DESCRIPTION
## Changes

Fixes `astro-island`'s hydration import retry (added in #16412) so it actually recovers in dev, and hardens its e2e test so a page reload can no longer satisfy it.

This unblocks #17286, whose e2e failures are not a false positive: they expose that the retry never worked in dev for React components. Details below.

### Why the retry was broken in dev

`importWithRetry` retried with a URL **fragment** cache buster (`#astro-retry=<ts>`). A fragment only changes the module map key of the top-level module and never reaches the server. In dev, `@vitejs/plugin-react` emits a self-import of the module's own bare URL for react-refresh:

```js
import * as __vite_react_currentExports from "/src/components/Counter.jsx";
```

Once the first import attempt fails, Chrome caches the failed fetch for the bare URL in its module map. The fragment-busted retry still depends on that poisoned bare URL, so the retry rejects with `Failed to fetch dynamically imported module` even though the network request returns 200.

A **query** parameter reaches the server, so Vite propagates it into the transformed module's self-import and every module map key in the retried graph is fresh. Verified with in-page probes: after a failed import, a fragment-busted re-import rejects while a query-busted re-import resolves.

### Why this was never caught

The e2e test `recovers hydration after first failed component import` has been passing by accident. Since #12938, `buildStart` invalidates the content data store and sends a `full-reload` that Vite buffers and flushes to the first client that connects (the bug reported in #17283). That reload recovered the test page before the island's retry was ever exercised. #17286 removes the spurious reload, which is why its e2e run fails deterministically on both runners.

### Test changes

The test now exercises the retry regardless of server reload behavior:

- `beforeAll` drains startup-buffered HMR messages with a throwaway page, so a buffered `full-reload` cannot recover the page mid-test.
- The test asserts hydration recovers without any main-frame navigation, so recovery via reload now fails the test instead of passing it.

### Verification

| island retry | startup reload (pre-#17286) | result |
|---|---|---|
| query (this PR) | present | pass |
| query (this PR) | removed (#17286 applied) | pass |
| hash (current main) | present | **fail** (test now correctly detects the broken retry) |

## Testing

Ran `playwright test astro-island-hydration-error` locally (Chrome) in all three configurations above.

## Docs

N/A, bug fix. Changeset included.