### PR TITLE
fix(render): render popover as a boolean attribute on custom elements

### DIFF
--- a/.changeset/tidy-plums-attend.md
+++ b/.changeset/tidy-plums-attend.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `popover` being rendered as `popover="true"`/`popover="false"` on custom elements (tag names containing a hyphen). Per the Popover API, the attribute only accepts `"auto"`, `"manual"`, or being absent, so boolean values are now always rendered as a bare `popover` attribute (or omitted), regardless of the tag name.

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -69,6 +69,12 @@ function handleBooleanAttribute(
 	shouldEscape: boolean,
 	tagName?: string,
 ): string {
+	// The Popover API only accepts "auto", "manual", or the attribute being absent.
+	// There's no valid string value for "off", so it must always be rendered as a
+	// boolean attribute, even on custom elements.
+	if (key === 'popover') {
+		return markHTMLString(value ? ` ${key}` : '');
+	}
 	// For custom elements, always render as string attributes
 	if (tagName && isCustomElement(tagName)) {
 		return markHTMLString(` ${key}="${toAttributeString(value, shouldEscape)}"`);

--- a/packages/astro/test/units/app/astro-attrs.test.ts
+++ b/packages/astro/test/units/app/astro-attrs.test.ts
@@ -69,6 +69,10 @@ const attributesPage = createComponent(() => {
     <dialog id="popover-false"${addAttribute(false, 'popover')} />
     <dialog id="popover-string-empty"${addAttribute('', 'popover')} />
 
+    <custom-el id="popover-custom-el-true"${addAttribute(true, 'popover', true, 'custom-el')} />
+    <custom-el id="popover-custom-el-false"${addAttribute(false, 'popover', true, 'custom-el')} />
+    <custom-el id="popover-custom-el-auto"${addAttribute('auto', 'popover', true, 'custom-el')} />
+
     <div id="hidden-until-found"${addAttribute('until-found', 'hidden')} />
     <div id="hidden-true"${addAttribute(true, 'hidden')} />
     <div id="hidden-false"${addAttribute(false, 'hidden')} />
@@ -196,6 +200,9 @@ describe('Attributes', async () => {
 			'popover-true': { attribute: 'popover', value: '' },
 			'popover-false': { attribute: 'popover', value: undefined },
 			'popover-string-empty': { attribute: 'popover', value: '' },
+			'popover-custom-el-true': { attribute: 'popover', value: '' },
+			'popover-custom-el-false': { attribute: 'popover', value: undefined },
+			'popover-custom-el-auto': { attribute: 'popover', value: 'auto' },
 			// Note: cheerio normalizes boolean `hidden` to the string "hidden",
 			// so we use "hidden" as the expected value instead of ""
 			'hidden-true': { attribute: 'hidden', value: 'hidden' },


### PR DESCRIPTION
## Changes

Fixes #17398

`<my-element popover>` rendered as `popover="true"` (and `popover={false}` as `popover="false"`), because `handleBooleanAttribute` stringifies boolean attributes on custom elements. The Popover API only accepts `"auto"`, `"manual"`, or the attribute being absent — and `popover="false"` actually *enables* a manual popover, inverting the author's intent.

`popover` is now always rendered as a bare boolean attribute (or omitted) regardless of tag name, matching the existing behavior for built-in elements. Explicit string values like `popover="auto"` are unaffected, as is the custom-element stringification for `download`/`hidden`.

## Testing

Added regression cases to `test/units/app/astro-attrs.test.ts` covering `popover={true}` (bare attribute), `popover={false}` (omitted), and `popover="auto"` (kept) on a custom element. The true-case fails before the fix (`'true' !== ''`) and passes after. 150 tests across the attribute/custom-element rendering suites pass locally.

## Docs

No docs change needed — this aligns rendering with documented Popover API semantics. Changeset included.

---

Note: this fix was developed with AI assistance (Claude) and verified locally as described above.
