### PR TITLE
fix(mdx): declare satteri as a direct dependency

### DIFF
--- a/.changeset/mdx-declare-satteri.md
+++ b/.changeset/mdx-declare-satteri.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/mdx': patch
+---
+
+Adds `satteri` as a direct dependency of `@astrojs/mdx`. The Sätteri MDX entrypoints import `satteri`, but it was previously only available transitively via the optional `@astrojs/markdown-satteri` peer. Under pnpm's isolated `node_modules`, that could fail with `ERR_MODULE_NOT_FOUND` when looking up the bare `satteri` import.
+

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -45,6 +45,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-smartypants": "^3.0.2",
+    "satteri": "^0.9.1",
     "source-map": "^0.7.6",
     "unist-util-visit": "^5.1.0",
     "vfile": "^6.0.3"
@@ -76,7 +77,6 @@
     "remark-math": "^6.0.0",
     "remark-rehype": "^11.1.2",
     "remark-toc": "^9.0.0",
-    "satteri": "^0.9.1",
     "shiki": "^4.0.2",
     "unified": "^11.0.5",
     "vite": "^8.0.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5198,6 +5198,9 @@ importers:
       remark-smartypants:
         specifier: ^3.0.2
         version: 3.0.2
+      satteri:
+        specifier: ^0.9.1
+        version: 0.9.1
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
@@ -5259,9 +5262,6 @@ importers:
       remark-toc:
         specifier: ^9.0.0
         version: 9.0.0
-      satteri:
-        specifier: ^0.9.1
-        version: 0.9.1
       shiki:
         specifier: ^4.0.2
         version: 4.0.2


### PR DESCRIPTION
## Changes

- Moves `satteri` from `@astrojs/mdx` `devDependencies` to `dependencies` so the bare `import … from 'satteri'` in the Sätteri MDX entrypoints is declared for consumers
- Adds a changeset

`@astrojs/mdx` statically imports `satteri` from `src/satteri/*`, but previously relied on it only transitively via the optional `@astrojs/markdown-satteri` peer (or a `devDependency` that is not published to consumers). Under pnpm’s isolated `node_modules`, that can fail with `ERR_MODULE_NOT_FOUND` for the bare `satteri` import during `astro build` of MDX pages.

Fixes #17371

## Testing

- Minimal Astro + MDX repro: https://github.com/grant/astro-mdx-satteri-undeclared-dep-repro  
  (`pnpm install && pnpm repro` runs a real `astro build`, then again after removing `.pnpm/node_modules/satteri`)
- Lockfile updated with `pnpm install --lockfile-only`