### PR TITLE
fix(client-router): reuse the response downloaded by prefetch on navigation

### DIFF
--- a/.changeset/mighty-pandas-brake.md
+++ b/.changeset/mighty-pandas-brake.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a bug where `<ClientRouter />` downloaded a page a second time even though prefetching had just downloaded it. The router now reuses the response of a recent prefetch instead of going back to the network for pages that are served without cache headers, such as on-demand rendered pages.
+Fixes a bug where `<ClientRouter />` downloaded a page a second time even though prefetching had just downloaded it. The router now reuses (once per prefetch) the response of a recent prefetch instead of going back to the network for pages that are served without cache headers, such as on-demand rendered pages.

--- a/.changeset/mighty-pandas-brake.md
+++ b/.changeset/mighty-pandas-brake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where `<ClientRouter />` downloaded a page a second time even though prefetching had just downloaded it. The router now reuses the response of a recent prefetch instead of going back to the network for pages that are served without cache headers, such as on-demand rendered pages.

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -3,7 +3,7 @@
 */
 
 import { internalFetchHeaders } from 'virtual:astro:adapter-config/client';
-import { hasBeenPrefetched, recordPrefetch } from './registry.js';
+import { hasBeenPrefetched, normalizePrefetchUrl, recordPrefetch } from './registry.js';
 
 const debug = import.meta.env.DEV ? console.debug : undefined;
 const inBrowser = import.meta.env.SSR === false;
@@ -218,7 +218,9 @@ export interface PrefetchOptions {
  */
 export function prefetch(url: string, opts?: PrefetchOptions) {
 	// Remove url hash to avoid prefetching the same URL multiple times
-	url = url.replace(/#.*/, '');
+	// One normalization for the link href, the speculation rules, and the registry key
+	// (also resolves against location.href rather than a potentially divergent <base href>).
+	url = normalizePrefetchUrl(url);
 
 	const ignoreSlowConnection = opts?.ignoreSlowConnection ?? false;
 	if (!canPrefetchUrl(url, ignoreSlowConnection)) return;

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -3,11 +3,10 @@
 */
 
 import { internalFetchHeaders } from 'virtual:astro:adapter-config/client';
+import { hasBeenPrefetched, recordPrefetch } from './registry.js';
 
 const debug = import.meta.env.DEV ? console.debug : undefined;
 const inBrowser = import.meta.env.SSR === false;
-// Track prefetched URLs so we don't prefetch twice
-const prefetchedUrls = new Set<string>();
 // Track listened anchors so we don't attach duplicated listeners
 const listenedAnchors = new WeakSet<HTMLAnchorElement>();
 
@@ -223,7 +222,7 @@ export function prefetch(url: string, opts?: PrefetchOptions) {
 
 	const ignoreSlowConnection = opts?.ignoreSlowConnection ?? false;
 	if (!canPrefetchUrl(url, ignoreSlowConnection)) return;
-	prefetchedUrls.add(url);
+	recordPrefetch(url);
 
 	// Prefetch with speculationrules if `clientPrerender` is enabled and supported
 	// NOTE: This condition is tree-shaken if `clientPrerender` is false as its a static value
@@ -267,7 +266,7 @@ function canPrefetchUrl(url: string, ignoreSlowConnection: boolean) {
 		return (
 			location.origin === urlObj.origin &&
 			(location.pathname !== urlObj.pathname || location.search !== urlObj.search) &&
-			!prefetchedUrls.has(url)
+			!hasBeenPrefetched(url)
 		);
 	} catch {}
 	return false;

--- a/packages/astro/src/prefetch/registry.ts
+++ b/packages/astro/src/prefetch/registry.ts
@@ -1,0 +1,48 @@
+/*
+  NOTE: This module is shared between the prefetch script (`astro:prefetch`) and the view
+  transitions router (`astro:transitions/client`). Keep it small and dependency-free so that
+  importing it from the router does not pull the prefetch script into bundles that don't use it.
+*/
+
+// The number of milliseconds after a URL is prefetched during which the router may reuse
+// the response the prefetch downloaded without revalidating it. This matches the window
+// Chromium applies to its own prefetched responses (`kPrefetchReuseMins` in `net/http/http_cache.h`).
+const PREFETCH_REUSE_WINDOW = 5 * 60 * 1000;
+
+// Track prefetched URLs and when they were prefetched, so we don't prefetch twice and so
+// navigations that happen shortly after a prefetch can reuse the prefetched response.
+const prefetchedUrls = new Map<string, number>();
+
+/**
+ * Normalize a full or partial URL string so that the prefetch script and the view transitions
+ * router agree on the key used to track it, no matter in which form the URL was handed to them.
+ */
+export function normalizePrefetchUrl(url: string): string {
+	const urlObj = new URL(url, location.href);
+	// Ignore the hash as it points into the same document
+	urlObj.hash = '';
+	return urlObj.href;
+}
+
+/**
+ * Record that a URL has just been prefetched.
+ */
+export function recordPrefetch(url: string) {
+	prefetchedUrls.set(normalizePrefetchUrl(url), Date.now());
+}
+
+/**
+ * Whether a URL has been prefetched before, no matter how long ago.
+ */
+export function hasBeenPrefetched(url: string): boolean {
+	return prefetchedUrls.has(normalizePrefetchUrl(url));
+}
+
+/**
+ * Whether a URL was prefetched recently enough that the response the prefetch downloaded
+ * can be reused without revalidation, mirroring how browsers treat their own prefetches.
+ */
+export function wasPrefetchedRecently(url: string): boolean {
+	const prefetchedAt = prefetchedUrls.get(normalizePrefetchUrl(url));
+	return prefetchedAt !== undefined && Date.now() - prefetchedAt < PREFETCH_REUSE_WINDOW;
+}

--- a/packages/astro/src/prefetch/registry.ts
+++ b/packages/astro/src/prefetch/registry.ts
@@ -41,8 +41,20 @@ export function hasBeenPrefetched(url: string): boolean {
 /**
  * Whether a URL was prefetched recently enough that the response the prefetch downloaded
  * can be reused without revalidation, mirroring how browsers treat their own prefetches.
+ *
+ * Consuming: reuse is valid for a single navigation. The entry's timestamp is zeroed (not
+ * deleted) so `hasBeenPrefetched()` keeps deduplicating, but later navigations to the same
+ * URL revalidate normally instead of freezing on-demand pages on the first prefetched body
+ * for the whole window. A navigation aborted mid-fetch loses its reuse, which is a missed
+ * optimization rather than a correctness problem. Whether `hasBeenPrefetched()` itself
+ * should expire (allowing re-prefetch) was considered and deliberately left out here.
  */
-export function wasPrefetchedRecently(url: string): boolean {
-	const prefetchedAt = prefetchedUrls.get(normalizePrefetchUrl(url));
-	return prefetchedAt !== undefined && Date.now() - prefetchedAt < PREFETCH_REUSE_WINDOW;
+export function consumePrefetchReuse(url: string): boolean {
+	const key = normalizePrefetchUrl(url);
+	const prefetchedAt = prefetchedUrls.get(key);
+	if (prefetchedAt === undefined || prefetchedAt === 0) return false;
+	if (Date.now() - prefetchedAt >= PREFETCH_REUSE_WINDOW) return false;
+	// Still deduped by hasBeenPrefetched(), no longer reusable.
+	prefetchedUrls.set(key, 0);
+	return true;
 }

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -1,4 +1,5 @@
 import { internalFetchHeaders } from 'virtual:astro:adapter-config/client';
+import { wasPrefetchedRecently } from '../prefetch/registry.js';
 import type { TransitionBeforePreparationEvent } from './events.js';
 
 import { doPreparation, doSwap, onPageLoad, triggerEvent, updateScrollPosition } from './events.js';
@@ -94,7 +95,15 @@ async function fetchHTML(
 		for (const [key, value] of Object.entries(internalFetchHeaders) as [string, string][]) {
 			headers.set(key, value);
 		}
-		const res = await fetch(href, { ...init, headers });
+		const fetchInit: RequestInit = { ...init, headers };
+		// If our own prefetch downloaded this URL only moments ago, reuse the response it
+		// downloaded. On-demand rendered pages typically carry no cache headers, so with the
+		// default cache mode the browser would download the page a second time (#17549).
+		// Form submissions must always reach the server, so they never reuse the cache.
+		if (!init?.method && wasPrefetchedRecently(href)) {
+			fetchInit.cache = 'force-cache';
+		}
+		const res = await fetch(href, fetchInit);
 		const contentType = res.headers.get('content-type') ?? '';
 		// drop potential charset (+ other name/value pairs) as parser needs the mediaType
 		const mediaType = contentType.split(';', 1)[0].trim();

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -1,5 +1,5 @@
 import { internalFetchHeaders } from 'virtual:astro:adapter-config/client';
-import { wasPrefetchedRecently } from '../prefetch/registry.js';
+import { consumePrefetchReuse } from '../prefetch/registry.js';
 import type { TransitionBeforePreparationEvent } from './events.js';
 
 import { doPreparation, doSwap, onPageLoad, triggerEvent, updateScrollPosition } from './events.js';
@@ -89,6 +89,12 @@ async function fetchHTML(
 	href: string,
 	init?: RequestInit,
 ): Promise<null | { html: string; redirected?: string; mediaType: DOMParserSupportedType }> {
+	// If our own prefetch downloaded this URL only moments ago, reuse the response it
+	// downloaded (once). On-demand rendered pages typically carry no cache headers, so with
+	// the default cache mode the browser would download the page a second time (#17549).
+	// Form submissions must always reach the server, so they never reuse the cache. Kept
+	// outside the try so a registry error can never turn into a full page load below.
+	const reusePrefetched = !init?.method && consumePrefetchReuse(href);
 	try {
 		// Apply adapter-specific headers for internal fetches
 		const headers = new Headers(init?.headers);
@@ -96,11 +102,7 @@ async function fetchHTML(
 			headers.set(key, value);
 		}
 		const fetchInit: RequestInit = { ...init, headers };
-		// If our own prefetch downloaded this URL only moments ago, reuse the response it
-		// downloaded. On-demand rendered pages typically carry no cache headers, so with the
-		// default cache mode the browser would download the page a second time (#17549).
-		// Form submissions must always reach the server, so they never reuse the cache.
-		if (!init?.method && wasPrefetchedRecently(href)) {
+		if (reusePrefetched) {
 			fetchInit.cache = 'force-cache';
 		}
 		const res = await fetch(href, fetchInit);

--- a/packages/astro/test/units/prefetch/registry.test.ts
+++ b/packages/astro/test/units/prefetch/registry.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import {
+	hasBeenPrefetched,
+	normalizePrefetchUrl,
+	recordPrefetch,
+	wasPrefetchedRecently,
+} from '../../../dist/prefetch/registry.js';
+
+// Matches Chromium's `kPrefetchReuseMins` (see `packages/astro/src/prefetch/registry.ts`)
+const PREFETCH_REUSE_WINDOW = 5 * 60 * 1000;
+
+describe('prefetch registry', () => {
+	// The registry runs in the browser and resolves partial URLs against the current page,
+	// just like the prefetch script and the view transitions router do.
+	const originalLocation = (globalThis as any).location;
+
+	beforeEach(() => {
+		(globalThis as any).location = { href: 'https://example.com/page/' };
+	});
+
+	afterEach(() => {
+		if (originalLocation === undefined) {
+			delete (globalThis as any).location;
+		} else {
+			(globalThis as any).location = originalLocation;
+		}
+		mock.timers.reset();
+	});
+
+	describe('normalizePrefetchUrl()', () => {
+		it('resolves partial URLs against the current page', () => {
+			assert.equal(normalizePrefetchUrl('/about'), 'https://example.com/about');
+			assert.equal(normalizePrefetchUrl('sibling'), 'https://example.com/page/sibling');
+		});
+
+		it('strips the hash', () => {
+			assert.equal(normalizePrefetchUrl('/about#team'), 'https://example.com/about');
+			assert.equal(
+				normalizePrefetchUrl('https://example.com/about#team'),
+				'https://example.com/about',
+			);
+		});
+
+		it('keeps the query string', () => {
+			assert.equal(normalizePrefetchUrl('/search?q=astro'), 'https://example.com/search?q=astro');
+		});
+	});
+
+	describe('wasPrefetchedRecently()', () => {
+		it('matches an absolute URL with a hash after prefetching a relative URL', () => {
+			// `prefetch()` can be handed a relative URL, while the router looks up
+			// `preparationEvent.to.href`, which is absolute and may carry a hash.
+			recordPrefetch('/relative-vs-absolute');
+			assert.equal(wasPrefetchedRecently('https://example.com/relative-vs-absolute#section'), true);
+		});
+
+		it('matches a relative URL after prefetching an absolute URL', () => {
+			recordPrefetch('https://example.com/absolute-vs-relative');
+			assert.equal(wasPrefetchedRecently('/absolute-vs-relative'), true);
+		});
+
+		it('does not match URLs that were never prefetched', () => {
+			assert.equal(wasPrefetchedRecently('/never-prefetched'), false);
+		});
+
+		it('does not match a URL with a different query string', () => {
+			recordPrefetch('/list?page=1');
+			assert.equal(wasPrefetchedRecently('/list?page=2'), false);
+		});
+
+		it('stops matching once the reuse window has passed', () => {
+			const start = 1_000_000;
+			mock.timers.enable({ apis: ['Date'], now: start });
+			recordPrefetch('/expires');
+
+			mock.timers.setTime(start + PREFETCH_REUSE_WINDOW - 1);
+			assert.equal(wasPrefetchedRecently('/expires'), true);
+
+			mock.timers.setTime(start + PREFETCH_REUSE_WINDOW);
+			assert.equal(wasPrefetchedRecently('/expires'), false);
+		});
+	});
+
+	describe('hasBeenPrefetched()', () => {
+		it('shares the normalization with recordPrefetch()', () => {
+			recordPrefetch('/dedupe#top');
+			assert.equal(hasBeenPrefetched('https://example.com/dedupe#bottom'), true);
+			assert.equal(hasBeenPrefetched('/elsewhere'), false);
+		});
+
+		it('keeps tracking a URL after the reuse window has passed', () => {
+			const start = 2_000_000;
+			mock.timers.enable({ apis: ['Date'], now: start });
+			recordPrefetch('/old-prefetch');
+
+			mock.timers.setTime(start + PREFETCH_REUSE_WINDOW + 1);
+			// Still deduplicated by the prefetch script...
+			assert.equal(hasBeenPrefetched('/old-prefetch'), true);
+			// ...but too old for the router to reuse without revalidation.
+			assert.equal(wasPrefetchedRecently('/old-prefetch'), false);
+		});
+	});
+});

--- a/packages/astro/test/units/prefetch/registry.test.ts
+++ b/packages/astro/test/units/prefetch/registry.test.ts
@@ -4,7 +4,7 @@ import {
 	hasBeenPrefetched,
 	normalizePrefetchUrl,
 	recordPrefetch,
-	wasPrefetchedRecently,
+	consumePrefetchReuse,
 } from '../../../dist/prefetch/registry.js';
 
 // Matches Chromium's `kPrefetchReuseMins` (see `packages/astro/src/prefetch/registry.ts`)
@@ -47,38 +47,62 @@ describe('prefetch registry', () => {
 		});
 	});
 
-	describe('wasPrefetchedRecently()', () => {
+	describe('consumePrefetchReuse()', () => {
 		it('matches an absolute URL with a hash after prefetching a relative URL', () => {
 			// `prefetch()` can be handed a relative URL, while the router looks up
 			// `preparationEvent.to.href`, which is absolute and may carry a hash.
 			recordPrefetch('/relative-vs-absolute');
-			assert.equal(wasPrefetchedRecently('https://example.com/relative-vs-absolute#section'), true);
+			assert.equal(consumePrefetchReuse('https://example.com/relative-vs-absolute#section'), true);
 		});
 
 		it('matches a relative URL after prefetching an absolute URL', () => {
 			recordPrefetch('https://example.com/absolute-vs-relative');
-			assert.equal(wasPrefetchedRecently('/absolute-vs-relative'), true);
+			assert.equal(consumePrefetchReuse('/absolute-vs-relative'), true);
 		});
 
 		it('does not match URLs that were never prefetched', () => {
-			assert.equal(wasPrefetchedRecently('/never-prefetched'), false);
+			assert.equal(consumePrefetchReuse('/never-prefetched'), false);
 		});
 
 		it('does not match a URL with a different query string', () => {
 			recordPrefetch('/list?page=1');
-			assert.equal(wasPrefetchedRecently('/list?page=2'), false);
+			assert.equal(consumePrefetchReuse('/list?page=2'), false);
 		});
 
 		it('stops matching once the reuse window has passed', () => {
 			const start = 1_000_000;
 			mock.timers.enable({ apis: ['Date'], now: start });
-			recordPrefetch('/expires');
+			recordPrefetch('/expires-in-window');
+			recordPrefetch('/expires-out-of-window');
 
 			mock.timers.setTime(start + PREFETCH_REUSE_WINDOW - 1);
-			assert.equal(wasPrefetchedRecently('/expires'), true);
+			assert.equal(consumePrefetchReuse('/expires-in-window'), true);
 
 			mock.timers.setTime(start + PREFETCH_REUSE_WINDOW);
-			assert.equal(wasPrefetchedRecently('/expires'), false);
+			assert.equal(consumePrefetchReuse('/expires-out-of-window'), false);
+		});
+
+		it('consumes the entry: only the first navigation reuses the prefetched response', () => {
+			// Anything else would freeze on-demand rendered pages on the first prefetched
+			// body for the whole window (carts, inboxes, dashboards).
+			recordPrefetch('/consume-once');
+			assert.equal(consumePrefetchReuse('/consume-once'), true);
+			assert.equal(consumePrefetchReuse('/consume-once'), false);
+		});
+
+		it('keeps a consumed entry deduplicated for the prefetch script', () => {
+			recordPrefetch('/consumed-but-deduped');
+			assert.equal(consumePrefetchReuse('/consumed-but-deduped'), true);
+			assert.equal(hasBeenPrefetched('/consumed-but-deduped'), true);
+		});
+
+		it('does not resurrect a consumed entry via re-recording within the same window', () => {
+			// recordPrefetch() after consumption restores reusability, which is correct:
+			// it means the prefetch script actually fetched a fresh copy.
+			recordPrefetch('/re-prefetched');
+			assert.equal(consumePrefetchReuse('/re-prefetched'), true);
+			recordPrefetch('/re-prefetched');
+			assert.equal(consumePrefetchReuse('/re-prefetched'), true);
 		});
 	});
 
@@ -98,7 +122,7 @@ describe('prefetch registry', () => {
 			// Still deduplicated by the prefetch script...
 			assert.equal(hasBeenPrefetched('/old-prefetch'), true);
 			// ...but too old for the router to reuse without revalidation.
-			assert.equal(wasPrefetchedRecently('/old-prefetch'), false);
+			assert.equal(consumePrefetchReuse('/old-prefetch'), false);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #17549, reported by @iseraph-dev, following the issue's "no new API" design preference.

The ClientRouter re-downloaded pages its own prefetch had just fetched: `fetchHTML()` used the default cache mode, and SSR pages carry no cache headers, so navigation always refetched.

The fix adds a tiny dependency-free `prefetch/registry.ts` shared by both bundles that records when each URL was prefetched, under one normalization (now used by `prefetch()` itself too, so the link href, speculation rules, and registry key are byte-identical and resolve against `location.href` rather than a divergent `<base href>`). `fetchHTML()` uses `cache: 'force-cache'` when the URL was prefetched within Chromium's 5-minute prefetch-reuse window, gated on `!init?.method` so form POSTs always hit the server.

Per @iseraph-dev's measured review: the reuse entry is **consumed on first navigation** (`consumePrefetchReuse()` zeroes the timestamp, `hasBeenPrefetched()` keeps deduplicating), so this is "reuse the prefetch once", not a five-minute client-side HTML cache; later visits revalidate normally. The registry call is hoisted above `fetchHTML`'s catch-all so a registry error can never fall back to a full page load. Whether `hasBeenPrefetched()` should itself expire (allowing re-prefetch) was considered and left out deliberately.

Two scope notes worth naming: this also fixes the same double-download for `experimental.clientPrerender` users (speculation-rules prefetches populate the HTTP cache the same way, measured in the review); and for `Cache-Control: no-cache` + ETag setups the single reused navigation skips one revalidation, bounded to seconds after the prefetch, which we think is defensible without an opt-out.

Thirteen unit tests lock the registry semantics including one-shot consumption; the unit suite passes with zero new failures, biome/eslint gates clean. The `force-cache` wiring itself is only verifiable in the Playwright e2e suite; happy to add the SSR fixture e2e from the review's pointers if you want it in this PR.
