### PR TITLE
fix(create-astro): create astro uses correct project name when using directory "."

### DIFF
--- a/.changeset/loud-geckos-pump.md
+++ b/.changeset/loud-geckos-pump.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes create astro to use correct project name when creating in current directory "."

--- a/packages/create-astro/src/actions/project-name.ts
+++ b/packages/create-astro/src/actions/project-name.ts
@@ -40,21 +40,17 @@ export async function projectName(
 		});
 
 		ctx.cwd = name!.trim();
-		ctx.projectName = toValidName(name!);
 		if (ctx.dryRun) {
+			ctx.projectName = toValidName(name!);
 			await info('--dry-run', 'Skipping project naming');
 			return;
 		}
+	}
+
+	if (ctx.cwd.startsWith('@') && ctx.cwd.includes('/')) {
+		ctx.projectName = toValidName(ctx.cwd);
 	} else {
-		let name = ctx.cwd;
-		if (name === '.' || name === './') {
-			const parts = process.cwd().split(path.sep);
-			name = parts[parts.length - 1];
-		} else if (name.startsWith('./') || name.startsWith('../')) {
-			const parts = name.split('/');
-			name = parts[parts.length - 1];
-		}
-		ctx.projectName = toValidName(name);
+		ctx.projectName = toValidName(path.basename(path.resolve(ctx.cwd)));
 	}
 
 	if (!ctx.cwd) {

--- a/packages/create-astro/test/project-name.test.ts
+++ b/packages/create-astro/test/project-name.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 import { projectName } from '../dist/index.js';
 import { mockExit, mockPrompt, type ProjectNameContext, setup } from './test-utils.ts';
@@ -171,5 +172,29 @@ describe('project name', async () => {
 		};
 		await projectName(context);
 		assert.equal(context.projectName, 'empty');
+	});
+
+	it('prompt with dot', async () => {
+		const context: ProjectNameContext = {
+			projectName: '',
+			cwd: '',
+			prompt: mockPrompt({ name: '.' }),
+			exit: mockExit,
+		};
+		await projectName(context);
+		assert.equal(context.cwd, '.');
+		assert.equal(context.projectName, path.basename(process.cwd()));
+	});
+
+	it('prompt with dot slash', async () => {
+		const context: ProjectNameContext = {
+			projectName: '',
+			cwd: '',
+			prompt: mockPrompt({ name: './' }),
+			exit: mockExit,
+		};
+		await projectName(context);
+		assert.equal(context.cwd, './');
+		assert.equal(context.projectName, path.basename(process.cwd()));
 	});
 });


### PR DESCRIPTION
## Changes

When running `npm create astro@latest` and then using `.` for the output directory, Astro generates a package.json with an empty `""` package name. In contrast, running `npm create astro .` uses the current working directory's basename.

This PR makes both invocation styles behave consistently by always deriving the package name from the generated project's basename. This behavior is also consistent with Vite's, Nuxt's, and Next's `npm create` commands.

**Before / After**

<img height="200" alt="Before package json" src="https://github.com/user-attachments/assets/76a909f3-f533-4df7-8666-c79f3be7e91b" />
<img height="200" alt="After package json" src="https://github.com/user-attachments/assets/caf2e122-9470-4a83-a95a-265f71ac9ee3" />

## Testing

I tested locally and added tests for `npm create astro` with dot for the project location prompt.

## Docs

Sufficient docs exist for the create astro command.