### PR TITLE
chore: use star import consistently for 'smol-toml'

### DIFF
--- a/packages/astro/src/content/loaders/file.ts
+++ b/packages/astro/src/content/loaders/file.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
-import toml from 'smol-toml';
+import * as toml from 'smol-toml';
 import { FileGlobNotSupported, FileParserNotFound } from '../../core/errors/errors-data.js';
 import { AstroError } from '../../core/errors/index.js';
 import { posixRelative } from '../utils.js';

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import yaml from 'js-yaml';
-import toml from 'smol-toml';
+import * as toml from 'smol-toml';
 import { getContentPaths } from '../../content/index.js';
 import createPreferences from '../../preferences/index.js';
 import type { AstroSettings } from '../../types/astro.js';


### PR DESCRIPTION
## Changes

<!--
- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.
-->

Changes default to star import for `'smol-toml'`

`'smol-toml'` supports both, but default export is considered legacy and is [planned to be deprecated](https://github.com/squirrelchat/smol-toml/pull/50) in the future

[`/packages/internal-helpers`](https://github.com/withastro/astro/blob/3b93a1a1cce669b71729d2b946fa2d41dae79ad6/packages/internal-helpers/src/frontmatter.ts#L2) already uses star import, so this change make it consistent

No changeset needed


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

All existing tests pass

## Docs

No user-facing changes

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
