### PR TITLE
ci: auto close stale flue branches

### DIFF
--- a/.github/scripts/stale-flue-branches.ts
+++ b/.github/scripts/stale-flue-branches.ts
@@ -1,0 +1,85 @@
+import { execSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+	options: {
+		token: { type: 'string' },
+	},
+});
+
+if (!values.token) {
+	console.error(
+		'Usage: node --experimental-strip-types stale-flue-branches.ts --token <github-token>',
+	);
+	process.exit(1);
+}
+
+const REPO = 'withastro/astro';
+const gh = (command: string) =>
+	execSync(command, { encoding: 'utf-8', env: { ...process.env, GH_TOKEN: values.token } });
+
+// A `flue/` branch is stale when its tip commit is older than two calendar
+// months at the time this runs.
+const cutoff = new Date();
+cutoff.setMonth(cutoff.getMonth() - 2);
+
+interface Ref {
+	// Name without the `refs/heads/flue/` prefix, e.g. `fix-16800`.
+	name: string;
+	target: { committedDate?: string } | null;
+}
+
+// List every `flue/` branch with its tip commit date. GraphQL returns the date
+// in one paginated call; the REST branches endpoint omits it.
+const query = `query($owner:String!,$name:String!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    refs(refPrefix:"refs/heads/flue/",first:100,after:$cursor){
+      nodes{ name target{ ... on Commit { committedDate } } }
+      pageInfo{ hasNextPage endCursor }
+    }
+  }
+}`;
+
+const [owner, name] = REPO.split('/');
+const branches: { branch: string; committedDate: string }[] = [];
+let cursor: string | null = null;
+
+do {
+	const cursorArg = cursor ? ` -F cursor=${cursor}` : '';
+	const { data } = JSON.parse(
+		gh(
+			`gh api graphql -f query='${query}' -F owner=${owner} -F name=${name}${cursorArg}`,
+		),
+	) as {
+		data: {
+			repository: {
+				refs: { nodes: Ref[]; pageInfo: { hasNextPage: boolean; endCursor: string } };
+			};
+		};
+	};
+
+	const { nodes, pageInfo } = data.repository.refs;
+	for (const node of nodes) {
+		if (node.target?.committedDate) {
+			branches.push({ branch: `flue/${node.name}`, committedDate: node.target.committedDate });
+		}
+	}
+
+	cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+} while (cursor);
+
+// Branches with an open PR (including drafts) are kept regardless of age.
+const openPrBranches = new Set<string>(
+	gh(`gh pr list --repo ${REPO} --state open --json headRefName --limit 500 --jq '.[].headRefName'`)
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean),
+);
+
+const stale = branches
+	.filter(({ committedDate }) => new Date(committedDate) < cutoff)
+	.map(({ branch }) => branch)
+	.filter((branch) => !openPrBranches.has(branch));
+
+// biome-ignore lint/suspicious/noConsole: valid for CI
+console.log(JSON.stringify(stale));

--- a/.github/workflows/cleanup-flue-branches.yml
+++ b/.github/workflows/cleanup-flue-branches.yml
@@ -1,0 +1,45 @@
+name: Cleanup flue branches
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List stale branches without deleting them"
+        type: boolean
+        default: true
+
+jobs:
+  cleanup-flue-branches:
+    if: github.repository == 'withastro/astro'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.18.0
+
+      - name: Find stale flue branches
+        id: find-stale
+        run: echo "branches=$(node --experimental-strip-types .github/scripts/stale-flue-branches.ts --token ${{ secrets.GITHUB_TOKEN }})" >> "$GITHUB_OUTPUT"
+
+      - name: Delete stale flue branches
+        if: steps.find-stale.outputs.branches != '[]'
+        env:
+          GH_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          echo '${{ steps.find-stale.outputs.branches }}' | jq -r '.[]' | while read -r branch; do
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] would delete $branch"
+            else
+              gh api --method DELETE "repos/${{ github.repository }}/git/refs/heads/$branch"
+              echo "Deleted branch $branch"
+            fi
+          done


### PR DESCRIPTION
## Changes

Adds a cron workflows that purges all stale `flue/*` branches. Stale branches are the ones there its last commit is older than two months.

## Testing

I tested the script locally with a token of mine, and it pulls the branches. 

We can use the dry-run after merge

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
