### PR TITLE
fix(astro): always bundle neotraverse to avoid hoisted version conflict

### DIFF
--- a/.changeset/neotraverse-noexternal.md
+++ b/.changeset/neotraverse-noexternal.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a build failure (`does not provide an export named 'forEach'`) when another dependency in the project pulls in an older `neotraverse@^0.6.x`. `neotraverse` is now always bundled so the prerender output resolves Astro's own copy instead of a hoisted incompatible one.

--- a/packages/astro/src/vite-plugin-environment/index.ts
+++ b/packages/astro/src/vite-plugin-environment/index.ts
@@ -26,6 +26,8 @@ const ALWAYS_NOEXTERNAL = [
 	'@nanostores/preact',
 	// fontsource packages are CSS that need to be processed
 	'@fontsource/*',
+	// Bundle so a hoisted older version from another dependency isn't used instead
+	'neotraverse',
 ];
 
 interface Payload {


### PR DESCRIPTION
## Changes

- Adds `neotraverse` to the `ALWAYS_NOEXTERNAL` list so it gets bundled into the prerender output instead of staying external. Since #17446 the content layer runtime imports `forEach` from `neotraverse`, and that export only exists in v1. If another dependency in the project needs the old `neotraverse@^0.6.x`, npm hoists that copy to the project root while Astro's v1 stays nested under `node_modules/astro`. The prerender bundle then emits a bare `import { forEach } from "neotraverse"`, and Node resolves it to the hoisted 0.6.x copy, which has no `forEach`. So `astro build` dies with `The requested module 'neotraverse' does not provide an export named 'forEach'`. Bundling it keeps Astro on its own copy.

Fixes #17508

## Testing

No test added. It's a one-line entry in the noexternal list, same as the neighbours. I confirmed the root cause first: the main entry of `neotraverse@0.6.x` exports only `Traverse`, so the external bare import breaks whenever that version wins the hoist. Keeping it noexternal stops the bare import from being emitted at all.

## Docs

No docs needed. This is an internal build-config change with no user-facing API change.
