### PR TITLE
chore: migrate Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
     "config:recommended",
     "schedule:weekly",
     ":disablePeerDependencies",
-    "regexManagers:biomeVersions",
+    "customManagers:biomeVersions",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
## Changes

Migrate Renovate config. Rename `regexManagers` to `customManagers` (See https://github.com/renovatebot/renovate/pull/24451).


Replace https://github.com/withastro/astro/pull/17429 

## Testing

Green CI.


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
