### PR TITLE
fix(astro): hide console window for background dev server on Windows

### DIFF
--- a/.changeset/silver-windows-hide.md
+++ b/.changeset/silver-windows-hide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevents a visible terminal window from popping up on Windows when the dev server runs in background mode. The detached child process is now spawned with `windowsHide: true`, so console-subsystem grandchildren (such as `workerd.exe`) no longer get a new focus-stealing window allocated by Windows Terminal.

--- a/packages/astro/src/cli/dev/background.ts
+++ b/packages/astro/src/cli/dev/background.ts
@@ -110,9 +110,14 @@ export async function background({
 	// `astro/bin/astro.mjs` is not exported, so resolve via the package manifest.
 	const astroBin = resolve(dirname(require.resolve('astro/package.json')), 'bin', 'astro.mjs');
 
-	// Spawn the dev server as a detached child process
+	// Spawn the dev server as a detached child process.
+	// `windowsHide: true` prevents a console window from popping up: on Windows
+	// `detached: true` maps to DETACHED_PROCESS, so the child has no console and
+	// any console-subsystem grandchild it spawns (e.g. workerd.exe) gets a brand
+	// new, visible, focus-stealing window allocated by Windows Terminal.
 	const child = spawn(process.execPath, [astroBin, ...args], {
 		detached: true,
+		windowsHide: true,
 		stdio: ['ignore', logFd, logFd],
 		cwd: rootPath,
 		env: { ...process.env, ASTRO_DEV_BACKGROUND: '1' },


### PR DESCRIPTION
## Changes

Fixes #17516.

`astro dev` in background mode spawns the detached child dev server in `packages/astro/src/cli/dev/background.ts` with `detached: true` but no `windowsHide: true`.

On Windows, `detached: true` maps to `DETACHED_PROCESS`, so the spawned Node process has no console. Any console-subsystem grandchild it later spawns (for example `workerd.exe` when using `@astrojs/cloudflare`) then gets a brand new console allocated for it. On Windows 11 that console is hosted by Windows Terminal, so a real, visible, focus-stealing window appears and stays open for the lifetime of the dev server.

This is now the default experience for anyone running the dev server from an AI coding agent on Windows, since `astro dev` auto-detects an agentic environment and backgrounds itself.

- Add `windowsHide: true` to the detached `spawn` options so no console window is shown.

This is the only detached spawn in the package; the change is a single option and is a no-op on macOS/Linux.

## Testing

- `pnpm --filter astro build` typechecks cleanly.
- Existing `test/units/dev/dev-output.test.ts` suite passes (14/14).
- The spawn wiring itself is not covered by unit tests today (the existing suite only exercises the pure output formatters), and the behavior is Windows-only, so no automated test is added. `windowsHide` is a standard Node `spawn` option and has no effect on non-Windows platforms.

## Docs

No docs changes needed; this is an internal, platform-specific behavior fix with no user-facing API change.