### PR TITLE
feat(logger): allow passing entrypoint as URL

### DIFF
--- a/.changeset/tasty-windows-lead.md
+++ b/.changeset/tasty-windows-lead.md
@@ -1,0 +1,17 @@
+---
+'astro': minor
+---
+
+Allows passing URL entrypoints when configuring the logger
+
+Matching other APIs like session drivers or font providers, the logger entrypoint can now be a URL:
+
+```js
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  logger: {
+    entrypoint: new URL("./logger.js", import.meta.url),
+  }
+});
+```

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -555,7 +555,7 @@ export const AstroConfigSchema = z.object({
 	fetchFile: z.string().nullable().optional().default(ASTRO_CONFIG_DEFAULTS.fetchFile),
 	logger: z
 		.object({
-			entrypoint: z.string(),
+			entrypoint: z.union([z.string(), z.instanceof(URL)]),
 			config: z.record(z.string(), z.any()).optional(),
 		})
 		.optional(),

--- a/packages/astro/src/core/logger/config.ts
+++ b/packages/astro/src/core/logger/config.ts
@@ -2,5 +2,5 @@ export interface LoggerHandlerConfig {
 	/** Serializable options used by the driver implementation */
 	config?: Record<string, any> | undefined;
 	/** URL or package import */
-	entrypoint: string;
+	entrypoint: string | URL;
 }

--- a/packages/astro/src/core/logger/load.ts
+++ b/packages/astro/src/core/logger/load.ts
@@ -8,11 +8,16 @@ import { default as consoleLoggerCreator } from './impls/console.js';
 import { default as jsonLoggerCreator } from './impls/json.js';
 import { default as composeLoggerCreator } from './impls/compose.js';
 
+function normalizeEntrypoint(entrypoint: LoggerHandlerConfig['entrypoint']): string {
+	return entrypoint instanceof URL ? entrypoint.href : entrypoint;
+}
+
 export async function loadLogger(
 	config: LoggerHandlerConfig,
 	level: AstroLoggerLevel = 'info',
 ): Promise<AstroLogger> {
 	let cause: Error | undefined = undefined;
+	const entrypoint = normalizeEntrypoint(config.entrypoint);
 
 	try {
 		switch (config.entrypoint) {
@@ -40,7 +45,9 @@ export async function loadLogger(
 					const loggers: LoggerHandlerConfig[] = config.config?.loggers;
 					destinations = await Promise.all(
 						loggers.map(async (loggerConfig) => {
-							const logger = await import(/* @vite-ignore */ loggerConfig.entrypoint);
+							const logger = await import(
+								/* @vite-ignore */ normalizeEntrypoint(loggerConfig.entrypoint)
+							);
 							return logger.default(loggerConfig.config) as AstroLoggerDestination;
 						}),
 					);
@@ -52,9 +59,9 @@ export async function loadLogger(
 				});
 			}
 			default: {
-				const nodeLogger = await import(/* @vite-ignore */ config.entrypoint);
+				const logger = await import(/* @vite-ignore */ entrypoint);
 				return new AstroLogger({
-					destination: nodeLogger.default(config.config),
+					destination: logger.default(config.config),
 					level,
 				});
 			}
@@ -67,7 +74,7 @@ export async function loadLogger(
 
 	const error = new AstroError({
 		...UnableToLoadLogger,
-		message: UnableToLoadLogger.message(config.entrypoint),
+		message: UnableToLoadLogger.message(entrypoint),
 	});
 	if (cause) {
 		error.cause = cause;

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1459,7 +1459,7 @@ export interface AstroUserConfig<
 	/**
 	 * @docs
 	 * @name logger.entrypoint
-	 * @type {string}
+	 * @type {string | URL}
 	 * @version 7.0.0
 	 * @description
 	 *

--- a/packages/astro/test/units/logger/load.test.ts
+++ b/packages/astro/test/units/logger/load.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { AstroLogger } from '../../../dist/core/logger/core.js';
+import { loadLogger } from '../../../dist/core/logger/load.js';
+
+// A real logger impl module on disk whose default export returns a destination.
+const CONSOLE_IMPL_URL = new URL('../../../dist/core/logger/impls/console.js', import.meta.url);
+
+describe('loadLogger', () => {
+	it('loads a custom logger from a string entrypoint', async () => {
+		const logger = await loadLogger({ entrypoint: CONSOLE_IMPL_URL.href });
+		assert.ok(logger instanceof AstroLogger);
+	});
+
+	it('loads a custom logger from a URL entrypoint', async () => {
+		const logger = await loadLogger({ entrypoint: CONSOLE_IMPL_URL });
+		assert.ok(logger instanceof AstroLogger);
+	});
+
+	it('loads composed loggers from URL entrypoints', async () => {
+		const logger = await loadLogger({
+			entrypoint: 'astro/logger/compose',
+			config: {
+				loggers: [{ entrypoint: CONSOLE_IMPL_URL }, { entrypoint: CONSOLE_IMPL_URL }],
+			},
+		});
+		assert.ok(logger instanceof AstroLogger);
+	});
+
+	it('throws with the resolved href when a URL entrypoint cannot be loaded', async () => {
+		const missing = new URL('../../../dist/core/logger/impls/does-not-exist.js', import.meta.url);
+		await assert.rejects(loadLogger({ entrypoint: missing }), (error: Error) => {
+			// The error message should surface the normalized href, not "[object URL]".
+			assert.match(error.message, /does-not-exist\.js/);
+			return true;
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- When trying to use loggers in a project, I found this inconsistency

## Testing

Adds a unit test (help from Claude)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- Changeset
- No docs PR, updating the types jsdocs is enough

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
