### PR TITLE
Fix Markdoc custom transform silently dropped for hyphenated tag/node names

### DIFF
--- a/.changeset/crisp-jokes-occur.md
+++ b/.changeset/crisp-jokes-occur.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fixes custom `transform` functions being incorrectly dropped for tags and nodes whose names require bracket access (e.g. `side-note`)

--- a/packages/integrations/markdoc/src/runtime.ts
+++ b/packages/integrations/markdoc/src/runtime.ts
@@ -147,11 +147,15 @@ function syncTagNodeAttributes(config: MergedConfig): void {
  */
 function transformRespectsRender(transform: { toString(): string }, configKey: string): boolean {
 	const source = transform.toString();
-	// Astro's transforms check config.nodes?.X?.render or config.tags?.X?.render
-	return (
-		source.includes(`config.nodes?.${configKey}?.render`) ||
-		source.includes(`config.tags?.${configKey}?.render`)
+	// `configKey` may not be a valid identifier (e.g. `side-note`), so a render-respecting
+	// transform can read `render` via dot or bracket access. Escape the key and match either.
+	const key = configKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const member = (prop: string) =>
+		`(?:\\??\\.\\s*${prop}|\\??\\.?\\s*\\[\\s*['"\`]${prop}['"\`]\\s*\\])`;
+	const pattern = new RegExp(
+		`config\\s*\\??\\.\\s*(?:nodes|tags)\\s*${member(key)}\\s*${member('render')}`,
 	);
+	return pattern.test(source);
 }
 
 export function resolveComponentImports(

--- a/packages/integrations/markdoc/test/units/resolve-component-imports.test.ts
+++ b/packages/integrations/markdoc/test/units/resolve-component-imports.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { AstroInstance } from 'astro';
+import { resolveComponentImports } from '../../dist/runtime.js';
+
+type MarkdocConfig = Parameters<typeof resolveComponentImports>[0];
+type NodeComponentMap = Parameters<typeof resolveComponentImports>[2];
+
+const Component = (() => null) as unknown as AstroInstance['default'];
+const noNodeComponents = {} as NodeComponentMap;
+
+describe('Markdoc - resolveComponentImports', () => {
+	it('keeps a render-respecting transform for tag names that need bracket access', () => {
+		const markdocConfig: MarkdocConfig = {
+			tags: {
+				'side-note': {
+					transform(node, config) {
+						if (config.tags?.['side-note']?.render) return [];
+						return node.transformChildren(config);
+					},
+				},
+			},
+			nodes: {},
+		};
+
+		const resolved = resolveComponentImports(
+			markdocConfig,
+			{ 'side-note': Component },
+			noNodeComponents,
+		);
+
+		assert.equal(resolved.tags['side-note'].render, Component);
+		assert.equal(
+			typeof resolved.tags['side-note'].transform,
+			'function',
+			'a render-respecting transform should be preserved for dashed tag names',
+		);
+	});
+
+	it('removes a transform that does not respect render so the custom component wins', () => {
+		const markdocConfig: MarkdocConfig = {
+			tags: {
+				'side-note': {
+					transform(node, config) {
+						return node.transformChildren(config);
+					},
+				},
+			},
+			nodes: {},
+		};
+
+		const resolved = resolveComponentImports(
+			markdocConfig,
+			{ 'side-note': Component },
+			noNodeComponents,
+		);
+
+		assert.equal(resolved.tags['side-note'].render, Component);
+		assert.equal(
+			resolved.tags['side-note'].transform,
+			undefined,
+			'a non-render-respecting transform should be removed so `render` wins',
+		);
+	});
+
+	it('keeps a render-respecting transform using dot notation', () => {
+		const markdocConfig: MarkdocConfig = {
+			tags: {
+				sidenote: {
+					transform(node, config) {
+						if (config.tags?.sidenote?.render) return [];
+						return node.transformChildren(config);
+					},
+				},
+			},
+			nodes: {},
+		};
+
+		const resolved = resolveComponentImports(
+			markdocConfig,
+			{ sidenote: Component },
+			noNodeComponents,
+		);
+
+		assert.equal(resolved.tags['sidenote'].render, Component);
+		assert.equal(
+			typeof resolved.tags['sidenote'].transform,
+			'function',
+			'a render-respecting transform should be preserved for simple tag names',
+		);
+	});
+});


### PR DESCRIPTION
## Changes

- Custom `transform` functions defined on Markdoc tags or nodes with hyphenated names (e.g. `side-note`) were silently deleted by `resolveComponentImports`. Hyphenated names require bracket notation in JS (`config.tags?.['side-note']?.render`), which the old `String.includes()` check never matched.
- Replaces the `String.includes()` checks in `transformRespectsRender` with a regex that matches both dot notation and bracket notation access, with optional chaining and whitespace tolerance.

Closes #17459

## Testing

- Adds `packages/integrations/markdoc/test/units/resolve-component-imports.test.ts` with three cases: keeps a transform using bracket notation for a hyphenated key, removes a transform that ignores render, and keeps a transform using standard dot notation.

## Docs

- No docs update needed; this restores behavior that was always intended to work.
