### PR TITLE
fix(@astrojs/vercel): improve internal ISR route handling

### DIFF
--- a/.changeset/modern-otters-smoke.md
+++ b/.changeset/modern-otters-smoke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Improves internal ISR route handling

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -736,7 +736,7 @@ class VercelBuilder {
 		await writeJson(prerenderConfig, {
 			expiration: isr.expiration ?? false,
 			bypassToken: isr.bypassToken,
-			allowQuery: [ASTRO_PATH_PARAM],
+			allowQuery: [ASTRO_PATH_PARAM, ASTRO_PATH_TOKEN_PARAM],
 			passQuery: true,
 		});
 	}

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -45,6 +45,15 @@ export const ASTRO_PATH_HEADER = 'x-astro-path';
 export const ASTRO_PATH_PARAM = 'x_astro_path';
 
 /**
+ * ISR functions receive the target path through the `x_astro_path` query
+ * parameter instead of a header. Because that parameter travels on the URL, it
+ * is accompanied by this token so the entrypoint can confirm the path override
+ * came from Astro's own build-time route rewrite rather than from an arbitrary
+ * caller. The value is the per-build `middlewareSecret`.
+ */
+export const ASTRO_PATH_TOKEN_PARAM = 'x_astro_path_token';
+
+/**
  * The edge function calls the node server at /_render,
  * with the locals serialized into this header.
  */
@@ -60,7 +69,10 @@ const MIDDLEWARE_PATH = '_middleware';
 // This isn't documented by vercel anywhere, but unlike serverless
 // and edge functions, isr functions are not passed the original path.
 // Instead, we have to use $0 to refer to the regex match from "src".
-const ISR_PATH = `/_isr?${ASTRO_PATH_PARAM}=$0`;
+// The path token is appended so the entrypoint can verify the rewrite
+// originated from this build's route table and not from an external caller.
+const getIsrPath = (pathToken: string) =>
+	`/_isr?${ASTRO_PATH_PARAM}=$0&${ASTRO_PATH_TOKEN_PARAM}=${pathToken}`;
 
 // https://vercel.com/docs/concepts/functions/serverless-functions/runtimes/node-js#node.js-version
 const SUPPORTED_NODE_VERSIONS: Record<
@@ -487,7 +499,7 @@ export default function vercelAdapter({
 								const dest =
 									src.startsWith('^\\/_image') || src.startsWith('^\\/_server-islands')
 										? NODE_PATH
-										: ISR_PATH;
+										: getIsrPath(middlewareSecret);
 								if (!route.isPrerendered)
 									routeDefinitions.push({
 										src,

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -4,6 +4,7 @@ import {
 	ASTRO_MIDDLEWARE_SECRET_HEADER,
 	ASTRO_PATH_HEADER,
 	ASTRO_PATH_PARAM,
+	ASTRO_PATH_TOKEN_PARAM,
 } from '../index.js';
 import { middlewareSecret, skewProtection } from 'virtual:astro-vercel:config';
 import { createApp } from 'astro/app/entrypoint';
@@ -21,11 +22,18 @@ export default {
 		let realPath = undefined;
 		if (hasValidMiddlewareSecret) {
 			realPath = request.headers.get(ASTRO_PATH_HEADER);
-		} else if (request.headers.get('x-vercel-isr') === '1') {
+		} else if (url.searchParams.get(ASTRO_PATH_TOKEN_PARAM) === middlewareSecret) {
+			// ISR functions only receive the target path via the URL, so the route
+			// rewrite carries the build's path token alongside it. Only honor the
+			// override when that token matches, otherwise the path is ignored and
+			// the request is served as `/_isr`.
 			realPath = url.searchParams.get(ASTRO_PATH_PARAM);
 		}
 		if (typeof realPath === 'string') {
 			url.pathname = realPath;
+			// Remove the internal routing params so they never reach user code.
+			url.searchParams.delete(ASTRO_PATH_PARAM);
+			url.searchParams.delete(ASTRO_PATH_TOKEN_PARAM);
 			request = new Request(url.toString(), {
 				method: request.method,
 				headers: request.headers,

--- a/packages/integrations/vercel/test/isr.test.ts
+++ b/packages/integrations/vercel/test/isr.test.ts
@@ -19,7 +19,7 @@ describe('ISR', () => {
 		assert.deepEqual(vcConfig, {
 			expiration: 120,
 			bypassToken: '1c9e601d-9943-4e7c-9575-005556d774a8',
-			allowQuery: ['x_astro_path'],
+			allowQuery: ['x_astro_path', 'x_astro_path_token'],
 			passQuery: true,
 		});
 	});
@@ -81,6 +81,26 @@ describe('ISR', () => {
 				status: 404,
 			},
 		]);
+	});
+
+	it('allow-lists every query param used in the ISR rewrite', { timeout: 30000 }, async () => {
+		// Vercel strips any query param not present in `allowQuery` before invoking
+		// the ISR function. If the rewrite `dest` references a param that isn't
+		// allow-listed (e.g. the path token), that param never reaches the
+		// entrypoint and every ISR route 404s. Assert the two stay in sync.
+		const prerenderConfig = JSON.parse(
+			await fixture.readFile('../.vercel/output/functions/_isr.prerender-config.json'),
+		);
+		const token = await readPathToken();
+		const isrRoute = new URL(
+			`https://example.com/_isr?x_astro_path=/one&x_astro_path_token=${token}`,
+		);
+		for (const param of isrRoute.searchParams.keys()) {
+			assert.ok(
+				prerenderConfig.allowQuery.includes(param),
+				`ISR rewrite param "${param}" must be present in allowQuery`,
+			);
+		}
 	});
 
 	async function loadIsrFunction() {

--- a/packages/integrations/vercel/test/isr.test.ts
+++ b/packages/integrations/vercel/test/isr.test.ts
@@ -26,8 +26,19 @@ describe('ISR', () => {
 
 	it('generates expected routes', { timeout: 30000 }, async () => {
 		const deploymentConfig = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
+		// The path token embedded in the ISR rewrites is a random per-build value,
+		// so normalize it to a stable placeholder before comparing.
+		const routes = deploymentConfig.routes.slice(2).map((route: Record<string, unknown>) => {
+			if (typeof route.dest === 'string') {
+				return {
+					...route,
+					dest: route.dest.replace(/x_astro_path_token=[^&]+/, 'x_astro_path_token=$TOKEN'),
+				};
+			}
+			return route;
+		});
 		// the first two are /_astro/*, and filesystem routes
-		assert.deepEqual(deploymentConfig.routes.slice(2), [
+		assert.deepEqual(routes, [
 			{
 				src: '^/two$',
 				dest: '_render',
@@ -58,11 +69,11 @@ describe('ISR', () => {
 			},
 			{
 				src: '^/one/?$',
-				dest: '/_isr?x_astro_path=$0',
+				dest: '/_isr?x_astro_path=$0&x_astro_path_token=$TOKEN',
 			},
 			{
 				src: '^/404/?$',
-				dest: '/_isr?x_astro_path=$0',
+				dest: '/_isr?x_astro_path=$0&x_astro_path_token=$TOKEN',
 			},
 			{
 				dest: '_render',
@@ -70,5 +81,59 @@ describe('ISR', () => {
 				status: 404,
 			},
 		]);
+	});
+
+	async function loadIsrFunction() {
+		const functionConfig = JSON.parse(
+			await fixture.readFile('../.vercel/output/functions/_isr.func/.vc-config.json'),
+		);
+		const functionEntry = new URL(
+			`../.vercel/output/functions/_isr.func/${functionConfig.handler}`,
+			fixture.config.outDir,
+		);
+		return import(functionEntry.href);
+	}
+
+	async function readPathToken() {
+		const deploymentConfig = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
+		const isrRoute = deploymentConfig.routes.find(
+			(route: { dest?: string }) =>
+				typeof route.dest === 'string' && route.dest.startsWith('/_isr?'),
+		);
+		return new URL(isrRoute.dest, 'https://example.com').searchParams.get('x_astro_path_token');
+	}
+
+	it('ignores x_astro_path without a valid path token', { timeout: 30000 }, async () => {
+		const isrFunction = await loadIsrFunction();
+		const response = await isrFunction.default.fetch(
+			new Request('https://example.com/_isr?x_astro_path=/one'),
+		);
+		// Without the build's token the override is ignored, so `/_isr` matches no
+		// route and does not render the target page.
+		assert.equal(response.status, 404);
+		assert.equal((await response.text()).includes('<h1>One</h1>'), false);
+	});
+
+	it('ignores x_astro_path when only the x-vercel-isr header is set', {
+		timeout: 30000,
+	}, async () => {
+		const isrFunction = await loadIsrFunction();
+		const response = await isrFunction.default.fetch(
+			new Request('https://example.com/_isr?x_astro_path=/one', {
+				headers: { 'x-vercel-isr': '1' },
+			}),
+		);
+		assert.equal(response.status, 404);
+		assert.equal((await response.text()).includes('<h1>One</h1>'), false);
+	});
+
+	it('honors x_astro_path when the valid path token is present', { timeout: 30000 }, async () => {
+		const isrFunction = await loadIsrFunction();
+		const token = await readPathToken();
+		const response = await isrFunction.default.fetch(
+			new Request(`https://example.com/_isr?x_astro_path=/one&x_astro_path_token=${token}`),
+		);
+		assert.equal(response.status, 200);
+		assert.equal((await response.text()).includes('<h1>One</h1>'), true);
 	});
 });


### PR DESCRIPTION
## Changes

- Adds a build-generated token to the internal ISR route rewrite, so the `_isr` function only applies the `x_astro_path` path override when the token matches the current build's route table. This replaces the previous `x-vercel-isr` header check.
- Strips the internal `x_astro_path` and `x_astro_path_token` params from the URL before rendering, so they never reach user code.

## Testing

- Updates the ISR route-generation assertions to expect the new token param (normalized to a placeholder, since it's a random per-build value).
- Adds `_isr` entrypoint tests covering the override being ignored without a valid token, ignored when only `x-vercel-isr` is set, and applied when the valid token is present.

## Docs

- No docs update needed. The token and ISR routing params are internal implementation details with no public API change.
