### PR TITLE
fix(internal-helpers): preserve last segment slash in joinPaths when skipping non-string args

### DIFF
--- a/.changeset/fix-join-paths-skipped-segments.md
+++ b/.changeset/fix-join-paths-skipped-segments.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/internal-helpers': patch
+---
+
+Fixes `joinPaths()` mishandling the last path segment when an earlier argument is a non-string (e.g. `undefined`)
+
+`joinPaths()` filters out non-string arguments, but the check that identifies the last segment compared the index against the original (unfiltered) argument count. When a skipped argument preceded the final one, the real last segment was treated as a middle segment and had its trailing slash stripped. As a result, `joinPaths('/base', undefined, 'docs/setup/')` returned `/base/docs/setup` instead of `/base/docs/setup/`. The last-segment check now uses the filtered segment count, so a skipped argument no longer changes the result of the remaining segments.

--- a/packages/internal-helpers/src/path.ts
+++ b/packages/internal-helpers/src/path.ts
@@ -93,12 +93,12 @@ export function isInternalPath(path: string) {
 }
 
 export function joinPaths(...paths: (string | undefined)[]) {
-	return paths
-		.filter(isString)
+	const segments = paths.filter(isString);
+	return segments
 		.map((path, i) => {
 			if (i === 0) {
 				return removeTrailingForwardSlash(path);
-			} else if (i === paths.length - 1) {
+			} else if (i === segments.length - 1) {
 				return removeLeadingForwardSlash(path);
 			} else {
 				return trimSlashes(path);

--- a/packages/internal-helpers/test/path.test.ts
+++ b/packages/internal-helpers/test/path.test.ts
@@ -4,6 +4,7 @@ import {
 	isInternalPath,
 	isParentDirectory,
 	isRemotePath,
+	joinPaths,
 	normalizePathname,
 } from '../dist/path.js';
 
@@ -876,5 +877,36 @@ describe('isInternalPath', () => {
 	it('does not flag paths that are only slashes', () => {
 		assert.equal(isInternalPath('//'), false);
 		assert.equal(isInternalPath('///'), false);
+	});
+});
+
+describe('joinPaths', () => {
+	it('should join simple segments', () => {
+		assert.equal(joinPaths('a', 'b', 'c'), 'a/b/c');
+		assert.equal(joinPaths('/foo', 'bar'), '/foo/bar');
+	});
+
+	it('should trim inner slashes but keep the first leading and last trailing slash', () => {
+		assert.equal(joinPaths('/foo/', '/bar/', '/baz/'), '/foo/bar/baz/');
+	});
+
+	it('should ignore non-string arguments without affecting slash handling of the last segment', () => {
+		// A skipped (undefined) argument must produce the same result as omitting it.
+		assert.equal(
+			joinPaths('/foo', undefined, '/bar/'),
+			joinPaths('/foo', '/bar/'),
+			'undefined in the middle should not change the result',
+		);
+		// Regression: the trailing slash of the real last segment must be preserved
+		// even when an earlier argument is skipped (previously stripped because the
+		// last-element check compared against the unfiltered argument count).
+		assert.equal(joinPaths('/foo', undefined, '/bar/'), '/foo/bar/');
+		assert.equal(joinPaths('/base', undefined, 'pl', 'docs/setup/'), '/base/pl/docs/setup/');
+		assert.equal(joinPaths(undefined, 'pl', 'docs/setup/'), 'pl/docs/setup/');
+	});
+
+	it('should ignore a trailing non-string argument', () => {
+		assert.equal(joinPaths('/foo', 'bar/', undefined), joinPaths('/foo', 'bar/'));
+		assert.equal(joinPaths('/foo', 'bar/', undefined), '/foo/bar/');
 	});
 });


### PR DESCRIPTION
Rebased on latest main.