### PR TITLE
fix(language-tools): support multiline style lang attributes (issue #14657)

### DIFF
--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "Astro",
   "scopeName": "source.astro",
-  "fileTypes": ["astro"],
+  "fileTypes": [
+    "astro"
+  ],
   "injections": {
     "L:(meta.script.astro) (meta.lang.json) - (meta.embedded.block source)": {
       "patterns": [
@@ -766,6 +768,21 @@
         }
       ]
     },
+    "tags-lang-fallback-start-attributes": {
+      "begin": "\\G(?=[^\\n>]*(?:/>|>))",
+      "end": "(?=/>)|>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.astro"
+        }
+      },
+      "name": "meta.tag.start.astro",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
     "tags-start-node": {
       "match": "(<)([^/\\s>/]*)",
       "captures": {
@@ -857,7 +874,7 @@
       "name": "meta.scope.tag.$1.astro meta.$1.astro",
       "patterns": [
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
+          "begin": "(?:\\G|\\s+)(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.json.astro",
           "patterns": [
@@ -867,7 +884,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
+          "begin": "(?:\\G|\\s+)(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.javascript.astro",
           "patterns": [
@@ -877,7 +894,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
+          "begin": "(?:\\G|\\s+)(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
           "end": "(?=</|/>)",
           "name": "meta.lang.$3.astro",
           "patterns": [
@@ -887,7 +904,7 @@
           ]
         },
         {
-          "include": "#tags-lang-start-attributes"
+          "include": "#tags-lang-fallback-start-attributes"
         }
       ]
     },

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -514,6 +514,14 @@ repository:
     name: meta.tag.start.astro
     patterns: [include: '#attributes']
 
+  # Fallback attributes for script/style tags that do not declare a language (only lines with > or />)
+  tags-lang-fallback-start-attributes:
+    begin: \G(?=[^\n>]*(?:/>|>))
+    end: (?=/>)|>
+    endCaptures: { 0: { name: punctuation.definition.tag.end.astro } }
+    name: meta.tag.start.astro
+    patterns: [include: '#attributes']
+
   # Matches the beginning (`<name`) section of a tag start node.
   tags-start-node:
     match: (<)([^/\s>/]*)
@@ -554,22 +562,22 @@ repository:
     name: meta.scope.tag.$1.astro meta.$1.astro
     patterns:
       # Injecting into `meta.lang.ld+json` doesn't seem possible, so we set it to `meta.lang.json`
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2)
+      - begin: (?:\G|\s+)(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2)
         end: (?=</|/>)
         name: meta.lang.json.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Treat 'module' as JavaScript
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(module)\2)
+      - begin: (?:\G|\s+)(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(module)\2)
         end: (?=</|/>)
         name: meta.lang.javascript.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Tags with a language specified.
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2)
+      - begin: (?:\G|\s+)(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2)
         end: (?=</|/>)
         name: meta.lang.$3.astro
         patterns: [include: '#tags-lang-start-attributes']
-      # Fallback to default language.
-      - include: '#tags-lang-start-attributes'
+      # Fallback for lines that contain the closing > or />
+      - include: '#tags-lang-fallback-start-attributes'
 
   # Void element tags. They must be treated separately due to their lack of end nodes.
   # A void element cannot be differentiated from other tags, unless you look at their name.

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro
@@ -1,0 +1,9 @@
+<style
+  lang="sass"
+  define:vars={{
+    foo: '#fff',
+  }}
+>
+  .bar
+    color: var(--foo)
+</style>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro.snap
@@ -1,0 +1,33 @@
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>  lang="sass"
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro
+#  ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#            ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>  define:vars={{
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+#  ^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro entity.other.attribute-name.astro
+#             ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.separator.key-value.astro
+#              ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.begin.astro
+#               ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>    foo: '#fff',
+#^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>  }}
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+#  ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.end.astro
+#   ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  .bar
+#^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+>    color: var(--foo)
+#^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>


### PR DESCRIPTION
﻿When `<style lang="sass">` (or any non-CSS/JS language) has the `lang` attribute on a different line than the opening `<style` tag, the TextMate grammar failed to detect the language and fell back to CSS/JS highlighting.

**Root cause:** The lang detection patterns in `tags-lang` used `\G` anchors, which can only match on the same line as the `begin` pattern. Multi-line attributes bypassed detection entirely, and the fallback `#tags-lang-start-attributes` would then take over permanently.

**Fix:**
1. Changed `\G` → `(?:\\G|\\s+)` in all three lang detection patterns so they can match on subsequent lines
2. Added `#tags-lang-fallback-start-attributes` with a restricted `begin` that only matches lines containing `>` or `/>` (the last line of the tag open)
3. Used this restricted fallback instead of the original `#tags-lang-start-attributes` which matched unconditionally

This ensures that multiline `lang`/`type` attributes are detected on any line, while attributes on the closing line of the tag open still work as before.

**Test:** Added `test/grammar/fixtures/style/sass-multiline.astro` snapshot test.
