### PR TITLE
Fix tsconfig path aliases not resolving in astro.config.ts

### DIFF
--- a/.changeset/wise-suits-itch.md
+++ b/.changeset/wise-suits-itch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes TypeScript path aliases from `tsconfig.json` not resolving in `astro.config.ts`

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -38,7 +38,7 @@ export async function loadConfigWithVite({
 	let server: ViteDevServer | undefined;
 	try {
 		const plugins = loadFallbackPlugin({ fs, root: pathToFileURL(root) });
-		server = await createMinimalViteDevServer(plugins);
+		server = await createMinimalViteDevServer(plugins, root);
 		if (isRunnableDevEnvironment(server.environments[ASTRO_VITE_ENVIRONMENT_NAMES.ssr])) {
 			const environment = server.environments[
 				ASTRO_VITE_ENVIRONMENT_NAMES.ssr

--- a/packages/astro/src/core/createMinimalViteDevServer.ts
+++ b/packages/astro/src/core/createMinimalViteDevServer.ts
@@ -6,14 +6,19 @@ import { createServer, type ViteDevServer, type Plugin } from 'vite';
  * NOTE: This is intentionally in its own module to avoid pulling `vite`'s heavy `createServer`
  * (and transitively Rollup) into every file that imports from `viteUtils.ts`.
  */
-export async function createMinimalViteDevServer(plugins: Plugin[] = []): Promise<ViteDevServer> {
+export async function createMinimalViteDevServer(
+	plugins: Plugin[] = [],
+	root?: string,
+): Promise<ViteDevServer> {
 	return await createServer({
+		root,
 		configFile: false,
 		server: { middlewareMode: true, hmr: false, watch: null, ws: false },
 		optimizeDeps: { noDiscovery: true },
 		clearScreen: false,
 		appType: 'custom',
 		ssr: { external: true },
+		resolve: { tsconfigPaths: true },
 		plugins,
 	});
 }

--- a/packages/astro/test/units/config/config-vite-load.test.ts
+++ b/packages/astro/test/units/config/config-vite-load.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { loadConfigWithVite } from '../../../dist/core/config/vite-load.js';
+import { createFixture } from '../test-utils.ts';
+import fs from 'node:fs';
+
+describe('loadConfigWithVite', () => {
+	it('resolves tsconfig path aliases in astro.config.ts', async () => {
+		const fixture = await createFixture({
+			'tsconfig.json': JSON.stringify({
+				compilerOptions: {
+					baseUrl: '.',
+					paths: {
+						'@config/*': ['src/config/*'],
+					},
+				},
+			}),
+			'src/config/site.ts': 'export const SITE_TITLE = "Test Site";',
+			'astro.config.ts': `
+				import { SITE_TITLE } from '@config/site';
+				export default { site: 'https://example.com', compressHTML: SITE_TITLE === "Test Site" };
+			`,
+		});
+
+		try {
+			const config = await loadConfigWithVite({
+				root: fixture.path,
+				configPath: fixture.getPath('astro.config.ts'),
+				fs,
+			});
+
+			assert.equal(config.site, 'https://example.com');
+			assert.equal(config.compressHTML, true);
+		} finally {
+			await fixture.rm();
+		}
+	});
+});


### PR DESCRIPTION
## Changes

- `tsconfig.json` path aliases (e.g. `@config/i18n`) now resolve correctly when used in `astro.config.ts`. Previously, the minimal Vite server created to load the config was missing `resolve: { tsconfigPaths: true }` and the project `root`, so Vite couldn't locate `tsconfig.json` or apply its `paths`. This was an oversight introduced in #17202.
- `createMinimalViteDevServer` now accepts an optional `root` parameter and sets `resolve: { tsconfigPaths: true }`, matching the behavior of the main Vite config.

Closes #17418

## Testing

- Added `packages/astro/test/units/config/config-vite-load.test.ts`: creates a fixture with a `tsconfig.json` path alias (`@config/*`) and a config file that imports via that alias, then asserts `loadConfigWithVite` resolves it correctly.

## Docs

- No docs update needed — this restores expected behavior for an existing feature (`tsconfig` path aliases) with no API surface change.
