### PR TITLE
Add more escaping for rendered content

### DIFF
--- a/.changeset/tidy-styles-harden.md
+++ b/.changeset/tidy-styles-harden.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hardens generated transition styles, development metadata, and server island URLs when embedding dynamic values

--- a/packages/astro/src/core/app/dev/pipeline.ts
+++ b/packages/astro/src/core/app/dev/pipeline.ts
@@ -10,6 +10,7 @@ import { type HeadElements, Pipeline, type TryRewriteResult } from '../../base-p
 import { ASTRO_VERSION } from '../../constants.js';
 import { createModuleScriptElement, createStylesheetElementSet } from '../../render/ssr-element.js';
 import { findRouteToRewrite } from '../../routing/rewrite.js';
+import { stringifyForScript } from '../../../runtime/server/escape.js';
 
 type DevPipelineCreate = Pick<NonRunnablePipeline, 'logger' | 'manifest' | 'streaming'>;
 
@@ -104,7 +105,7 @@ export class NonRunnablePipeline extends Pipeline {
 			};
 
 			// Additional data for the dev overlay
-			const children = `window.__astro_dev_toolbar__ = ${JSON.stringify(additionalMetadata)}`;
+			const children = `window.__astro_dev_toolbar__ = ${stringifyForScript(additionalMetadata)}`;
 			scripts.add({ props: {}, children });
 		}
 

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -15,6 +15,11 @@ export function stringifyForScript(value: any): string {
 	return JSON.stringify(value)?.replace(/</g, '\\u003c');
 }
 
+/** Escapes CSS text so it can be embedded inside a `<style>` tag. */
+export function escapeStyleText(value: string): string {
+	return value.replaceAll('<', '\\3C ');
+}
+
 export class HTMLBytes extends Uint8Array {}
 
 // TypeScript won't let us define this in the class body so have to do it

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -7,6 +7,7 @@ import type { RenderDestination } from './common.js';
 import { createRenderInstruction } from './instruction.js';
 import { SERVER_ISLAND_START } from './server-islands-shared.js';
 import { type ComponentSlots, type SlotString, renderSlotToString } from './slot.js';
+import { toAttributeString } from './util.js';
 
 const internalProps = new Set([
 	'server:component-path',
@@ -198,7 +199,7 @@ export class ServerIslandComponent {
 			serverIslandUrl += '?' + potentialSearchParams.toString();
 			this.result._metadata.extraHead.push(
 				markHTMLString(
-					`<link rel="preload" as="fetch" href="${serverIslandUrl}" crossorigin="anonymous">`,
+					`<link rel="preload" as="fetch" href="${toAttributeString(serverIslandUrl)}" crossorigin="anonymous">`,
 				),
 			);
 		}
@@ -206,11 +207,12 @@ export class ServerIslandComponent {
 		// Get adapter headers for inline script
 		const adapterHeaders = this.result.internalFetchHeaders || {};
 		const headersJson = stringifyForScript(adapterHeaders);
+		const serverIslandUrlJson = stringifyForScript(serverIslandUrl);
 
 		const method = useGETRequest
 			? // GET request
 				`const headers = new Headers(${headersJson});
-let response = await fetch('${serverIslandUrl}', { headers });`
+let response = await fetch(${serverIslandUrlJson}, { headers });`
 			: // POST request
 				`let data = {
 	encryptedComponentExport: ${stringifyForScript(componentExportEncrypted)},
@@ -218,13 +220,13 @@ let response = await fetch('${serverIslandUrl}', { headers });`
 	encryptedSlots: ${stringifyForScript(slotsEncrypted)},
 };
 const headers = new Headers({ 'Content-Type': 'application/json', ...${headersJson} });
-let response = await fetch('${serverIslandUrl}', {
+let response = await fetch(${serverIslandUrlJson}, {
 	method: 'POST',
 	body: JSON.stringify(data),
 	headers,
 });`;
 
-		this.islandContent = `${method}replaceServerIsland('${hostId}', response);`;
+		this.islandContent = `${method}replaceServerIsland(${stringifyForScript(hostId)}, response);`;
 		return this.islandContent;
 	}
 }

--- a/packages/astro/src/runtime/server/transition.ts
+++ b/packages/astro/src/runtime/server/transition.ts
@@ -7,7 +7,7 @@ import type {
 	TransitionAnimationValue,
 	TransitionDirectionalAnimations,
 } from '../../types/public/view-transitions.js';
-import { markHTMLString } from './escape.js';
+import { escapeStyleText, markHTMLString } from './escape.js';
 
 const transitionNameMap = new WeakMap<SSRResult, number>();
 function incrementTransitionNumber(result: SSRResult) {
@@ -110,7 +110,7 @@ export function renderTransition(
 		sheet.addModern('group', 'animation: none');
 	}
 
-	const css = sheet.toString();
+	const css = escapeStyleText(sheet.toString());
 	result._metadata.extraHead.push(markHTMLString(`<style>${css}</style>`));
 	return scope;
 }

--- a/packages/astro/src/vite-plugin-app/pipeline.ts
+++ b/packages/astro/src/vite-plugin-app/pipeline.ts
@@ -11,6 +11,7 @@ import type { DefaultRouteParams } from '../core/routing/default.js';
 import { routeIsRedirect } from '../core/routing/helpers.js';
 import { findRouteToRewrite } from '../core/routing/rewrite.js';
 import { isPage } from '../core/util.js';
+import { stringifyForScript } from '../runtime/server/escape.js';
 import type {
 	AstroSettings,
 	ComponentInstance,
@@ -134,7 +135,7 @@ export class RunnablePipeline extends Pipeline {
 					};
 
 					// Additional data for the dev overlay
-					const children = `window.__astro_dev_toolbar__ = ${JSON.stringify(additionalMetadata)}`;
+					const children = `window.__astro_dev_toolbar__ = ${stringifyForScript(additionalMetadata)}`;
 					scripts.add({ props: {}, children });
 				}
 			}

--- a/packages/astro/test/server-islands.test.ts
+++ b/packages/astro/test/server-islands.test.ts
@@ -93,7 +93,7 @@ describe('Server islands', () => {
 				const res = await fixture.fetch('/fragment');
 				assert.equal(res.status, 200);
 				const html = await res.text();
-				const fetchMatch = /fetch\('\/_server-islands\/Island\?[^']*p=([^&']*)/.exec(html)!;
+				const fetchMatch = /fetch\(["']\/_server-islands\/Island\?[^"']*p=([^&"']*)/.exec(html)!;
 				assert.equal(fetchMatch.length, 2, 'should include props in the query string');
 				assert.equal(fetchMatch[1], '', 'should not include encrypted empty props');
 			});
@@ -102,7 +102,7 @@ describe('Server islands', () => {
 				const res = await fixture.fetch('/fragment');
 				assert.equal(res.status, 200);
 				const html = await res.text();
-				const fetchMatch = /fetch\('\/_server-islands\/Island\?[^']*p=([^&']*)/.exec(html)!;
+				const fetchMatch = /fetch\(["']\/_server-islands\/Island\?[^"']*p=([^&"']*)/.exec(html)!;
 				assert.equal(fetchMatch.length, 2, 'should include props in the query string');
 				assert.equal(fetchMatch[1], '', 'should not include encrypted empty props');
 			});
@@ -111,7 +111,7 @@ describe('Server islands', () => {
 				const res = await fixture.fetch('/slot-with-script');
 				assert.equal(res.status, 200);
 				const html = await res.text();
-				const urlMatch = /fetch\('(\/_server-islands\/Wrapper\?[^']+)'/.exec(html)!;
+				const urlMatch = /fetch\(["'](\/_server-islands\/Wrapper\?[^"']+)["']/.exec(html)!;
 				assert.ok(urlMatch, 'should have a server island fetch URL');
 				const islandRes = await fixture.fetch(urlMatch[1]);
 				assert.equal(islandRes.status, 200);
@@ -273,7 +273,7 @@ describe('Server islands', () => {
 				const res = await app.render(request);
 				assert.equal(res.status, 200);
 				const html = await res.text();
-				const fetchMatch = /fetch\('\/_server-islands\/Island\?[^']*p=([^&']*)/.exec(html)!;
+				const fetchMatch = /fetch\(["']\/_server-islands\/Island\?[^"']*p=([^&"']*)/.exec(html)!;
 				assert.equal(fetchMatch.length, 2, 'should include props in the query string');
 				assert.equal(fetchMatch[1], '', 'should not include encrypted empty props');
 			});
@@ -342,7 +342,7 @@ describe('Server islands', () => {
 				const res = await devFixture.fetch('/');
 				assert.equal(res.status, 200);
 				const html = await res.text();
-				const fetchMatch = /fetch\('(\/_server-islands\/Island[^']*)/.exec(html)!;
+				const fetchMatch = /fetch\(["'](\/_server-islands\/Island[^"']*)/.exec(html)!;
 				assert.ok(fetchMatch, 'should have a server island fetch URL');
 				const islandRes = await devFixture.fetch(fetchMatch[1]);
 				assert.equal(

--- a/packages/astro/test/units/render/escape.test.ts
+++ b/packages/astro/test/units/render/escape.test.ts
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
 	escapeHTML,
+	escapeStyleText,
 	isHTMLString,
 	markHTMLString,
+	stringifyForScript,
 	unescapeHTML,
 } from '../../../dist/runtime/server/escape.js';
 
@@ -64,6 +66,24 @@ describe('escapeHTML', () => {
 		const result = escapeHTML('<b>test</b>');
 		assert.equal(typeof result, 'string');
 		assert.equal(result, '&lt;b&gt;test&lt;/b&gt;');
+	});
+});
+
+describe('raw text escaping', () => {
+	it('escapes less-than signs in inline style text as CSS', () => {
+		assert.equal(
+			escapeStyleText('animation-name: </STYLE><script>test</script>'),
+			'animation-name: \\3C /STYLE>\\3C script>test\\3C /script>',
+		);
+	});
+
+	it('preserves ordinary inline style text', () => {
+		assert.equal(escapeStyleText('animation-duration: 300ms'), 'animation-duration: 300ms');
+	});
+
+	it('serializes values without literal less-than signs for inline scripts', () => {
+		const result = stringifyForScript({ value: '</SCRIPT><script>test</script>' });
+		assert.equal(result, '{"value":"\\u003c/SCRIPT>\\u003cscript>test\\u003c/script>"}');
 	});
 });
 

--- a/packages/astro/test/units/render/transitions.test.ts
+++ b/packages/astro/test/units/render/transitions.test.ts
@@ -1,12 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import {
 	ViewTransitionStyleSheet,
 	reEncode,
+	renderTransition,
 	stringifyAnimation,
 	stringifyAnimations,
 	toTimeValue,
 } from '../../../dist/runtime/server/transition.js';
+import type { SSRResult } from '../../../dist/types/public/internal.js';
 
 describe('reEncode', () => {
 	it('passes through simple alphanumeric strings unchanged', () => {
@@ -194,5 +197,31 @@ describe('ViewTransitionStyleSheet', () => {
 		sheet.addFallback('old', 'animation: none;');
 		const css = sheet.toString();
 		assert.ok(!css.includes('@layer'), 'should not include @layer when no modern rules');
+	});
+});
+
+describe('renderTransition', () => {
+	it('keeps animation values inside the generated style element', () => {
+		const result = {
+			_metadata: { extraHead: [] },
+		} as unknown as SSRResult;
+		const animation = {
+			forwards: {
+				old: { name: 'fade', duration: '</style><script>test</script>' },
+				new: { name: 'fade' },
+			},
+			backwards: {
+				old: { name: 'fade' },
+				new: { name: 'fade' },
+			},
+		};
+
+		renderTransition(result, 'hash', animation, 'name');
+
+		const style = String(result._metadata.extraHead[0]);
+		const $ = cheerio.load(`<head>${style}</head>`);
+		assert.equal($('head style').length, 1);
+		assert.equal($('head script').length, 0);
+		assert.ok(style.includes('\\3C /style>\\3C script>test\\3C /script>'));
 	});
 });

--- a/packages/astro/test/units/server-islands/server-islands-render.test.ts
+++ b/packages/astro/test/units/server-islands/server-islands-render.test.ts
@@ -203,7 +203,7 @@ describe('ServerIslandComponent', () => {
 			const content = await component.getIslandContent();
 			// A small payload should use a plain fetch() GET call (no method: 'POST')
 			assert.ok(!content.includes("method: 'POST'"), 'small payloads should use GET, not POST');
-			assert.ok(content.includes("fetch('"), 'should use fetch()');
+			assert.ok(content.includes('fetch("'), 'should use fetch()');
 		});
 
 		it('uses a POST request for large payloads (over 2048 chars)', async () => {
@@ -224,6 +224,18 @@ describe('ServerIslandComponent', () => {
 				content.includes('/app/_server-islands/Island'),
 				`island URL should include base + componentId, got: ${content}`,
 			);
+		});
+
+		it('escapes the island URL for script and attribute contexts', async () => {
+			const result = await createStubResult({ base: '/"</script><script>test</script>' });
+			const component = new ServerIslandComponent(result, islandProps(), {}, 'Island');
+			const content = await component.getIslandContent();
+			const preload = String(result._metadata.extraHead[0]);
+
+			assert.ok(!content.includes('</script>'));
+			assert.ok(content.includes('\\u003c/script>'));
+			assert.ok(preload.includes('&quot;'));
+			assert.ok(!preload.includes('href="/"'));
 		});
 
 		it('appends a trailing slash when trailingSlash is "always"', async () => {

--- a/packages/integrations/cloudflare/test/prerender-node-env.test.ts
+++ b/packages/integrations/cloudflare/test/prerender-node-env.test.ts
@@ -70,7 +70,7 @@ describe('prerenderEnvironment: node', () => {
 			'Expected fallback content in prerendered HTML',
 		);
 
-		const islandUrlMatch = /fetch\('(\/_server-islands\/[^']+)'/.exec(html);
+		const islandUrlMatch = /fetch\(["'](\/_server-islands\/[^"']+)["']/.exec(html);
 		assert.ok(islandUrlMatch, 'Expected prerendered HTML to include a server island fetch URL');
 
 		const islandRes = await fixture.fetch(islandUrlMatch[1]);


### PR DESCRIPTION
## Changes

- Escapes generated transition styles for inline CSS contexts.
- Serializes dev toolbar metadata
- Serializes server island URLs

## Testing

- Adds unit coverage for style, script, attribute, and URL serialization.

## Docs

- No docs update needed because public APIs are unchanged.