### PR TITLE
Use `os.availableParallelism()` for image optimization queue to fix OOM in CPU-limited containers

### DIFF
--- a/.changeset/thick-waves-fall.md
+++ b/.changeset/thick-waves-fall.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes image optimization during `astro build` using too many parallel processes in CPU-limited containers. Builds now respect the container's CPU limit, reducing peak memory usage and avoiding out-of-memory crashes.
+</content>
+</invoke>

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -236,7 +236,7 @@ export async function generatePages(
 		const totalCount = Array.from(staticImageList.values())
 			.map((x) => x.transforms.size)
 			.reduce((a, b) => a + b, 0);
-		const cpuCount = os.cpus().length;
+		const cpuCount = os.availableParallelism();
 		const assetsCreationPipeline = await prepareAssetsGenerationEnv(options, totalCount);
 		const queue = new PQueue({ concurrency: Math.max(cpuCount, 1) });
 		const errors: Error[] = [];
@@ -302,7 +302,7 @@ export async function generatePages(
 			//   where tasks are added to the queue after the queue.onIdle() resolves.
 			//   This can break tests and create annoying race conditions.
 			// * Exposing a concurrency property in `astro.config.mjs` to allow users
-			//   to override Node’s os.cpus().length default.
+			//   to override Node’s os.availableParallelism() default.
 			// * Create a proper performance benchmark for asset transformations of
 			//   projects in varying sizes of source images and transforms.
 			queue


### PR DESCRIPTION
## Changes

- Replaces `os.cpus().length` with `os.availableParallelism()` when sizing the image optimization queue in `generate.ts`. `os.cpus().length` returns the **host** CPU count and ignores cgroup CPU quotas — in a `--cpus=2` container on a 4-core host it returns 4, so Astro starts 4 concurrent image pipelines instead of 2. Each pipeline holds a fully decoded source image in sharp/libvips native memory, directly multiplying peak memory and causing OOM kills in memory-limited containers.
- `os.availableParallelism()` respects cgroup quotas and CPU affinity masks. On unconstrained hosts it returns the same value as `os.cpus().length`, so the change is behavior-neutral outside containers.

## Testing

- No new tests added. The fix is a single-line API swap; all 111 existing image tests pass unchanged.

## Docs

- No docs update needed. This is an internal queue-sizing detail with no user-facing API change.

Closes #17425