### PR TITLE
Local font file IDs now hash content only, not content + absolute path

### DIFF
--- a/packages/astro/src/assets/fonts/infra/fs-font-file-content-resolver.ts
+++ b/packages/astro/src/assets/fonts/infra/fs-font-file-content-resolver.ts
@@ -17,10 +17,11 @@ export class FsFontFileContentResolver implements FontFileContentResolver {
 			return url;
 		}
 		try {
-			// We use the url and the file content for the id generation because:
-			// - The URL is not hashed unlike remote providers
-			// - A font file can renamed and swapped so we would incorrectly cache it
-			return url + this.#readFileSync(url);
+			// We only use the file content for the id generation to ensure
+			// deterministic output filenames regardless of the project's location
+			// on disk. The absolute path is excluded so that the same font file
+			// produces the same hash across different checkout directories.
+			return this.#readFileSync(url);
 		} catch (cause) {
 			throw new AstroError(AstroErrorData.UnknownFilesystemError, { cause });
 		}

--- a/packages/astro/test/units/assets/fonts/infra.test.ts
+++ b/packages/astro/test/units/assets/fonts/infra.test.ts
@@ -767,12 +767,12 @@ describe('fonts infra', () => {
 			assert.equal(fontFileIdContentResolver.resolve(url), url);
 		});
 
-		it('returns url and content when absolute', () => {
+		it('returns content only when absolute', () => {
 			const url = fileURLToPath(new URL(import.meta.url));
 			const fontFileIdContentResolver = new FsFontFileContentResolver({
 				readFileSync: () => 'content',
 			});
-			assert.equal(fontFileIdContentResolver.resolve(url), url + 'content');
+			assert.equal(fontFileIdContentResolver.resolve(url), 'content');
 		});
 	});
 


### PR DESCRIPTION
## Changes

- Local font filenames (`/_astro/fonts/<hash>.<ext>`) are now deterministic regardless of where the project is checked out. Previously, `FsFontFileContentResolver.resolve()` returned `absolutePath + fileContent`, so the same font produced different hashes on different machines or CI workspace paths. Now only the file content is hashed, matching how all other bundled assets (JS, CSS, images) are identified.

## Testing

- Updated the existing unit test in `packages/astro/test/units/assets/fonts/infra.test.ts`: the assertion for the absolute-path case now expects `'content'` instead of `url + 'content'`, reflecting that the path is no longer included in the resolved value.

## Docs

- No docs update needed — this is a bug fix restoring expected deterministic behavior with no API changes.

Closes #17377