### PR TITLE
fix(cli): forward documented flags to the background server process

### DIFF
--- a/.changeset/olive-donuts-marry.md
+++ b/.changeset/olive-donuts-marry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro dev --background` and `astro preview --background` silently dropping the `--mode`, `--site`, `--base`, `--outDir`, `--verbose`, and `--silent` flags when spawning the server process

--- a/packages/astro/src/cli/server.ts
+++ b/packages/astro/src/cli/server.ts
@@ -110,6 +110,12 @@ function getRootURL(flags: Flags): URL {
 	return pathToFileURL(resolveRoot(flags.root) + '/');
 }
 
+/**
+ * Build the argv for the spawned foreground child process (no `--background`),
+ * forwarding every flag that `flagsToAstroInlineConfig` consumes so the
+ * background server behaves the same as a foreground one started with the
+ * same flags.
+ */
 export function buildBackgroundArgs(command: ServerCommand, flags: Flags): string[] {
 	const args: string[] = [command];
 	if (flags.port) args.push('--port', String(flags.port));
@@ -123,6 +129,12 @@ export function buildBackgroundArgs(command: ServerCommand, flags: Flags): strin
 	if (flags.config) args.push('--config', String(flags.config));
 	if (flags.root) args.push('--root', String(flags.root));
 	if (flags.allowedHosts) args.push('--allowed-hosts', String(flags.allowedHosts));
+	if (flags.mode) args.push('--mode', String(flags.mode));
+	if (flags.site) args.push('--site', String(flags.site));
+	if (flags.base) args.push('--base', String(flags.base));
+	if (flags.outDir) args.push('--outDir', String(flags.outDir));
+	if (flags.verbose) args.push('--verbose');
+	if (flags.silent) args.push('--silent');
 	if (flags.json) args.push('--json');
 	return args;
 }

--- a/packages/astro/test/units/cli/background-args.test.ts
+++ b/packages/astro/test/units/cli/background-args.test.ts
@@ -1,0 +1,92 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildBackgroundArgs } from '../../../dist/cli/server.js';
+import type { Flags } from '../../../dist/cli/flags.js';
+
+function makeFlags(overrides: Record<string, unknown> = {}): Flags {
+	return { _: [], ...overrides };
+}
+
+describe('buildBackgroundArgs', () => {
+	it('returns only the command when no flags are set', () => {
+		assert.deepEqual(buildBackgroundArgs('dev', makeFlags()), ['dev']);
+		assert.deepEqual(buildBackgroundArgs('preview', makeFlags()), ['preview']);
+	});
+
+	it('never includes --background', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ background: true }));
+		assert.equal(args.includes('--background'), false);
+	});
+
+	it('forwards --port', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ port: 3000 }));
+		assert.deepEqual(args, ['dev', '--port', '3000']);
+	});
+
+	it('forwards --host with a custom address', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ host: '0.0.0.0' }));
+		assert.deepEqual(args, ['dev', '--host', '0.0.0.0']);
+	});
+
+	it('forwards bare --host', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ host: true }));
+		assert.deepEqual(args, ['dev', '--host']);
+	});
+
+	it('forwards --config and --root', () => {
+		const args = buildBackgroundArgs(
+			'dev',
+			makeFlags({ config: 'astro.custom.mjs', root: './site' }),
+		);
+		assert.deepEqual(args, ['dev', '--config', 'astro.custom.mjs', '--root', './site']);
+	});
+
+	it('forwards --allowed-hosts', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ allowedHosts: 'example.com,foo.dev' }));
+		assert.deepEqual(args, ['dev', '--allowed-hosts', 'example.com,foo.dev']);
+	});
+
+	it('forwards --mode', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ mode: 'staging' }));
+		assert.deepEqual(args, ['dev', '--mode', 'staging']);
+	});
+
+	it('forwards --site, --base and --outDir', () => {
+		const args = buildBackgroundArgs(
+			'dev',
+			makeFlags({ site: 'https://example.com', base: '/docs', outDir: './build' }),
+		);
+		assert.deepEqual(args, [
+			'dev',
+			'--site',
+			'https://example.com',
+			'--base',
+			'/docs',
+			'--outDir',
+			'./build',
+		]);
+	});
+
+	it('forwards --verbose', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ verbose: true }));
+		assert.deepEqual(args, ['dev', '--verbose']);
+	});
+
+	it('forwards --silent', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ silent: true }));
+		assert.deepEqual(args, ['dev', '--silent']);
+	});
+
+	it('forwards --json', () => {
+		const args = buildBackgroundArgs('dev', makeFlags({ json: true }));
+		assert.deepEqual(args, ['dev', '--json']);
+	});
+
+	it('forwards the same flags for the preview command', () => {
+		const args = buildBackgroundArgs(
+			'preview',
+			makeFlags({ mode: 'staging', outDir: './build', silent: true }),
+		);
+		assert.deepEqual(args, ['preview', '--mode', 'staging', '--outDir', './build', '--silent']);
+	});
+});


### PR DESCRIPTION
## Changes

- `astro dev --background` (and, since #17174, `astro preview --background`) spawns a plain foreground child process, but `buildBackgroundArgs` only forwarded `--port`, `--host`, `--config`, `--root`, `--allowed-hosts`, and `--json`. The `--mode`, `--site`, `--base`, `--outDir`, `--verbose`, and `--silent` flags were silently dropped even though `flagsToAstroInlineConfig` consumes all of them, so a background server could behave differently from a foreground one started with the same flags (e.g. `astro dev --background --mode staging` starts the server in the default mode).
- Forwards the missing flags from `buildBackgroundArgs` in `packages/astro/src/cli/server.ts`. `--open`, `--force`, and `--ignore-lock` are intentionally not forwarded since they are handled at the parent level or don't apply to the child process.
- Same class of issue as #17158 (`--host` not taken into account with `--background`), for the remaining documented flags.
- Changeset included (`astro` patch).

Note on scope: this PR originally patched the argv builder inside `cli/dev/background.ts`. #17174 moved that builder to the shared `cli/server.ts` as `buildBackgroundArgs(command, flags)`, so after rebasing, the same one-place fix now covers both `astro dev --background` and `astro preview --background`. The dev-only helper this PR used to add is gone; nothing in #17174 forwarded the missing flags.

Reproduction (before, from `packages/astro/test/fixtures/astro-basic`):

```
$ node ../../../bin/astro.mjs dev --background --mode staging --port 4877
$ ps -p <pid> -o command
node .../bin/astro.mjs dev --port 4877 --json   # --mode dropped
```

After this change the child process argv is `dev --port 4877 --mode staging --json`.

## Testing

- Adds `test/units/cli/background-args.test.ts` (13 unit tests) covering the child argv mapping: defaults for both commands, port/host variants (`--host` with and without a value), config/root, allowed-hosts, each newly forwarded flag, that the same flags are forwarded for `preview`, and that `--background` itself is never passed to the child.
- Reverting only the `server.ts` hunk leaves 8 of those 13 tests passing and turns 5 red (`--mode`, `--site`/`--base`/`--outDir`, `--verbose`, `--silent`, and the `preview` case), so the new tests do guard exactly this change.
- Full `pnpm test:unit` on the rebased branch: 3287 tests, 3286 pass, 0 fail, 1 skipped (Node 24.18.0). `prettier --check`, `biome lint`, `biome check`, and `eslint` are clean on the touched files.
- Manually verified earlier on macOS that the spawned child process argv contains `--mode staging` (checked via `ps`), and that `astro dev stop` still works.

## Docs

No docs changes needed: this makes background mode honor already-documented `astro dev` / `astro preview` flags.
