### PR TITLE
Normalize domain-based i18n request paths consistently

### DIFF
--- a/.changeset/tidy-pathnames-agree.md
+++ b/.changeset/tidy-pathnames-agree.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Uses the normalized request pathname when deriving paths for domain-based i18n routing
+Fixes encoded request paths being routed incorrectly when using domain-based i18n

--- a/.changeset/tidy-pathnames-agree.md
+++ b/.changeset/tidy-pathnames-agree.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Uses the normalized request pathname when deriving paths for domain-based i18n routing

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -268,8 +268,10 @@ export class FetchState implements AstroFetchState {
 		this.slots = undefined;
 		// Parse the URL once and derive both pathname and url from it.
 		const url = new URL(request.url);
-		const publicPathname = this.#normalizePathname(url);
+		const publicPathname = this.#normalizePathname(url.pathname);
 		const pathname = this.#computePathname(publicPathname);
+		url.pathname = publicPathname;
+		url.pathname = collapseDuplicateSlashes(url.pathname);
 		// For domain-based i18n routing, the locale prefix is derived from the
 		// request's Host header rather than its URL. When a locale is detected,
 		// the resulting pathname includes the prefix (e.g. /en/boats/1/foo) that
@@ -975,8 +977,7 @@ export class FetchState implements AstroFetchState {
 	 * Decodes and normalizes the public request pathname before deriving the
 	 * separate pathname used for route matching.
 	 */
-	#normalizePathname(url: URL): string {
-		let pathname = url.pathname;
+	#normalizePathname(pathname: string): string {
 		try {
 			pathname = validateAndDecodePathname(pathname);
 		} catch (e: any) {
@@ -989,15 +990,7 @@ export class FetchState implements AstroFetchState {
 				this.pipeline.logger.error(null, e.toString());
 			}
 		}
-		url.pathname = collapseDuplicateSlashes(pathname);
-		try {
-			// URL.pathname re-encodes Unicode after applying WHATWG path
-			// canonicalization. Escape bare percent signs so we can recover the
-			// decoded string without treating them as malformed sequences.
-			return decodeURI(url.pathname.replace(/%(?![0-9a-f]{2})/gi, '%25'));
-		} catch {
-			return url.pathname;
-		}
+		return collapseDuplicateSlashes(pathname);
 	}
 
 	/**

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -1,6 +1,7 @@
 import colors from 'piccolore';
 import {
 	collapseDuplicateLeadingSlashes,
+	collapseDuplicateSlashes,
 	prependForwardSlash,
 	removeTrailingForwardSlash,
 } from '@astrojs/internal-helpers/path';
@@ -35,7 +36,6 @@ import {
 import { getParams, getProps } from '../render/index.js';
 import { Rewrites } from '../rewrites/handler.js';
 import { isRoute404or500, isRouteServerIsland } from '../routing/match.js';
-import { normalizeUrl } from '../util/normalized-url.js';
 import { MultiLevelEncodingError, validateAndDecodePathname } from '../util/pathname.js';
 import { getOriginPathname, setOriginPathname } from '../routing/rewrite.js';
 import { computePathnameFromDomain } from '../i18n/domain.js';
@@ -268,6 +268,8 @@ export class FetchState implements AstroFetchState {
 		this.slots = undefined;
 		// Parse the URL once and derive both pathname and url from it.
 		const url = new URL(request.url);
+		const publicPathname = this.#normalizePathname(url);
+		const pathname = this.#computePathname(publicPathname);
 		// For domain-based i18n routing, the locale prefix is derived from the
 		// request's Host header rather than its URL. When a locale is detected,
 		// the resulting pathname includes the prefix (e.g. /en/boats/1/foo) that
@@ -280,21 +282,18 @@ export class FetchState implements AstroFetchState {
 			pipeline.manifest.base,
 			pipeline.manifest.trailingSlash,
 			pipeline.logger,
+			pathname,
 		);
 		if (domainPathname) {
 			this.#domainPathname = domainPathname;
-			try {
-				this.pathname = decodeURI(domainPathname);
-			} catch {
-				this.pathname = domainPathname;
-			}
+			this.pathname = domainPathname;
 		} else {
-			this.pathname = this.#computePathname(url);
+			this.pathname = pathname;
 		}
 		this.timeStart = performance.now();
 		this.clientAddress = options?.clientAddress;
 		this.locals = (options?.locals ?? {}) as App.Locals;
-		this.url = normalizeUrl(url);
+		this.url = url;
 		this.cookies = new AstroCookies(request);
 
 		// Apply X-Forwarded-* headers only when the user has configured
@@ -955,34 +954,49 @@ export class FetchState implements AstroFetchState {
 	}
 
 	/**
-	 * Strips the pipeline's base from the request URL, prepends a forward
-	 * slash, and decodes the pathname. Falls back to the raw (not decoded)
-	 * pathname if `decodeURI` throws.
+	 * Strips the pipeline's base from a normalized request pathname and prepends
+	 * a forward slash.
 	 *
 	 * Mirrors `BaseApp.removeBase`, including the
 	 * `collapseDuplicateLeadingSlashes` fix that prevents middleware
 	 * authorization bypass when the URL starts with `//`.
 	 */
-	#computePathname(url: URL): string {
-		let pathname = collapseDuplicateLeadingSlashes(url.pathname);
+	#computePathname(normalizedPathname: string): string {
+		let pathname = collapseDuplicateLeadingSlashes(normalizedPathname);
 		const base = this.pipeline.manifest.base;
 		if (pathname.startsWith(base)) {
 			const baseWithoutTrailingSlash = removeTrailingForwardSlash(base);
 			pathname = pathname.slice(baseWithoutTrailingSlash.length + 1);
 		}
-		pathname = prependForwardSlash(pathname);
+		return prependForwardSlash(pathname);
+	}
+
+	/**
+	 * Decodes and normalizes the public request pathname before deriving the
+	 * separate pathname used for route matching.
+	 */
+	#normalizePathname(url: URL): string {
+		let pathname = url.pathname;
 		try {
-			return validateAndDecodePathname(pathname);
+			pathname = validateAndDecodePathname(pathname);
 		} catch (e: any) {
 			// The path was encoded too many times to fully decode. Mark it so
 			// the handler can reject the request with a 400 before middleware
 			// or routing run, instead of working with a half-decoded path.
 			if (e instanceof MultiLevelEncodingError) {
 				this.invalidEncoding = true;
-				return pathname;
+			} else {
+				this.pipeline.logger.error(null, e.toString());
 			}
-			this.pipeline.logger.error(null, e.toString());
-			return pathname;
+		}
+		url.pathname = collapseDuplicateSlashes(pathname);
+		try {
+			// URL.pathname re-encodes Unicode after applying WHATWG path
+			// canonicalization. Escape bare percent signs so we can recover the
+			// decoded string without treating them as malformed sequences.
+			return decodeURI(url.pathname.replace(/%(?![0-9a-f]{2})/gi, '%25'));
+		} catch {
+			return url.pathname;
 		}
 	}
 

--- a/packages/astro/src/core/i18n/domain.ts
+++ b/packages/astro/src/core/i18n/domain.ts
@@ -25,6 +25,7 @@ export function computePathnameFromDomain(
 	base: SSRManifest['base'],
 	trailingSlash: SSRManifest['trailingSlash'],
 	logger: AstroLogger,
+	pathnameFromRequest?: string,
 ): string | undefined {
 	let pathname: string | undefined = undefined;
 
@@ -71,14 +72,13 @@ export function computePathnameFromDomain(
 				}
 
 				if (locale) {
-					pathname = prependForwardSlash(
-						joinPaths(normalizeTheLocale(locale), removeBase(url.pathname, base)),
-					);
+					const requestPathname = pathnameFromRequest ?? removeBase(url.pathname, base);
+					pathname = prependForwardSlash(joinPaths(normalizeTheLocale(locale), requestPathname));
 					if (trailingSlash === 'always') {
 						pathname = appendForwardSlash(pathname);
 					} else if (trailingSlash === 'never') {
 						pathname = removeTrailingForwardSlash(pathname);
-					} else if (url.pathname.endsWith('/')) {
+					} else if (requestPathname.endsWith('/')) {
 						// trailingSlash === 'ignore': preserve the original trailing slash
 						pathname = appendForwardSlash(pathname);
 					}

--- a/packages/astro/test/units/i18n/i18n-app.test.ts
+++ b/packages/astro/test/units/i18n/i18n-app.test.ts
@@ -37,7 +37,7 @@ const localePage = createComponent((result, props, slots) => {
 
 const paramsPage = createComponent((result, props, slots) => {
 	const Astro = result.createAstro(props, slots);
-	return render`<h1 id="locale">${Astro.currentLocale}</h1><span id="id">${Astro.params.id}</span><span id="slug">${Astro.params.slug}</span>`;
+	return render`<h1 id="locale">${Astro.currentLocale}</h1><span id="id">${Astro.params.id}</span><span id="slug">${Astro.params.slug}</span><span id="path">${Astro.url.pathname}</span>`;
 });
 
 const notFoundPage = createComponent(() => {
@@ -478,6 +478,29 @@ describe('i18n via App - domains-prefix-other-locales with dynamic params (#1685
 		assert.equal($('#id').text(), '2');
 		assert.equal($('#slug').text(), 'blue-wave');
 		assert.equal($('#locale').text(), 'fi');
+	});
+
+	it('normalizes the public pathname before deriving the domain pathname', async () => {
+		const app = createDomainApp();
+		const res = await app.render(
+			new Request('https://en.example.com/boats/3/caf%25C3%25A9', {
+				headers: { 'X-Forwarded-Host': 'en.example.com', 'X-Forwarded-Proto': 'https' },
+			}),
+		);
+		assert.equal(res.status, 200);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('#slug').text(), 'café');
+		assert.equal($('#path').text(), '/boats/3/caf%C3%A9');
+	});
+
+	it('rejects over-encoded paths on a mapped domain', async () => {
+		const app = createDomainApp();
+		const res = await app.render(
+			new Request('https://en.example.com/%2525252525252525252561dmin', {
+				headers: { 'X-Forwarded-Host': 'en.example.com', 'X-Forwarded-Proto': 'https' },
+			}),
+		);
+		assert.equal(res.status, 400);
 	});
 });
 


### PR DESCRIPTION
## Changes

- Normalizes the public request pathname once before deriving base-stripped and domain-prefixed routing paths, keeping middleware and routing canonicalization aligned.
- Reuses that normalized pathname for domain-based i18n instead of decoding the derived pathname separately.

## Testing

- Adds domain-i18n coverage for multi-encoded Unicode path parameters and the public `Astro.url` pathname.
- Adds a regression assertion that over-encoded paths on mapped domains return `400`.

## Docs

- No docs update needed because this fixes internal routing consistency without changing the public API.