### PR TITLE
Fix race condition causing NoMatchingStaticPathFound with concurrent i18n fallback rewrites

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -154,6 +154,22 @@ export async function generatePages(
 			return false;
 		});
 
+		// Pre-populate distURL for every path so that concurrent i18n fallback
+		// rewrites can look up whether a dynamic route generates a given pathname.
+		// Without this, a slow page's distURL entry is missing when a concurrent
+		// fallback tries to rewrite to it, causing the rewrite to fall through to
+		// the wrong catch-all route. See https://github.com/withastro/astro/issues/17533
+		for (const { pathname, route } of filteredPaths) {
+			const encodedPath = encodeURI(pathname);
+			const outFolder = getOutFolder(options.settings, encodedPath, route);
+			const outFile = getOutFile(config.build.format, outFolder, encodedPath, route);
+			if (route.distURL) {
+				route.distURL.push(outFile);
+			} else {
+				route.distURL = [outFile];
+			}
+		}
+
 		// Generate each path
 		if (config.build.concurrency > 1) {
 			const limit = PLimit(config.build.concurrency);

--- a/packages/astro/test/fixtures/i18n-concurrent-fallback/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-concurrent-fallback/astro.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  output: 'static',
+  build: {
+    concurrency: 10,
+  },
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    fallback: {
+      es: 'en',
+    },
+    routing: {
+      fallbackType: 'rewrite',
+    },
+  },
+});

--- a/packages/astro/test/fixtures/i18n-concurrent-fallback/package.json
+++ b/packages/astro/test/fixtures/i18n-concurrent-fallback/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/i18n-concurrent-fallback",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/i18n-concurrent-fallback/src/pages/[...slug].astro
+++ b/packages/astro/test/fixtures/i18n-concurrent-fallback/src/pages/[...slug].astro
@@ -1,0 +1,14 @@
+---
+export function getStaticPaths() {
+  return [
+    { params: { slug: undefined }, props: { title: 'Home' } },
+    { params: { slug: 'about' }, props: { title: 'About' } },
+  ];
+}
+
+const { title } = Astro.props;
+---
+<html>
+<head><title>{title}</title></head>
+<body><h1>{title}</h1></body>
+</html>

--- a/packages/astro/test/fixtures/i18n-concurrent-fallback/src/pages/articles/[slug].astro
+++ b/packages/astro/test/fixtures/i18n-concurrent-fallback/src/pages/articles/[slug].astro
@@ -1,0 +1,27 @@
+---
+export async function getStaticPaths() {
+  const articles = [
+    { slug: 'fast-page-1', title: 'Fast Page 1', delay: 0 },
+    { slug: 'fast-page-2', title: 'Fast Page 2', delay: 0 },
+    { slug: 'fast-page-3', title: 'Fast Page 3', delay: 0 },
+    { slug: 'fast-page-4', title: 'Fast Page 4', delay: 0 },
+    { slug: 'fast-page-5', title: 'Fast Page 5', delay: 0 },
+    { slug: 'slow-page', title: 'Slow Page', delay: 1000 },
+  ];
+
+  return articles.map((article) => ({
+    params: { slug: article.slug },
+    props: { title: article.title, delay: article.delay },
+  }));
+}
+
+const { title, delay } = Astro.props;
+
+if (delay > 0) {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+}
+---
+<html>
+<head><title>{title}</title></head>
+<body><h1>{title}</h1></body>
+</html>

--- a/packages/astro/test/i18n-concurrent-fallback.test.ts
+++ b/packages/astro/test/i18n-concurrent-fallback.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('i18n fallback with build.concurrency', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/i18n-concurrent-fallback/',
+		});
+		await fixture.build();
+	});
+
+	it('generates the slow fallback page without NoMatchingStaticPathFound', async () => {
+		const html = await fixture.readFile('/es/articles/slow-page/index.html');
+		assert.ok(html.includes('Slow Page'));
+	});
+
+	it('generates fast fallback pages', async () => {
+		const html = await fixture.readFile('/es/articles/fast-page-1/index.html');
+		assert.ok(html.includes('Fast Page 1'));
+	});
+
+	it('generates original pages', async () => {
+		const html = await fixture.readFile('/articles/slow-page/index.html');
+		assert.ok(html.includes('Slow Page'));
+	});
+
+	it('generates catch-all pages', async () => {
+		const html = await fixture.readFile('/about/index.html');
+		assert.ok(html.includes('About'));
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3459,6 +3459,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/i18n-concurrent-fallback:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/i18n-css-leak-basic:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Pre-populates `route.distURL` for all static paths before concurrent rendering starts. Previously, `distURL` was populated as a side effect of each page finishing — meaning a slow page's entry was missing when a concurrent i18n fallback tried to rewrite to it. `findRouteToRewrite` would then skip the correct dynamic route and fall through to a catch-all, triggering `NoMatchingStaticPathFound`.
- The pre-population loop in `generatePages()` uses the same `getOutFolder`/`getOutFile` functions as `renderPath`, so the entries are consistent. Duplicate entries added later by `renderPath` are harmless since `distURL` is only used for `.find()` lookups.

Closes #17533

## Testing

- New fixture `fixtures/i18n-concurrent-fallback/` with `build.concurrency: 10`, i18n `fallbackType: 'rewrite'`, a slow dynamic route (`articles/[slug]`), and a catch-all (`[...slug]`).
- New test file `test/i18n-concurrent-fallback.test.ts` covering the slow fallback page, fast fallback pages, original pages, and catch-all pages.

## Docs

No docs update needed — this is an internal race condition fix with no API changes.