### PR TITLE
Skip URL normalization writes that would not change the path

### DIFF
--- a/.changeset/cyan-bikes-visit.md
+++ b/.changeset/cyan-bikes-visit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Skips no-op pathname writes when normalizing SSR request URLs

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -34,6 +34,7 @@ import { getParams, getProps } from '../render/index.js';
 import { executeRewrite } from '../rewrites/handler.js';
 import { isRoute404or500, isRouteServerIsland } from '../routing/match.js';
 import { MultiLevelEncodingError, validateAndDecodePathname } from '../util/pathname.js';
+import { setPathname } from '../util/normalized-url.js';
 import { getOriginPathname, setOriginPathname } from '../routing/rewrite.js';
 import { computePathnameFromDomain } from '../i18n/domain.js';
 import { getCustom404Route, routeHasHtmlExtension } from '../routing/helpers.js';
@@ -331,8 +332,8 @@ export class FetchState implements AstroFetchState {
 		const url = new URL(request.url);
 		const publicPathname = this.#normalizePathname(url.pathname);
 		const pathname = this.#computePathname(publicPathname);
-		url.pathname = publicPathname;
-		url.pathname = collapseDuplicateSlashes(url.pathname);
+		setPathname(url, publicPathname);
+		setPathname(url, collapseDuplicateSlashes(url.pathname));
 		// For domain-based i18n routing, the locale prefix is derived from the
 		// request's Host header rather than its URL. When a locale is detected,
 		// the resulting pathname includes the prefix (e.g. /en/boats/1/foo) that

--- a/packages/astro/src/core/util/normalized-url.ts
+++ b/packages/astro/src/core/util/normalized-url.ts
@@ -10,20 +10,33 @@ export function createNormalizedUrl(requestUrl: string): URL {
 }
 
 /**
+ * Assigns `url.pathname` only when the value differs.
+ * The setter re-parses the whole URL, so a no-op write is still expensive.
+ */
+export function setPathname(url: URL, pathname: string): void {
+	if (url.pathname !== pathname) {
+		url.pathname = pathname;
+	}
+}
+
+/**
  * Normalizes an already-parsed URL in place: decodes and validates the
  * pathname, collapses duplicate slashes. Returns the same URL object.
+ *
+ * Collapse runs after the decode is written back: the pathname setter
+ * rewrites `\` to `/`, so a decoded backslash only becomes `//` once assigned.
  */
 export function normalizeUrl(url: URL): URL {
 	try {
-		url.pathname = validateAndDecodePathname(url.pathname);
+		setPathname(url, validateAndDecodePathname(url.pathname));
 	} catch {
 		// For decoding failures (truly malformed URLs), fall back gracefully.
 		try {
-			url.pathname = decodeURI(url.pathname);
+			setPathname(url, decodeURI(url.pathname));
 		} catch {
 			// If even basic decoding fails, return URL as-is
 		}
 	}
-	url.pathname = collapseDuplicateSlashes(url.pathname);
+	setPathname(url, collapseDuplicateSlashes(url.pathname));
 	return url;
 }

--- a/packages/astro/test/units/util/normalized-url.test.ts
+++ b/packages/astro/test/units/util/normalized-url.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createNormalizedUrl, normalizeUrl } from '../../../dist/core/util/normalized-url.js';
+
+describe('normalizeUrl', () => {
+	// #region Plain paths (the common case: nothing to rewrite)
+
+	it('leaves an ordinary path unchanged', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/about')).pathname, '/about');
+	});
+
+	it('leaves the root path unchanged', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/')).pathname, '/');
+	});
+
+	it('preserves the search and hash', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/x?q=1#h')).href, 'https://e.com/x?q=1#h');
+	});
+
+	it('returns the same URL object', () => {
+		const url = new URL('https://e.com/a');
+		assert.equal(normalizeUrl(url), url);
+	});
+
+	// #endregion
+	// #region Duplicate slashes
+
+	it('collapses duplicate slashes', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/a//b')).pathname, '/a/b');
+		assert.equal(normalizeUrl(new URL('https://e.com///a///b')).pathname, '/a/b');
+	});
+
+	// #endregion
+	// #region Encoding
+
+	it('decodes single-encoded unreserved characters', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/api/%61dmin')).pathname, '/api/admin');
+	});
+
+	it('fully decodes multi-encoded unreserved characters', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/api/%2561dmin')).pathname, '/api/admin');
+	});
+
+	it('keeps reserved characters encoded', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/path%3Fname')).pathname, '/path%3Fname');
+	});
+
+	it('re-encodes characters the pathname setter escapes', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/a%20b')).pathname, '/a%20b');
+	});
+
+	// #endregion
+	// #region Backslash
+
+	// Pathname setter rewrites `\` to `/`, so collapse must run after the
+	// decode is assigned: `/a%5C/b` -> `/a\/b` -> `/a//b` -> `/a/b`.
+	it('collapses a slash introduced by decoding a backslash', () => {
+		assert.equal(normalizeUrl(new URL('https://e.com/a%5C/b')).pathname, '/a/b');
+	});
+
+	// #endregion
+});
+
+describe('createNormalizedUrl', () => {
+	it('parses and normalizes a request URL string', () => {
+		assert.equal(createNormalizedUrl('https://e.com/a//%61dmin').pathname, '/a/admin');
+	});
+});


### PR DESCRIPTION
## Changes

- Assigning `url.pathname` re-parses the whole URL, so a no-op write is still expensive. `normalizeUrl` (rewrites) and the `FetchState` constructor (`Astro.url`, every SSR request) now skip each write when the value would not change. Ordinary paths like `/about` skip both.
- Collapse still runs after the decode is assigned. The pathname setter turns `\` into `/`, so `/a%5C/b` only becomes `/a//b` once written back.

## Testing

- Adds `test/units/util/normalized-url.test.ts` covering plain, encoded, duplicate-slash, and backslash paths, including the decode-then-collapse order.

## Docs

- None. Internal request-path change, no public API or behavior difference.

## Benchmarks

Local, WSL2, Node 24. Ordinary paths are the stable row (~half the cost). Encoded and duplicate-slash paths still need the first write. CodSpeed will not show this: its benches are render-bound.

| Path | Before | After |
| --- | --- | --- |
| `/blog/post-1` | ~870 ns | ~435 ns |
| `/a%20b` | ~1000 ns | ~810 ns |
| `/a//b` | ~900 ns | ~715 ns |

Measured with Grok.
