### PR TITLE
fix: prevent ENOENT crash from IDE temporary files during file save

### DIFF
--- a/.changeset/fix-ide-temp-file-crash.md
+++ b/.changeset/fix-ide-temp-file-crash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix an `ENOENT` crash during file watching caused by IDEs rapidly creating and deleting temporary files on save.

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -157,7 +157,7 @@ function createFileBasedRoutes(
 		for (const basename of files) {
 			const resolved = path.join(dir, basename);
 			const file = slash(path.relative(cwd || rootPath, resolved));
-			const isDir = fs.statSync(resolved).isDirectory();
+			const isDir = fs.existsSync(resolved) && fs.statSync(resolved).isDirectory();
 
 			const ext = path.extname(basename);
 			const name = ext ? basename.slice(0, -ext.length) : basename;


### PR DESCRIPTION
## Changes

- Added an `fs.existsSync(resolved)` check before calling `fs.statSync(resolved).isDirectory()`.
- **Why:** Fixes a race condition where the process crashes with an `ENOENT` error. This occurs because some IDEs create and rapidly delete temporary files during the save process. If the temporary file is deleted just before `fs.statSync` is executed, it causes an error. This extra check prevents the crash.

## Testing

Manually tested by modifying and saving files using an IDE in a local environment. Verified that the dev server/watcher no longer crashes with an `ENOENT` error when temporary files are rapidly created and deleted.

## Docs

No docs added. This is a purely internal bug fix to improve stability during file watching and does not affect any user-facing APIs or behaviors.