### PR TITLE
feat(core): add truncateMiddle helper function to core utils

### DIFF
--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -185,3 +185,12 @@ export function ensureProcessNodeEnv(defaultNodeEnv: string) {
 		process.env.NODE_ENV = defaultNodeEnv;
 	}
 }
+
+export function truncateMiddle(str: string, maxLength: number): string {
+	if (typeof str !== 'string' || str.length <= maxLength || maxLength <= 3) {
+		return str;
+	}
+	const charsToShow = Math.ceil((maxLength - 3) / 2);
+	const backChars = Math.floor((maxLength - 3) / 2);
+	return `${str.slice(0, charsToShow)}...${str.slice(str.length - backChars)}`;
+}


### PR DESCRIPTION
## Description
Adds a type-safe \	runcateMiddle(str, maxLength)\ string formatting helper function to \packages/astro/src/core/util.ts\ for cleanly formatting long file paths, route names, and component identifiers in Astro's build output.

## Features
- Middle string truncation with \...\ ellipsis.
- Preserves head and tail context for readability.