### PR TITLE
Fix dual React instances after mid-session SSR dep re-optimization in `@astrojs/cloudflare` dev

### DIFF
--- a/.changeset/cloudflare-stale-optimized-deps.md
+++ b/.changeset/cloudflare-stale-optimized-deps.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes React "Invalid hook call" errors when Vite's SSR dependency optimizer re-runs mid-session in dev
+
+When a request pulled in a dependency that was not part of the pre-optimized set (for example, a newly added island importing a package like `@phosphor-icons/react`), Vite re-optimized the server environment's dependencies and renamed the optimized module URLs. Modules already evaluated inside workerd kept the old React copy while newly evaluated modules loaded the new one, splitting React into two instances and breaking hooks in every island — often until `node_modules/.vite` was cleared and the dev server restarted.
+
+The adapter now sets `optimizeDeps.ignoreOutdatedRequests: false` for the server environments, restoring Vite's built-in recovery: a request that races the re-optimization fails fast with a clear "new version of the pre-bundle" error and the next request renders cleanly against a single React instance.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -311,6 +311,14 @@ export default function createIntegration({
 									if (isServerEnvironment && !_options.optimizeDeps?.noDiscovery) {
 										return {
 											optimizeDeps: {
+												// `@cloudflare/vite-plugin` defaults this to `true` in the workerd
+												// environment. That suppresses `ERR_OUTDATED_OPTIMIZED_DEP` when a
+												// mid-session re-optimization renames optimized dep URLs (`?v=` hash),
+												// so the workerd module runner silently evaluates a second copy of
+												// already-loaded deps. With React this means two React instances and
+												// "Invalid hook call" errors in islands (#17364). Throwing instead lets
+												// the request fail fast and re-render cleanly against the new bundle.
+												ignoreOutdatedRequests: false,
 												include: [
 													'@astrojs/cloudflare/image-service-workerd',
 													'@astrojs/cloudflare/entrypoints/server',

--- a/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/astro.config.mjs
@@ -1,0 +1,9 @@
+import cloudflare from '@astrojs/cloudflare';
+import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	integrations: [react()],
+	adapter: cloudflare(),
+	output: 'server',
+});

--- a/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@test/astro-cloudflare-lazy-dep-discovery",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"@astrojs/cloudflare": "workspace:*",
+		"@astrojs/react": "workspace:*",
+		"astro": "workspace:*",
+		"react": "^19.2.4",
+		"react-dom": "^19.2.4",
+		"use-sync-external-store": "^1.4.0"
+	}
+}

--- a/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/src/components/Component.tsx
+++ b/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/src/components/Component.tsx
@@ -1,0 +1,8 @@
+import { useRef, useState } from 'react';
+
+export const Component = () => {
+	const renders = useRef(0);
+	const [count] = useState(0);
+	renders.current++;
+	return <div className="react">React Content {count}</div>;
+};

--- a/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+import { Component } from '../components/Component';
+---
+
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+<h1>Testing</h1>
+<Component client:load />
+</body>
+</html>

--- a/packages/integrations/cloudflare/test/lazy-dep-discovery.test.ts
+++ b/packages/integrations/cloudflare/test/lazy-dep-discovery.test.ts
@@ -1,0 +1,140 @@
+import * as assert from 'node:assert/strict';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { Writable } from 'node:stream';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
+import { AstroLogger, type AstroLoggerMessage } from '../../../astro/dist/core/logger/core.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+
+// ref: https://github.com/withastro/astro/issues/17364
+// When the SSR dep optimizer discovers a new dependency mid-session (here: a new island
+// importing `use-sync-external-store`, added while the dev server is running), the
+// re-optimization renames optimized dep URLs. Stale modules in the workerd module runner
+// then hold a second React copy, breaking hooks with "Invalid hook call" — unless outdated
+// requests are allowed to fail fast (`ignoreOutdatedRequests: false`) so rendering retries
+// against the new bundle.
+describe('Lazy dependency discovery mid-session', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+	const logs: AstroLoggerMessage[] = [];
+	const newFiles: string[] = [];
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/lazy-dep-discovery/',
+		});
+
+		// Start from a cold Vite cache so the optimizer state matches a fresh session.
+		const viteCacheDir = new URL('./node_modules/.vite/', fixture.config.root);
+		rmSync(fileURLToPath(viteCacheDir), { recursive: true, force: true });
+
+		devServer = await fixture.startDevServer({
+			vite: { logLevel: 'info' },
+			// @ts-expect-error use of internal APIs
+			_logger: new AstroLogger({
+				level: 'info',
+				destination: new Writable({
+					objectMode: true,
+					write(event, _, callback) {
+						logs.push(event);
+						callback();
+					},
+				}),
+			}),
+		});
+	});
+
+	after(async () => {
+		await devServer.stop();
+		for (const file of newFiles) {
+			rmSync(file, { force: true });
+		}
+	});
+
+	it('does not corrupt React after a new island triggers dep re-optimization', async () => {
+		// Warm the session: the pre-existing island renders fine.
+		const baseline = await fixture.fetch('/');
+		assert.equal(baseline.status, 200);
+		const $baseline = cheerio.load(await baseline.text());
+		assert.match($baseline('.react').text(), /React Content/);
+
+		// Simulate the user adding new files during the live session. The new island
+		// imports a React-dependent package that is not part of the pre-optimized set,
+		// which forces mid-session dependency discovery on the next request.
+		const componentPath = fileURLToPath(
+			new URL('./src/components/LazyComp.tsx', fixture.config.root),
+		);
+		const pagePath = fileURLToPath(new URL('./src/pages/lazy.astro', fixture.config.root));
+		mkdirSync(fileURLToPath(new URL('./src/components/', fixture.config.root)), {
+			recursive: true,
+		});
+		writeFileSync(
+			componentPath,
+			`import { useSyncExternalStore } from 'use-sync-external-store/shim';
+const subscribe = () => () => {};
+const getSnapshot = () => 'snapshot';
+export const LazyComp = () => {
+	const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+	return <div className="lazy">Lazy: {value}</div>;
+};
+`,
+		);
+		writeFileSync(
+			pagePath,
+			`---
+import { LazyComp } from '../components/LazyComp';
+import { Component } from '../components/Component';
+---
+<html>
+<head><title>Lazy</title></head>
+<body>
+<LazyComp client:load />
+<Component client:load />
+</body>
+</html>
+`,
+		);
+		newFiles.push(componentPath, pagePath);
+
+		// Poll the new page. Transient non-200 responses are allowed while the route is
+		// registered and while an in-flight request races the re-optimization (that race
+		// is expected to fail fast and recover). What must never happen is a 200 that is
+		// missing the island markup: that is the dual-React corruption signature.
+		let sawHealthyResponse = false;
+		for (let attempt = 0; attempt < 30 && !sawHealthyResponse; attempt++) {
+			const res = await fixture.fetch('/lazy');
+			if (res.status === 200) {
+				const $ = cheerio.load(await res.text());
+				assert.match(
+					$('.lazy').text(),
+					/Lazy: snapshot/,
+					'a 200 response must contain the new island markup',
+				);
+				assert.match(
+					$('.react').text(),
+					/React Content/,
+					'a 200 response must contain the pre-existing island markup',
+				);
+				sawHealthyResponse = true;
+			} else {
+				await new Promise((resolve) => setTimeout(resolve, 500));
+			}
+		}
+		assert.ok(sawHealthyResponse, 'the new page must eventually render successfully');
+
+		// The pre-existing page must still render.
+		const index = await fixture.fetch('/');
+		assert.equal(index.status, 200);
+		const $index = cheerio.load(await index.text());
+		assert.match($index('.react').text(), /React Content/);
+
+		// And at no point may React have been split into two instances.
+		const invalidHookLog = logs.find((log) => log.message?.includes('Invalid hook call'));
+		assert.equal(
+			invalidHookLog,
+			undefined,
+			`React was instantiated twice during re-optimization: ${invalidHookLog?.message}`,
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4613,6 +4613,27 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/cloudflare/test/fixtures/lazy-dep-discovery:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../../../react
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      use-sync-external-store:
+        specifier: ^1.4.0
+        version: 1.6.0(react@19.2.4)
+
   packages/integrations/cloudflare/test/fixtures/no-output:
     dependencies:
       '@astrojs/cloudflare':
@@ -7598,11 +7619,11 @@ packages:
     resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
-    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz}
     engines: {node: '>=22.0.0'}
 
   '@cloudflare/unenv-preset@2.16.1':
-    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==, tarball: https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: '>1.20260305.0 <2.0.0-0'
@@ -7611,43 +7632,43 @@ packages:
         optional: true
 
   '@cloudflare/vite-plugin@1.39.0':
-    resolution: {integrity: sha512-AHC+KSR+3dtGu7Ab7I0Ode4Whx12TxMEmiZt7w+Fc3/2wYNByIzbb6cndWZ78tnveFdO1xhNLv1YaNngxGtOPg==}
+    resolution: {integrity: sha512-AHC+KSR+3dtGu7Ab7I0Ode4Whx12TxMEmiZt7w+Fc3/2wYNByIzbb6cndWZ78tnveFdO1xhNLv1YaNngxGtOPg==, tarball: https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.39.0.tgz}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.95.0
 
   '@cloudflare/workerd-darwin-64@1.20260526.1':
-    resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==}
+    resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260526.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260526.1':
-    resolution: {integrity: sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==}
+    resolution: {integrity: sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260526.1.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20260526.1':
-    resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==}
+    resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260526.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260526.1':
-    resolution: {integrity: sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==}
+    resolution: {integrity: sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260526.1.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-windows-64@1.20260526.1':
-    resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==}
+    resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260526.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
   '@cloudflare/workers-types@4.20260527.1':
-    resolution: {integrity: sha512-GK+C05N4fGptp1uG+pbjC/7Udonz8EhMEYvYFnVKdLLnEGS9nsmVOFi/RLQr7tq9l/0UEzcWjudzeY2ssuqyIA==}
+    resolution: {integrity: sha512-GK+C05N4fGptp1uG+pbjC/7Udonz8EhMEYvYFnVKdLLnEGS9nsmVOFi/RLQr7tq9l/0UEzcWjudzeY2ssuqyIA==, tarball: https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260527.1.tgz}
 
   '@codspeed/core@5.2.0':
     resolution: {integrity: sha512-CmDhpWjcOJg2iBOQ/BmBnSBq8qxlM3r4h8uvYDkoUaba+EKRT3T73BZtKuml/48jZMsB+4/FG2UbTBinDWtuvw==}
@@ -15568,6 +15589,11 @@ packages:
 
   urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -26011,6 +26037,10 @@ snapshots:
   urlpattern-polyfill@10.1.0: {}
 
   urlpattern-polyfill@8.0.2: {}
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Changes

- Fixes #17364 — React "Invalid hook call" / `Cannot read properties of null (reading 'useRef')` errors in dev when Vite's SSR dep optimizer re-runs mid-session under `@astrojs/cloudflare`.
- The adapter now sets `optimizeDeps.ignoreOutdatedRequests: false` for the server environments (`astro`, `ssr`, `prerender`), overriding the `true` default from `@cloudflare/vite-plugin`.
- Why this works: when a request pulls in a dependency outside the pre-optimized set (e.g. a newly added island importing `@phosphor-icons/react`, or `astro/zod` on a cold first request), the re-optimization renames optimized dep URLs (`?v=` hash). Modules already evaluated in the workerd module runner keep the old React copy while newly evaluated modules load the new one — two React instances, so hooks break in every island, sometimes until `node_modules/.vite` is cleared and the server restarted. Vite's built-in recovery for exactly this situation is throwing `ERR_OUTDATED_OPTIMIZED_DEP` on stale requests (its module runner special-cases that error during `full-reload`), but `ignoreOutdatedRequests: true` suppresses it, silently evaluating the stale copy instead.
- New behavior: the one request that races the re-optimization fails fast with Vite's clear "There is a new version of the pre-bundle … a page reload is going to ask for it" error, and the next render sees a single coherent React. This matches what Node SSR users get from Vite's own middleware (a 504 with "Outdated Optimize Dep") — a loud transient instead of silent corruption.
- This closes the gap left by the previous `optimizeDeps.include` padding fixes (#17187, #17323): those prevent *known* modules from being discovered lazily, but user dependencies can never be enumerated ahead of time. A possible follow-up is pre-scanning user island dependencies into the first optimize pass to shrink the race window further.
- Changeset included.

## Testing

- Added `test/lazy-dep-discovery.test.ts` with a dedicated `lazy-dep-discovery` fixture: starts a dev server, renders a hook-using React island (baseline), then writes a new island importing `use-sync-external-store` plus a new page *while the server is running*, and polls the new route. It asserts that no 200 response is ever missing island markup (the dual-React corruption signature), that both pages render correctly afterwards, and that no "Invalid hook call" appears in the dev logs.
- Verified the test is a true regression test: it fails on `main` and passes with this change.
- Manually reproduced the original report end-to-end before and after the fix; before: silent HTTP 200 with broken islands and dual-React stack traces (optimized `react-dom_server.js?v=…` alongside raw `node_modules/.pnpm/react…/react.development.js`); after: one fast-failing request, then clean renders.
- Full adapter suite shows no new failures compared to a control run on `main` (identical failure sets locally; the only diff is the new test flipping from red to green).

## Docs

No docs changes needed: this is a dev-server bug fix with no API or config surface change. The changeset describes the user-visible behavior change (a racing request now fails fast with a clear error instead of silently rendering with a corrupted React state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
