### PR TITLE
fix(fonts): hash local font files by content only for deterministic filenames

### DIFF
--- a/.changeset/olive-cups-cheer.md
+++ b/.changeset/olive-cups-cheer.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Makes local provider font filenames deterministic by hashing only the file content instead of the absolute file path and content

--- a/packages/astro/src/assets/fonts/infra/fs-font-file-content-resolver.ts
+++ b/packages/astro/src/assets/fonts/infra/fs-font-file-content-resolver.ts
@@ -17,10 +17,10 @@ export class FsFontFileContentResolver implements FontFileContentResolver {
 			return url;
 		}
 		try {
-			// We use the url and the file content for the id generation because:
-			// - The URL is not hashed unlike remote providers
-			// - A font file can renamed and swapped so we would incorrectly cache it
-			return url + this.#readFileSync(url);
+			// We only hash the file content, not the url, so the generated id is
+			// deterministic across different absolute paths (eg. CI vs local checkouts).
+			// A swapped font file will have different content and thus a different id.
+			return this.#readFileSync(url);
 		} catch (cause) {
 			throw new AstroError(AstroErrorData.UnknownFilesystemError, { cause });
 		}

--- a/packages/astro/test/units/assets/fonts/infra.test.ts
+++ b/packages/astro/test/units/assets/fonts/infra.test.ts
@@ -767,12 +767,12 @@ describe('fonts infra', () => {
 			assert.equal(fontFileIdContentResolver.resolve(url), url);
 		});
 
-		it('returns url and content when absolute', () => {
+		it('returns content when absolute', () => {
 			const url = fileURLToPath(new URL(import.meta.url));
 			const fontFileIdContentResolver = new FsFontFileContentResolver({
 				readFileSync: () => 'content',
 			});
-			assert.equal(fontFileIdContentResolver.resolve(url), url + 'content');
+			assert.equal(fontFileIdContentResolver.resolve(url), 'content');
 		});
 	});
 


### PR DESCRIPTION
## Changes

Local provider font files were hashed using their absolute path plus content, so the emitted `/_astro/fonts/<hash>.<ext>` filename changed depending on the checkout directory. This makes it hash the content only, so the same font produces the same filename across machines and CI, like every other bundled asset.

Fixes #17377

## Testing

Updated the existing `FsFontFileContentResolver` unit test to assert the resolved value is content-only.

## Docs

N/A
