### PR TITLE
Return a response when request finalization fails

### DIFF
--- a/.changeset/khaki-peaches-appear.md
+++ b/.changeset/khaki-peaches-appear.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where an error while finalizing a request could prevent a response from being sent

--- a/packages/astro/src/core/routing/handler.ts
+++ b/packages/astro/src/core/routing/handler.ts
@@ -114,6 +114,7 @@ export class AstroHandler {
 		state.status = defaultStatus;
 
 		let response;
+		let finalizeError: unknown;
 		try {
 			// `provideCache` always runs so `Astro.cache` is defined even
 			// when caching is disabled — it registers a no-op shim that
@@ -179,8 +180,25 @@ export class AstroHandler {
 				pathname: state.pathname,
 			});
 		} finally {
-			const finalize = state.finalizeAll();
-			if (finalize) await finalize;
+			// finalizeAll runs after the response is produced, so a rejection
+			// here would otherwise escape the handler. Capture it and turn it
+			// into a 500 below so the request always completes.
+			try {
+				const finalize = state.finalizeAll();
+				if (finalize) await finalize;
+			} catch (err: any) {
+				finalizeError = err;
+				this.#app.logger.error(null, err.stack || err.message || String(err));
+			}
+		}
+
+		if (finalizeError) {
+			return this.#app.renderError(request, {
+				...state.renderOptions,
+				status: 500,
+				error: finalizeError,
+				pathname: state.pathname,
+			});
 		}
 
 		if (

--- a/packages/astro/test/units/fetch/provider-finalize.test.ts
+++ b/packages/astro/test/units/fetch/provider-finalize.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getFetchStateFromAPIContext } from '../../../dist/core/fetch/fetch-state.js';
+import { createEndpoint, createTestApp } from '../mocks.ts';
+
+describe('context provider finalization', () => {
+	it('still produces a response when a provider finalize callback rejects', async () => {
+		const endpoint = createEndpoint(
+			{
+				GET: (ctx) => {
+					const state = getFetchStateFromAPIContext(ctx);
+					state.provide('unit-probe', {
+						create: () => ({}),
+						finalize: () => Promise.reject(new Error('finalize failure')),
+					});
+					// Resolve the provider so it is included in finalizeAll().
+					state.resolve('unit-probe');
+					return new Response('ok');
+				},
+			},
+			{ route: '/probe' },
+		);
+		const app = createTestApp([endpoint]);
+		const request = new Request('http://example.com/probe');
+
+		const response = await app.render(request);
+		assert.equal(response.status, 500);
+	});
+});


### PR DESCRIPTION
## Changes

- `AstroHandler.render()` awaits `state.finalizeAll()` in a `finally` block, which runs after the response is produced. A rejection there escaped the handler and propagated out of `App.render()` instead of producing a response. The finalize step is now wrapped so a failure is logged and turned into a 500, ensuring the request always completes.

## Testing

- Adds `test/units/fetch/provider-finalize.test.ts`, which registers a context provider whose `finalize` callback rejects and asserts `app.render()` still returns a response.

## Docs

- No docs update needed; this is an internal reliability fix with no user-facing API change.