### PR TITLE
Deserialize each route once when loading the manifest

### DIFF
--- a/.changeset/dedupe-route-deserialization.md
+++ b/.changeset/dedupe-route-deserialization.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Deserializes each route once when loading the SSR manifest

--- a/packages/astro/src/core/app/manifest.ts
+++ b/packages/astro/src/core/app/manifest.ts
@@ -23,9 +23,6 @@ export function deserializeManifest(
 				...serializedRoute,
 				routeData: deserializeRouteData(serializedRoute.routeData),
 			});
-
-			const route = serializedRoute as unknown as RouteInfo;
-			route.routeData = deserializeRouteData(serializedRoute.routeData);
 		}
 	}
 	if (routesList) {


### PR DESCRIPTION
## Changes

- `deserializeManifest` deserialized every route twice on startup: once for the returned `routes` array, and again onto the input object. Nothing reads that second result. This deletes those two lines.
- Both callers (`loadManifest` and the generated `virtual:astro:manifest` module) pass a fresh object they never read back. The returned routes are separate copies, so dropping the mutation does not change behavior.

## Testing

- No new tests. The removed pass only mutated the input object, which neither caller reads.

## Docs

- None. Internal, no public API or behavior change.

Measured with Grok.
