### PR TITLE
Fix `create-astro` silently scaffolding into wrong directory on Linux with non-ASCII paths

### DIFF
--- a/.changeset/young-mugs-film.md
+++ b/.changeset/young-mugs-film.md
@@ -2,4 +2,4 @@
 'create-astro': patch
 ---
 
-Fixes `create-astro` silently writing template files to the wrong directory on Linux when the path contains non-ASCII characters (e.g., Turkish `ü`). Updates `@bluwy/giget-core` to pick up the upstream fix in `modern-tar` v0.7.7 for Unicode NFC/NFD path normalization.
+Fixes `create-astro` silently writing template files to the wrong directory on Linux when the path contains non-ASCII characters.

--- a/.changeset/young-mugs-film.md
+++ b/.changeset/young-mugs-film.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes `create-astro` silently writing template files to the wrong directory on Linux when the path contains non-ASCII characters (e.g., Turkish `ü`). Updates `@bluwy/giget-core` to pick up the upstream fix in `modern-tar` v0.7.7 for Unicode NFC/NFD path normalization.

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -32,7 +32,7 @@
   "//b": "DEPENDENCIES IS FOR UNBUNDLED PACKAGES",
   "dependencies": {
     "@astrojs/cli-kit": "^0.4.1",
-    "@bluwy/giget-core": "^0.1.6"
+    "@bluwy/giget-core": "^0.1.7"
   },
   "devDependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,7 @@ settings:
 
 overrides:
   '@types/node@22': ^22.19.0
+  modern-tar: '>=0.7.7'
 
 importers:
 
@@ -4349,8 +4350,8 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1
       '@bluwy/giget-core':
-        specifier: ^0.1.6
-        version: 0.1.6
+        specifier: ^0.1.7
+        version: 0.1.7
     devDependencies:
       '@astrojs/internal-helpers':
         specifier: workspace:*
@@ -7493,8 +7494,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@bluwy/giget-core@0.1.6':
-    resolution: {integrity: sha512-5BwSIzqhpzXKUnSSheB0M+Qb4iGskepb35FiPA1/7AciPArTqt9H5yc53NmV21gNkDFrgbDBuzSWwrlo2aAKxg==}
+  '@bluwy/giget-core@0.1.7':
+    resolution: {integrity: sha512-6XG8TZt8DVYLuGDVSpFJaSMlNowOg5RGecvWbKvlgMoqVbztUAQ3AcWq6oZ5DoCnTzNAPcO7rhkwt8ZVgrS7CQ==}
     engines: {node: '>=18'}
 
   '@borewit/text-codec@0.2.2':
@@ -13560,12 +13561,8 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
-  modern-tar@0.3.5:
-    resolution: {integrity: sha512-TIALaZ8AjtEHFOZj1wRreDfaobCybvzPkvevpup/XtKOha3TmJWSwrh0ghc/QwAdAtt6oqIN6z6eIlo+HbDnzg==}
-    engines: {node: '>=18.0.0'}
-
-  modern-tar@0.7.6:
-    resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
+  modern-tar@0.7.7:
+    resolution: {integrity: sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==}
     engines: {node: '>=18.0.0'}
 
   module-definition@6.0.1:
@@ -16888,9 +16885,9 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.3':
     optional: true
 
-  '@bluwy/giget-core@0.1.6':
+  '@bluwy/giget-core@0.1.7':
     dependencies:
-      modern-tar: 0.3.5
+      modern-tar: 0.7.7
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -22794,7 +22791,7 @@ snapshots:
       file-type: 21.3.4
       ini: 6.0.0
       minimatch: 10.2.4
-      modern-tar: 0.7.6
+      modern-tar: 0.7.7
       papaparse: 5.5.3
       quickjs-emscripten: 0.32.0
       re2js: 1.3.3
@@ -23731,9 +23728,7 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  modern-tar@0.3.5: {}
-
-  modern-tar@0.7.6: {}
+  modern-tar@0.7.7: {}
 
   module-definition@6.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,8 @@ overrides:
   # with `@types/node@22`, one with `@types/node@25`, etc.. By adding this override, we force
   # pnpm to only keep one installation of `vite@7.3.2` with `@types/node@22`.
   '@types/node@22': '^22.19.0'
+  # Force modern-tar to 0.7.7 which fixes Unicode NFC/NFD path normalization on Linux (issue #17381)
+  'modern-tar': '>=0.7.7'
 
 # Wait until three days after release to install new versions of packages
 minimumReleaseAge: 4320
@@ -50,6 +52,8 @@ minimumReleaseAgeExclude:
   # compiler-rs 0.2.3's wasm binding needs freshly-published napi runtime
   - '@napi-rs/wasm-runtime@1.1.6'
   - '@tybys/wasm-util@0.10.3'
+  # modern-tar 0.7.7 fixes Unicode NFC/NFD path normalization on Linux (issue #17381)
+  - 'modern-tar@0.7.7'
 peerDependencyRules:
   allowAny:
     - 'astro'


### PR DESCRIPTION
Closes #17381

## Changes

- Fixes `create-astro` silently producing an empty project on Linux when the target directory path contains non-ASCII characters (Turkish, German, French, Scandinavian, etc.). `modern-tar` (a transitive dep via `@bluwy/giget-core`) unconditionally rewrites destination paths to NFD (decomposed Unicode) form. On byte-preserving filesystems like ext4, NFD and NFC are distinct byte sequences, so `modern-tar` extracts template files into a separate NFD-encoded sibling directory while the CLI still exits 0 — leaving the user's NFC directory with only `AGENTS.md`/`CLAUDE.md` and no `package.json`, `src/`, or `astro.config.mjs`.
- Adds `relocateNFDFiles()` in `template.ts`, called immediately after `downloadTemplate`. It computes the NFD variant of the resolved working directory, checks whether a separate NFD-encoded directory was created (by comparing inodes — same inode means macOS/APFS normalized them to one entry, so no action needed), moves all entries from the NFD directory to the correct NFC directory via `fs.renameSync`, and removes the now-empty NFD directory tree.

> **Note:** The ideal long-term fix is upstream in `modern-tar` — NFD-normalizing tar entry names for comparison is defensible, but rewriting the *destination path's* Unicode form is not. This PR is a targeted workaround in `create-astro` to unblock affected users.

## Testing

- Adds `packages/create-astro/test/units/relocate-nfd.test.ts` with 3 unit tests: moves files from the NFD directory to the NFC directory (the main fix path); no-op for ASCII-only paths where NFC and NFD are identical; no-op when no NFD sibling directory exists. All three tests auto-skip on macOS where HFS+/APFS treats NFC and NFD as the same filesystem entry.

## Docs

- No docs update needed; this is a transparent fix to CLI scaffolding behavior with no user-facing API changes.