### PR TITLE
fix(react): guard against undefined $$typeof in check()

### DIFF
--- a/packages/integrations/react/src/server.ts
+++ b/packages/integrations/react/src/server.ts
@@ -23,7 +23,8 @@ async function check(
 	// Note: there are packages that do some unholy things to create "components".
 	// Checking the $$typeof property catches most of these patterns.
 	if (typeof Component === 'object') {
-		return Component['$$typeof'].toString().slice('Symbol('.length).startsWith('react');
+		const $$typeof = Component['$$typeof'];
+		return $$typeof != null && $$typeof.toString().slice('Symbol('.length).startsWith('react');
 	}
 	if (typeof Component !== 'function') return false;
 	if (Component.name === 'QwikComponent') return false;


### PR DESCRIPTION
## Changes

Adds a null guard in the `check()` function in `@astrojs/react`'s server renderer to prevent `TypeError` when `Component["$$typeof"]` is undefined on non-React component objects.

## Background

When `@astrojs/react` is used alongside other framework integrations (e.g. `@astrojs/svelte`), the `check()` function may receive non-React component objects. The current code calls `.toString()` on `Component["$$typeof"]` without checking if it exists:

```ts
if (typeof Component === "object") {
    return Component["$$typeof"].toString()... // TypeError when $$typeof is undefined
}
```

## Fix

Extract `$$typeof` into a local variable and use `!= null` short-circuit, returning `false` for components that lack the property:

```ts
if (typeof Component === "object") {
    const $$typeof = Component["$$typeof"];
    return $$typeof != null && $$typeof.toString().slice("Symbol(".length).startsWith("react");
}
```

## Related issue

Closes #17552