### PR TITLE
Add missing changeset for #17384

### DIFF
--- a/.changeset/deterministic-local-font-ids.md
+++ b/.changeset/deterministic-local-font-ids.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes non-deterministic filenames for fonts from the `local` provider. Font file IDs are now hashed from the file content only, not the absolute file path and content, so the same font produces the same `/_astro/fonts/<hash>.<ext>` URL across machines and CI checkouts.


### PR DESCRIPTION
## Changes

#17384 (the fix for #17377) was merged without a changeset — changeset-bot flagged it — so the fix currently won't appear in the changelog. This adds the missing changeset (`astro` patch) describing the fix.

## Testing

N/A — changeset only.

## Docs

N/A