### PR TITLE
Parse each request URL once by caching it on the request

### DIFF
--- a/.changeset/shaky-paths-go.md
+++ b/.changeset/shaky-paths-go.md
@@ -1,0 +1,20 @@
+---
+'astro': minor
+'@astrojs/cloudflare': patch
+'@astrojs/netlify': patch
+'@astrojs/vercel': patch
+---
+
+Adds `getRequestURL()`, exported from `astro/app`, which returns the parsed `URL` of a request and parses `request.url` at most once per request
+
+An adapter usually needs a request's URL before it hands the request to `app.match()` and `app.render()`, and until now each of those steps parsed the same string over again. `getRequestURL()` lets them all share one parse:
+
+```js
+import { getRequestURL } from 'astro/app';
+
+const url = getRequestURL(request);
+```
+
+The returned `URL` is shared with everything else that asks for this request's URL, so treat it as read-only. Code that needs to rewrite a URL should build its own with `new URL(request.url)`.
+
+Astro's own adapters now use it, which takes a typical SSR request down from three or four `request.url` parses to two.

--- a/.changeset/shaky-paths-go.md
+++ b/.changeset/shaky-paths-go.md
@@ -17,4 +17,4 @@ const url = getRequestURL(request);
 
 The returned `URL` is shared with everything else that asks for this request's URL, so treat it as read-only. Code that needs to rewrite a URL should build its own with `new URL(request.url)`.
 
-Astro's own adapters now use it, which takes a typical SSR request down from three or four `request.url` parses to two.
+Astro's own adapters now use it. On a request that reaches `app.match()`, the adapter's own lookup and the two parses inside `match()` become a single shared parse.

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -22,6 +22,7 @@ import { DefaultErrorHandler } from '../errors/default-handler.js';
 import type { ErrorHandler } from '../errors/handler.js';
 import { isRoute404, isRoute500 } from '../routing/internal/route-errors.js';
 import { setRenderOptions } from './render-options.js';
+import { getRequestURL } from './request-url.js';
 import type { WaitUntilHook } from '../wait-until.js';
 import type { AppPipeline } from './pipeline.js';
 import type { SSRManifest } from './types.js';
@@ -284,7 +285,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 	 * Used by adapters to compute the pathname for dev-mode route matching.
 	 */
 	public getPathnameFromRequest(request: Request): string {
-		const url = new URL(request.url);
+		const url = getRequestURL(request);
 		const pathname = prependForwardSlash(this.removeBase(url.pathname));
 		return this.safeDecodeURI(pathname);
 	}
@@ -298,7 +299,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 	 * @param allowPrerenderedRoutes
 	 */
 	public match(request: Request, allowPrerenderedRoutes = false): RouteData | undefined {
-		const url = new URL(request.url);
+		const url = getRequestURL(request);
 		// ignore requests matching public assets
 		if (this.manifest.assets.has(url.pathname)) return undefined;
 		let pathname = this.computePathnameFromDomain(request);
@@ -340,7 +341,7 @@ export abstract class BaseApp<P extends Pipeline = AppPipeline> {
 	private computePathnameFromDomain(request: Request): string | undefined {
 		return computePathnameFromDomain(
 			request,
-			new URL(request.url),
+			getRequestURL(request),
 			this.manifest.i18n,
 			this.manifest.base,
 			this.manifest.trailingSlash,

--- a/packages/astro/src/core/app/entrypoints/index.ts
+++ b/packages/astro/src/core/app/entrypoints/index.ts
@@ -16,3 +16,4 @@ export {
 	serializeRouteInfo,
 } from '../manifest.js';
 export { AppPipeline } from '../pipeline.js';
+export { getRequestURL } from '../request-url.js';

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -4,6 +4,7 @@ import { Http2ServerResponse } from 'node:http2';
 import type { Socket } from 'node:net';
 import type { RemotePattern } from '../../types/public/config.js';
 import { clientAddressSymbol, nodeRequestAbortControllerCleanupSymbol } from '../constants.js';
+import { setRequestURL } from './request-url.js';
 import { deserializeManifest } from './manifest.js';
 import { createOutgoingHttpHeaders } from './createOutgoingHttpHeaders.js';
 import type { RenderOptions } from './base.js';
@@ -93,6 +94,13 @@ export function createRequestFromNodeRequest(
 	}
 
 	const request = new Request(url, options);
+
+	// The URL had to be parsed to build the request, so keep it rather than
+	// leaving route matching to parse the same string over again. `Request`
+	// re-serializes the URL it is given, so only keep it if it survived intact.
+	if (request.url === url.href) {
+		setRequestURL(request, url);
+	}
 
 	wireAbortController(req, controller);
 
@@ -196,6 +204,13 @@ export function createRequest(
 	}
 
 	const request = new Request(url, options);
+
+	// The URL had to be parsed to build the request, so keep it rather than
+	// leaving route matching to parse the same string over again. `Request`
+	// re-serializes the URL it is given, so only keep it if it survived intact.
+	if (request.url === url.href) {
+		setRequestURL(request, url);
+	}
 
 	wireAbortController(req, controller);
 

--- a/packages/astro/src/core/app/request-url.ts
+++ b/packages/astro/src/core/app/request-url.ts
@@ -1,0 +1,40 @@
+/**
+ * Symbol used to cache the parsed `URL` of a `Request` on the request itself,
+ * so that a request is parsed at most once no matter how many times the core
+ * and the adapter each need its URL.
+ */
+const requestUrlSymbol = Symbol.for('astro.requestURL');
+
+/**
+ * Returns the parsed `URL` for a request, parsing `request.url` at most once
+ * per request.
+ *
+ * The returned object is shared with everything else that asks for this
+ * request's URL, so **treat it as read-only**. Code that needs to rewrite a URL
+ * must build its own (`new URL(request.url)`); a `URL` is not worth cloning
+ * defensively, because constructing one from another `URL` serializes and
+ * re-parses it, and so costs more than parsing `request.url` again.
+ *
+ * The cached URL cannot disagree with the request, because `request.url` is
+ * immutable per the Fetch spec and a rewritten request is a different object
+ * with its own entry.
+ */
+export function getRequestURL(request: Request): URL {
+	let url: URL | undefined = Reflect.get(request, requestUrlSymbol);
+	if (url === undefined) {
+		url = new URL(request.url);
+		Reflect.set(request, requestUrlSymbol, url);
+	}
+	return url;
+}
+
+/**
+ * Caches an already-parsed `URL` on a request, for callers that had to parse
+ * `request.url` in order to build the `Request` in the first place.
+ *
+ * The URL must be the one the request was built from; callers that cannot
+ * guarantee that should let {@link getRequestURL} do the parsing instead.
+ */
+export function setRequestURL(request: Request, url: URL): void {
+	Reflect.set(request, requestUrlSymbol, url);
+}

--- a/packages/integrations/cloudflare/src/cache/provider.ts
+++ b/packages/integrations/cloudflare/src/cache/provider.ts
@@ -1,4 +1,5 @@
 import type { CacheProviderFactory } from 'astro';
+import { getRequestURL } from 'astro/app';
 import {
 	buildCacheControlDirectives,
 	collectInvalidationTags,
@@ -24,7 +25,7 @@ const factory: CacheProviderFactory = () => {
 
 			// Auto-tag with the request path for path-based invalidation via tag purge.
 			const tags = [...(options.tags ?? [])];
-			const { pathname } = new URL(request.url);
+			const { pathname } = getRequestURL(request);
 			tags.push(pathTag(pathname));
 
 			headers.set('Cache-Tag', tags.join(','));

--- a/packages/integrations/cloudflare/src/fetch.ts
+++ b/packages/integrations/cloudflare/src/fetch.ts
@@ -62,7 +62,7 @@ export async function cf(
 	ensureInitialized();
 	injectSessionBinding(app!.manifest, env);
 
-	const staticAsset = matchStaticAsset(app!.manifest, state.request.url, env);
+	const staticAsset = matchStaticAsset(app!.manifest, state.request, env);
 	if (staticAsset) return staticAsset;
 
 	if (!state.routeData) {

--- a/packages/integrations/cloudflare/src/utils/cf-helpers.ts
+++ b/packages/integrations/cloudflare/src/utils/cf-helpers.ts
@@ -4,6 +4,7 @@
  * Testable without a Vite build context.
  */
 import { getValidatedIpFromHeader } from '@astrojs/internal-helpers/request';
+import { getRequestURL } from 'astro/app';
 
 export interface Runtime {
 	cfContext: ExecutionContext;
@@ -21,12 +22,12 @@ export interface ManifestLike {
  */
 export function matchStaticAsset(
 	manifest: ManifestLike,
-	requestUrl: string,
+	request: Request,
 	env: Env,
 ): Response | undefined {
-	const { pathname } = new URL(requestUrl);
+	const { pathname } = getRequestURL(request);
 	if (manifest.assets.has(pathname)) {
-		return env.ASSETS.fetch(requestUrl.replace(/\.html$/, '')) as unknown as Response;
+		return env.ASSETS.fetch(request.url.replace(/\.html$/, '')) as unknown as Response;
 	}
 	return undefined;
 }

--- a/packages/integrations/cloudflare/src/utils/handler.ts
+++ b/packages/integrations/cloudflare/src/utils/handler.ts
@@ -71,7 +71,7 @@ export async function handle(
 	injectSessionBinding(app.manifest, env);
 
 	// NOTE this ASSETS binding path is needed for users who are using `run_worker_first` routing
-	const staticAsset = matchStaticAsset(app.manifest, request.url, env);
+	const staticAsset = matchStaticAsset(app.manifest, request, env);
 	if (staticAsset) return staticAsset as CfResponse;
 
 	let routeData: RouteData | undefined = undefined;

--- a/packages/integrations/cloudflare/test/cf-helpers.test.ts
+++ b/packages/integrations/cloudflare/test/cf-helpers.test.ts
@@ -119,7 +119,11 @@ describe('matchStaticAsset', () => {
 	it('returns a response when the pathname matches a known asset', async () => {
 		const manifest = { assets: new Set(['/style.css']) };
 		const env = createMockEnv();
-		const result = matchStaticAsset(manifest as any, 'http://example.com/style.css', env as any);
+		const result = matchStaticAsset(
+			manifest as any,
+			new Request('http://example.com/style.css'),
+			env as any,
+		);
 		assert.ok(result != null);
 		const response = await result;
 		assert.equal(response.status, 200);
@@ -128,7 +132,11 @@ describe('matchStaticAsset', () => {
 	it('strips .html extension when fetching from ASSETS', async () => {
 		const manifest = { assets: new Set(['/page.html']) };
 		const env = createMockEnv();
-		const result = matchStaticAsset(manifest as any, 'http://example.com/page.html', env as any);
+		const result = matchStaticAsset(
+			manifest as any,
+			new Request('http://example.com/page.html'),
+			env as any,
+		);
 		const response = await result!;
 		assert.equal(response.headers.get('x-fetched-url'), 'http://example.com/page');
 	});
@@ -136,7 +144,11 @@ describe('matchStaticAsset', () => {
 	it('returns undefined when the pathname is not a known asset', () => {
 		const manifest = { assets: new Set(['/style.css']) };
 		const env = createMockEnv();
-		const result = matchStaticAsset(manifest as any, 'http://example.com/other.js', env as any);
+		const result = matchStaticAsset(
+			manifest as any,
+			new Request('http://example.com/other.js'),
+			env as any,
+		);
 		assert.equal(result, undefined);
 	});
 });

--- a/packages/integrations/netlify/src/cache/provider.ts
+++ b/packages/integrations/netlify/src/cache/provider.ts
@@ -1,4 +1,5 @@
 import type { CacheProviderFactory } from 'astro';
+import { getRequestURL } from 'astro/app';
 import {
 	buildCacheControlDirectives,
 	collectInvalidationTags,
@@ -23,7 +24,7 @@ const factory: CacheProviderFactory = () => {
 
 			// Auto-tag with the request path for path-based invalidation
 			const tags = [...(options.tags ?? [])];
-			const { pathname } = new URL(request.url);
+			const { pathname } = getRequestURL(request);
 			tags.push(pathTag(pathname));
 
 			headers.set('Netlify-Cache-Tag', tags.join(','));

--- a/packages/integrations/vercel/src/cache/provider.ts
+++ b/packages/integrations/vercel/src/cache/provider.ts
@@ -1,4 +1,5 @@
 import type { CacheProviderFactory } from 'astro';
+import { getRequestURL } from 'astro/app';
 import {
 	buildCacheControlDirectives,
 	collectInvalidationTags,
@@ -21,7 +22,7 @@ const factory: CacheProviderFactory = () => {
 
 			// Auto-tag with the request path for path-based invalidation
 			const tags = [...(options.tags ?? [])];
-			const { pathname } = new URL(request.url);
+			const { pathname } = getRequestURL(request);
 			tags.push(pathTag(pathname));
 
 			headers.set('Vercel-Cache-Tag', tags.join(','));

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -8,6 +8,7 @@ import {
 } from '../index.js';
 import { middlewareSecret, skewProtection } from 'virtual:astro-vercel:config';
 import { createApp } from 'astro/app/entrypoint';
+import { getRequestURL } from 'astro/app';
 import { getClientIpAddress } from '@astrojs/internal-helpers/request';
 
 setGetEnv((key) => process.env[key]);
@@ -16,7 +17,7 @@ const app = createApp();
 
 export default {
 	async fetch(request: Request): Promise<Response> {
-		const url = new URL(request.url);
+		const url = getRequestURL(request);
 		const middlewareSecretHeader = request.headers.get(ASTRO_MIDDLEWARE_SECRET_HEADER);
 		const hasValidMiddlewareSecret = middlewareSecretHeader === middlewareSecret;
 		let realPath = undefined;
@@ -30,11 +31,13 @@ export default {
 			realPath = url.searchParams.get(ASTRO_PATH_PARAM);
 		}
 		if (typeof realPath === 'string') {
-			url.pathname = realPath;
+			// `url` is shared with the rest of the request, so rewrite a copy of it.
+			const rewritten = new URL(request.url);
+			rewritten.pathname = realPath;
 			// Remove the internal routing params so they never reach user code.
-			url.searchParams.delete(ASTRO_PATH_PARAM);
-			url.searchParams.delete(ASTRO_PATH_TOKEN_PARAM);
-			request = new Request(url.toString(), {
+			rewritten.searchParams.delete(ASTRO_PATH_PARAM);
+			rewritten.searchParams.delete(ASTRO_PATH_TOKEN_PARAM);
+			request = new Request(rewritten.toString(), {
 				method: request.method,
 				headers: request.headers,
 				...(request.body ? { body: request.body, duplex: 'half' } : {}),


### PR DESCRIPTION
## Summary

An adapter almost always needs a request's URL before it hands the request to `app.match()` and `app.render()`: to check the static-asset manifest, to read a routing param, to tag a cache entry. Each of those steps parses the same immutable string over again.

`getRequestURL(request)` parses `request.url` on first use and keeps the result on the request, so everything that asks afterwards gets the same object for the cost of a symbol lookup, about 7 ns against about 200 ns for a parse.

```js
import { getRequestURL } from 'astro/app';

const url = getRequestURL(request);
```

The returned `URL` is shared with the rest of the request, so it is read-only by contract. Code that needs to rewrite a URL builds its own with `new URL(request.url)`.

This is a `minor` because it adds one public function. The three adapter changes are `patch`.

## How many parses this removes

The claim worth making is the narrow one, because it is the one the benchmark measures. On a request that reaches `app.match()`, three parses become one:

- the adapter's own lookup, for example Cloudflare's static-asset check or Vercel's routing-param read
- `BaseApp.match()`, once for the asset check
- `BaseApp.match()` again, for the domain-i18n probe, which parses whether or not domain routing is configured

Core still parses `request.url` in two more places on the same request, and this PR does not change either: the `FetchState` constructor (deliberately, see below) and `TrailingSlashHandler.handle()`, which runs for every request through `AstroHandler`. `BaseApp.render()` also runs its own domain probe when the adapter passes no `routeData`.

## Why `FetchState` still parses its own

Deliberately, and this is the part that makes the shared object safe.

`FetchState` owns its URL and mutates it. It rewrites `url.pathname` to produce what user code reads as `Astro.url`, and `#applyForwardedHeaders()` rewrites `protocol`, `hostname` and `port` before rebuilding the request. A read-only object cannot serve that.

Cloning the shared URL instead is not an option: constructing a `URL` from another `URL` serializes and re-parses it, so it costs more than parsing `request.url` again, about 275 ns against about 200 ns. There is no cheap defensive copy. A shared URL can only go to readers, which is why `FetchState` keeps its own parse.

## Why not a pre-parsed URL threaded through the API

Worth recording, since this is the design question review asked about on #17227, which has since been closed unmerged.

That approach threaded a pre-parsed `URL` through `RenderOptions`, added a third parameter to `match()`, and changed `createRequestFromNodeRequest` to return `{ request, url }`. Three API changes, and the doc comment had to ask callers to honor two rules nothing enforced: the URL must equal `new URL(request.url)`, and it must not be reused after `render`, because the pipeline normalizes it in place. `TrailingSlashHandler` derives redirects from the request URL, so a caller passing a mismatched URL would have silently changed redirect behavior.

Deriving the URL from `request.url` on demand removes both rules rather than documenting them:

- It cannot disagree with the request. `request.url` is immutable per the Fetch spec, and a rewritten request is a different object with its own entry.
- It needs no signature changes, so `createRequestFromNodeRequest` keeps returning a `Request` and simply hands over the URL it had already parsed. Changing that return type would have been a breaking change to a published export, not a `minor`.
- It is one concept instead of three, and community adapters get it too.

## What changed

- Adds `packages/astro/src/core/app/request-url.ts` and exports `getRequestURL` from `astro/app`. It follows the existing `render-options.ts`, which already carries per-request data on a `Request` behind a `Symbol.for`.
- `BaseApp.match()`, `getPathnameFromRequest()` and `computePathnameFromDomain()` use it. All three only read from the URL.
- `createRequestFromNodeRequest` and `createRequest` hand over the URL they already parsed to build the `Request`, guarded on `request.url === url.href` so a `Request` constructor normalization can never seed a mismatched URL. Signatures unchanged.
- Cloudflare: `matchStaticAsset` takes the `Request` instead of a URL string, and the cache provider uses the shared URL. `matchStaticAsset` is not in the package's exports map, so this is internal.
- Vercel: the serverless entrypoint uses the shared URL for its param reads, and rewrites a copy for the `realPath` override rather than mutating the shared object.
- Netlify: the cache provider only. Its SSR function never parsed a URL of its own.
- Node: no adapter change at all. It benefits from the seeding above.

## Follow-up

`TrailingSlashHandler` is the obvious next candidate. It parses on every request and only reads `pathname` and `search`, so it can move onto the helper as is.

The in-memory cache provider cannot, at least not directly. `core/cache/handler.ts` passes that URL into the public `CacheProvider.onRequest` API, so routing it through `getRequestURL()` would hand a shared mutable URL to third-party provider code that never agreed to the read-only contract. That one needs a copy or a contract change, so it is deliberately left alone here.

## Compatibility note

The adapters ship as `patch` but now import an export that only exists from the astro `minor` this PR adds, while their peer range stays `astro: ^7.0.0`. Upgrading an adapter alone, on an older astro 7.x, fails at module load with a missing named export. Happy to bump the peer ranges instead if that is the convention you prefer.

The `changes-requested` review on this PR is the bot flagging the `minor` changeset, which is expected.

## Testing

`astro` unit suite: 3195 pass, 0 fail, 1 skipped, on the branch rebased onto current `main`. `@astrojs/cloudflare` `cf-helpers` 18/18 and `fetch-lazy-init` 4/4. `@astrojs/vercel` `path-override-security` 2/2 and `isr` 6/6, the latter covering the honored `realPath` rewrite this touches. `astro` and the three adapters build and typecheck clean. The adapter figures were measured before the rebase, which changed none of the files involved.

The benchmark harness asserts the cache's semantics against the real shipped function: one object per request, always matching `request.url`, never shared across requests.

## Benchmarks

Local, WSL2, Node 24, medians across repeated runs. Absolute figures drift 10 to 25% between sessions on this machine; the ratios are what travels.

| Operation | ns/op |
| --- | --- |
| `getRequestURL(request)` (cached) | ~7 |
| `new URL(request.url)` (what it replaces) | ~200 |
| `new URL(urlObject)` (why nothing clones) | ~275 |

The harness asserts the parse count rather than reasoning about it: it swaps in a counting `URL` and checks that the adapter plus `match()` sequence drops to a single parse.

This is small next to HTML rendering. It shows up on light responses such as endpoints, redirects and 304s, and on short-lived serverless instances, where per-request setup is a bigger slice of the work and CPU time is billed directly.

Investigated and measured with Claude Opus 4.8, reviewed with Claude Opus 5.
