### PR TITLE
Restore `getFallback` export from `astro:transitions/client`

### DIFF
--- a/.changeset/yellow-trams-wonder.md
+++ b/.changeset/yellow-trams-wonder.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Restores `getFallback()` export, a documented helper of the client router.

--- a/.changeset/yellow-trams-wonder.md
+++ b/.changeset/yellow-trams-wonder.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Restores `getFallback()` export, a documented helper of the client router.
+Restores `getFallback()` export, a documented helper of the view transitions router.

--- a/packages/astro/src/transitions/vite-plugin-transitions.ts
+++ b/packages/astro/src/transitions/vite-plugin-transitions.ts
@@ -39,7 +39,7 @@ export default function astroTransitions({ settings }: { settings: AstroSettings
 				if (id === RESOLVED_VIRTUAL_CLIENT_MODULE_ID) {
 					return {
 						code: `
-						export { navigate, supportsViewTransitions, transitionEnabledOnThisPage } from "astro/virtual-modules/transitions-router.js";
+						export { getFallback, navigate, supportsViewTransitions, transitionEnabledOnThisPage } from "astro/virtual-modules/transitions-router.js";
 						export * from "astro/virtual-modules/transitions-types.js";
 						export {
 							TransitionBeforePreparationEvent,

--- a/packages/astro/types/transitions.d.ts
+++ b/packages/astro/types/transitions.d.ts
@@ -5,6 +5,7 @@ declare module 'astro:transitions' {
 
 declare module 'astro:transitions/client' {
 	export {
+		getFallback,
 		navigate,
 		supportsViewTransitions,
 		transitionEnabledOnThisPage,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6975,12 +6975,6 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
-  triage/repro-17482:
-    dependencies:
-      astro:
-        specifier: workspace:*
-        version: link:../../packages/astro
-
 packages:
 
   '@anthropic-ai/sdk@0.91.1':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6975,6 +6975,12 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
+  triage/repro-17482:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+
 packages:
 
   '@anthropic-ai/sdk@0.91.1':


### PR DESCRIPTION
## Changes

- Restores `getFallback` as a named export from `astro:transitions/client`. The function was still present in the source but was dropped from the explicit named-export list in the Vite virtual module and the TypeScript declaration file when PR #9090 switched from `export *` to an explicit list. Users following the [official docs](https://docs.astro.build/en/reference/modules/astro-transitions/#getfallback) would hit both a `ts(2724)` type error and a build-time "Missing export" error.

## Testing

- No new tests added. The fix is a two-line addition to the named export list; all existing transition tests continue to pass.

## Docs

- No docs change needed — `getFallback` is already documented at https://docs.astro.build/en/reference/modules/astro-transitions/#getfallback.

Closes #17482