### PR TITLE
chore(deps): update `magic-string` to v1

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -145,7 +145,7 @@
     "http-cache-semantics": "^4.2.0",
     "js-yaml": "^4.1.1",
     "jsonc-parser": "^3.3.1",
-    "magic-string": "^0.30.21",
+    "magic-string": "^1.0.0",
     "magicast": "^0.5.2",
     "mrmime": "^2.0.1",
     "neotraverse": "^0.6.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,8 +805,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       magic-string:
-        specifier: ^0.30.21
-        version: 0.30.21
+        specifier: ^1.0.0
+        version: 1.0.0
       magicast:
         specifier: ^0.5.2
         version: 0.5.2
@@ -13160,6 +13160,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magic-string@1.0.0:
+    resolution: {integrity: sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==}
+
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
@@ -22967,6 +22970,10 @@ snapshots:
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.0.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 


### PR DESCRIPTION
## Changes
 
Update `magic-string` from v0.30 to v1. `magic-string` v1 is now pure-ESM.

See changelog: https://github.com/Rich-Harris/magic-string/releases/tag/v1.0.0

## Testing

green CI.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A. 

`magic-string` is in `astro`'s `dependencies`, so we technically need a Changesets file to trigger a version bumping. However, `astro` releases frequently enough that we do not need it in particular. 

`magic-string` v1 has no breaking changes except for the pure-ESM migration, so all users should not be affected.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
