### PR TITLE
Fix dev server 404 for ?url imported assets on browser navigation

### DIFF
--- a/.changeset/green-clocks-greet.md
+++ b/.changeset/green-clocks-greet.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes dev server returning 404 for `?url` imported assets when accessed via browser navigation

--- a/packages/astro/src/vite-plugin-astro-server/route-guard.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route-guard.ts
@@ -112,9 +112,12 @@ export function routeGuardMiddleware(settings: AstroSettings): vite.Connect.Next
 			return next();
 		}
 
+		const resolved = new URL('.' + pathname, config.root);
 		const fsInfo: RouteGuardFsInfo = {
-			existsInPublic: fs.existsSync(new URL('.' + pathname, config.publicDir)),
-			existsInSrc: fs.existsSync(new URL('.' + pathname, config.srcDir)),
+			existsInPublic:
+				resolved.pathname.startsWith(config.publicDir.pathname) && fs.existsSync(resolved),
+			existsInSrc:
+				resolved.pathname.startsWith(config.srcDir.pathname) && fs.existsSync(resolved),
 			existsAtRootAsFile: false,
 		};
 

--- a/packages/astro/test/units/dev/route-guard-middleware.test.ts
+++ b/packages/astro/test/units/dev/route-guard-middleware.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+import { routeGuardMiddleware } from '../../../dist/vite-plugin-astro-server/route-guard.js';
+import { createBasicSettings, createFixture, createRequestAndResponse } from '../test-utils.ts';
+
+describe('routeGuardMiddleware — filesystem resolution', () => {
+	let fixture: Awaited<ReturnType<typeof createFixture>>;
+
+	after(async () => {
+		await fixture?.rm();
+	});
+
+	it('allows src/ files through on browser navigation (Accept: text/html)', async () => {
+		fixture = await createFixture({
+			'src/downloads/a.pdf': '%PDF-1.4 test',
+		});
+		const settings = await createBasicSettings({ root: fixture.path });
+		const middleware = routeGuardMiddleware(settings);
+
+		// Simulate browser navigation to /src/downloads/a.pdf
+		const { req, res } = createRequestAndResponse({
+			method: 'GET',
+			url: '/src/downloads/a.pdf',
+			headers: { accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' },
+		});
+
+		let nextCalled = false;
+		middleware(req, res, () => {
+			nextCalled = true;
+		});
+
+		assert.equal(nextCalled, true, 'next() should be called — file is inside srcDir');
+		assert.notEqual(
+			(res as any).statusCode,
+			404,
+			'should not return 404 for files inside srcDir',
+		);
+	});
+
+	it('blocks root-level files outside srcDir/publicDir', async () => {
+		fixture = await createFixture({
+			'README.md': '# Test',
+			'src/pages/index.astro': '',
+		});
+		const settings = await createBasicSettings({ root: fixture.path });
+		const middleware = routeGuardMiddleware(settings);
+
+		const { req, res } = createRequestAndResponse({
+			method: 'GET',
+			url: '/README.md',
+			headers: { accept: 'text/html' },
+		});
+
+		let nextCalled = false;
+		middleware(req, res, () => {
+			nextCalled = true;
+		});
+
+		assert.equal(nextCalled, false, 'next() should NOT be called — file is at root');
+		assert.equal((res as any).statusCode, 404, 'should return 404 for root-level files');
+	});
+});


### PR DESCRIPTION
Closes #17177

## Changes

- Files imported with `?url` (e.g. `import pdf from '../downloads/a.pdf?url'`) now serve correctly in the dev server when accessed via browser navigation. Previously, browsers received a 404 because they send `Accept: text/html` on navigation, which triggered the route guard — but the guard was computing `existsInSrc` incorrectly.
- The bug was in `route-guard.ts`: resolving `new URL('.' + pathname, config.srcDir)` for a path like `/src/downloads/a.pdf` produced `<root>/src/src/downloads/a.pdf` (double-nested), which doesn't exist. The fix resolves from `config.root` instead and checks containment using `startsWith`, so the path is correctly identified as inside `srcDir`.

## Testing

- Added `packages/astro/test/units/dev/route-guard-middleware.test.ts` with two cases: one that confirms `src/` files pass through the guard on browser navigation (previously failing), and one that confirms root-level files (e.g. `README.md`) are still blocked.

## Docs

- No docs update needed — this restores expected Vite `?url` import behavior with no API changes.
