### PR TITLE
fix: chuncked content collections

### DIFF
--- a/.changeset/old-pets-stand.md
+++ b/.changeset/old-pets-stand.md
@@ -1,0 +1,21 @@
+---
+'astro': patch
+---
+
+Adds a feature to `experimental.collectionStorage` that allows to change the size of chunks.
+
+For example, you can reduce the size of chunks to 1MB:
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  experimental: {
+    collectionStorage: {
+      type: 'chunked',
+      chunkSize: 1024 * 1024,
+    }
+  }
+})
+```

--- a/.changeset/pretty-animals-pick.md
+++ b/.changeset/pretty-animals-pick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a bug where Cloudflare couldn't load chunked collections via `experimental.collectionStorage: 'chunked'`.

--- a/packages/astro/src/content/consts.ts
+++ b/packages/astro/src/content/consts.ts
@@ -45,3 +45,8 @@ export const COLLECTIONS_DIR = 'collections/';
 
 export const CONTENT_LAYER_TYPE = 'content_layer';
 export const LIVE_CONTENT_TYPE = 'live';
+
+export const DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX = `${DATA_STORE_VIRTUAL_ID}-chunk:`;
+export const RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX = `\0${DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX}`;
+export const RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_SUFFIX = '.mjs';
+export const DATA_STORE_CHUNK_FILE_NAME_PATTERN = /^[a-f0-9]{16}\.txt$/;

--- a/packages/astro/src/content/data-store-writer.ts
+++ b/packages/astro/src/content/data-store-writer.ts
@@ -4,9 +4,6 @@ import xxhash, { type XXHashAPI } from 'xxhash-wasm';
 import { emptyDir } from '../core/fs/index.js';
 import { DATA_STORE_MANIFEST_FILE } from './consts.js';
 
-/** Maximum size, in UTF-8 bytes, of a single part file. */
-const CHUNK_SIZE_LIMIT = 20 * 1024 * 1024; // 20 MB
-
 /**
  * A chunked store manifest: each collection maps to the list of part file names
  * whose contents concatenate back into that collection's serialized string.
@@ -139,11 +136,13 @@ export class FileWriter implements DataStoreWriter {
 export class ChunkedWriter implements DataStoreWriter {
 	#dir: URL;
 	#manifestFile: URL;
+	#chunkSize: number;
 	#hasher?: XXHashAPI;
 
-	constructor(dir: URL) {
+	constructor(dir: URL, chunkSize: number) {
 		this.#dir = dir;
 		this.#manifestFile = new URL(`./${DATA_STORE_MANIFEST_FILE}`, dir);
+		this.#chunkSize = chunkSize;
 	}
 
 	async write(collections: Map<string, Map<string, any>>): Promise<void> {
@@ -161,7 +160,7 @@ export class ChunkedWriter implements DataStoreWriter {
 			const stringified = devalue.stringify(entries);
 			// Split the serialized collection so no single file grows unbounded.
 			const parts: string[] = [];
-			for (const part of chunkString(stringified, CHUNK_SIZE_LIMIT)) {
+			for (const part of chunkString(stringified, this.#chunkSize)) {
 				const fileName = `${h64ToString(part)}.txt`;
 				await writeFileAtomic(new URL(`./${fileName}`, this.#dir), part);
 				parts.push(fileName);

--- a/packages/astro/src/content/data-store.ts
+++ b/packages/astro/src/content/data-store.ts
@@ -89,9 +89,9 @@ export class ImmutableDataStore {
 	 * names have already been swapped for their contents.
 	 *
 	 * Each collection maps to a list of parts. A part is either a raw string
-	 * (when the store is loaded from disk) or an ESM namespace from a `?raw`
-	 * import (`{ default: string }`, when emitted into the virtual module at
-	 * runtime). A collection's parts are concatenated back into the exact
+	 * (when the store is loaded from disk) or an ESM namespace from a virtual
+	 * chunk import (`{ default: string }`, when emitted at runtime). A collection's
+	 * parts are concatenated back into the exact
 	 * serialized string, then parsed with devalue. This is the inverse of
 	 * {@link import('./data-store-writer.js').ChunkedWriter} and stays free of
 	 * Node built-ins so it can run at runtime.

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -507,13 +507,13 @@ export default new Map([\n${lines.join(',\n')}]);
 	}
 
 	/**
-	 * Loads a MutableDataStore from a chunked store directory (experimental
-	 * `collectionStorage: 'chunked'`), reading the manifest and its referenced parts.
+	 * Loads a MutableDataStore from a chunked store directory, reading the manifest
+	 * and its referenced parts.
 	 * If the directory has no manifest yet (fresh build) it starts empty. If the
 	 * manifest exists but can't be read (corrupt cache), it warns and starts
 	 * empty so loaders rebuild it, rather than failing the sync.
 	 */
-	static async fromDir(dirPath: URL) {
+	static async fromDir(dirPath: URL, chunkSize: number) {
 		const manifestFile = new URL(`./${DATA_STORE_MANIFEST_FILE}`, dirPath);
 		if (existsSync(manifestFile)) {
 			try {
@@ -530,7 +530,7 @@ export default new Map([\n${lines.join(',\n')}]);
 				}
 				const map = ImmutableDataStore.manifestToMap(expanded);
 				const store = await MutableDataStore.fromMap(map);
-				store.#writer = new ChunkedWriter(dirPath);
+				store.#writer = new ChunkedWriter(dirPath, chunkSize);
 				return store;
 			} catch (err) {
 				// The manifest exists but couldn't be read/parsed, or a referenced
@@ -545,7 +545,7 @@ export default new Map([\n${lines.join(',\n')}]);
 		// Fresh build, or recovering from a corrupt cache: start empty.
 		await fs.mkdir(dirPath, { recursive: true });
 		const store = new MutableDataStore();
-		store.#writer = new ChunkedWriter(dirPath);
+		store.#writer = new ChunkedWriter(dirPath, chunkSize);
 		return store;
 	}
 }

--- a/packages/astro/src/content/paths.ts
+++ b/packages/astro/src/content/paths.ts
@@ -12,11 +12,16 @@ export function getDataStoreFile(settings: AstroSettings, isDev: boolean) {
 
 export function getDataStoreChunkSize(settings: AstroSettings) {
 	const storage = settings.config.experimental.collectionStorage;
-	if (storage === undefined || storage === 'single-file') return undefined;
+	// Single file doesn't have a chunk size
+	if (storage === undefined || storage === 'single-file') {
+		return undefined;
+	}
+	// Here we handle the case where users specified only 'chunked' in their config. By default, it's 20MB
 	if (storage === 'chunked') {
 		// Defaults to 20MB
 		return 20 * 1024 * 1024;
 	}
+	// This is the object variant. `chunkSize` is mandatory.
 	return storage.chunkSize;
 }
 

--- a/packages/astro/src/content/paths.ts
+++ b/packages/astro/src/content/paths.ts
@@ -10,9 +10,19 @@ export function getDataStoreFile(settings: AstroSettings, isDev: boolean) {
 	return new URL(DATA_STORE_FILE, isDev ? settings.dotAstroDir : settings.config.cacheDir);
 }
 
+export function getDataStoreChunkSize(settings: AstroSettings) {
+	const storage = settings.config.experimental.collectionStorage;
+	if (storage === undefined || storage === 'single-file') return undefined;
+	if (storage === 'chunked') {
+		// Defaults to 20MB
+		return 20 * 1024 * 1024;
+	}
+	return storage.chunkSize;
+}
+
 /**
  * Get the path to the data store directory, used when the store is split across
- * multiple files (experimental `collectionStorage: 'chunked'`).
+ * multiple files.
  * During development, this is in the `.astro` directory so that the Vite watcher can see it.
  * In production, it's in the cache directory so that it's preserved between builds.
  */

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -15,16 +15,20 @@ import {
 	ASSET_IMPORTS_VIRTUAL_ID,
 	CONTENT_MODULE_FLAG,
 	CONTENT_RENDER_FLAG,
+	DATA_STORE_CHUNK_FILE_NAME_PATTERN,
+	DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX,
 	DATA_STORE_MANIFEST_FILE,
 	DATA_STORE_VIRTUAL_ID,
 	MODULES_IMPORTS_FILE,
 	MODULES_MJS_ID,
 	MODULES_MJS_VIRTUAL_ID,
+	RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX,
+	RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_SUFFIX,
 	RESOLVED_DATA_STORE_VIRTUAL_ID,
 	RESOLVED_VIRTUAL_MODULE_ID,
 	VIRTUAL_MODULE_ID,
 } from './consts.js';
-import { getDataStoreDir, getDataStoreFile } from './paths.js';
+import { getDataStoreChunkSize, getDataStoreDir, getDataStoreFile } from './paths.js';
 import { getContentPaths, isDeferredModule } from './utils.js';
 
 /**
@@ -118,11 +122,11 @@ export function astroContentVirtualModPlugin({
 		enforce: 'pre',
 		config(_, env) {
 			isDev = env.command === 'serve';
-			if (settings.config.experimental.collectionStorage === 'chunked') {
-				dataStoreDir = getDataStoreDir(settings, env.command === 'serve');
+			dataStoreDir = getDataStoreDir(settings, isDev);
+			if (getDataStoreChunkSize(settings) !== undefined) {
 				dataStoreFile = new URL(DATA_STORE_MANIFEST_FILE, dataStoreDir);
 			} else {
-				dataStoreFile = getDataStoreFile(settings, env.command === 'serve');
+				dataStoreFile = getDataStoreFile(settings, isDev);
 			}
 			const contentPaths = getContentPaths(
 				settings.config,
@@ -148,7 +152,7 @@ export function astroContentVirtualModPlugin({
 		resolveId: {
 			filter: {
 				id: new RegExp(
-					`^(${VIRTUAL_MODULE_ID}|${DATA_STORE_VIRTUAL_ID}|${MODULES_MJS_ID}|${ASSET_IMPORTS_VIRTUAL_ID})$|(?:\\?|&)${CONTENT_MODULE_FLAG}(?:&|=|$)`,
+					`^(${VIRTUAL_MODULE_ID}|${DATA_STORE_VIRTUAL_ID}|${MODULES_MJS_ID}|${ASSET_IMPORTS_VIRTUAL_ID})$|^${DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX}|(?:\\?|&)${CONTENT_MODULE_FLAG}(?:&|=|$)`,
 				),
 			},
 			async handler(id, importer) {
@@ -165,6 +169,13 @@ export function astroContentVirtualModPlugin({
 				}
 				if (id === DATA_STORE_VIRTUAL_ID) {
 					return RESOLVED_DATA_STORE_VIRTUAL_ID;
+				}
+				if (id.startsWith(DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX)) {
+					const fileName = id.slice(DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX.length);
+					if (!DATA_STORE_CHUNK_FILE_NAME_PATTERN.test(fileName)) {
+						this.error(`Invalid data-store chunk: ${fileName}`);
+					}
+					return `${RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX}${fileName}${RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_SUFFIX}`;
 				}
 
 				if (isDeferredModule(id)) {
@@ -200,10 +211,31 @@ export function astroContentVirtualModPlugin({
 		load: {
 			filter: {
 				id: new RegExp(
-					`^(${RESOLVED_VIRTUAL_MODULE_ID}|${RESOLVED_DATA_STORE_VIRTUAL_ID}|${ASSET_IMPORTS_RESOLVED_STUB_ID}|${MODULES_MJS_VIRTUAL_ID})$`,
+					`^(${RESOLVED_VIRTUAL_MODULE_ID}|${RESOLVED_DATA_STORE_VIRTUAL_ID}|${ASSET_IMPORTS_RESOLVED_STUB_ID}|${MODULES_MJS_VIRTUAL_ID})$|^${RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX}`,
 				),
 			},
 			async handler(id) {
+				if (id.startsWith(RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX)) {
+					const resolvedFileName = id.slice(RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX.length);
+					if (!resolvedFileName.endsWith(RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_SUFFIX)) {
+						this.error(`Invalid data-store chunk: ${resolvedFileName}`);
+					}
+					const fileName = resolvedFileName.slice(
+						0,
+						-RESOLVED_DATA_STORE_CHUNK_VIRTUAL_ID_SUFFIX.length,
+					);
+					if (!DATA_STORE_CHUNK_FILE_NAME_PATTERN.test(fileName)) {
+						this.error(`Invalid data-store chunk: ${fileName}`);
+					}
+					const contents = await fs.promises.readFile(
+						new URL(`./${fileName}`, dataStoreDir),
+						'utf-8',
+					);
+					return {
+						code: `export default ${JSON.stringify(contents)}`,
+						map: { mappings: '' },
+					};
+				}
 				if (id === RESOLVED_VIRTUAL_MODULE_ID) {
 					const isClient = isAstroClientEnvironment(this.environment);
 					const code = await generateContentEntryFile({
@@ -227,23 +259,18 @@ export function astroContentVirtualModPlugin({
 					}
 					const jsonData = await fs.promises.readFile(dataStoreFile, 'utf-8');
 
-					if (settings.config.experimental.collectionStorage === 'chunked') {
+					if (getDataStoreChunkSize(settings) !== undefined) {
 						try {
 							const manifest: Record<string, string[]> = JSON.parse(jsonData);
-							// Emit each part as a lazy `?raw` import so the parts stay separate
+							// Emit each part as a lazy virtual import so the parts stay separate
 							// chunks instead of being inlined into one huge module (the very
 							// thing chunking avoids). manifestToMap reads the resolved
 							// namespace's `default` export back into the concatenated string.
-							const rawImport = (fileName: string) => {
-								const path = rootRelativePath(
-									settings.config.root,
-									new URL(`./${fileName}`, dataStoreDir),
-								);
-								return `(await import(${JSON.stringify(`${path}?raw`)}))`;
-							};
+							const chunkImport = (fileName: string) =>
+								`(await import(${JSON.stringify(`${DATA_STORE_CHUNK_VIRTUAL_ID_PREFIX}${fileName}`)}))`;
 							const entries = Object.entries(manifest).map(
 								([collection, parts]) =>
-									`${JSON.stringify(collection)}:[${parts.map(rawImport).join(',')}]`,
+									`${JSON.stringify(collection)}:[${parts.map(chunkImport).join(',')}]`,
 							);
 							const code = `export default{${entries.join(',')}}`;
 							return { code, map: { mappings: '' } };

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -523,7 +523,14 @@ export const AstroConfigSchema = z.object({
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.chromeDevtoolsWorkspace),
 			svgOptimizer: SvgOptimizerSchema.optional(),
 			collectionStorage: z
-				.enum(['single-file', 'chunked'])
+				.union([
+					z.literal('single-file'),
+					z.literal('chunked'),
+					z.strictObject({
+						type: z.literal('chunked'),
+						chunkSize: z.number().int().positive(),
+					}),
+				])
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.collectionStorage),
 		})

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -5,7 +5,7 @@ import { performance } from 'node:perf_hooks';
 import colors from 'piccolore';
 import { gt, major, minor, patch } from 'semver';
 import type * as vite from 'vite';
-import { getDataStoreDir, getDataStoreFile } from '../../content/paths.js';
+import { getDataStoreChunkSize, getDataStoreDir, getDataStoreFile } from '../../content/paths.js';
 import { globalContentLayer } from '../../content/instance.js';
 import { attachContentServerListeners } from '../../content/index.js';
 import { MutableDataStore } from '../../content/mutable-data-store.js';
@@ -91,9 +91,10 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 
 	let store: MutableDataStore | undefined;
 	try {
-		if (restart.container.settings.config.experimental.collectionStorage === 'chunked') {
+		const chunkSize = getDataStoreChunkSize(restart.container.settings);
+		if (chunkSize !== undefined) {
 			const dataStoreDir = getDataStoreDir(restart.container.settings, true);
-			store = await MutableDataStore.fromDir(dataStoreDir);
+			store = await MutableDataStore.fromDir(dataStoreDir, chunkSize);
 		} else {
 			const dataStoreFile = getDataStoreFile(restart.container.settings, true);
 			store = await MutableDataStore.fromFile(dataStoreFile);

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -6,7 +6,7 @@ import colors from 'piccolore';
 import { createServer, type FSWatcher, type HotPayload, type ViteDevServer } from 'vite';
 import { syncFonts } from '../../assets/fonts/sync.js';
 import { CONTENT_TYPES_FILE } from '../../content/consts.js';
-import { getDataStoreDir, getDataStoreFile } from '../../content/paths.js';
+import { getDataStoreChunkSize, getDataStoreDir, getDataStoreFile } from '../../content/paths.js';
 import { globalContentLayer } from '../../content/instance.js';
 import { createContentTypesGenerator } from '../../content/index.js';
 import { MutableDataStore } from '../../content/mutable-data-store.js';
@@ -96,7 +96,7 @@ export async function clearContentLayerCache({
 	fs?: typeof fsMod;
 	isDev: boolean;
 }) {
-	if (settings.config.experimental.collectionStorage === 'chunked') {
+	if (getDataStoreChunkSize(settings) !== undefined) {
 		const dataStore = getDataStoreDir(settings, isDev);
 		if (fs.existsSync(dataStore)) {
 			logger.debug('content', 'clearing data store');
@@ -149,9 +149,10 @@ export async function syncInternal({
 
 			let store: MutableDataStore | undefined;
 			try {
-				if (settings.config.experimental.collectionStorage === 'chunked') {
+				const chunkSize = getDataStoreChunkSize(settings);
+				if (chunkSize !== undefined) {
 					const dataStoreDir = getDataStoreDir(settings, isDev);
-					store = await MutableDataStore.fromDir(dataStoreDir);
+					store = await MutableDataStore.fromDir(dataStoreDir, chunkSize);
 				} else {
 					const dataStoreFile = getDataStoreFile(settings, isDev);
 					store = await MutableDataStore.fromFile(dataStoreFile);

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -3292,7 +3292,7 @@ export interface AstroUserConfig<
 
 		/**
 		 * @name experimental.collectionStorage
-		 * @type {'single-file' | 'chunked'}
+		 * @type {'single-file' | 'chunked' | { type: 'chunked', chunkSize: number }}
 		 * @default `'single-file'`
 		 * @version 7.1.0
 		 * @description
@@ -3303,22 +3303,34 @@ export interface AstroUserConfig<
 		 * file. For very large content collections, this file can grow large
 		 * enough to hit platform file-size limits.
 		 *
-		 * When set to `'chunked'`, the store is split across many smaller,
-		 * content-addressed files so that no single file grows unbounded.
+		 * When set to `'chunked'`, the store is split into files
+		 * with a maximum size of 20 MiB each. To customize the maximum size,
+		 * pass an object with `type: 'chunked'` and `chunkSize`. A 1 MiB limit
+		 * is recommended for broad adapter compatibility.
 		 *
 		 * ```js
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
 		 *   experimental: {
-		 *     collectionStorage: 'chunked',
+		 *     collectionStorage: {
+		 *       type: 'chunked',
+		 *       chunkSize: 1024 * 1024,
+		 *     },
 		 *   },
 		 * });
 		 * ```
 		 *
 		 * See the [experimental data store chunking documentation](https://docs.astro.build/en/reference/experimental-flags/collection-storage/) for more information.
 		 */
-		collectionStorage?: 'single-file' | 'chunked';
+		collectionStorage?:
+			| 'single-file'
+			| 'chunked'
+			| {
+					type: 'chunked';
+					/** Maximum UTF-8 byte size of each data store chunk. */
+					chunkSize: number;
+			  };
 	};
 }
 

--- a/packages/astro/test/content-collections-chunked.test.ts
+++ b/packages/astro/test/content-collections-chunked.test.ts
@@ -5,7 +5,7 @@ import { type Fixture, loadFixture } from './test-utils.ts';
 
 // End-to-end coverage for the experimental chunked data store. Building the
 // fixture exercises the full pipeline: the ChunkedWriter serializes the store to
-// content-addressed parts, the content virtual module emits them as lazy `?raw`
+// content-addressed parts, the content virtual module emits them as lazy virtual
 // imports, and `getCollection` reassembles them at runtime via `manifestToMap`.
 describe('Content Collections (chunked data store)', () => {
 	let fixture: Fixture;

--- a/packages/astro/test/test-utils.ts
+++ b/packages/astro/test/test-utils.ts
@@ -200,7 +200,7 @@ export async function loadFixture(inlineConfig: AstroInlineConfig): Promise<Fixt
 			}
 
 			const dataStoreFile = path.join(root as string, '.astro', 'data-store.json');
-			// In chunked mode (experimental `collectionStorage: 'chunked'`) the store is a
+			// In chunked mode the store is a
 			// directory whose manifest is written last, so a manifest change marks a
 			// completed store update.
 			const dataStoreManifestFile = path.join(

--- a/packages/astro/test/units/config/config-validate.test.ts
+++ b/packages/astro/test/units/config/config-validate.test.ts
@@ -706,4 +706,39 @@ describe('Config Validation', () => {
 			);
 		});
 	});
+
+	describe('experimental.collectionStorage', () => {
+		it('accepts the chunked shorthand', async () => {
+			const result = await validateConfig({
+				experimental: { collectionStorage: 'chunked' },
+			});
+
+			assert.equal(result.experimental.collectionStorage, 'chunked');
+		});
+
+		it('accepts a positive integer chunk size', async () => {
+			const result = await validateConfig({
+				experimental: {
+					collectionStorage: { type: 'chunked', chunkSize: 1024 * 1024 },
+				},
+			});
+
+			assert.deepEqual(result.experimental.collectionStorage, {
+				type: 'chunked',
+				chunkSize: 1024 * 1024,
+			});
+		});
+
+		it('rejects invalid chunk sizes', async () => {
+			for (const chunkSize of [0, -1, 1.5]) {
+				const configError = await validateConfig({
+					experimental: {
+						collectionStorage: { type: 'chunked', chunkSize },
+					},
+				}).catch((error) => error);
+
+				assert.equal(configError instanceof z.ZodError, true);
+			}
+		});
+	});
 });

--- a/packages/astro/test/units/content-layer/content-virtual-mod.test.ts
+++ b/packages/astro/test/units/content-layer/content-virtual-mod.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
 import nodeFs from 'node:fs';
+import { describe, it } from 'node:test';
 import { astroContentVirtualModPlugin } from '../../../dist/content/vite-plugin-content-virtual-mod.js';
 import { createMinimalSettings, createTempDir } from './test-helpers.ts';
 
@@ -49,6 +49,89 @@ function createMockViteDevServer() {
 }
 
 describe('astroContentVirtualModPlugin', () => {
+	it('loads chunk files through validated virtual modules', async () => {
+		const root = createTempDir('content-virtual-mod-chunks-test-');
+		const dataStoreDir = new URL('./.astro/data-store/', root);
+		const fileName = '0123456789abcdef.txt';
+		const contents = 'serialized data\nwith "quotes"';
+		await nodeFs.promises.mkdir(dataStoreDir, { recursive: true });
+		await nodeFs.promises.writeFile(new URL(fileName, dataStoreDir), contents);
+		await nodeFs.promises.writeFile(
+			new URL('manifest.json', dataStoreDir),
+			JSON.stringify({ entries: [fileName] }),
+		);
+
+		const settings = createMinimalSettings(root, {
+			config: {
+				experimental: {
+					collectionStorage: { type: 'chunked', chunkSize: 1024 },
+				},
+				legacy: {},
+			},
+		});
+		const plugin = astroContentVirtualModPlugin({ settings, fs: nodeFs });
+		// @ts-expect-error - mock args are sufficient for this test
+		plugin.config?.({}, { command: 'serve' });
+		assert.ok(plugin.resolveId && typeof plugin.resolveId === 'object');
+		assert.ok(plugin.load && typeof plugin.load === 'object');
+
+		const context = {
+			error(message: string) {
+				throw new Error(message);
+			},
+		};
+		const chunkId = `astro:data-layer-content-chunk:${fileName}`;
+		// @ts-expect-error - mock context supplies the hook behavior this path uses
+		const resolvedChunkId = await plugin.resolveId.handler.call(context, chunkId);
+		assert.equal(resolvedChunkId, `\0${chunkId}.mjs`);
+
+		// @ts-expect-error - mock context supplies the hook behavior this path uses
+		const chunkModule = await plugin.load.handler.call(context, resolvedChunkId);
+		assert.deepEqual(chunkModule, {
+			code: `export default ${JSON.stringify(contents)}`,
+			map: { mappings: '' },
+		});
+
+		// @ts-expect-error - mock context supplies the hook behavior this path uses
+		const storeModule = await plugin.load.handler.call(context, '\0astro:data-layer-content');
+		assert.ok(storeModule && typeof storeModule === 'object' && 'code' in storeModule);
+		assert.match(storeModule.code, /astro:data-layer-content-chunk:0123456789abcdef\.txt/);
+		assert.doesNotMatch(storeModule.code, /\?raw/);
+	});
+
+	it('rejects invalid chunk virtual module IDs', async () => {
+		const root = createTempDir('content-virtual-mod-invalid-chunk-test-');
+		const settings = createMinimalSettings(root, {
+			config: {
+				experimental: {
+					collectionStorage: { type: 'chunked', chunkSize: 1024 },
+				},
+				legacy: {},
+			},
+		});
+		const plugin = astroContentVirtualModPlugin({ settings, fs: nodeFs });
+		// @ts-expect-error - mock args are sufficient for this test
+		plugin.config?.({}, { command: 'serve' });
+		assert.ok(plugin.resolveId && typeof plugin.resolveId === 'object');
+		assert.ok(plugin.load && typeof plugin.load === 'object');
+		const context = {
+			error(message: string) {
+				throw new Error(message);
+			},
+		};
+
+		await assert.rejects(
+			// @ts-expect-error - mock context supplies the hook behavior this path uses
+			plugin.resolveId.handler.call(context, 'astro:data-layer-content-chunk:../../secret.txt'),
+			/Invalid data-store chunk/,
+		);
+		await assert.rejects(
+			// @ts-expect-error - mock context supplies the hook behavior this path uses
+			plugin.load.handler.call(context, '\0astro:data-layer-content-chunk:../../secret.txt.mjs'),
+			/Invalid data-store chunk/,
+		);
+	});
+
 	it('does not send full-reload to client during buildStart', () => {
 		const root = createTempDir('content-virtual-mod-test-');
 		const settings = createMinimalSettings(root, {

--- a/packages/astro/test/units/content-layer/paths.test.ts
+++ b/packages/astro/test/units/content-layer/paths.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getDataStoreChunkSize } from '../../../dist/content/paths.js';
+import { createMinimalSettings, createTempDir } from './test-helpers.ts';
+
+describe('getDataStoreChunkSize', () => {
+	it('uses the previous limit for the chunked shorthand', () => {
+		const settings = createMinimalSettings(createTempDir(), {
+			config: { experimental: { collectionStorage: 'chunked' } },
+		});
+
+		assert.equal(getDataStoreChunkSize(settings), 20 * 1024 * 1024);
+	});
+
+	it('uses the configured chunk size', () => {
+		const settings = createMinimalSettings(createTempDir(), {
+			config: {
+				experimental: {
+					collectionStorage: { type: 'chunked', chunkSize: 1024 },
+				},
+			},
+		});
+
+		assert.equal(getDataStoreChunkSize(settings), 1024);
+	});
+});

--- a/packages/astro/test/units/content-layer/store-persistence.test.ts
+++ b/packages/astro/test/units/content-layer/store-persistence.test.ts
@@ -6,6 +6,8 @@ import { DATA_STORE_MANIFEST_FILE } from '../../../dist/content/consts.js';
 import { MutableDataStore } from '../../../dist/content/mutable-data-store.js';
 import { createTempDir } from './test-helpers.ts';
 
+const CHUNK_SIZE = 1024 * 1024;
+
 describe('Content Layer - Store Persistence', () => {
 	it('updates the store on new builds', async () => {
 		const tempDir = createTempDir();
@@ -219,7 +221,7 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		const dataStoreDir = new URL('./data-store/', tempDir);
 
 		// First build - create initial data and write it to the chunked store.
-		const store1 = await MutableDataStore.fromDir(dataStoreDir);
+		const store1 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store1.set('dogs', 'beagle', {
 			id: 'beagle',
 			data: { breed: 'Beagle', temperament: ['Friendly'] },
@@ -227,7 +229,7 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		await store1.waitUntilSaveComplete();
 
 		// Second build - load from the directory and verify existing data persists.
-		const store2 = await MutableDataStore.fromDir(dataStoreDir);
+		const store2 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		const beagle = store2.get('dogs', 'beagle');
 		assert.ok(beagle);
 		assert.equal(beagle.data.breed, 'Beagle');
@@ -240,7 +242,7 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		await store2.waitUntilSaveComplete();
 
 		// Third build - verify both entries exist.
-		const store3 = await MutableDataStore.fromDir(dataStoreDir);
+		const store3 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		assert.equal(store3.values('dogs').length, 2);
 		assert.ok(store3.get('dogs', 'beagle'));
 		assert.ok(store3.get('dogs', 'poodle'));
@@ -251,7 +253,7 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		const dataStoreDir = new URL('./data-store/', tempDir);
 
 		// First build - create data across two collections.
-		const store1 = await MutableDataStore.fromDir(dataStoreDir);
+		const store1 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store1.set('dogs', 'beagle', { id: 'beagle', data: { breed: 'Beagle' } });
 		store1.metaStore().set('content-config-digest', 'digest1');
 		await store1.waitUntilSaveComplete();
@@ -263,13 +265,13 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		assert.ok(partsAfterFirst.length > 0, 'expected the first snapshot to write part files');
 
 		// Second build - clear everything and write different data.
-		const store2 = await MutableDataStore.fromDir(dataStoreDir);
+		const store2 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store2.clearAll();
 		store2.set('cats', 'siamese', { id: 'siamese', data: { breed: 'Siamese' } });
 		await store2.waitUntilSaveComplete();
 
 		// Old data is gone, new data exists.
-		const store3 = await MutableDataStore.fromDir(dataStoreDir);
+		const store3 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		assert.equal(store3.values('dogs').length, 0);
 		assert.equal(store3.values('cats').length, 1);
 		assert.ok(store3.get('cats', 'siamese'));
@@ -291,7 +293,7 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		const dataStoreDir = new URL('./data-store/', tempDir);
 
 		// First build - an entry that references another collection.
-		const store1 = await MutableDataStore.fromDir(dataStoreDir);
+		const store1 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store1.set('cats', 'siamese', { id: 'siamese', data: { breed: 'Siamese' } });
 		store1.set('posts', 'post1', {
 			id: 'post1',
@@ -300,7 +302,7 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		await store1.waitUntilSaveComplete();
 
 		// Second build - rename the referenced entry and update the reference.
-		const store2 = await MutableDataStore.fromDir(dataStoreDir);
+		const store2 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store2.delete('cats', 'siamese');
 		store2.set('cats', 'siamese-cat', { id: 'siamese-cat', data: { breed: 'Siamese' } });
 		const post: any = store2.get('posts', 'post1');
@@ -309,7 +311,7 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 		await store2.waitUntilSaveComplete();
 
 		// Cross-collection references survive the chunk split and rejoin.
-		const store3 = await MutableDataStore.fromDir(dataStoreDir);
+		const store3 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		assert.ok(!store3.get('cats', 'siamese'));
 		assert.ok(store3.get('cats', 'siamese-cat'));
 		const updatedPost: any = store3.get('posts', 'post1');
@@ -330,11 +332,11 @@ describe('Content Layer - Store Persistence (chunked)', () => {
 			accented: 'café déjà vu',
 		};
 
-		const store1 = await MutableDataStore.fromDir(dataStoreDir);
+		const store1 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store1.set('notes', 'unicode', { id: 'unicode', data: richData });
 		await store1.waitUntilSaveComplete();
 
-		const store2 = await MutableDataStore.fromDir(dataStoreDir);
+		const store2 = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		const entry: any = store2.get('notes', 'unicode');
 		assert.ok(entry);
 		assert.deepEqual(entry.data, richData);
@@ -363,7 +365,7 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		const tempDir = createTempDir();
 		const dataStoreDir = new URL('./data-store/', tempDir);
 
-		const store = await MutableDataStore.fromDir(dataStoreDir);
+		const store = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store.set('pets', 'cat', { id: 'cat', data: { legs: 4 } });
 		// `writeToDisk()` runs synchronously up to its first internal await, so it
 		// leaves `#writeInProgress` set and returns a pending promise.
@@ -376,7 +378,7 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		await store.waitUntilSaveComplete();
 
 		// The final on-disk snapshot has both entries.
-		const reloaded = await MutableDataStore.fromDir(dataStoreDir);
+		const reloaded = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		assert.equal(reloaded.values('pets').length, 2);
 		assert.ok(reloaded.get('pets', 'cat'));
 		assert.ok(reloaded.get('pets', 'dog'));
@@ -398,7 +400,7 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		const tempDir = createTempDir();
 		const dataStoreDir = new URL('./data-store/', tempDir);
 
-		const store = await MutableDataStore.fromDir(dataStoreDir);
+		const store = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store.set('pets', 'cat', { id: 'cat', data: { legs: 4 } });
 		await store.waitUntilSaveComplete();
 
@@ -408,7 +410,7 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		await fs.writeFile(orphan, 'written before the manifest was committed');
 
 		// Loading uses only the manifest, so the committed snapshot is intact.
-		const reloaded = await MutableDataStore.fromDir(dataStoreDir);
+		const reloaded = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		assert.equal(reloaded.values('pets').length, 1);
 		assert.ok(reloaded.get('pets', 'cat'));
 
@@ -425,7 +427,7 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		const tempDir = createTempDir();
 		const dataStoreDir = new URL('./data-store/', tempDir);
 
-		const store = await MutableDataStore.fromDir(dataStoreDir);
+		const store = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		store.set('pets', 'cat', { id: 'cat', data: { legs: 4 } });
 		await store.waitUntilSaveComplete();
 
@@ -436,7 +438,7 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		const warn = mock.method(console, 'warn', () => {});
 		let reloaded: MutableDataStore;
 		try {
-			reloaded = await MutableDataStore.fromDir(dataStoreDir);
+			reloaded = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		} finally {
 			warn.mock.restore();
 		}
@@ -452,7 +454,7 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		const tempDir = createTempDir();
 		const dataStoreDir = new URL('./data-store/', tempDir);
 
-		const store = await MutableDataStore.fromDir(dataStoreDir);
+		const store = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
 		// Two collections whose serialized chunk is byte-for-byte identical (the
 		// collection name is a manifest key, not part of the serialized content).
 		const entry = { id: 'x', data: { value: 1 } };

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -33,6 +33,7 @@ import cfPrismPlugin from './vite-plugin-prism.js';
 import { loadWranglerEnv } from './utils/wrangler-config.js';
 
 const CLOUDFLARE_KV_SESSION_DRIVER_ENTRYPOINT = sessionDrivers.cloudflareKVBinding().entrypoint;
+const CONTENT_CHUNK_SIZE = 1024 * 1024;
 
 function usesCloudflareKVSessionDriver(session: AstroConfig['session']): boolean {
 	const driver = session?.driver;
@@ -276,6 +277,11 @@ export default function createIntegration({
 				}
 
 				updateConfig({
+					...(config.experimental.collectionStorage === 'chunked' && {
+						experimental: {
+							collectionStorage: { type: 'chunked', chunkSize: CONTENT_CHUNK_SIZE },
+						},
+					}),
 					build: {
 						redirects: false,
 					},

--- a/packages/integrations/cloudflare/test/content-collections-chunked.test.ts
+++ b/packages/integrations/cloudflare/test/content-collections-chunked.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { after, before, describe, it } from 'node:test';
+import cloudflare from '../dist/index.js';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+
+describe('Chunked collection storage', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/content-collections-chunked/',
+			outDir: './dist/chunked/',
+			adapter: cloudflare(),
+			output: 'server',
+			experimental: { collectionStorage: 'chunked' },
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('loads a multi-chunk entry in workerd development', async () => {
+		const manifest = JSON.parse(
+			await readFile(new URL('./.astro/data-store/manifest.json', fixture.config.root), 'utf-8'),
+		) as Record<string, string[]>;
+		assert.ok(new Set(manifest.generated).size > 1);
+
+		const response = await fixture.fetch('/');
+		assert.equal(response.status, 200);
+	});
+});

--- a/packages/integrations/cloudflare/test/fixtures/content-collections-chunked/src/content.config.ts
+++ b/packages/integrations/cloudflare/test/fixtures/content-collections-chunked/src/content.config.ts
@@ -1,0 +1,11 @@
+import { defineCollection } from 'astro:content';
+
+const generated = defineCollection({
+	loader: () => ({
+		entry: {
+			payload: ['a', 'b', 'c'].map((character) => character.repeat(1024 * 1024)).join(''),
+		},
+	}),
+});
+
+export const collections = { generated };

--- a/packages/integrations/cloudflare/test/fixtures/content-collections-chunked/src/pages/index.ts
+++ b/packages/integrations/cloudflare/test/fixtures/content-collections-chunked/src/pages/index.ts
@@ -1,0 +1,12 @@
+import { getEntry } from 'astro:content';
+
+export const prerender = false;
+
+export async function GET() {
+	const entry = await getEntry('generated', 'entry');
+	if (entry?.data.payload.length !== 3 * 1024 * 1024) {
+		return new Response('Invalid collection entry', { status: 500 });
+	}
+
+	return new Response('ok');
+}


### PR DESCRIPTION
## Changes

This PR fixes two bugs related to `collectionStorage`:
- The  chunks were loaded via  `.txt?raw`, and this triggered workderd runtime somehow, causing problems during the loading. This PR changes by moving the loading via vite
- Adds a new feature to the experimental feature. With `workerd`, there's a limit to the size of the assets. This PR adds a new variant of the config that allows changing the limit
- The CF integration now uses that new variant, so that sets a limit to 1MB when only `'chunked` variant is passed

## Testing

Added new tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/14311

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
