### PR TITLE
Update TypeScript peer dependency to include v7.0.0

### DIFF
--- a/packages/language-tools/astro-check/package.json
+++ b/packages/language-tools/astro-check/package.json
@@ -44,6 +44,6 @@
     "tsx": "^4.22.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
## Changes

Fixing an unmet peer dependency:
```
✕ unmet peer typescript
  Installed: 7.0.2
  Wanted:
    "^5.0.0 || ^6.0.0":
      @astrojs/check@0.9.9
```

## Testing

Manually tested.

## Docs

(Just fixing a peer dependency mis-match)
