### PR TITLE
Fix glob() loader watcher ignoring negation patterns, causing unrelated files to be ingested

### DIFF
--- a/.changeset/sparkly-pumas-enter.md
+++ b/.changeset/sparkly-pumas-enter.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the `glob()` loader watcher so negation patterns like `!docs/drafts/**` correctly exclude files during development, matching the behavior of the initial scan. Previously, negations were treated as independent matchers, causing unrelated files (including `.astro/data-store.json`) to be ingested as collection entries

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -343,8 +343,19 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 
 			watcher.add(filePath);
 
+			// Split negation patterns out and pass them as picomatch's `ignore` option
+			// so watcher filtering matches tinyglobby's semantics (set subtraction),
+			// not picomatch's default (any-match union). See #17484.
+			const patterns = Array.isArray(globOptions.pattern)
+				? globOptions.pattern
+				: [globOptions.pattern];
+			const positivePatterns = patterns.filter((p) => !p.startsWith('!'));
+			const negationPatterns = patterns.filter((p) => p.startsWith('!')).map((p) => p.slice(1));
 			const matchesGlob = (entry: string) =>
-				!entry.startsWith('../') && picomatch.isMatch(entry, globOptions.pattern);
+				!entry.startsWith('../') &&
+				picomatch.isMatch(entry, positivePatterns, {
+					ignore: negationPatterns.length > 0 ? negationPatterns : undefined,
+				});
 
 			const basePath = fileURLToPath(baseDir);
 


### PR DESCRIPTION
## Changes

- Fixes the watcher's `matchesGlob` filter in the `glob()` loader so negation patterns like `!docs/drafts/**` correctly exclude files, matching the semantics of the initial `tinyglobby` scan. Previously, `picomatch.isMatch` with a mixed pattern array treated each element as an independent matcher — a negation like `!docs/drafts/**` matched *every path outside that subtree*, so all files under the base passed the filter and were ingested.
- When `base: "."` is used (common in docs-site setups), this caused `.astro/data-store.json` to be ingested as a collection entry and re-ingest itself on every write, creating an unbounded feedback loop that grew the data store by megabytes per minute.
- Fix: split the pattern array into positive patterns and negations, then pass negations via picomatch's `ignore` option (set-subtraction semantics, consistent with `tinyglobby`).

Closes #17484

## Testing

- No new test added — the existing `handles negative matches in glob pattern` unit test covers the initial scan path. The watcher path requires a live dev server to exercise end-to-end; the fix was verified by the reporter using the preview release.

## Docs

- No docs update needed; this is a bug fix restoring already-documented glob pattern behavior.
