### PR TITLE
Fix TC39 standard decorators broken by Rolldown/oxc in Vite 8

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -55,6 +55,7 @@ import { isObject } from './util-runtime.js';
 import { vitePluginEnvironment } from '../vite-plugin-environment/index.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from './constants.js';
 import { vitePluginChromedevtools } from '../vite-plugin-chromedevtools/index.js';
+import { vitePluginDecorators } from '../vite-plugin-decorators/index.js';
 import { vitePluginDevStatus } from '../vite-plugin-dev-status/index.js';
 import { vitePluginAstroServerClient } from '../vite-plugin-overlay/index.js';
 
@@ -185,6 +186,7 @@ export async function createVite(
 					}
 				},
 			},
+			vitePluginDecorators(),
 			serializedManifestPlugin({ settings, command, sync }),
 			vitePluginRenderers({
 				settings,

--- a/packages/astro/src/vite-plugin-decorators/index.ts
+++ b/packages/astro/src/vite-plugin-decorators/index.ts
@@ -1,0 +1,53 @@
+import { transform } from 'esbuild';
+import type { Plugin } from 'vite';
+
+// Matches @ followed by an identifier character — a minimal signal that
+// the file *might* contain decorator syntax.  Combined with the `class`
+// keyword check this keeps false-positive esbuild invocations low while
+// avoiding expensive parsing.
+const DECORATOR_RE = /@[\w$]/;
+
+/**
+ * Vite plugin that lowers TC39 standard (non-legacy) decorators.
+ *
+ * Rolldown / oxc (Vite 8) strips TypeScript syntax but does **not** lower
+ * TC39 decorators at any target level.  This plugin detects TypeScript files
+ * that likely contain decorator syntax and pre-processes them with esbuild
+ * (`target: "es2024"`), which *does* lower TC39 decorators.
+ *
+ * The plugin runs with `enforce: "pre"` so the code has already been
+ * lowered by the time Vite's built-in oxc transform sees it.
+ */
+export function vitePluginDecorators(): Plugin {
+	return {
+		name: 'astro:decorators',
+		enforce: 'pre',
+		async transform(code, id) {
+			const [filepath] = id.split('?');
+
+			// Only TypeScript files can contain decorators that need lowering.
+			if (!/\.[cm]?tsx?$/.test(filepath)) return;
+			// Skip declaration files – they never execute.
+			if (/\.d\.[cm]?ts$/.test(filepath)) return;
+
+			// Fast bail-out: no `@` or no `class` → definitely no decorators.
+			if (!DECORATOR_RE.test(code) || !/\bclass\b/.test(code)) return;
+
+			const loader: 'ts' | 'tsx' = /tsx?$/.test(filepath) && filepath.endsWith('x') ? 'tsx' : 'ts';
+
+			const result = await transform(code, {
+				loader,
+				// es2024 is the highest target at which esbuild still lowers
+				// TC39 decorators (esnext keeps them as-is).
+				target: 'es2024',
+				sourcemap: true,
+				sourcefile: filepath,
+			});
+
+			return {
+				code: result.code,
+				map: result.map || null,
+			};
+		},
+	};
+}

--- a/packages/astro/test/fixtures/tc39-decorators/src/Example.ts
+++ b/packages/astro/test/fixtures/tc39-decorators/src/Example.ts
@@ -1,0 +1,8 @@
+import { logCall } from './decorator';
+
+export class Example {
+	@logCall
+	greet(name: string): string {
+		return `Hello, ${name}!`;
+	}
+}

--- a/packages/astro/test/fixtures/tc39-decorators/src/decorator.ts
+++ b/packages/astro/test/fixtures/tc39-decorators/src/decorator.ts
@@ -1,0 +1,9 @@
+export function logCall<This, Args extends unknown[], Return>(
+	originalMethod: (this: This, ...args: Args) => Return,
+	context: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>,
+) {
+	return function (this: This, ...args: Args): Return {
+		console.log(`Calling ${String(context.name)}`);
+		return originalMethod.call(this, ...args);
+	};
+}

--- a/packages/astro/test/fixtures/tc39-decorators/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tc39-decorators/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import { Example } from '../Example';
+
+const example = new Example();
+const greeting = example.greet('Astro');
+---
+
+<p id="greeting">{greeting}</p>

--- a/packages/astro/test/tc39-decorators.test.ts
+++ b/packages/astro/test/tc39-decorators.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+
+describe('TC39 decorators', () => {
+	describe('build', () => {
+		let fixture: Fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/tc39-decorators/',
+			});
+			await fixture.build();
+		});
+
+		it('lowers TC39 decorators and renders correctly', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			assert.equal($('#greeting').text(), 'Hello, Astro!');
+		});
+	});
+
+	describe('dev', () => {
+		let fixture: Fixture;
+		let devServer: DevServer;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/tc39-decorators/',
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('lowers TC39 decorators and renders correctly', async () => {
+			const res = await fixture.fetch('/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#greeting').text(), 'Hello, Astro!');
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,6 +607,12 @@ importers:
         specifier: ^7.1.1
         version: link:../../packages/astro
 
+  examples/repro-17409:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+
   examples/ssr:
     dependencies:
       '@astrojs/node':


### PR DESCRIPTION
## Changes

- TC39 standard decorators (i.e. `@decorator` without `experimentalDecorators`) now work in Astro 7. Astro 7 upgraded to Vite 8 (Rolldown/oxc), which strips TypeScript types but does **not** lower TC39 decorator syntax at any target level — causing a `SyntaxError: Invalid or unexpected token` at runtime in both `astro dev` and `astro build`. This was a silent regression from Astro 6, where esbuild lowered decorators automatically.
- Adds a new `astro:decorators` Vite plugin (`enforce: "pre"`) that detects TypeScript files likely containing decorator syntax (fast `@` + `class` keyword check) and pre-processes them through esbuild at `target: "es2024"`, which does lower TC39 decorators. By the time Vite's oxc transform runs, the decorator syntax is already gone.

Closes #17409

## Testing

- Added `packages/astro/test/tc39-decorators.test.ts` with build and dev test cases covering a `@logCall` method decorator, verifying the decorated method executes correctly and the page renders the expected output.

## Docs

- No docs update needed — this restores behavior that worked in Astro 6, not a new feature.
