### PR TITLE
fix(mdx): emit HTML attribute casing on the Sätteri MDX path

### DIFF
--- a/.changeset/silly-planes-relate.md
+++ b/.changeset/silly-planes-relate.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fixes `.mdx` files emitting React-cased attribute names for elements added by a Sätteri `hastPlugin`. Attributes such as `strokeWidth` and `clipPath` leaked into the HTML verbatim, where browsers ignore them, while the same plugin running over a `.md` file produced `stroke-width` and `clip-path`. Both pipelines now emit the same HTML/SVG attribute names.

--- a/.changeset/silly-planes-relate.md
+++ b/.changeset/silly-planes-relate.md
@@ -2,4 +2,4 @@
 '@astrojs/mdx': patch
 ---
 
-Fixes `.mdx` files emitting React-cased attribute names for elements added by a Sätteri `hastPlugin`. Attributes such as `strokeWidth` and `clipPath` leaked into the HTML verbatim, where browsers ignore them, while the same plugin running over a `.md` file produced `stroke-width` and `clip-path`. Both pipelines now emit the same HTML/SVG attribute names.
+Fixes a bug where the integration was emitting React-cased attribute names.

--- a/packages/integrations/mdx/src/satteri/index.ts
+++ b/packages/integrations/mdx/src/satteri/index.ts
@@ -135,6 +135,10 @@ export function createMdxProcessor(
 				},
 				fileURL: pathToFileURL(filePath),
 				jsxImportSource: 'astro',
+				// Plugin-added elements carry hast property names (`strokeWidth`, `clipPath`).
+				// Satteri defaults to React casing, which would emit those verbatim as invalid
+				// HTML/SVG attributes; `'html'` resolves them the way `.md` rendering does.
+				elementAttributeNameCase: 'html',
 				data: { astro: astroData },
 			});
 			let compiled = mdxResult.code;

--- a/packages/integrations/mdx/src/satteri/index.ts
+++ b/packages/integrations/mdx/src/satteri/index.ts
@@ -135,10 +135,6 @@ export function createMdxProcessor(
 				},
 				fileURL: pathToFileURL(filePath),
 				jsxImportSource: 'astro',
-				// Rehype-produced elements carry hast property names (`strokeWidth`, `clipPath`),
-				// and Astro's JSX runtime emits prop names verbatim, so satteri's default React
-				// casing would put them in the HTML unchanged. `'html'` maps them to their
-				// HTML/SVG spellings, matching what the `.md` pipeline serializes.
 				elementAttributeNameCase: 'html',
 				data: { astro: astroData },
 			});

--- a/packages/integrations/mdx/src/satteri/index.ts
+++ b/packages/integrations/mdx/src/satteri/index.ts
@@ -135,9 +135,10 @@ export function createMdxProcessor(
 				},
 				fileURL: pathToFileURL(filePath),
 				jsxImportSource: 'astro',
-				// Plugin-added elements carry hast property names (`strokeWidth`, `clipPath`).
-				// Satteri defaults to React casing, which would emit those verbatim as invalid
-				// HTML/SVG attributes; `'html'` resolves them the way `.md` rendering does.
+				// Rehype-produced elements carry hast property names (`strokeWidth`, `clipPath`),
+				// and Astro's JSX runtime emits prop names verbatim, so satteri's default React
+				// casing would put them in the HTML unchanged. `'html'` maps them to their
+				// HTML/SVG spellings, matching what the `.md` pipeline serializes.
 				elementAttributeNameCase: 'html',
 				data: { astro: astroData },
 			});

--- a/packages/integrations/mdx/test/fixtures/mdx-satteri-attribute-case/src/pages/from-md.md
+++ b/packages/integrations/mdx/test/fixtures/mdx-satteri-attribute-case/src/pages/from-md.md
@@ -1,0 +1,1 @@
+A [link](https://example.com/) here.

--- a/packages/integrations/mdx/test/fixtures/mdx-satteri-attribute-case/src/pages/from-mdx.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-satteri-attribute-case/src/pages/from-mdx.mdx
@@ -1,0 +1,1 @@
+A [link](https://example.com/) here.

--- a/packages/integrations/mdx/test/fixtures/mdx-satteri-attribute-case/src/pages/from-mdx.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-satteri-attribute-case/src/pages/from-mdx.mdx
@@ -1,1 +1,3 @@
 A [link](https://example.com/) here.
+
+<span id="author-jsx" className="kept" strokeWidth="9" />

--- a/packages/integrations/mdx/test/mdx-satteri.test.ts
+++ b/packages/integrations/mdx/test/mdx-satteri.test.ts
@@ -3,7 +3,7 @@ import { before, describe, it } from 'node:test';
 import mdx from '@astrojs/mdx';
 import { satteri } from '@astrojs/markdown-satteri';
 import { parseHTML } from 'linkedom';
-import { defineHastPlugin, type HastPluginDefinition, type MdastPluginDefinition } from 'satteri';
+import { defineHastPlugin, type MdastPluginDefinition } from 'satteri';
 import { loadFixture, type Fixture } from './test-utils.ts';
 
 const injectFrontmatter: MdastPluginDefinition = {
@@ -107,14 +107,13 @@ describe('MDX Sätteri highlighting routes through components.pre with optimize'
 describe('MDX Sätteri attribute name casing', () => {
 	let fixture: Fixture;
 
-	// Appends an `<svg>` carrying hast property names — the camelCased spellings
-	// `property-information` uses — so the emitted attribute names show which
-	// casing the compiler applied.
-	const appendSvg: HastPluginDefinition = defineHastPlugin({
+	// Properties use hast's camelCase names, so the emitted attribute names reveal
+	// the casing the compiler applied.
+	const appendSvg = defineHastPlugin({
 		name: 'append-svg',
 		element: {
 			filter: ['a'],
-			visit: (node, ctx) =>
+			visit(node, ctx) {
 				ctx.appendChild(node, {
 					type: 'element',
 					tagName: 'svg',
@@ -140,7 +139,8 @@ describe('MDX Sätteri attribute name casing', () => {
 							children: [],
 						},
 					],
-				}),
+				});
+			},
 		},
 	});
 
@@ -168,6 +168,13 @@ describe('MDX Sätteri attribute name casing', () => {
 	it('emits HTML attribute names for plugin-added elements', async () => {
 		const html = await fixture.readFile('/from-mdx/index.html');
 
+		// `viewBox` stays camelCase: it is the real SVG attribute name, not a hast spelling.
+		assert.deepEqual(attributesOf(html, 'svg'), {
+			class: 'glyph',
+			viewBox: '0 0 12 12',
+			'aria-hidden': 'true',
+		});
+
 		assert.deepEqual(attributesOf(html, 'path'), {
 			d: 'M7 1.5h3.5V5M10.5 1.5 5.5 6.5',
 			fill: 'none',
@@ -181,6 +188,18 @@ describe('MDX Sätteri attribute name casing', () => {
 			'text-anchor': 'middle',
 			'vector-effect': 'non-scaling-stroke',
 			'paint-order': 'stroke',
+		});
+	});
+
+	it('leaves attributes on author-written JSX alone', async () => {
+		const html = await fixture.readFile('/from-mdx/index.html');
+
+		// The casing option covers rehype-produced elements only. `className` still
+		// reaches the HTML as `class` because the JSX runtime maps that one prop.
+		assert.deepEqual(attributesOf(html, '#author-jsx'), {
+			id: 'author-jsx',
+			class: 'kept',
+			strokeWidth: '9',
 		});
 	});
 

--- a/packages/integrations/mdx/test/mdx-satteri.test.ts
+++ b/packages/integrations/mdx/test/mdx-satteri.test.ts
@@ -3,7 +3,7 @@ import { before, describe, it } from 'node:test';
 import mdx from '@astrojs/mdx';
 import { satteri } from '@astrojs/markdown-satteri';
 import { parseHTML } from 'linkedom';
-import type { MdastPluginDefinition } from 'satteri';
+import { defineHastPlugin, type HastPluginDefinition, type MdastPluginDefinition } from 'satteri';
 import { loadFixture, type Fixture } from './test-utils.ts';
 
 const injectFrontmatter: MdastPluginDefinition = {
@@ -101,5 +101,94 @@ describe('MDX Sätteri highlighting routes through components.pre with optimize'
 		const pre = document.querySelector('pre');
 		assert.equal(pre?.getAttribute('data-custom-pre'), 'rendered');
 		assert.match(pre?.innerHTML ?? '', /style="color:/);
+	});
+});
+
+describe('MDX Sätteri attribute name casing', () => {
+	let fixture: Fixture;
+
+	// Appends an `<svg>` carrying hast property names — the camelCased spellings
+	// `property-information` uses — so the emitted attribute names show which
+	// casing the compiler applied.
+	const appendSvg: HastPluginDefinition = defineHastPlugin({
+		name: 'append-svg',
+		element: {
+			filter: ['a'],
+			visit: (node, ctx) =>
+				ctx.appendChild(node, {
+					type: 'element',
+					tagName: 'svg',
+					properties: { className: ['glyph'], viewBox: '0 0 12 12', ariaHidden: 'true' },
+					children: [
+						{
+							type: 'element',
+							tagName: 'path',
+							properties: {
+								d: 'M7 1.5h3.5V5M10.5 1.5 5.5 6.5',
+								fill: 'none',
+								stroke: 'currentColor',
+								strokeWidth: '1.2',
+								strokeOpacity: '0.9',
+								fillOpacity: '0.9',
+								fillRule: 'evenodd',
+								clipPath: 'url(#c)',
+								fontSize: '10',
+								textAnchor: 'middle',
+								vectorEffect: 'non-scaling-stroke',
+								paintOrder: 'stroke',
+							},
+							children: [],
+						},
+					],
+				}),
+		},
+	});
+
+	function attributesOf(html: string, selector: string) {
+		const { document } = parseHTML(html);
+		const element = document.querySelector(selector);
+		assert.ok(element, `expected to find \`${selector}\` in the rendered page`);
+		return Object.fromEntries(
+			Array.from(element.attributes).map((attr) => [attr.name, attr.value]),
+		);
+	}
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-satteri-attribute-case/', import.meta.url),
+			integrations: [mdx()],
+			markdown: {
+				processor: satteri({ hastPlugins: [appendSvg] }),
+			},
+		});
+
+		await fixture.build();
+	});
+
+	it('emits HTML attribute names for plugin-added elements', async () => {
+		const html = await fixture.readFile('/from-mdx/index.html');
+
+		assert.deepEqual(attributesOf(html, 'path'), {
+			d: 'M7 1.5h3.5V5M10.5 1.5 5.5 6.5',
+			fill: 'none',
+			stroke: 'currentColor',
+			'stroke-width': '1.2',
+			'stroke-opacity': '0.9',
+			'fill-opacity': '0.9',
+			'fill-rule': 'evenodd',
+			'clip-path': 'url(#c)',
+			'font-size': '10',
+			'text-anchor': 'middle',
+			'vector-effect': 'non-scaling-stroke',
+			'paint-order': 'stroke',
+		});
+	});
+
+	it('matches the `.md` pipeline attribute for attribute', async () => {
+		const mdHtml = await fixture.readFile('/from-md/index.html');
+		const mdxHtml = await fixture.readFile('/from-mdx/index.html');
+
+		assert.deepEqual(attributesOf(mdxHtml, 'path'), attributesOf(mdHtml, 'path'));
+		assert.deepEqual(attributesOf(mdxHtml, 'svg'), attributesOf(mdHtml, 'svg'));
 	});
 });


### PR DESCRIPTION
## Changes

Closes #17512.

- Passes `elementAttributeNameCase: 'html'` to `mdxToJs()` in the Sätteri MDX path (`packages/integrations/mdx/src/satteri/index.ts`). The option was missing, so Sätteri fell back to its `"react"` default and emitted hast property names verbatim.
- The legacy `@mdx-js/mdx` path already sets this (`packages/integrations/mdx/src/plugins.ts:41`), so the same `hastPlugin` produced different attribute names depending on whether the page was `.md` or `.mdx`. For an appended `<svg>`, nine attributes leaked as invalid HTML — `strokeWidth`, `strokeOpacity`, `fillOpacity`, `fillRule`, `clipPath`, `fontSize`, `textAnchor`, `vectorEffect`, `paintOrder` — where the `.md` pipeline emitted `stroke-width`, `clip-path`, `paint-order` and so on. Browsers ignore the camelCased forms.
- `className` and `aria-*` already survived, because Astro's JSX runtime maps them, which is what made the divergence easy to miss.
- Adds a changeset.

`stylePropertyNameCase` is deliberately left unset: the legacy path doesn't pass it either, and both compilers default to `dom`, so the two pipelines already agree.

## Testing

New fixture `test/fixtures/mdx-satteri-attribute-case/` renders the same link from a `.md` and a `.mdx` page, with a `hastPlugin` that appends an `<svg>` carrying camelCased hast property names. Two tests in `test/mdx-satteri.test.ts`:

- `emits HTML attribute names for plugin-added elements` — asserts the exact attribute set on the `.mdx` output.
- ``matches the `.md` pipeline attribute for attribute`` — asserts the `<path>` and `<svg>` attribute maps are equal across both pipelines.

Both were confirmed to fail before the fix, reproducing exactly the nine leaked names from the issue, and to pass after. Full `@astrojs/mdx` suite: 199 passing, 0 failing, 1 pre-existing skip.

Also verified end to end with a real `astro build` on the issue's reproduction config: pre-fix, the nine camelCase attributes appear on the `.mdx` page only; post-fix, both pages emit byte-identical `<svg>` markup.

## Docs

No docs change. This aligns the Sätteri MDX path with the documented and already-shipped behavior of the `.md` pipeline and the legacy MDX path; no user-facing option or API changes.
