### PR TITLE
fix(cli): do not crash writing the dev lock file with a non-loopback `--host`

### DIFF
--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -1,0 +1,9 @@
+---
+'astro': patch
+---
+
+Fixes `astro dev` crashing with `Invalid URL` when `--host` is set to a specific non-loopback address
+
+Vite only reports a `local` URL for loopback hosts. When the dev server was started with `--host <custom-address>` bound to a specific non-loopback address (a LAN or Tailscale IP, for example), the URL was reported under `network` and `local` was empty, so writing the dev lock file threw `Invalid URL` and killed a server that had already started successfully.
+
+The lock file URL now falls back to the network URL, and a server that exposes no URL at all is left untracked rather than being taken down by lock file bookkeeping.

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -1,5 +1,6 @@
 import { detectAgenticEnvironment } from 'am-i-vibing';
 import colors from 'piccolore';
+import type { ResolvedServerUrls } from 'vite';
 import devServer from '../../core/dev/index.js';
 import { pathToFileURL } from 'node:url';
 import {
@@ -56,6 +57,28 @@ export function getBackgroundIgnoreLockConflict(
 		'Background dev servers rely on the lock file so `astro dev stop`, `astro dev status`, and `astro dev logs` can find them.',
 		'Run the dev server in the foreground to use --ignore-lock.',
 	].join('\n');
+}
+
+/**
+ * Pick the URL to record in the lock file.
+ *
+ * Vite only reports a `local` URL for loopback hosts. With `--host <custom-address>` set to a
+ * specific non-loopback address the URL lands in `network` instead and `local` is empty, so
+ * prefer `local` but fall back to `network` rather than reading `undefined`.
+ *
+ * Returns `null` when the server exposed no usable URL, which leaves the (purely bookkeeping)
+ * lock file unwritten instead of taking down an otherwise healthy dev server.
+ */
+export function resolveLockFileUrl(resolvedUrls: ResolvedServerUrls): string | null {
+	const resolved = resolvedUrls.local[0] ?? resolvedUrls.network[0];
+	if (!resolved) {
+		return null;
+	}
+	try {
+		return new URL(resolved).origin;
+	} catch {
+		return null;
+	}
 }
 
 /**
@@ -213,23 +236,25 @@ export async function dev({ flags }: DevOptions) {
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 	const server = await devServer(inlineConfig);
 
-	// Use Vite's resolved local URL which accounts for host and protocol (http/https).
-	const serverUrl = new URL(server.resolvedUrls.local[0]).origin;
-	writeLockFile(root, {
-		pid: process.pid,
-		port: server.address.port,
-		url: serverUrl,
-		urls: server.resolvedUrls,
-		background: !!process.env.ASTRO_DEV_BACKGROUND,
-		startedAt: new Date().toISOString(),
-	});
+	// Use Vite's resolved URL which accounts for host and protocol (http/https).
+	const serverUrl = resolveLockFileUrl(server.resolvedUrls);
+	if (serverUrl) {
+		writeLockFile(root, {
+			pid: process.pid,
+			port: server.address.port,
+			url: serverUrl,
+			urls: server.resolvedUrls,
+			background: !!process.env.ASTRO_DEV_BACKGROUND,
+			startedAt: new Date().toISOString(),
+		});
 
-	// Wrap the original stop to also clean up the lock file
-	const originalStop = server.stop.bind(server);
-	server.stop = async () => {
-		removeLockFile(root);
-		await originalStop();
-	};
+		// Wrap the original stop to also clean up the lock file
+		const originalStop = server.stop.bind(server);
+		server.stop = async () => {
+			removeLockFile(root);
+			await originalStop();
+		};
+	}
 
 	return server;
 }

--- a/packages/astro/test/units/dev/lockfile-url.test.ts
+++ b/packages/astro/test/units/dev/lockfile-url.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveLockFileUrl } from '../../../dist/cli/dev/index.js';
+
+describe('resolveLockFileUrl', () => {
+	it('uses the local URL when one is available', () => {
+		assert.equal(
+			resolveLockFileUrl({ local: ['http://localhost:4321/'], network: [] }),
+			'http://localhost:4321',
+		);
+	});
+
+	it('prefers the local URL over the network URL', () => {
+		assert.equal(
+			resolveLockFileUrl({
+				local: ['http://localhost:4321/'],
+				network: ['http://192.168.1.50:4321/'],
+			}),
+			'http://localhost:4321',
+		);
+	});
+
+	// `--host <non-loopback-address>`: Vite reports the URL under `network` and leaves `local`
+	// empty, which used to crash with `Invalid URL` after the server had already started.
+	it('falls back to the network URL when there is no local URL', () => {
+		assert.equal(
+			resolveLockFileUrl({ local: [], network: ['http://192.168.1.50:4321/'] }),
+			'http://192.168.1.50:4321',
+		);
+	});
+
+	it('preserves a non-default protocol', () => {
+		assert.equal(
+			resolveLockFileUrl({ local: [], network: ['https://192.168.1.50:4321/'] }),
+			'https://192.168.1.50:4321',
+		);
+	});
+
+	it('returns null when the server exposed no URL at all', () => {
+		assert.equal(resolveLockFileUrl({ local: [], network: [] }), null);
+	});
+
+	it('returns null instead of throwing on an unparseable URL', () => {
+		assert.equal(resolveLockFileUrl({ local: ['not a url'], network: [] }), null);
+	});
+});


### PR DESCRIPTION
## Changes

Fixes #17527 — `astro dev --host <custom-address>` bound to a specific non-loopback address crashed with `Invalid URL` immediately *after* the server had started successfully.

- Vite only reports a `local` URL for loopback hosts. For a specific non-loopback address the URL is reported under `network` and `local` is left empty:

  ```
  --host 127.0.0.1        {"local":["http://127.0.0.1:5173/"],"network":[]}
  --host 100.100.30.30    {"local":[],"network":["http://100.100.30.30:5173/"]}
  ```

  So `resolvedUrls.local[0]` was `undefined` and `new URL(undefined)` threw while writing the dev lock file, taking down a server that was already up and serving.

- Extracts `resolveLockFileUrl()`, which prefers the local URL and falls back to the network one. Loopback hosts keep recording exactly the URL they did before.

- When neither array yields a usable URL it returns `null` and the lock file is skipped, so lock file bookkeeping can no longer kill a healthy dev server. Such an instance is simply untracked by `astro dev stop`/`status`/`logs`, the same as `--ignore-lock`.

Only the bare `--host` (which binds `0.0.0.0` and still resolves a local URL) was unaffected, which is why this slipped through — the documented `--host <custom-address>` form is exactly the one that broke.

Changeset included (`patch`).

## Testing

New unit tests in `packages/astro/test/units/dev/lockfile-url.test.ts` (6 cases: local present, local preferred over network, **network fallback**, non-default protocol preserved, both empty → `null`, unparseable URL → `null` rather than a throw). Existing `ignore-lock-flag`, `lockfile` and `dev-output` unit suites still pass.

Verified end-to-end against `examples/basics` with the built package. Before the fix the last row crashed; the others are unchanged:

| flag | `dev.json` `url` | `Invalid URL` |
|---|---|---|
| *(none)* | `http://localhost:9310` | no |
| `--host` | `http://localhost:9311` | no |
| `--host 127.0.0.1` | `http://127.0.0.1:9312` | no |
| `--host localhost` | `http://localhost:9313` | no |
| `--host 0.0.0.0` | `http://localhost:9314` | no |
| `--host 100.100.30.30` | `http://100.100.30.30:9315` | no *(crashed before)* |

`astro dev status` and `astro dev stop` both work against a server started with a non-loopback `--host`, and `status` lists the network URL.

## Docs

No docs change needed — this restores the documented behaviour of `--host <custom-address>` ("Expose on a network IP address at `<custom-address>`") rather than changing it. No flags, output shape or lock file fields were added or removed.
