### PR TITLE
fix(sessions): route session diagnostics through AstroLogger and reset partial state after regeneration failure

### DIFF
--- a/.changeset/session-logger-bug-fix.md
+++ b/.changeset/session-logger-bug-fix.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Routes session runtime diagnostics through `AstroLogger` to respect user configuration, and properly resets the internal session partial state after recovery from storage regeneration failures to avoid unnecessary storage access.

--- a/.changeset/session-logger-bug-fix.md
+++ b/.changeset/session-logger-bug-fix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Routes session runtime diagnostics through `AstroLogger` to respect user configuration, and properly resets the internal session partial state after recovery from storage regeneration failures to avoid unnecessary storage access.

--- a/.changeset/session-logger-fix.md
+++ b/.changeset/session-logger-fix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Routes session runtime diagnostics through `AstroLogger` instead of `console.error`/`logger.warn` to respect user logging configuration. Also resets the internal `#partial` flag after a storage failure during `regenerate()` to prevent unnecessary storage round-trips on subsequent reads.

--- a/.changeset/session-logger-fix.md
+++ b/.changeset/session-logger-fix.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Routes session runtime diagnostics through `AstroLogger` instead of `console.error`/`logger.warn` to respect user logging configuration. Also resets the internal `#partial` flag after a storage failure during `regenerate()` to prevent unnecessary storage round-trips on subsequent reads.
+Session runtime warnings are now routed through Astro's structured logger instead of `console.error`, so they respect your configured log level and appear in custom log sinks. Additionally, a session that fails to load during `regenerate()` is no longer left in a partial state, preventing unnecessary storage reads on subsequent operations.

--- a/.changeset/session-logger-fix.md
+++ b/.changeset/session-logger-fix.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Session runtime warnings are now routed through Astro's structured logger instead of `console.error`, so they respect your configured log level and appear in custom log sinks. Additionally, a session that fails to load during `regenerate()` is no longer left in a partial state, preventing unnecessary storage reads on subsequent operations.
+Fixes session runtime errors being silently swallowed by `console.error` instead of routing through Astro's logger

--- a/.changeset/session-regenerate-partial-fix.md
+++ b/.changeset/session-regenerate-partial-fix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a session being left in a partial state after a storage failure during `session.regenerate()`, preventing unnecessary storage reads on subsequent operations

--- a/packages/astro/src/core/session/handler.ts
+++ b/packages/astro/src/core/session/handler.ts
@@ -39,6 +39,7 @@ async function provideSessionAsync(
 				runtimeMode: pipeline.runtimeMode,
 				driverFactory,
 				mockStorage: null,
+				logger: pipeline.logger,
 			});
 		},
 		finalize(session) {

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -383,7 +383,7 @@ export class AstroSession {
 		try {
 			const storedMap = unflatten(raw);
 			if (!(storedMap instanceof Map)) {
-				await this.destroy();
+				this.destroy();
 				throw new AstroError({
 					...SessionStorageInitError,
 					message: SessionStorageInitError.message(
@@ -409,7 +409,7 @@ export class AstroSession {
 			this.#partial = false;
 			return this.#data;
 		} catch (err) {
-			await this.destroy();
+			this.destroy();
 			if (err instanceof AstroError) {
 				throw err;
 			}

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -32,6 +32,15 @@ const stringify: typeof rawStringify = (data, _) => {
 	});
 };
 
+export interface AstroSessionOptions {
+	cookies: AstroCookies;
+	config: SSRManifestSession | undefined;
+	runtimeMode: RuntimeMode;
+	driverFactory: SessionDriverFactory | null;
+	mockStorage: Storage | null;
+	logger: AstroLogger;
+}
+
 export class AstroSession {
 	// The cookies object.
 	#cookies: AstroCookies;
@@ -254,7 +263,7 @@ export class AstroSession {
 
 		if (oldSessionId && this.#storage) {
 			this.#storage.removeItem(oldSessionId).catch((err) => {
-				this.#logger?.warn('session', `Failed to remove old session ${oldSessionId}: ${err}`);
+				this.#logger.error('session', `Failed to remove old session ${oldSessionId}: ${err}`);
 			});
 		}
 	}
@@ -297,7 +306,7 @@ export class AstroSession {
 		if (this.#toDestroy.size > 0) {
 			const cleanupPromises = [...this.#toDestroy].map((sessionId) =>
 				storage.removeItem(sessionId).catch((err) => {
-					this.#logger?.warn('session', `Failed to remove session ${sessionId}: ${err}`);
+					this.#logger.error('session', `Failed to remove session ${sessionId}: ${err}`);
 				}),
 			);
 			await Promise.all(cleanupPromises);

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -219,26 +219,18 @@ export class AstroSession {
 	}
 
 	/**
-	 * Destroys the session, clearing the cookie and eagerly removing the storage entry.
+	 * Destroys the session, clearing the cookie and storage if it exists.
 	 */
-	async destroy(): Promise<void> {
+	destroy() {
 		// We don't use #ensureSessionID here because we don't want to create a new session ID if it doesn't exist.
 		const sessionId = this.#sessionID ?? this.#cookies.get(this.#cookieName)?.value;
+		if (sessionId) {
+			this.#toDestroy.add(sessionId);
+		}
 		this.#cookies.delete(this.#cookieName, this.#cookieConfig);
 		this.#sessionID = undefined;
 		this.#data = undefined;
-		this.#partial = true;
-		this.#dirty = false;
-		if (sessionId) {
-			// Remove from storage immediately when available; PERSIST_SYMBOL may not run on error paths.
-			if (this.#storage) {
-				await this.#storage.removeItem(sessionId).catch((err) => {
-					this.#logger.error('session', `Failed to remove session ${sessionId}: ${err}`);
-				});
-			} else {
-				this.#toDestroy.add(sessionId);
-			}
-		}
+		this.#dirty = true;
 	}
 
 	/**

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -62,7 +62,7 @@ export class AstroSession {
 	// When we load the data from storage, we need to merge it with the local partial data,
 	// preserving in-memory changes and deletions.
 	#partial = true;
-	#logger: AstroLogger | undefined;
+	#logger: AstroLogger;
 	#driverFactory: SessionDriverFactory | null;
 
 	static #sharedStorage = new Map<string, Storage>();
@@ -74,14 +74,7 @@ export class AstroSession {
 		driverFactory,
 		mockStorage,
 		logger,
-	}: {
-		cookies: AstroCookies;
-		config: SSRManifestSession | undefined;
-		runtimeMode: RuntimeMode;
-		driverFactory: SessionDriverFactory | null;
-		mockStorage: Storage | null;
-		logger?: AstroLogger;
-	}) {
+	}: AstroSessionOptions) {
 		this.#logger = logger;
 		if (!config) {
 			throw new AstroError({
@@ -230,7 +223,7 @@ export class AstroSession {
 			// Remove from storage immediately when available; PERSIST_SYMBOL may not run on error paths.
 			if (this.#storage) {
 				await this.#storage.removeItem(sessionId).catch((err) => {
-					this.#logger?.warn('session', `Failed to remove session ${sessionId}: ${err}`);
+					this.#logger.error('session', `Failed to remove session ${sessionId}: ${err}`);
 				});
 			} else {
 				this.#toDestroy.add(sessionId);
@@ -247,7 +240,7 @@ export class AstroSession {
 		try {
 			data = await this.#ensureData();
 		} catch (err) {
-			this.#logger?.warn('session', `Failed to load session data during regeneration: ${err}`);
+			this.#logger.error('session', `Failed to load session data during regeneration: ${err}`);
 			this.#partial = false;
 		}
 

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -3,6 +3,7 @@ import type { RuntimeMode } from '../../types/public/config.js';
 import type { AstroCookieSetOptions, AstroCookies } from '../cookies/cookies.js';
 import { SessionStorageInitError, SessionStorageSaveError } from '../errors/errors-data.js';
 import { AstroError } from '../errors/index.js';
+import type { AstroLogger } from '../logger/core.js';
 import type { SessionDriverFactory } from './types.js';
 import type { SSRManifestSession } from '../app/types.js';
 import { createStorage, type Storage } from 'unstorage';
@@ -61,7 +62,7 @@ export class AstroSession {
 	// When we load the data from storage, we need to merge it with the local partial data,
 	// preserving in-memory changes and deletions.
 	#partial = true;
-	// The driver factory function provided by the pipeline
+	#logger: AstroLogger | undefined;
 	#driverFactory: SessionDriverFactory | null;
 
 	static #sharedStorage = new Map<string, Storage>();
@@ -72,13 +73,16 @@ export class AstroSession {
 		runtimeMode,
 		driverFactory,
 		mockStorage,
+		logger,
 	}: {
 		cookies: AstroCookies;
 		config: SSRManifestSession | undefined;
 		runtimeMode: RuntimeMode;
 		driverFactory: SessionDriverFactory | null;
 		mockStorage: Storage | null;
+		logger?: AstroLogger;
 	}) {
+		this.#logger = logger;
 		if (!config) {
 			throw new AstroError({
 				...SessionStorageInitError,
@@ -213,18 +217,25 @@ export class AstroSession {
 	}
 
 	/**
-	 * Destroys the session, clearing the cookie and storage if it exists.
+	 * Destroys the session, clearing the cookie and eagerly removing the storage entry.
 	 */
-	destroy() {
-		// We don't use #ensureSessionID here because we don't want to create a new session ID if it doesn't exist.
+	async destroy(): Promise<void> {
 		const sessionId = this.#sessionID ?? this.#cookies.get(this.#cookieName)?.value;
-		if (sessionId) {
-			this.#toDestroy.add(sessionId);
-		}
 		this.#cookies.delete(this.#cookieName, this.#cookieConfig);
 		this.#sessionID = undefined;
 		this.#data = undefined;
-		this.#dirty = true;
+		this.#partial = true;
+		this.#dirty = false;
+		if (sessionId) {
+			// Remove from storage immediately when available; PERSIST_SYMBOL may not run on error paths.
+			if (this.#storage) {
+				await this.#storage.removeItem(sessionId).catch((err) => {
+					this.#logger?.warn('session', `Failed to remove session ${sessionId}: ${err}`);
+				});
+			} else {
+				this.#toDestroy.add(sessionId);
+			}
+		}
 	}
 
 	/**
@@ -236,24 +247,21 @@ export class AstroSession {
 		try {
 			data = await this.#ensureData();
 		} catch (err) {
-			// Log the error but continue with empty data
-			console.error('Failed to load session data during regeneration:', err);
+			this.#logger?.warn('session', `Failed to load session data during regeneration: ${err}`);
+			this.#partial = false;
 		}
 
-		// Store the old session ID for cleanup
 		const oldSessionId = this.#sessionID;
 
-		// Create new session
 		this.#sessionID = crypto.randomUUID();
 		this.#sessionIDFromCookie = false;
 		this.#data = data;
 		this.#dirty = true;
 		await this.#setCookie();
 
-		// Clean up old session asynchronously
 		if (oldSessionId && this.#storage) {
 			this.#storage.removeItem(oldSessionId).catch((err) => {
-				console.error('Failed to remove old session data:', err);
+				this.#logger?.warn('session', `Failed to remove old session ${oldSessionId}: ${err}`);
 			});
 		}
 	}
@@ -293,11 +301,10 @@ export class AstroSession {
 			this.#dirty = false;
 		}
 
-		// Handle destroyed session cleanup
 		if (this.#toDestroy.size > 0) {
 			const cleanupPromises = [...this.#toDestroy].map((sessionId) =>
 				storage.removeItem(sessionId).catch((err) => {
-					console.error('Failed to clean up session %s:', sessionId, err);
+					this.#logger?.warn('session', `Failed to remove session ${sessionId}: ${err}`);
 				}),
 			);
 			await Promise.all(cleanupPromises);

--- a/packages/astro/src/core/session/runtime.ts
+++ b/packages/astro/src/core/session/runtime.ts
@@ -222,6 +222,7 @@ export class AstroSession {
 	 * Destroys the session, clearing the cookie and eagerly removing the storage entry.
 	 */
 	async destroy(): Promise<void> {
+		// We don't use #ensureSessionID here because we don't want to create a new session ID if it doesn't exist.
 		const sessionId = this.#sessionID ?? this.#cookies.get(this.#cookieName)?.value;
 		this.#cookies.delete(this.#cookieName, this.#cookieConfig);
 		this.#sessionID = undefined;

--- a/packages/astro/test/types/session-data.ts
+++ b/packages/astro/test/types/session-data.ts
@@ -23,6 +23,7 @@ function createSession() {
 		runtimeMode: 'production',
 		driverFactory: null,
 		mockStorage: null,
+		logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
 	});
 }
 

--- a/packages/astro/test/types/session-data.ts
+++ b/packages/astro/test/types/session-data.ts
@@ -2,6 +2,7 @@ import './session-env.d.ts';
 import { describe, it } from 'node:test';
 import { expectTypeOf } from 'expect-type';
 import { AstroSession } from '../../dist/core/session/runtime.js';
+import { AstroLogger } from '../../dist/core/logger/core.js';
 import type { AstroCookies } from '../../dist/types/public/index.js';
 
 const defaultMockCookies = {
@@ -23,7 +24,7 @@ function createSession() {
 		runtimeMode: 'production',
 		driverFactory: null,
 		mockStorage: null,
-		logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
+		logger: new AstroLogger({ destination: { write: () => {} }, level: 'silent' }),
 	});
 }
 

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -606,6 +606,7 @@ describe('AstroSession - No-Cookie Short Circuit', () => {
 			runtimeMode: 'production',
 			driverFactory: countingDriverFactory,
 			mockStorage: null,
+			logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
 		});
 
 		const value = await session.get('nonexistent');
@@ -660,12 +661,26 @@ describe('AstroSession - No-Cookie Short Circuit', () => {
 describe('AstroSession - regenerate() error path', () => {
 	it('should route errors to logger and reset #partial flag', async () => {
 		let storageGetCount = 0;
+		// The cookie mock returns 'old-session' so that ensureData() will try to
+		// load from storage using that key and hit the corrupt data path.
+		const cookies: MockCookies = {
+			set: () => {},
+			delete: () => {},
+			get: (name: string) => (name === 'test-session' ? { value: 'old-session' } : undefined),
+		};
+		let errorCalled = false;
+		const mockLogger = {
+			info: () => {},
+			warn: () => {},
+			error: () => { errorCalled = true; },
+			debug: () => {},
+		};
 		const mockStorage = {
 			async get(key: string) {
 				storageGetCount++;
 				if (key === 'old-session') {
-					// Return a string that unflatten() will parse into an Array, not a Map
-					// This causes unflatten(raw) instanceof Map to be false, throwing an AstroError
+					// Return a string that unflatten() will parse into an Array, not a Map.
+					// This causes unflatten(raw) instanceof Map to be false, throwing an AstroError.
 					return '[1,2,3]';
 				}
 				return null;
@@ -685,7 +700,7 @@ describe('AstroSession - regenerate() error path', () => {
 			cookies,
 			mockStorage as any,
 			'production',
-			mockLogger
+			mockLogger,
 		);
 
 		// This will trigger ensureData() under the hood.
@@ -703,7 +718,7 @@ describe('AstroSession - regenerate() error path', () => {
 		// If #partial is true, this will call storage.get() for the new session ID.
 		// If #partial is correctly reset to false, this will use the in-memory Map.
 		await session.get('foo');
-		
+
 		assert.equal(storageGetCount, 0, 'Should not round-trip to storage; #partial should be false after regeneration');
 	});
 });

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -40,6 +40,7 @@ function createSession(
 	cookies: MockCookies = defaultMockCookies,
 	mockStorage: Storage | null = null,
 	runtimeMode: RuntimeMode = 'production',
+	logger: any = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
 ) {
 	// driverFactory from unstorage/drivers/memory accepts no config; wrap it to satisfy SessionDriverFactory
 	const typedDriverFactory: SessionDriverFactory = () => driverFactory();
@@ -49,6 +50,7 @@ function createSession(
 		runtimeMode,
 		driverFactory: typedDriverFactory,
 		mockStorage,
+		logger,
 	});
 }
 
@@ -653,3 +655,72 @@ describe('AstroSession - No-Cookie Short Circuit', () => {
 });
 
 // #endregion No-Cookie Short Circuit
+
+// #region Error Recovery
+describe('AstroSession - regenerate() error path', () => {
+	it('should route errors to logger and reset #partial flag', async () => {
+		let storageGetCount = 0;
+		const mockStorage = {
+			async get(key: string) {
+				storageGetCount++;
+				if (key === 'old-session') {
+					// Return a string that unflatten() will parse into an Array, not a Map
+					// This causes unflatten(raw) instanceof Map to be false, throwing an AstroError
+					return '[1,2,3]';
+				}
+				return null;
+			},
+			async setItem() {},
+			async removeItem() {},
+			async getKeys() { return []; },
+			async clear() {},
+			async dispose() {},
+			async hasItem() { return false; },
+			async setItemRaw() {},
+			async getItemRaw() { return null; },
+			async getMeta() { return {}; },
+			async watch() {},
+			async unwatch() {},
+		};
+
+		let errorCalled = false;
+		const mockLogger: any = {
+			error: () => {
+				errorCalled = true;
+			}
+		};
+
+		const cookies: any = {
+			get: () => ({ value: 'old-session' }),
+			set: () => {},
+			delete: () => {},
+		};
+
+		const session = createSession(
+			defaultConfig,
+			cookies,
+			mockStorage as any,
+			'production',
+			mockLogger
+		);
+
+		// This will trigger ensureData() under the hood.
+		// It fetches 'old-session' which returns invalid data, throwing an error.
+		// regenerate() catches this, should log an error, and reset #partial.
+		await session.regenerate();
+
+		// 1. Verify logging behavior
+		assert.equal(errorCalled, true, 'Should use logger.error');
+
+		// Reset storage count before checking get()
+		storageGetCount = 0;
+
+		// 2. Verify #partial state
+		// If #partial is true, this will call storage.get() for the new session ID.
+		// If #partial is correctly reset to false, this will use the in-memory Map.
+		await session.get('foo');
+		
+		assert.equal(storageGetCount, 0, 'Should not round-trip to storage; #partial should be false after regeneration');
+	});
+});
+// #endregion

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -130,7 +130,7 @@ describe('AstroSession - Cookie Management', () => {
 		};
 
 		const session = createSession(defaultConfig, mockCookies);
-		session.destroy();
+		await session.destroy();
 		assert.equal(cookieDeletedName, 'test-session');
 		assert.equal(cookieDeletedArgs?.path, '/');
 	});
@@ -462,7 +462,7 @@ describe('AstroSession - Cleanup Operations', () => {
 		const oldId = session.sessionID;
 
 		// Destroy it
-		session.destroy();
+		await session.destroy();
 
 		// Simulate end of request
 		await session[PERSIST_SYMBOL]();
@@ -481,7 +481,7 @@ describe('AstroSession - Cleanup Operations', () => {
 		} as unknown as Storage;
 
 		const session = createSession(defaultConfig, defaultMockCookies, mockStorage);
-		session.destroy();
+		await session.destroy();
 
 		// Simulate end of request
 		await session[PERSIST_SYMBOL]();

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -131,7 +131,7 @@ describe('AstroSession - Cookie Management', () => {
 		};
 
 		const session = createSession(defaultConfig, mockCookies);
-		await session.destroy();
+		session.destroy();
 		assert.equal(cookieDeletedName, 'test-session');
 		assert.equal(cookieDeletedArgs?.path, '/');
 	});
@@ -463,7 +463,7 @@ describe('AstroSession - Cleanup Operations', () => {
 		const oldId = session.sessionID;
 
 		// Destroy it
-		await session.destroy();
+		session.destroy();
 
 		// Simulate end of request
 		await session[PERSIST_SYMBOL]();
@@ -482,7 +482,7 @@ describe('AstroSession - Cleanup Operations', () => {
 		} as unknown as Storage;
 
 		const session = createSession(defaultConfig, defaultMockCookies, mockStorage);
-		await session.destroy();
+		session.destroy();
 
 		// Simulate end of request
 		await session[PERSIST_SYMBOL]();

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -265,6 +265,7 @@ describe('AstroSession - Error Handling', () => {
 		const mockStorage = {
 			get: async () => 'invalid-json',
 			setItem: async () => {},
+			removeItem: async () => {},
 		} as unknown as Storage;
 
 		const session = createSession(defaultConfig, defaultMockCookies, mockStorage);
@@ -570,6 +571,7 @@ describe('AstroSession - Storage Errors', () => {
 		const mockStorage = {
 			get: async () => stringify({ notAMap: true }),
 			setItem: async () => {},
+			removeItem: async () => {},
 		} as unknown as Storage;
 
 		const session = createSession(defaultConfig, defaultMockCookies, mockStorage);

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -41,7 +41,7 @@ function createSession(
 	cookies: MockCookies = defaultMockCookies,
 	mockStorage: Storage | null = null,
 	runtimeMode: RuntimeMode = 'production',
-	logger: any = new SpyLogger()
+	logger: SpyLogger = new SpyLogger()
 ) {
 	// driverFactory from unstorage/drivers/memory accepts no config; wrap it to satisfy SessionDriverFactory
 	const typedDriverFactory: SessionDriverFactory = () => driverFactory();
@@ -609,7 +609,7 @@ describe('AstroSession - No-Cookie Short Circuit', () => {
 			runtimeMode: 'production',
 			driverFactory: countingDriverFactory,
 			mockStorage: null,
-			logger: new SpyLogger() as any,
+			logger: new SpyLogger(),
 		});
 
 		const value = await session.get('nonexistent');

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -11,6 +11,7 @@ import type {
 	AstroCookieDeleteOptions,
 } from '../../../dist/core/cookies/cookies.js';
 import type { SessionDriverFactory } from '../../../dist/core/session/types.js';
+import { SpyLogger } from '../test-utils.ts';
 
 // #region Helpers
 
@@ -40,7 +41,7 @@ function createSession(
 	cookies: MockCookies = defaultMockCookies,
 	mockStorage: Storage | null = null,
 	runtimeMode: RuntimeMode = 'production',
-	logger: any = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+	logger: any = new SpyLogger()
 ) {
 	// driverFactory from unstorage/drivers/memory accepts no config; wrap it to satisfy SessionDriverFactory
 	const typedDriverFactory: SessionDriverFactory = () => driverFactory();
@@ -608,7 +609,7 @@ describe('AstroSession - No-Cookie Short Circuit', () => {
 			runtimeMode: 'production',
 			driverFactory: countingDriverFactory,
 			mockStorage: null,
-			logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
+			logger: new SpyLogger() as any,
 		});
 
 		const value = await session.get('nonexistent');
@@ -670,13 +671,7 @@ describe('AstroSession - regenerate() error path', () => {
 			delete: () => {},
 			get: (name: string) => (name === 'test-session' ? { value: 'old-session' } : undefined),
 		};
-		let errorCalled = false;
-		const mockLogger = {
-			info: () => {},
-			warn: () => {},
-			error: () => { errorCalled = true; },
-			debug: () => {},
-		};
+		const spyLogger = new SpyLogger();
 		const mockStorage = {
 			async get(key: string) {
 				storageGetCount++;
@@ -702,7 +697,7 @@ describe('AstroSession - regenerate() error path', () => {
 			cookies,
 			mockStorage as any,
 			'production',
-			mockLogger,
+			spyLogger,
 		);
 
 		// This will trigger ensureData() under the hood.
@@ -711,7 +706,11 @@ describe('AstroSession - regenerate() error path', () => {
 		await session.regenerate();
 
 		// 1. Verify logging behavior
-		assert.equal(errorCalled, true, 'Should use logger.error');
+		assert.equal(
+			spyLogger.logs.some((e) => e.level === 'error'),
+			true,
+			'Should route errors through logger.error',
+		);
 
 		// Reset storage count before checking get()
 		storageGetCount = 0;

--- a/packages/astro/test/units/sessions/astro-session.test.ts
+++ b/packages/astro/test/units/sessions/astro-session.test.ts
@@ -678,22 +678,6 @@ describe('AstroSession - regenerate() error path', () => {
 			async hasItem() { return false; },
 			async setItemRaw() {},
 			async getItemRaw() { return null; },
-			async getMeta() { return {}; },
-			async watch() {},
-			async unwatch() {},
-		};
-
-		let errorCalled = false;
-		const mockLogger: any = {
-			error: () => {
-				errorCalled = true;
-			}
-		};
-
-		const cookies: any = {
-			get: () => ({ value: 'old-session' }),
-			set: () => {},
-			delete: () => {},
 		};
 
 		const session = createSession(


### PR DESCRIPTION
## Related Issue

Closes #17420

## Changes

This PR fixes two issues in the `AstroSession` runtime (`packages/astro/src/core/session/runtime.ts`).

### Route session diagnostics through `AstroLogger`

Session runtime warnings were previously emitted using `console.error`, bypassing Astro's structured logging system. This prevented these diagnostics from respecting the configured logger and log level and made them unavailable to custom log sinks.

This PR updates the session runtime to use `AstroLogger` for these warning paths, ensuring logging behavior is consistent with the rest of the Astro runtime.

### Reset partial session state after regeneration failures

When `#ensureData()` throws during `regenerate()`, the session falls back to a new empty data store but leaves the internal `#partial` flag unchanged.

This PR resets the partial state after the recovery path completes, ensuring the regenerated session is internally consistent and preventing unnecessary storage access on subsequent session operations.

### Summary

- Route session runtime diagnostics through `AstroLogger`.
- Ensure regenerated sessions are no longer marked as partial after recovery.
- Keep session state consistent after regeneration failures.
- Preserve existing public API behavior.

## Testing

The implementation has been verified against the reported issue and resolves both behaviors described in #17420.

## Docs

No documentation changes are required.

These changes affect only the internal session runtime implementation and do not introduce any changes to Astro's public API or user-facing behavior.