### PR TITLE
fix(prefetch): swallow fetch-fallback rejection to avoid unhandled 'Load failed' on WebKit

### DIFF
--- a/.changeset/prefetch-swallow-fetch-rejection.md
+++ b/.changeset/prefetch-swallow-fetch-rejection.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevents an unhandled promise rejection from the prefetch `fetch` fallback. In WebKit (Safari), `<link rel="prefetch">` is unsupported, so prefetch uses the `fetch()` fallback; on a flaky connection that fetch rejects with `TypeError: Load failed`, and because the promise was not awaited or caught, it surfaced as an unhandled rejection to the page's global error handlers. The best-effort prefetch now swallows the failure with `.catch()`.

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -247,7 +247,12 @@ export function prefetch(url: string, opts?: PrefetchOptions) {
 		for (const [key, value] of Object.entries(internalFetchHeaders) as [string, string][]) {
 			headers.set(key, value);
 		}
-		fetch(url, { priority: 'low', headers });
+		// The `<link rel="prefetch">` branch above is unsupported in WebKit
+		// (Safari), so this fetch fallback is the path there. A prefetch is a
+		// best-effort hint, so swallow network failures — otherwise a flaky
+		// connection surfaces an unhandled `TypeError: Load failed` rejection
+		// to the page's global error handlers (and trips no-floating-promises).
+		fetch(url, { priority: 'low', headers }).catch(() => {});
 	}
 }
 


### PR DESCRIPTION
## What

The prefetch `fetch()` fallback is a floating promise with no `.catch()`. This PR adds `.catch(() => {})` so a failed prefetch can't surface as an unhandled rejection.

## Why

In `packages/astro/src/prefetch/index.ts`, `prefetch()` uses `<link rel="prefetch">` when supported and otherwise falls back to `fetch(url, { priority: 'low', headers })`. **WebKit (Safari) does not support `<link rel="prefetch">`**, so Safari always takes the `fetch` fallback. On a flaky connection that fetch rejects with `TypeError: Load failed`, and because the promise is neither awaited nor caught, it bubbles up as an **unhandled promise rejection** to the page's global error handlers.

For sites with production error monitoring, this shows up as recurring noise (`window.onunhandledrejection` → "Load failed") on Safari/iOS, with no filename/stack to diagnose it — it is not an application error, just a best-effort prefetch that didn't complete.

The fallback was added in #10464 (prefetch on Firefox/Safari); the missing `.catch()` slipped past `no-floating-promises` (enabled in #11089) because it's in this fallback branch.

## Change

```diff
-		fetch(url, { priority: 'low', headers });
+		// best-effort hint — swallow network failures (WebKit fetch fallback)
+		fetch(url, { priority: 'low', headers }).catch(() => {});
```

A prefetch is a best-effort hint; swallowing the failure is the correct behavior (the real navigation will surface any genuine error). Changeset included (`patch`).
