### PR TITLE
fix(cloudflare): respect explicit `cache.enabled: false` in wrangler config

### DIFF
--- a/.changeset/some-banks-fix.md
+++ b/.changeset/some-banks-fix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a bug where an explicit `cache: { enabled: false }` in your wrangler config was overridden and forced to `true` when a Workers cache provider was configured

--- a/packages/integrations/cloudflare/src/wrangler.ts
+++ b/packages/integrations/cloudflare/src/wrangler.ts
@@ -70,7 +70,7 @@ export function cloudflareConfigCustomizer(
 						binding: DEFAULT_ASSETS_BINDING_NAME,
 					},
 			// Enable the Worker caching layer when a Cloudflare cache provider is configured
-			cache: needsWorkerCache && !config.cache?.enabled ? { enabled: true } : undefined,
+			cache: needsWorkerCache && config.cache?.enabled === undefined ? { enabled: true } : undefined,
 			previews: getNonInheritableBindings(config.previews),
 		};
 	};

--- a/packages/integrations/cloudflare/test/wrangler.test.ts
+++ b/packages/integrations/cloudflare/test/wrangler.test.ts
@@ -237,6 +237,36 @@ describe('cloudflareConfigCustomizer', () => {
 		});
 	});
 
+	describe('worker cache', () => {
+		it('enables cache when needsWorkerCache is true and cache is not configured', () => {
+			const customizer = cloudflareConfigCustomizer({ needsWorkerCache: true });
+			const result = customizer({});
+
+			assert.deepEqual(result.cache, { enabled: true });
+		});
+
+		it('does not enable cache when needsWorkerCache is false', () => {
+			const customizer = cloudflareConfigCustomizer({ needsWorkerCache: false });
+			const result = customizer({});
+
+			assert.equal(result.cache, undefined);
+		});
+
+		it('does not override cache when already enabled', () => {
+			const customizer = cloudflareConfigCustomizer({ needsWorkerCache: true });
+			const result = customizer({ cache: { enabled: true } });
+
+			assert.equal(result.cache, undefined);
+		});
+
+		it('does not override explicit cache.enabled: false (#17375)', () => {
+			const customizer = cloudflareConfigCustomizer({ needsWorkerCache: true });
+			const result = customizer({ cache: { enabled: false } });
+
+			assert.equal(result.cache, undefined);
+		});
+	});
+
 	describe('default binding names', () => {
 		it('exports DEFAULT_SESSION_KV_BINDING_NAME as SESSION', () => {
 			assert.equal(DEFAULT_SESSION_KV_BINDING_NAME, 'SESSION');


### PR DESCRIPTION
## Summary

Fixes a bug where `cloudflareConfigCustomizer` would silently override an explicit `cache: { enabled: false }` in the user's wrangler config when `cacheCloudflare()` was configured as a cache provider.

## Root Cause

In `packages/integrations/cloudflare/src/wrangler.ts`, the cache auto-enable condition used a falsy check:

```ts
// Before
cache: needsWorkerCache && !config.cache?.enabled ? { enabled: true } : undefined,
```

`!config.cache?.enabled` evaluates to `true` for both:
- `config.cache` is `undefined` — cache not configured at all (correct: should auto-enable)
- `config.cache.enabled` is `false` — user explicitly opted out (incorrect: should be respected)

## Fix

Changed to a strict `=== undefined` check so auto-enabling only applies when the user hasn't set the `cache` field at all:

```ts
// After
cache: needsWorkerCache && config.cache?.enabled === undefined ? { enabled: true } : undefined,
```

An explicit `cache: { enabled: false }` is now preserved through the build. This is consistent with how other fields in the same function (`main`, `compatibility_date`, `assets`) handle their defaults using nullish coalescing.

## Why this matters

Workers Cache supports per-entrypoint enablement via the `exports` block. A valid pattern is to leave the top-level `enabled: false` while enabling cache on specific named entrypoints — e.g., an uncached gateway entry that routes into a cached worker export. Previously the only workaround was post-processing `dist/server/wrangler.json` after the build.

## Testing

Four new unit tests added under a `worker cache` describe block in `packages/integrations/cloudflare/test/wrangler.test.ts`:

1. Auto-enables cache when `needsWorkerCache: true` and cache is unconfigured
2. Does not enable cache when `needsWorkerCache: false`
3. Does not override when cache is already `enabled: true`
4. **Does not override explicit `cache.enabled: false`** (regression test for this issue)

Confirmed working by issue reporter @skezo against the preview build.

Closes #17375
