### PR TITLE
fix(astro): use os.availableParallelism() for image optimization concurrency

### DIFF
--- a/.changeset/available-parallelism-image-concurrency.md
+++ b/.changeset/available-parallelism-image-concurrency.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Uses `os.availableParallelism()` instead of `os.cpus().length` to size the image-optimization concurrency queue during `astro build`. On CPU-limited containers (e.g. Docker/Kubernetes with `--cpus`), `os.cpus().length` returns the host core count, oversubscribing the available CPU and multiplying peak memory, which can trigger OOM kills. `os.availableParallelism()` reflects the CPU actually available to the process. On unconstrained hosts the two return the same value, so behavior is unchanged outside containers.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -236,7 +236,7 @@ export async function generatePages(
 		const totalCount = Array.from(staticImageList.values())
 			.map((x) => x.transforms.size)
 			.reduce((a, b) => a + b, 0);
-		const cpuCount = os.cpus().length;
+		const cpuCount = os.availableParallelism();
 		const assetsCreationPipeline = await prepareAssetsGenerationEnv(options, totalCount);
 		const queue = new PQueue({ concurrency: Math.max(cpuCount, 1) });
 		const errors: Error[] = [];
@@ -302,7 +302,7 @@ export async function generatePages(
 			//   where tasks are added to the queue after the queue.onIdle() resolves.
 			//   This can break tests and create annoying race conditions.
 			// * Exposing a concurrency property in `astro.config.mjs` to allow users
-			//   to override Node’s os.cpus().length default.
+			//   to override Node’s os.availableParallelism() default.
 			// * Create a proper performance benchmark for asset transformations of
 			//   projects in varying sizes of source images and transforms.
 			queue


### PR DESCRIPTION
## What & why

Fixes #17425.

The image-optimization queue in `generatePages` (`packages/astro/src/core/build/generate.ts`) sized its concurrency with `os.cpus().length`, which returns the host's **total** core count — not the CPU available to the process.

In CPU-limited containers (e.g. Docker/Kubernetes with `--cpus=2` on a 4-core host), this oversubscribes the available CPU and multiplies peak memory, which can trigger **OOM kills** during `astro build`. (See the issue for repro steps.)

`os.availableParallelism()` returns the CPU actually available to the process and is the API Node.js recommends for sizing worker pools:

> Returns an estimate of the default amount of parallelism a program should use... `os.availableParallelism()` ... is a more appropriate measure... than `os.cpus().length`.

It is available since Node 18.14; Astro requires Node >= 22.12.0, so there is no compatibility concern.

On unconstrained hosts `availableParallelism()` returns the same value as `cpus().length`, so **behavior is unchanged outside containers** — this only fixes the container oversubscription.

## The change

`packages/astro/src/core/build/generate.ts` — in `generatePages()`:

```diff
- const cpuCount = os.cpus().length;
+ const cpuCount = os.availableParallelism();
```

Plus a one-line update to the nearby design-decision comment that referenced `os.cpus().length`, so the comment stays accurate (it now reads `os.availableParallelism()`). The `cpuCount` local is used only to build the `PQueue` concurrency a few lines below — no exported symbol or public API is touched.

## Notes

- Single-expression behavior fix; no public-API change, no signature change, no new exports.
- Behavior-neutral on unconstrained hosts (same return value), so no regression risk for existing users.
- Follows the Node.js guidance for exactly this use case.

## Changeset

Added `.changeset/available-parallelism-image-concurrency.md` (`astro`: patch).

## AI assistance disclosure

I used an AI assistant (Claude) to help research this issue and draft the change. Astro's `AGENTS.md` does not require AI disclosure, but I'm noting it in good faith. I have reviewed, understand, and take full responsibility for the change — it's a one-line fix to use a Node.js API that the Node docs explicitly recommend for worker-pool sizing, and the rationale above is mine. The commit credits the assistant via a `Co-authored-by` trailer. I'm the human owner and will engage substantively with any review feedback.

Happy to adjust the changeset wording, add a test, or restructure if the maintainers prefer a different approach.