### PR TITLE
chore: use star import for `js-yaml`

### DIFF
--- a/packages/astro/src/content/loaders/file.ts
+++ b/packages/astro/src/content/loaders/file.ts
@@ -1,6 +1,6 @@
 import { existsSync, promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import * as toml from 'smol-toml';
 import { FileGlobNotSupported, FileParserNotFound } from '../../core/errors/errors-data.js';
 import { AstroError } from '../../core/errors/index.js';

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import * as toml from 'smol-toml';
 import { getContentPaths } from '../../content/index.js';
 import createPreferences from '../../preferences/index.js';

--- a/packages/internal-helpers/src/frontmatter.ts
+++ b/packages/internal-helpers/src/frontmatter.ts
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import * as toml from 'smol-toml';
 
 export function isFrontmatterValid(frontmatter: Record<string, any>) {

--- a/packages/language-tools/vscode/scripts/build-grammar.mjs
+++ b/packages/language-tools/vscode/scripts/build-grammar.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { dim, green } from 'kleur/colors';
 
 const dt = new Intl.DateTimeFormat('en-us', {


### PR DESCRIPTION
## Changes

Follow up to #17473 

Changes default to star import for `'js-yaml'`

This is recommended and allows consumers to use `"overrides"` with `js-yaml@5` which removes default export

No changeset needed


## Testing

All existing tests pass


## Docs

No user-facing changes
