### PR TITLE
fix(astro): update `cookie` to v2

### DIFF
--- a/.changeset/cookie-v2-upgrade.md
+++ b/.changeset/cookie-v2-upgrade.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Updates `cookie` to v2. Cookie values made entirely of URL-safe characters are no longer percent-encoded in `Set-Cookie` headers; encoded values round-trip exactly as before.
+Updates dependency `cookie` to v2. Cookie values made entirely of URL-safe characters are no longer percent-encoded in `Set-Cookie` headers; encoded values round-trip exactly as before.

--- a/.changeset/cookie-v2-upgrade.md
+++ b/.changeset/cookie-v2-upgrade.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates `cookie` to v2. Cookie values made entirely of URL-safe characters are no longer percent-encoded in `Set-Cookie` headers; encoded values round-trip exactly as before.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -131,7 +131,7 @@
     "ci-info": "^4.4.0",
     "clsx": "^2.1.1",
     "common-ancestor-path": "^2.0.0",
-    "cookie": "^1.1.1",
+    "cookie": "^2.0.1",
     "devalue": "^5.8.1",
     "diff": "^8.0.3",
     "dset": "^3.1.4",

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -94,7 +94,7 @@ class AstroCookies implements AstroCookiesInterface {
 				value: DELETED_VALUE,
 				expires: DELETED_EXPIRATION,
 				// Unset `expires` to to ensure that `expires` takes precedence.
-				maxAge: undefined
+				maxAge: undefined,
 			}),
 			false,
 		]);
@@ -193,7 +193,8 @@ class AstroCookies implements AstroCookiesInterface {
 
 		this.#ensureOutgoingMap().set(key, [
 			serializedValue,
-			stringifySetCookie({ ...attributes, name: key, value: serializedValue }, { encode }),
+			stringifySetCookie({ 
+				...attributes, name: key, value: serializedValue }, { encode }),
 			true,
 		]);
 

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -1,5 +1,5 @@
 import type { SerializeOptions } from 'cookie';
-import { parse, serialize } from 'cookie';
+import { parseCookie, stringifySetCookie } from 'cookie';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 
 export type AstroCookieSetOptions = Pick<
@@ -96,15 +96,16 @@ class AstroCookies implements AstroCookiesInterface {
 			expires: _ignoredExpires,
 			...sanitizedOptions
 		} = options || {};
-		const serializeOptions: SerializeOptions = {
-			expires: DELETED_EXPIRATION,
-			...sanitizedOptions,
-		};
 
 		// Set-Cookie: token=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT
 		this.#ensureOutgoingMap().set(key, [
 			DELETED_VALUE,
-			serialize(key, DELETED_VALUE, serializeOptions),
+			stringifySetCookie({
+				name: key,
+				value: DELETED_VALUE,
+				expires: DELETED_EXPIRATION,
+				...sanitizedOptions,
+			}),
 			false,
 		]);
 	}
@@ -198,14 +199,11 @@ class AstroCookies implements AstroCookiesInterface {
 			}
 		}
 
-		const serializeOptions: SerializeOptions = {};
-		if (options) {
-			Object.assign(serializeOptions, options);
-		}
+		const { encode, ...attributes } = options ?? {};
 
 		this.#ensureOutgoingMap().set(key, [
 			serializedValue,
-			serialize(key, serializedValue, serializeOptions),
+			stringifySetCookie({ name: key, value: serializedValue, ...attributes }, { encode }),
 			true,
 		]);
 
@@ -283,7 +281,7 @@ class AstroCookies implements AstroCookiesInterface {
 		}
 		// Pass identity function for decoding so it doesn't use the default.
 		// We'll do the actual decoding when we read the value.
-		this.#requestValues = parse(raw, { decode: identity });
+		this.#requestValues = parseCookie(raw, { decode: identity });
 	}
 }
 

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -86,14 +86,12 @@ class AstroCookies implements AstroCookiesInterface {
 	 */
 	delete(key: string, options?: AstroCookieDeleteOptions): void {
 		/**
-		 * The `@ts-expect-error` is necessary because `maxAge` and `expires` properties
+		 * The `@ts-expect-error` is necessary because `maxAge` property
 		 * must not appear in the AstroCookieDeleteOptions type.
 		 */
 		const {
 			// @ts-expect-error
 			maxAge: _ignoredMaxAge,
-			// @ts-expect-error
-			expires: _ignoredExpires,
 			...sanitizedOptions
 		} = options || {};
 
@@ -101,10 +99,10 @@ class AstroCookies implements AstroCookiesInterface {
 		this.#ensureOutgoingMap().set(key, [
 			DELETED_VALUE,
 			stringifySetCookie({
+				...sanitizedOptions,
 				name: key,
 				value: DELETED_VALUE,
 				expires: DELETED_EXPIRATION,
-				...sanitizedOptions,
 			}),
 			false,
 		]);

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -85,24 +85,16 @@ class AstroCookies implements AstroCookiesInterface {
 	 * @param options Options related to this deletion, such as the path of the cookie.
 	 */
 	delete(key: string, options?: AstroCookieDeleteOptions): void {
-		/**
-		 * The `@ts-expect-error` is necessary because `maxAge` property
-		 * must not appear in the AstroCookieDeleteOptions type.
-		 */
-		const {
-			// @ts-expect-error
-			maxAge: _ignoredMaxAge,
-			...sanitizedOptions
-		} = options || {};
-
 		// Set-Cookie: token=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT
 		this.#ensureOutgoingMap().set(key, [
 			DELETED_VALUE,
 			stringifySetCookie({
-				...sanitizedOptions,
+				...options,
 				name: key,
 				value: DELETED_VALUE,
 				expires: DELETED_EXPIRATION,
+				// Unset `expires` to to ensure that `expires` takes precedence.
+				maxAge: undefined
 			}),
 			false,
 		]);

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -193,7 +193,7 @@ class AstroCookies implements AstroCookiesInterface {
 
 		this.#ensureOutgoingMap().set(key, [
 			serializedValue,
-			stringifySetCookie({ name: key, value: serializedValue, ...attributes }, { encode }),
+			stringifySetCookie({ ...attributes, name: key, value: serializedValue }, { encode }),
 			true,
 		]);
 

--- a/packages/astro/test/units/cookies/set.test.ts
+++ b/packages/astro/test/units/cookies/set.test.ts
@@ -13,15 +13,26 @@ describe('astro/src/core/cookies', () => {
 			assert.equal(headers[0], 'foo=bar');
 		});
 
-		it('Sets a cookie value that can be serialized w/ defaultencodeURIComponent behavior', () => {
+		it('Sets a cookie value without encoding when it only contains cookie-safe characters', () => {
 			let req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);
 			const url = 'http://localhost/path';
 			cookies.set('url', url);
 			let headers = Array.from(cookies.headers());
 			assert.equal(headers.length, 1);
-			// by default cookie value is URI encoded
-			assert.equal(headers[0], `url=${encodeURIComponent(url)}`);
+			// cookie-safe values are emitted as-is by default
+			assert.equal(headers[0], `url=${url}`);
+		});
+
+		it('Sets a cookie value that is URI encoded when it contains unsafe characters', () => {
+			let req = new Request('http://example.com/');
+			let cookies = new AstroCookies(req);
+			const value = 'hello world';
+			cookies.set('greeting', value);
+			let headers = Array.from(cookies.headers());
+			assert.equal(headers.length, 1);
+			// values with unsafe characters are URI encoded by default
+			assert.equal(headers[0], `greeting=${encodeURIComponent(value)}`);
 		});
 
 		it('Sets a cookie value that can be serialized w/ custom encode behavior', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,7 +241,7 @@ importers:
         version: 0.2.0
       eslint:
         specifier: ^10.4.0
-        version: 10.4.0(jiti@2.6.1)
+        version: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       eslint-plugin-regexp:
         specifier: ^3.1.0
         version: 3.1.0(eslint@10.4.0)
@@ -271,7 +271,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.59.1
-        version: 8.59.2(eslint@10.4.0)(typescript@6.0.3)
+        version: 8.59.2(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)
       valibot:
         specifier: ^1.2.0
         version: 1.2.0(typescript@6.0.3)
@@ -763,8 +763,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       cookie:
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^2.0.1
+        version: 2.0.1
       devalue:
         specifier: ^5.8.1
         version: 5.8.1
@@ -5216,7 +5216,7 @@ importers:
         version: 4.0.2
       '@shikijs/twoslash':
         specifier: ^4.0.2
-        version: 4.0.2(typescript@6.0.3)
+        version: 4.0.2(supports-color@8.1.1)(typescript@6.0.3)
       '@types/estree':
         specifier: ^1.0.8
         version: 1.0.8
@@ -5471,7 +5471,7 @@ importers:
         version: 5.2.0
       '@netlify/vite-plugin':
         specifier: ^2.12.3
-        version: 2.12.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)(vite@8.1.0)
+        version: 2.12.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)(supports-color@8.1.1)(vite@8.1.0)
       '@vercel/nft':
         specifier: ^1.3.2
         version: 1.3.2
@@ -5844,7 +5844,7 @@ importers:
         version: link:../../internal-helpers
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.0)(vite@8.1.0)
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.0)(supports-color@8.1.1)(vite@8.1.0)
       '@preact/signals':
         specifier: ^2.8.2
         version: 2.8.2(preact@10.29.0)
@@ -6360,7 +6360,7 @@ importers:
         version: 8.1.0(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.0
-        version: 8.1.0(vite@8.1.0)(vue@3.5.30)
+        version: 8.1.0(supports-color@8.1.1)(vite@8.1.0)(vue@3.5.30)
     devDependencies:
       astro:
         specifier: workspace:*
@@ -6388,7 +6388,7 @@ importers:
         version: link:../../../../../astro
       vite-svg-loader:
         specifier: 5.1.1
-        version: 5.1.1(vue@3.5.30)
+        version: 5.1.1(supports-color@8.1.1)(vue@3.5.30)
       vue:
         specifier: ^3.5.30
         version: 3.5.30(typescript@6.0.3)
@@ -6403,7 +6403,7 @@ importers:
         version: link:../../../../../astro
       vite-svg-loader:
         specifier: 5.1.1
-        version: 5.1.1(vue@3.5.30)
+        version: 5.1.1(supports-color@8.1.1)(vue@3.5.30)
       vue:
         specifier: ^3.5.30
         version: 3.5.30(typescript@6.0.3)
@@ -6427,7 +6427,7 @@ importers:
         version: link:../../../../../astro
       vite-svg-loader:
         specifier: 5.1.1
-        version: 5.1.1(vue@3.5.30)
+        version: 5.1.1(supports-color@8.1.1)(vue@3.5.30)
       vue:
         specifier: ^3.5.30
         version: 3.5.30(typescript@6.0.3)
@@ -6763,7 +6763,7 @@ importers:
         version: 11.7.5
       ovsx:
         specifier: ^0.10.10
-        version: 0.10.10
+        version: 0.10.10(supports-color@8.1.1)
       tsx:
         specifier: ^4.22.0
         version: 4.22.3
@@ -11393,6 +11393,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
 
   copy-file@11.1.0:
     resolution: {integrity: sha512-X8XDzyvYaA6msMyAM575CUoygY5b44QzLcGRKsK3MFmXcOvQa518dNPLsKYwkYsn72g3EiW+LE0ytd/FlqWmyw==}
@@ -17704,12 +17708,12 @@ snapshots:
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0)':
     dependencies:
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@8.1.1)
@@ -18386,7 +18390,7 @@ snapshots:
       uuid: 13.0.0
       write-file-atomic: 5.0.1
 
-  '@netlify/dev@4.18.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)':
+  '@netlify/dev@4.18.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)(supports-color@8.1.1)':
     dependencies:
       '@netlify/ai': 0.4.1
       '@netlify/blobs': 10.7.5
@@ -18394,7 +18398,7 @@ snapshots:
       '@netlify/database-dev': 0.10.1
       '@netlify/dev-utils': 4.4.3
       '@netlify/edge-functions-dev': 1.0.17
-      '@netlify/functions-dev': 1.2.8
+      '@netlify/functions-dev': 1.2.8(supports-color@8.1.1)
       '@netlify/headers': 2.1.8
       '@netlify/images': 1.3.7(@azure/identity@4.13.0)(@netlify/blobs@10.7.5)(@vercel/functions@3.4.3)
       '@netlify/redirects': 3.1.10
@@ -18466,7 +18470,7 @@ snapshots:
     dependencies:
       '@netlify/types': 2.6.0
 
-  '@netlify/functions-dev@1.2.8':
+  '@netlify/functions-dev@1.2.8(supports-color@8.1.1)':
     dependencies:
       '@netlify/blobs': 10.7.5
       '@netlify/dev-utils': 4.4.3
@@ -18474,7 +18478,7 @@ snapshots:
       '@netlify/zip-it-and-ship-it': 14.5.6
       cron-parser: 4.9.0
       decache: 4.6.2
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(supports-color@8.1.1)
       is-stream: 4.0.1
       jwt-decode: 4.0.0
       lambda-local: 2.2.0
@@ -18577,9 +18581,9 @@ snapshots:
 
   '@netlify/types@2.6.0': {}
 
-  '@netlify/vite-plugin@2.12.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)(vite@8.1.0)':
+  '@netlify/vite-plugin@2.12.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)(supports-color@8.1.1)(vite@8.1.0)':
     dependencies:
-      '@netlify/dev': 4.18.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)
+      '@netlify/dev': 4.18.3(@azure/identity@4.13.0)(@vercel/functions@3.4.3)(supports-color@8.1.1)
       '@netlify/dev-utils': 4.4.3
       dedent: 1.7.1
       vite: 8.1.0(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
@@ -18928,7 +18932,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.0)(vite@8.1.0)':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.0)(supports-color@8.1.1)(vite@8.1.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
@@ -19185,11 +19189,11 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.0.2
 
-  '@shikijs/twoslash@4.0.2(typescript@6.0.3)':
+  '@shikijs/twoslash@4.0.2(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@shikijs/core': 4.0.2
       '@shikijs/types': 4.0.2
-      twoslash: 0.3.8(typescript@6.0.3)
+      twoslash: 0.3.8(supports-color@8.1.1)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -19669,15 +19673,15 @@ snapshots:
       '@types/node': 22.19.19
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2)(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2)(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.2(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/type-utils': 8.59.2(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.59.2(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.59.2(eslint@10.4.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.2
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -19685,14 +19689,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.2(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.59.2(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -19728,13 +19732,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.2(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.59.2(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/utils': 8.59.2(eslint@10.4.0)(typescript@6.0.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -19778,7 +19782,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -19788,7 +19792,7 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/vfs@1.6.4(typescript@6.0.3)':
+  '@typescript/vfs@1.6.4(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
@@ -20123,7 +20127,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vscode/vsce@3.7.1':
+  '@vscode/vsce@3.7.1(supports-color@8.1.1)':
     dependencies:
       '@azure/identity': 4.13.0
       '@secretlint/node': 10.2.2
@@ -20146,7 +20150,7 @@ snapshots:
       minimatch: 3.1.2
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2
+      secretlint: 10.2.2(supports-color@8.1.1)
       semver: 7.8.5
       tmp: 0.2.5
       typed-rest-client: 1.8.11
@@ -20970,6 +20974,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cookie@2.0.1: {}
+
   copy-file@11.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -21471,7 +21477,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
       '@eslint-community/regexpp': 4.12.2
       comment-parser: 1.4.5
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       jsdoc-type-pratt-parser: 7.1.1
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
@@ -21488,11 +21494,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.0(jiti@2.6.1):
+  eslint@10.4.0(jiti@2.6.1)(supports-color@8.1.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.1
@@ -21668,7 +21674,7 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
-  extract-zip@2.0.1:
+  extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       get-stream: 5.2.0
@@ -23856,9 +23862,9 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  ovsx@0.10.10:
+  ovsx@0.10.10(supports-color@8.1.1):
     dependencies:
-      '@vscode/vsce': 3.7.1
+      '@vscode/vsce': 3.7.1(supports-color@8.1.1)
       commander: 6.2.1
       follow-redirects: 1.15.11
       is-ci: 2.0.0
@@ -25012,7 +25018,7 @@ snapshots:
 
   scule@1.3.0: {}
 
-  secretlint@10.2.2:
+  secretlint@10.2.2(supports-color@8.1.1):
     dependencies:
       '@secretlint/config-creator': 10.2.2
       '@secretlint/formatter': 10.2.2
@@ -25667,9 +25673,9 @@ snapshots:
 
   twoslash-protocol@0.3.8: {}
 
-  twoslash@0.3.8(typescript@6.0.3):
+  twoslash@0.3.8(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@typescript/vfs': 1.6.4(typescript@6.0.3)
+      '@typescript/vfs': 1.6.4(supports-color@8.1.1)(typescript@6.0.3)
       twoslash-protocol: 0.3.8
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -25716,13 +25722,13 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  typescript-eslint@8.59.2(eslint@10.4.0)(typescript@6.0.3):
+  typescript-eslint@8.59.2(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2)(eslint@10.4.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.59.2(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2)(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@10.4.0)(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/utils': 8.59.2(eslint@10.4.0)(typescript@6.0.3)
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.4.0(jiti@2.6.1)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -25956,7 +25962,7 @@ snapshots:
     dependencies:
       vite: 8.1.0(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  vite-plugin-inspect@11.3.3(vite@8.1.0):
+  vite-plugin-inspect@11.3.3(supports-color@8.1.1)(vite@8.1.0):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -25984,14 +25990,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@8.1.0(vite@8.1.0)(vue@3.5.30):
+  vite-plugin-vue-devtools@8.1.0(supports-color@8.1.1)(vite@8.1.0)(vue@3.5.30):
     dependencies:
       '@vue/devtools-core': 8.1.0(vue@3.5.30)
       '@vue/devtools-kit': 8.1.0
       '@vue/devtools-shared': 8.1.0
       sirv: 3.0.2
       vite: 8.1.0(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
-      vite-plugin-inspect: 11.3.3(vite@8.1.0)
+      vite-plugin-inspect: 11.3.3(supports-color@8.1.1)(vite@8.1.0)
       vite-plugin-vue-inspector: 5.3.2(vite@8.1.0)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -26023,7 +26029,7 @@ snapshots:
       stack-trace: 1.0.0-pre2
       vite: 8.1.0(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  vite-svg-loader@5.1.1(vue@3.5.30):
+  vite-svg-loader@5.1.1(supports-color@8.1.1)(vue@3.5.30):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       svgo: 3.3.3


### PR DESCRIPTION
## Changes

1. Updates `cookie` to v2
2. Migrates `AstroCookies` to the new `parseCookie` / `stringifySetCookie` API. 
3. Refactored the code by a bit.
 
The only observable change is the default `encode`: values made entirely of cookie-safe characters are no longer percent-encoded in `Set-Cookie` headers, and every value still round-trips exactly as before.

| `Astro.cookies.set('foo', value)` | `Set-Cookie` before <br> (`cookie` v1) | `Set-Cookie` after <br> (`cookie` v2) |
| --- | --- | --- |
| `'bar'` | `foo=bar` | `foo=bar` |
| `'http://localhost/path'` | `foo=http%3A%2F%2Flocalhost%2Fpath` | `foo=http://localhost/path` |
| `'hello world'` | `foo=hello%20world` | `foo=hello%20world` |


Changelog (not very useful IMO): https://github.com/jshttp/cookie/releases/tag/v2.0.0

## Testing

Added a new test 


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Added a Changesets file because there is a tiny behavior change. 

I could copy the Markdown table above into the Changesets file too if reviewers believe it would be better.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
