### PR TITLE
Preserve CSP resource defaults for element directives

### DIFF
--- a/.changeset/early-seas-mix.md
+++ b/.changeset/early-seas-mix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes element-specific CSP directives to preserve the existing behavior of configured script and style resources

--- a/packages/astro/src/runtime/server/render/csp.ts
+++ b/packages/astro/src/runtime/server/render/csp.ts
@@ -43,6 +43,8 @@ export function renderCspContent(result: SSRResult): string {
 		script.default.resources.length > 0 ? script.default.resources.join(' ') : "'self'";
 	const styleResources =
 		style.default.resources.length > 0 ? style.default.resources.join(' ') : "'self'";
+	const scriptElementDefaultResource = script.default.resources.length > 0 ? '' : "'self'";
+	const styleElementDefaultResource = style.default.resources.length > 0 ? '' : "'self'";
 
 	// `script-src`/`style-src` cover everything; the `-elem`/`-attr` variants are narrower:
 	//   - `*-src-elem` → tags (`<script>`, `<style>`, `<link rel="stylesheet">`)
@@ -76,7 +78,7 @@ export function renderCspContent(result: SSRResult): string {
 		? renderSpecificDirective(
 				'script-src-elem',
 				script.element.resources,
-				"'self'",
+				scriptElementDefaultResource,
 				finalScriptHashes,
 				script.element.hashes,
 				strictDynamicSuffix,
@@ -95,7 +97,7 @@ export function renderCspContent(result: SSRResult): string {
 		? renderSpecificDirective(
 				'style-src-elem',
 				style.element.resources,
-				"'self'",
+				styleElementDefaultResource,
 				finalStyleHashes,
 				style.element.hashes,
 			)
@@ -134,7 +136,7 @@ function isEnabled(sources: CspDirectiveSources): boolean {
  *
  * @param name The directive name, e.g. `"script-src-elem"`.
  * @param resources The sources the user scoped to this directive (e.g. `'self'` or a URL).
- * @param defaultResource The source to use when `resources` is empty (`'self'` for `-elem`, `'none'` for `-attr`).
+ * @param defaultResource The source to use when `resources` is empty. This is `'self'` for `-elem` without configured default resources and `'none'` for `-attr`.
  * @param sharedHashes Already-quoted hashes to also include here — Astro's tag hashes for `-elem`, or `undefined` for `-attr` (which never receives them).
  * @param ownHashes Unquoted hashes the user scoped to this directive.
  * @param suffix Optional text added at the end, e.g. ` 'strict-dynamic'`.

--- a/packages/astro/test/units/csp/render-csp.test.ts
+++ b/packages/astro/test/units/csp/render-csp.test.ts
@@ -80,6 +80,25 @@ describe('renderCspContent', () => {
 		);
 	});
 
+	it('does not add self to element directives when default resources are configured', () => {
+		assert.equal(
+			renderCspContent(
+				createCspResult({
+					scriptDirective: {
+						hashes: [{ hash: 'sha256-script', kind: 'element' }],
+						resources: ["'none'"],
+					},
+					styleDirective: {
+						hashes: [{ hash: 'sha256-style', kind: 'element' }],
+						resources: ['https://styles.example.com'],
+					},
+				}),
+			),
+			"script-src 'none' ; script-src-elem 'sha256-script'; " +
+				"style-src https://styles.example.com ; style-src-elem 'sha256-style';",
+		);
+	});
+
 	it('does not share default hashes into the -attr directives', () => {
 		assert.equal(
 			renderCspContent(


### PR DESCRIPTION
## Changes

- Preserves the pre-existing behavior of configured script and style resources when element-specific hashes are used.
- When generic resources are explicitly configured, enabling a `-elem` directive with a hash no longer implicitly adds `self`. Users who want same-origin resources on the element directive can still configure `self` explicitly.
- Keeps the implicit `self` fallback when no generic resources are configured.

Example case, you have this config:

```ts
// astro.config.mjs
import { defineConfig } from 'astro/config';

export default defineConfig({
  security: {
    csp: {
      scriptDirective: {
        resources: ["'none'"],
        hashes: [
          {
            hash: 'sha256-TRUSTED_INLINE_SCRIPT_HASH',
            kind: 'element',
          },
        ],
      },
    },
  },
});
```

Prior to this change you get this:

```
Content-Security-Policy:
  script-src 'none';
  script-src-elem 'self' 'sha256-TRUSTED_INLINE_SCRIPT_HASH';
```

With `'self'` overriding the more strict hash.

## Testing

- Adds renderer coverage for script and style element directives with configured generic resources.

## Docs

- No docs update needed; this restores the documented resource behavior.