### PR TITLE
fix(build): introduce two-staged build to prevent race condition with concurrent i18n rewrites

### DIFF
--- a/.changeset/chatty-eels-lose.md
+++ b/.changeset/chatty-eels-lose.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes concurrent static builds failing to generate i18n rewrite fallbacks for dynamic routes

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -157,28 +157,34 @@ export async function generatePages(
 		// Generate each path
 		if (config.build.concurrency > 1) {
 			const limit = PLimit(config.build.concurrency);
+			const generationPhases = [
+				filteredPaths.filter(({ route }) => route.type !== 'fallback'),
+				filteredPaths.filter(({ route }) => route.type === 'fallback'),
+			];
 			// Process in batches to avoid V8's Promise.all element limit, which is around ~123k items
 			//
 			// NOTE: ideally we could consider an iterator to avoid the batching limitation
 			const BATCH_SIZE = 100_000;
-			for (let i = 0; i < filteredPaths.length; i += BATCH_SIZE) {
-				const batch = filteredPaths.slice(i, i + BATCH_SIZE);
-				const promises: Promise<void>[] = [];
-				for (const { pathname, route } of batch) {
-					promises.push(
-						limit(() =>
-							generatePathWithPrerenderer(
-								prerenderer,
-								pathname,
-								route,
-								options,
-								routeToHeaders,
-								logger,
+			for (const paths of generationPhases) {
+				for (let i = 0; i < paths.length; i += BATCH_SIZE) {
+					const batch = paths.slice(i, i + BATCH_SIZE);
+					const promises: Promise<void>[] = [];
+					for (const { pathname, route } of batch) {
+						promises.push(
+							limit(() =>
+								generatePathWithPrerenderer(
+									prerenderer,
+									pathname,
+									route,
+									options,
+									routeToHeaders,
+									logger,
+								),
 							),
-						),
-					);
+						);
+					}
+					await Promise.all(promises);
 				}
-				await Promise.all(promises);
 			}
 		} else {
 			for (const { pathname, route } of filteredPaths) {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -154,8 +154,7 @@ export async function generatePages(
 			const paths = route.type === 'fallback' ? fallbackPaths : filteredPaths;
 			paths.push(pathWithRoute);
 		}
-		const fallbackStart = filteredPaths.length;
-		const orderedPaths = filteredPaths.concat(fallbackPaths);
+		const generationPhases = [filteredPaths, fallbackPaths];
 
 		// Generate each path
 		if (config.build.concurrency > 1) {
@@ -164,36 +163,37 @@ export async function generatePages(
 			//
 			// NOTE: ideally we could consider an iterator to avoid the batching limitation
 			const BATCH_SIZE = 100_000;
-			for (let i = 0; i < orderedPaths.length; ) {
-				const phaseEnd = i < fallbackStart ? fallbackStart : orderedPaths.length;
-				const batchEnd = Math.min(i + BATCH_SIZE, phaseEnd);
-				const promises = orderedPaths
-					.slice(i, batchEnd)
-					.map(({ pathname, route }) =>
-						limit(() =>
-							generatePathWithPrerenderer(
-								prerenderer,
-								pathname,
-								route,
-								options,
-								routeToHeaders,
-								logger,
+			for (const paths of generationPhases) {
+				for (let i = 0; i < paths.length; i += BATCH_SIZE) {
+					const promises = paths
+						.slice(i, i + BATCH_SIZE)
+						.map(({ pathname, route }) =>
+							limit(() =>
+								generatePathWithPrerenderer(
+									prerenderer,
+									pathname,
+									route,
+									options,
+									routeToHeaders,
+									logger,
+								),
 							),
-						),
-					);
-				await Promise.all(promises);
-				i = batchEnd;
+						);
+					await Promise.all(promises);
+				}
 			}
 		} else {
-			for (const { pathname, route } of orderedPaths) {
-				await generatePathWithPrerenderer(
-					prerenderer,
-					pathname,
-					route,
-					options,
-					routeToHeaders,
-					logger,
-				);
+			for (const paths of generationPhases) {
+				for (const { pathname, route } of paths) {
+					await generatePathWithPrerenderer(
+						prerenderer,
+						pathname,
+						route,
+						options,
+						routeToHeaders,
+						logger,
+					);
+				}
 			}
 		}
 
@@ -201,15 +201,17 @@ export async function generatePages(
 		// back to the original routes in allPages. The prerenderer operates on deserialized route
 		// objects (reconstructed from the serialized manifest), so distURL mutations during generation
 		// don't affect the original route objects that are later passed to the astro:build:done hook.
-		for (const { route: generatedRoute } of orderedPaths) {
-			if (generatedRoute.distURL && generatedRoute.distURL.length > 0) {
-				for (const pageData of Object.values(options.allPages)) {
-					if (
-						pageData.route.route === generatedRoute.route &&
-						pageData.route.component === generatedRoute.component
-					) {
-						pageData.route.distURL = generatedRoute.distURL;
-						break;
+		for (const paths of generationPhases) {
+			for (const { route: generatedRoute } of paths) {
+				if (generatedRoute.distURL && generatedRoute.distURL.length > 0) {
+					for (const pageData of Object.values(options.allPages)) {
+						if (
+							pageData.route.route === generatedRoute.route &&
+							pageData.route.component === generatedRoute.component
+						) {
+							pageData.route.distURL = generatedRoute.distURL;
+							break;
+						}
 					}
 				}
 			}

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -103,7 +103,10 @@ export async function generatePages(
 		// Filter paths for conflicts (same path from multiple routes)
 		const { config } = options.settings;
 		const builtPaths = new Set<string>();
-		const filteredPaths = pathsWithRoutes.filter(({ pathname, route }) => {
+		const filteredPaths: typeof pathsWithRoutes = [];
+		const fallbackPaths: typeof pathsWithRoutes = [];
+		for (const pathWithRoute of pathsWithRoutes) {
+			const { pathname, route } = pathWithRoute;
 			// i18n domains won't work with prerendered routes
 			if (hasI18nDomains && route.prerender) {
 				throw new AstroError({
@@ -117,77 +120,72 @@ export async function generatePages(
 			// Path hasn't been built yet, include it
 			if (!builtPaths.has(normalized)) {
 				builtPaths.add(normalized);
-				return true;
+			} else {
+				// Path was already built. Check if this route has higher priority.
+				const matchedRoute = matchRoute(decodeURI(pathname), options.routesList);
+				if (!matchedRoute) {
+					continue;
+				}
+
+				if (matchedRoute !== route) {
+					// Current route is lower-priority. Warn or error based on config.
+					if (config.prerenderConflictBehavior === 'error') {
+						throw new AstroError({
+							...AstroErrorData.PrerenderRouteConflict,
+							message: AstroErrorData.PrerenderRouteConflict.message(
+								matchedRoute.route,
+								route.route,
+								normalized,
+							),
+							hint: AstroErrorData.PrerenderRouteConflict.hint(matchedRoute.route, route.route),
+						});
+					} else if (config.prerenderConflictBehavior === 'warn') {
+						const msg = AstroErrorData.PrerenderRouteConflict.message(
+							matchedRoute.route,
+							route.route,
+							normalized,
+						);
+						logger.warn('build', msg);
+					}
+					continue;
+				}
 			}
 
-			// Path was already built. Check if this route has higher priority.
-			const matchedRoute = matchRoute(decodeURI(pathname), options.routesList);
-			if (!matchedRoute) {
-				return false;
-			}
-
-			if (matchedRoute === route) {
-				// Current route is higher-priority. Include it for building.
-				return true;
-			}
-
-			// Current route is lower-priority. Warn or error based on config.
-			if (config.prerenderConflictBehavior === 'error') {
-				throw new AstroError({
-					...AstroErrorData.PrerenderRouteConflict,
-					message: AstroErrorData.PrerenderRouteConflict.message(
-						matchedRoute.route,
-						route.route,
-						normalized,
-					),
-					hint: AstroErrorData.PrerenderRouteConflict.hint(matchedRoute.route, route.route),
-				});
-			} else if (config.prerenderConflictBehavior === 'warn') {
-				const msg = AstroErrorData.PrerenderRouteConflict.message(
-					matchedRoute.route,
-					route.route,
-					normalized,
-				);
-				logger.warn('build', msg);
-			}
-
-			return false;
-		});
+			const paths = route.type === 'fallback' ? fallbackPaths : filteredPaths;
+			paths.push(pathWithRoute);
+		}
+		const fallbackStart = filteredPaths.length;
+		const orderedPaths = filteredPaths.concat(fallbackPaths);
 
 		// Generate each path
 		if (config.build.concurrency > 1) {
 			const limit = PLimit(config.build.concurrency);
-			const generationPhases = [
-				filteredPaths.filter(({ route }) => route.type !== 'fallback'),
-				filteredPaths.filter(({ route }) => route.type === 'fallback'),
-			];
 			// Process in batches to avoid V8's Promise.all element limit, which is around ~123k items
 			//
 			// NOTE: ideally we could consider an iterator to avoid the batching limitation
 			const BATCH_SIZE = 100_000;
-			for (const paths of generationPhases) {
-				for (let i = 0; i < paths.length; i += BATCH_SIZE) {
-					const batch = paths.slice(i, i + BATCH_SIZE);
-					const promises: Promise<void>[] = [];
-					for (const { pathname, route } of batch) {
-						promises.push(
-							limit(() =>
-								generatePathWithPrerenderer(
-									prerenderer,
-									pathname,
-									route,
-									options,
-									routeToHeaders,
-									logger,
-								),
+			for (let i = 0; i < orderedPaths.length; ) {
+				const phaseEnd = i < fallbackStart ? fallbackStart : orderedPaths.length;
+				const batchEnd = Math.min(i + BATCH_SIZE, phaseEnd);
+				const promises = orderedPaths
+					.slice(i, batchEnd)
+					.map(({ pathname, route }) =>
+						limit(() =>
+							generatePathWithPrerenderer(
+								prerenderer,
+								pathname,
+								route,
+								options,
+								routeToHeaders,
+								logger,
 							),
-						);
-					}
-					await Promise.all(promises);
-				}
+						),
+					);
+				await Promise.all(promises);
+				i = batchEnd;
 			}
 		} else {
-			for (const { pathname, route } of filteredPaths) {
+			for (const { pathname, route } of orderedPaths) {
 				await generatePathWithPrerenderer(
 					prerenderer,
 					pathname,
@@ -203,7 +201,7 @@ export async function generatePages(
 		// back to the original routes in allPages. The prerenderer operates on deserialized route
 		// objects (reconstructed from the serialized manifest), so distURL mutations during generation
 		// don't affect the original route objects that are later passed to the astro:build:done hook.
-		for (const { route: generatedRoute } of filteredPaths) {
+		for (const { route: generatedRoute } of orderedPaths) {
 			if (generatedRoute.distURL && generatedRoute.distURL.length > 0) {
 				for (const pageData of Object.values(options.allPages)) {
 					if (

--- a/packages/astro/test/build-concurrency.test.ts
+++ b/packages/astro/test/build-concurrency.test.ts
@@ -27,3 +27,23 @@ describe('Building with concurrency > 1', () => {
 		assert.equal(built, false, 'Build should not complete');
 	});
 });
+
+describe('Building i18n fallbacks with concurrency > 1', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/build-concurrency-i18n-fallback/',
+			build: {
+				concurrency: 4,
+			},
+			outDir: './dist/build-concurrency-i18n-fallback/',
+		});
+	});
+
+	it('builds rewrite fallbacks after their source pages', async () => {
+		await fixture.build();
+
+		assert.match(await fixture.readFile('/es/articles/slow-page/index.html'), /Article: slow-page/);
+	});
+});

--- a/packages/astro/test/fixtures/build-concurrency-i18n-fallback/astro.config.mjs
+++ b/packages/astro/test/fixtures/build-concurrency-i18n-fallback/astro.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	i18n: {
+		locales: ['en', 'es'],
+		defaultLocale: 'en',
+		fallback: {
+			es: 'en',
+		},
+		routing: {
+			prefixDefaultLocale: false,
+			redirectToDefaultLocale: false,
+			fallbackType: 'rewrite',
+		},
+	},
+	trailingSlash: 'never',
+});

--- a/packages/astro/test/fixtures/build-concurrency-i18n-fallback/package.json
+++ b/packages/astro/test/fixtures/build-concurrency-i18n-fallback/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@test/build-concurrency-i18n-fallback",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"astro": "workspace:*"
+	}
+}

--- a/packages/astro/test/fixtures/build-concurrency-i18n-fallback/src/pages/[...slug].astro
+++ b/packages/astro/test/fixtures/build-concurrency-i18n-fallback/src/pages/[...slug].astro
@@ -1,0 +1,13 @@
+---
+export function getStaticPaths() {
+	return [
+		{
+			params: { slug: 'about' },
+		},
+	];
+}
+
+const { slug } = Astro.params;
+---
+
+<h1>Catch-all page: {slug}</h1>

--- a/packages/astro/test/fixtures/build-concurrency-i18n-fallback/src/pages/articles/[slug].astro
+++ b/packages/astro/test/fixtures/build-concurrency-i18n-fallback/src/pages/articles/[slug].astro
@@ -1,0 +1,18 @@
+---
+import { setTimeout } from 'node:timers/promises';
+
+export function getStaticPaths() {
+	return ['one', 'two', 'three', 'four', 'slow-page'].map((slug) => ({
+		params: { slug },
+	}));
+}
+
+const { slug } = Astro.params;
+const isDefaultLocale = Astro.currentLocale === undefined || Astro.currentLocale === 'en';
+
+if (slug === 'slow-page' && isDefaultLocale) {
+	await setTimeout(500);
+}
+---
+
+<h1>Article: {slug}</h1>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2652,6 +2652,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/build-concurrency-i18n-fallback:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/build-readonly-file:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

* Introduces two-stage build to prevent race conditions with i18n fallback rewrites when building with concurrency > 1.
* Non-fallback pages are built first, followed by fallback pages, which ensures they can be matched using `distURL`.

Fixes https://github.com/withastro/astro/issues/17533
Supersedes https://github.com/withastro/astro/pull/17535

## Testing

Test fixture added.

## Docs

Internal change.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
