### PR TITLE
Return 404 for action paths that reference action function properties

### DIFF
--- a/.changeset/metal-lions-smell.md
+++ b/.changeset/metal-lions-smell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes action path resolution so that properties of a resolved action function are not treated as routable path segments

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -374,6 +374,14 @@ export abstract class Pipeline {
 		}
 
 		for (const key of pathKeys) {
+			// An action is a leaf: once resolved to a function, its own properties
+			// are not part of the action namespace and cannot be traversed further.
+			if (typeof server === 'function') {
+				throw new AstroError({
+					...ActionNotFoundError,
+					message: ActionNotFoundError.message(pathKeys.join('.')),
+				});
+			}
 			if (FORBIDDEN_PATH_KEYS.has(key)) {
 				throw new AstroError({
 					...ActionNotFoundError,

--- a/packages/astro/test/units/actions/actions-app.test.ts
+++ b/packages/astro/test/units/actions/actions-app.test.ts
@@ -147,6 +147,27 @@ describe('Actions via App', () => {
 		assert.equal(res.status, 404);
 	});
 
+	it('does not resolve properties of an action function as a path', async () => {
+		let calls = 0;
+		const counterApp = createActionsApp({
+			increment: defineAction({
+				handler: async () => {
+					calls += 1;
+					return { calls };
+				},
+			}),
+		});
+
+		const req = new Request('http://example.com/_actions/increment.orThrow', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		const res = await counterApp.render(req);
+		assert.equal(res.status, 404);
+		assert.equal(calls, 0);
+	});
+
 	it('returns 404 for GET requests', async () => {
 		const req = new Request('http://example.com/_actions/subscribe', {
 			method: 'GET',


### PR DESCRIPTION
## Changes

- `getAction()` now stops path resolution once a segment resolves to a function, so properties on a resolved action function are no longer treated as routable segments. A path like `/_actions/foo.bar` (where `bar` is a property of the `foo` action) returns 404 instead of resolving to that property.
- Nested action namespaces (`/_actions/user.create`) are unaffected, since those traverse plain objects until reaching the action function.

## Testing

- Adds a unit test in `actions-app.test.ts` asserting that a path referencing a property of a resolved action function returns 404 and does not invoke the action handler.

## Docs

- No docs update needed; this aligns behavior with the documented action path format (`/_actions/<name>`) and changes no public API.