### PR TITLE
fix(content): preserve CSS cascade order for propagated assets

### DIFF
--- a/.changeset/content-collections-css-order-fix.md
+++ b/.changeset/content-collections-css-order-fix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the cascade order between inline styles and external stylesheets not being preserved when a content collection entry's propagated CSS is injected during the build. Both kinds are now kept in a single ordered list instead of being split into separate style/link buckets.

--- a/packages/astro/src/content/consts.ts
+++ b/packages/astro/src/content/consts.ts
@@ -21,7 +21,10 @@ export const DEFERRED_MODULE = 'astro:content-layer-deferred-module';
 // Used by the content layer to create a virtual module that loads the `assets.mjs`
 export const ASSET_IMPORTS_VIRTUAL_ID = 'astro:asset-imports';
 export const ASSET_IMPORTS_RESOLVED_STUB_ID = '\0' + ASSET_IMPORTS_VIRTUAL_ID;
-export const LINKS_PLACEHOLDER = '@@ASTRO-LINKS@@';
+// A single placeholder for the ordered list of stylesheets (inline + external).
+// Kept as one list (rather than separate style/link placeholders) so that the
+// original cascade order between inline styles and external stylesheets survives
+// the build's post-hook injection step.
 export const STYLES_PLACEHOLDER = '@@ASTRO-STYLES@@';
 export const IMAGE_IMPORT_PREFIX = '__ASTRO_IMAGE_';
 

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -6,6 +6,7 @@ import type * as zCore from 'zod/v4/core';
 import type { GetImageResult, ImageMetadata } from '../assets/types.js';
 import { createSvgComponent } from '../assets/runtime.js';
 import { imageSrcToImportId } from '../assets/utils/resolveImports.js';
+import type { StylesheetAsset } from '../core/app/types.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { isRemotePath, prependForwardSlash } from '../core/path.js';
 import {
@@ -609,7 +610,7 @@ async function render({
 	const { default: defaultMod } = baseMod;
 
 	if (isPropagatedAssetsModule(defaultMod)) {
-		const { collectedStyles, collectedLinks, collectedScripts, getMod } = defaultMod;
+		const { collectedStylesheets, collectedScripts, getMod } = defaultMod;
 		if (typeof getMod !== 'function') throw UnexpectedRenderError;
 		const propagationMod = await getMod();
 		if (propagationMod == null || typeof propagationMod !== 'object') throw UnexpectedRenderError;
@@ -617,25 +618,19 @@ async function render({
 		const Content = createComponent({
 			factory(result, baseProps, slots) {
 				let styles = '',
-					links = '',
 					scripts = '';
-				if (Array.isArray(collectedStyles)) {
-					styles = collectedStyles
-						.map((style: any) => {
-							return renderUniqueStylesheet(result, {
-								type: 'inline',
-								content: style,
-							});
-						})
-						.join('');
-				}
-				if (Array.isArray(collectedLinks)) {
-					links = collectedLinks
-						.map((link: any) => {
-							return renderUniqueStylesheet(result, {
-								type: 'external',
-								src: isRemotePath(link) ? link : prependForwardSlash(link),
-							});
+				if (Array.isArray(collectedStylesheets)) {
+					// Keep inline styles and external links in their original relative order,
+					// since CSS cascade is order-sensitive.
+					styles = collectedStylesheets
+						.map((sheet: StylesheetAsset) => {
+							if (sheet.type === 'external') {
+								return renderUniqueStylesheet(result, {
+									type: 'external',
+									src: isRemotePath(sheet.src) ? sheet.src : prependForwardSlash(sheet.src),
+								});
+							}
+							return renderUniqueStylesheet(result, sheet);
 						})
 						.join('');
 				}
@@ -653,7 +648,7 @@ async function render({
 				}
 
 				return createHeadAndContent(
-					unescapeHTML(styles + links + scripts) as any,
+					unescapeHTML(styles + scripts) as any,
 					renderTemplate`${renderComponent(
 						result,
 						'Content',
@@ -721,8 +716,7 @@ export function createReference() {
 type PropagatedAssetsModule = {
 	__astroPropagation: true;
 	getMod: () => Promise<any>;
-	collectedStyles: string[];
-	collectedLinks: string[];
+	collectedStylesheets: StylesheetAsset[];
 	collectedScripts: string[];
 };
 

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -1,6 +1,6 @@
 import { extname } from 'node:path';
 import { getAssetsPrefix } from '../assets/utils/getAssetsPrefix.js';
-import type { AssetsPrefix } from '../core/app/types.js';
+import type { AssetsPrefix, StylesheetAsset } from '../core/app/types.js';
 import { fileExtension } from '../core/path.js';
 import { fileURLToPath } from 'node:url';
 import { isRunnableDevEnvironment, type Plugin, type RunnableDevEnvironment } from 'vite';
@@ -14,7 +14,6 @@ import { crawlGraph } from '../vite-plugin-astro-server/vite.js';
 import {
 	CONTENT_IMAGE_FLAG,
 	CONTENT_RENDER_FLAG,
-	LINKS_PLACEHOLDER,
 	PROPAGATED_ASSET_FLAG,
 	STYLES_PLACEHOLDER,
 } from './consts.js';
@@ -104,7 +103,7 @@ export function astroContentAssetPropagationPlugin({
 			async handler(_, id) {
 				if (hasContentFlag(id, PROPAGATED_ASSET_FLAG)) {
 					const basePath = id.split('?')[0];
-					let stringifiedLinks: string, stringifiedStyles: string;
+					let stringifiedStylesheets: string;
 
 					// We can access the server in dev,
 					// so resolve collected styles and scripts here.
@@ -132,14 +131,18 @@ export function astroContentAssetPropagationPlugin({
 							}
 						}
 
-						stringifiedLinks = JSON.stringify([...urls]);
-						stringifiedStyles = JSON.stringify(styles.map((s) => s.content));
+						// Keep both kinds in a single ordered list so the relative cascade order
+						// between external stylesheets and inlined styles isn't lost.
+						const stylesheets: StylesheetAsset[] = [
+							...[...urls].map((src): StylesheetAsset => ({ type: 'external', src })),
+							...styles.map((s): StylesheetAsset => ({ type: 'inline', content: s.content })),
+						];
+						stringifiedStylesheets = JSON.stringify(stylesheets);
 					} else {
-						// Otherwise, use placeholders to inject styles and scripts
+						// Otherwise, use a placeholder to inject stylesheets
 						// during the production bundle step.
 						// @see the `astro:content-build-plugin` below.
-						stringifiedLinks = JSON.stringify(LINKS_PLACEHOLDER);
-						stringifiedStyles = JSON.stringify(STYLES_PLACEHOLDER);
+						stringifiedStylesheets = JSON.stringify(STYLES_PLACEHOLDER);
 					}
 
 					const code = `
@@ -147,9 +150,8 @@ export function astroContentAssetPropagationPlugin({
 					async function getMod() {
 						return import(${JSON.stringify(basePath)});
 					}
-					const collectedLinks = ${stringifiedLinks};
-					const collectedStyles = ${stringifiedStyles};
-					const defaultMod = { __astroPropagation: true, getMod, collectedLinks, collectedStyles, collectedScripts: [] };
+					const collectedStylesheets = ${stringifiedStylesheets};
+					const defaultMod = { __astroPropagation: true, getMod, collectedStylesheets, collectedScripts: [] };
 					export default defaultMod;
 				`;
 					// ^ Use a default export for tools like Markdoc
@@ -235,9 +237,9 @@ async function getStylesForURL(
 }
 
 /**
- * Post-build hook that injects propagated styles into content collection chunks.
- * Finds chunks with LINKS_PLACEHOLDER and STYLES_PLACEHOLDER, and replaces them
- * with actual styles from propagatedStylesMap.
+ * Post-build hook that injects propagated stylesheets into content collection chunks.
+ * Finds chunks with STYLES_PLACEHOLDER, and replaces it with the actual
+ * ordered list of stylesheets from propagatedStylesMap.
  */
 export async function contentAssetsBuildPostHook(
 	base: string,
@@ -251,25 +253,29 @@ export async function contentAssetsBuildPostHook(
 		mutate: (fileName: string, code: string, prerender: boolean) => void;
 	},
 ) {
-	// Process each chunk that contains placeholder placeholders for styles/links
+	// Process each chunk that contains a placeholder for stylesheets
 	for (const chunk of chunks) {
-		// Skip chunks that don't have content placeholders to inject
-		if (!chunk.code.includes(LINKS_PLACEHOLDER)) continue;
+		// Skip chunks that don't have a content placeholder to inject
+		if (!chunk.code.includes(STYLES_PLACEHOLDER)) continue;
 
-		const entryStyles = new Set<string>();
-		const entryLinks = new Set<string>();
+		const seen = new Set<string>();
+		const stylesheets: StylesheetAsset[] = [];
 
 		// For each module in this chunk, look up propagated styles from the map
 		for (const id of chunk.moduleIds) {
 			const entryCss = internals.propagatedStylesMap.get(id);
 			if (entryCss) {
-				// Collect both inline content and external links
-				// TODO: Separating styles and links this way is not ideal. The `entryCss` list is order-sensitive
-				// and splitting them into two sets causes the order to be lost, because styles are rendered after
-				// links. Refactor this away in the future.
+				// `entryCss` mixes inline styles and external links in the order they were
+				// encountered. Keep them in a single ordered list (deduping by content/href)
+				// so the original cascade order between the two is preserved.
 				for (const value of entryCss) {
-					if (value.type === 'inline') entryStyles.add(value.content);
-					if (value.type === 'external') {
+					if (value.type === 'inline') {
+						const key = `inline:${value.content}`;
+						if (!seen.has(key)) {
+							seen.add(key);
+							stylesheets.push({ type: 'inline', content: value.content });
+						}
+					} else if (value.type === 'external') {
 						let href: string;
 						if (assetsPrefix) {
 							const pf = getAssetsPrefix(fileExtension(value.src), assetsPrefix);
@@ -277,32 +283,21 @@ export async function contentAssetsBuildPostHook(
 						} else {
 							href = prependForwardSlash(joinPaths(base, slash(value.src)));
 						}
-						entryLinks.add(href);
+						const key = `external:${href}`;
+						if (!seen.has(key)) {
+							seen.add(key);
+							stylesheets.push({ type: 'external', src: href });
+						}
 					}
 				}
 			}
 		}
 
-		// Replace placeholders with actual styles and links
-		let newCode = chunk.code;
-		if (entryStyles.size) {
-			newCode = newCode.replace(
-				JSON.stringify(STYLES_PLACEHOLDER),
-				JSON.stringify(Array.from(entryStyles)),
-			);
-		} else {
-			// Replace with empty array if no styles found
-			newCode = newCode.replace(JSON.stringify(STYLES_PLACEHOLDER), '[]');
-		}
-		if (entryLinks.size) {
-			newCode = newCode.replace(
-				JSON.stringify(LINKS_PLACEHOLDER),
-				JSON.stringify(Array.from(entryLinks)),
-			);
-		} else {
-			// Replace with empty array if no links found
-			newCode = newCode.replace(JSON.stringify(LINKS_PLACEHOLDER), '[]');
-		}
+		// Replace the placeholder with the actual ordered stylesheet list
+		const newCode = chunk.code.replace(
+			JSON.stringify(STYLES_PLACEHOLDER),
+			JSON.stringify(stylesheets),
+		);
 		// Persist the mutation for writing to disk
 		mutate(chunk.fileName, newCode, chunk.prerender);
 	}

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import colors from 'piccolore';
 import * as vite from 'vite';
-import { LINKS_PLACEHOLDER } from '../../content/consts.js';
+import { STYLES_PLACEHOLDER } from '../../content/consts.js';
 import { contentAssetsBuildPostHook } from '../../content/vite-plugin-content-assets.js';
 import { type BuildInternals, createBuildInternals } from '../../core/build/internal.js';
 import { emptyDir, removeEmptyDirs } from '../../core/fs/index.js';
@@ -65,7 +65,7 @@ function extractRelevantChunks(
 		for (const chunk of output.output) {
 			if (chunk.type === 'asset') continue;
 
-			const needsContentInjection = chunk.code.includes(LINKS_PLACEHOLDER);
+			const needsContentInjection = chunk.code.includes(STYLES_PLACEHOLDER);
 			const needsManifestInjection = chunk.moduleIds.includes(SERIALIZED_MANIFEST_RESOLVED_ID);
 			const needsServerIslandInjection = chunk.code.includes(SERVER_ISLAND_MAP_MARKER);
 

--- a/packages/astro/test/units/content-collections/propagated-css-order.test.ts
+++ b/packages/astro/test/units/content-collections/propagated-css-order.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createBuildInternals } from '../../../dist/core/build/internal.js';
 import { contentAssetsBuildPostHook } from '../../../dist/content/vite-plugin-content-assets.js';
-import { LINKS_PLACEHOLDER, STYLES_PLACEHOLDER } from '../../../dist/content/consts.js';
+import { STYLESHEETS_PLACEHOLDER } from '../../../dist/content/consts.js';
 
 // Verify that later declared styles take precedence in the CSS cascade.
 // Refer: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Introduction
@@ -22,7 +22,7 @@ describe('content collections - propagated CSS order', () => {
 		const chunks = [
 			{
 				fileName: 'entry.js',
-				code: `const collectedLinks = ${JSON.stringify(LINKS_PLACEHOLDER)};\nconst collectedStyles = ${JSON.stringify(STYLES_PLACEHOLDER)};`,
+				code: `const collectedStylesheets = ${JSON.stringify(STYLESHEETS_PLACEHOLDER)};`,
 				moduleIds: [moduleId],
 				prerender: false,
 			},
@@ -37,16 +37,9 @@ describe('content collections - propagated CSS order', () => {
 		});
 
 		assert.ok(mutatedCode);
-		const linksMatch = /const collectedLinks = (\[.*?\]);/.exec(mutatedCode);
-		const stylesMatch = /const collectedStyles = (\[.*?\]);/.exec(mutatedCode);
-		assert.ok(linksMatch && stylesMatch);
-		const links: string[] = JSON.parse(linksMatch[1]);
-		const styles: string[] = JSON.parse(stylesMatch[1]);
-
-		const actualRenderOrder = [
-			...styles.map((content) => ({ type: 'inline', content })),
-			...links.map((src) => ({ type: 'external', src })),
-		];
+		const match = /const collectedStylesheets = (\[.*?\]);/.exec(mutatedCode);
+		assert.ok(match);
+		const actualRenderOrder = JSON.parse(match[1]);
 
 		// The correct order is the one the styles were actually declared in.
 		const expectedOrder = [

--- a/packages/astro/test/units/content-collections/propagated-css-order.test.ts
+++ b/packages/astro/test/units/content-collections/propagated-css-order.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createBuildInternals } from '../../../dist/core/build/internal.js';
+import { contentAssetsBuildPostHook } from '../../../dist/content/vite-plugin-content-assets.js';
+import { LINKS_PLACEHOLDER, STYLES_PLACEHOLDER } from '../../../dist/content/consts.js';
+
+// Verify that later declared styles take precedence in the CSS cascade.
+// Refer: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Introduction
+describe('content collections - propagated CSS order', () => {
+	it('loses the original order between an external stylesheet and a later inline style', async () => {
+		const internals = createBuildInternals();
+		const moduleId = '/src/content/docs/entry.mdx?astroPropagatedAssets';
+
+		internals.propagatedStylesMap.set(
+			moduleId,
+			new Set([
+				{ type: 'external', src: '/_astro/a.css' },
+				{ type: 'inline', content: '.cascade-test{color:blue}' },
+			]),
+		);
+
+		const chunks = [
+			{
+				fileName: 'entry.js',
+				code: `const collectedLinks = ${JSON.stringify(LINKS_PLACEHOLDER)};\nconst collectedStyles = ${JSON.stringify(STYLES_PLACEHOLDER)};`,
+				moduleIds: [moduleId],
+				prerender: false,
+			},
+		];
+
+		let mutatedCode: string | undefined;
+		await contentAssetsBuildPostHook('/', undefined, internals, {
+			chunks,
+			mutate: (_fileName, code) => {
+				mutatedCode = code;
+			},
+		});
+
+		assert.ok(mutatedCode);
+		const linksMatch = /const collectedLinks = (\[.*?\]);/.exec(mutatedCode);
+		const stylesMatch = /const collectedStyles = (\[.*?\]);/.exec(mutatedCode);
+		assert.ok(linksMatch && stylesMatch);
+		const links: string[] = JSON.parse(linksMatch[1]);
+		const styles: string[] = JSON.parse(stylesMatch[1]);
+
+		const actualRenderOrder = [
+			...styles.map((content) => ({ type: 'inline', content })),
+			...links.map((src) => ({ type: 'external', src })),
+		];
+
+		// The correct order is the one the styles were actually declared in.
+		const expectedOrder = [
+			{ type: 'external', src: '/_astro/a.css' },
+			{ type: 'inline', content: '.cascade-test{color:blue}' },
+		];
+
+		assert.deepEqual( actualRenderOrder, expectedOrder,);
+	});
+});

--- a/packages/astro/test/units/content-collections/propagated-css-order.test.ts
+++ b/packages/astro/test/units/content-collections/propagated-css-order.test.ts
@@ -2,12 +2,12 @@ import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createBuildInternals } from '../../../dist/core/build/internal.js';
 import { contentAssetsBuildPostHook } from '../../../dist/content/vite-plugin-content-assets.js';
-import { STYLESHEETS_PLACEHOLDER } from '../../../dist/content/consts.js';
+import { STYLES_PLACEHOLDER } from '../../../dist/content/consts.js';
 
 // Verify that later declared styles take precedence in the CSS cascade.
 // Refer: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Introduction
 describe('content collections - propagated CSS order', () => {
-	it('loses the original order between an external stylesheet and a later inline style', async () => {
+	it('preserves the original order between an external stylesheet and a later inline style', async () => {
 		const internals = createBuildInternals();
 		const moduleId = '/src/content/docs/entry.mdx?astroPropagatedAssets';
 
@@ -22,7 +22,7 @@ describe('content collections - propagated CSS order', () => {
 		const chunks = [
 			{
 				fileName: 'entry.js',
-				code: `const collectedStylesheets = ${JSON.stringify(STYLESHEETS_PLACEHOLDER)};`,
+				code: `const collectedStylesheets = ${JSON.stringify(STYLES_PLACEHOLDER)};`,
 				moduleIds: [moduleId],
 				prerender: false,
 			},
@@ -47,6 +47,6 @@ describe('content collections - propagated CSS order', () => {
 			{ type: 'inline', content: '.cascade-test{color:blue}' },
 		];
 
-		assert.deepEqual( actualRenderOrder, expectedOrder,);
+		assert.deepEqual(actualRenderOrder, expectedOrder);
 	});
 });


### PR DESCRIPTION
## Changes
Now in progress.

## Testing

### Reproduce this issue via using unit test
<img width="1101" height="318" alt="スクリーンショット 2026-07-28 8 03 15" src="https://github.com/user-attachments/assets/d8d2474a-065d-490a-8dae-7f259f5c6f41" />


## Docs

