### PR TITLE
add link for pnpm workspaces in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We recommend using Corepack, [read PNPM docs](https://pnpm.io/installation#using
 
 ### Setting up your local repo
 
-Astro uses pnpm workspaces, so you should **always run `pnpm install` from the top-level project directory**. Running `pnpm install` in the top-level project root will install dependencies for `astro`, and every package in the repo.
+Astro uses [pnpm workspaces](https://pnpm.io/workspaces), so you should **always run `pnpm install` from the top-level project directory**. Running `pnpm install` in the top-level project root will install dependencies for `astro`, and every package in the repo.
 
 ```shell
 git clone && cd ...


### PR DESCRIPTION
Other pnpm concepts are also linked so I figured it would make sense to have a link for pnpm workspaces as well

## Changes

- changes CONTRIBUTING.md by adding a link for pnpm workspaces.

## Testing

not relevant only markdown file was changed

## Docs

not relevant only markdown file was changed