### PR TITLE
Fix glob loader watcher with negation patterns incorrectly ingesting unrelated files

### DIFF
--- a/.changeset/mighty-rats-smell.md
+++ b/.changeset/mighty-rats-smell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the glob loader with a negation pattern (`!docs/drafts/**`) in the dev server watcher would ingest unrelated files, causing unbounded data store growth. Negation patterns are now correctly excluded during file watching

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -343,8 +343,14 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 
 			watcher.add(filePath);
 
-			const matchesGlob = (entry: string) =>
-				!entry.startsWith('../') && picomatch.isMatch(entry, globOptions.pattern);
+			const rawPatterns = Array.isArray(globOptions.pattern)
+				? globOptions.pattern
+				: [globOptions.pattern];
+			const positivePatterns = rawPatterns.filter((p) => !p.startsWith('!'));
+			const negationPatterns = rawPatterns.filter((p) => p.startsWith('!')).map((p) => p.slice(1));
+			const matcher = picomatch(positivePatterns, { ignore: negationPatterns });
+
+			const matchesGlob = (entry: string) => !entry.startsWith('../') && matcher(entry);
 
 			const basePath = fileURLToPath(baseDir);
 


### PR DESCRIPTION
Fixes #17484

## Changes

- Fixes the dev server watcher's `matchesGlob` function incorrectly treating negation patterns (`!docs/drafts/**`) as positive match conditions, causing unrelated files under the base directory to be ingested as content entries
- Splits the pattern array into positive patterns and negation patterns, passing negations to picomatch's `ignore` option to align the watcher's filtering semantics with `tinyglobby`'s set-subtraction behavior

## Testing

- The existing `handles negative matches in glob pattern` unit test verifies that `tinyglobby`-based initial sync correctly excludes negated patterns; the watcher fix changes `picomatch.isMatch` to match those same semantics

## Docs

- No docs update needed — this is a bug fix that aligns runtime behavior with documented glob semantics