### PR TITLE
feat(create-astro): add nub package manager support

### DIFF
--- a/.changeset/nub-package-manager.md
+++ b/.changeset/nub-package-manager.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Adds support for the [nub](https://nubjs.com) package manager. When `create-astro` is run through nub, the "next steps" output and processed template READMEs now print `nub run <script>` instead of an invalid `nub <script>` or a fallback to `npm run dev`.

--- a/packages/create-astro/src/actions/next-steps.ts
+++ b/packages/create-astro/src/actions/next-steps.ts
@@ -12,6 +12,7 @@ export async function next(
 		bun: 'bun run dev',
 		yarn: 'yarn dev',
 		pnpm: 'pnpm dev',
+		nub: 'nub run dev',
 	};
 
 	const devCmd = commandMap[ctx.packageManager as keyof typeof commandMap] || 'npm run dev';

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -36,8 +36,11 @@ export function processTemplateReadme(content: string, packageManager: string): 
 
 	// Replace package manager references if not npm
 	if (packageManager !== 'npm') {
+		// nub requires an explicit `run` for scripts, so `npm run <script>` maps to
+		// `nub run <script>` rather than dropping the `run` like pnpm/yarn/bun.
+		const runCommand = packageManager === 'nub' ? 'nub run' : packageManager;
 		processed = processed
-			.replace(/\bnpm run\b/g, packageManager)
+			.replace(/\bnpm run\b/g, runCommand)
 			.replace(/\bnpm\b/g, packageManager);
 	}
 


### PR DESCRIPTION
## Changes

`create-astro` already detects [nub](https://nubjs.com) as the active package manager (from `npm_config_user_agent`) and drives it correctly for install and `astro add` via the generic passthrough and `nub dlx`. Two printed run commands were still wrong for nub:

- `next-steps.ts` — the `commandMap` had no `nub` entry, so nub users fell back to `npm run dev`. Added `nub: 'nub run dev'`.
- `template.ts` (`processTemplateReadme`) — the non-npm path replaced `npm run` with the bare package-manager name, turning `npm run dev` into `nub dev`. nub has no implicit script shortcut, so that is invalid. It now maps `npm run <script>` to `nub run <script>`, keeping the explicit `run`.

pnpm/yarn/bun output is unchanged. Changeset included.

## Testing

Verified the code path a nub user hits: detection yields `packageManager === 'nub'`, `commandMap.nub` returns `nub run dev`, and `processTemplateReadme` rewrites `npm run dev` to `nub run dev` while leaving bare `npm` (e.g. `npm install` -> `nub install`) and the pnpm/yarn/bun branches untouched.

## Docs

No docs change needed — this only corrects the package-manager commands `create-astro` prints for an already-detected manager.
