### PR TITLE
fix: correct `Astro.url.pathname` for non-index pages with `build.format: 'preserve'`

### DIFF
--- a/.changeset/fix-preserve-url-pathname.md
+++ b/.changeset/fix-preserve-url-pathname.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.url.pathname` for non-index pages when using `build.format: 'preserve'`. Previously, a page like `src/pages/about-me.astro` would output to `dist/about-me.html` but `Astro.url.pathname` would incorrectly return `/about-me/` instead of `/about-me.html`.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -435,6 +435,7 @@ export async function renderPath({
 		config.build.format,
 		config.trailingSlash,
 		route.type,
+		route.isIndex,
 	);
 
 	const request = createRequest({
@@ -580,6 +581,7 @@ function getUrlForPath(
 	format: AstroConfig['build']['format'],
 	trailingSlash: AstroConfig['trailingSlash'],
 	routeType: RouteType,
+	isIndex: boolean,
 ): URL {
 	/**
 	 * Examples:
@@ -588,9 +590,12 @@ function getUrlForPath(
 	 */
 
 	let ending: string;
-	switch (format) {
-		case 'directory':
-		case 'preserve': {
+	// For `preserve`, non-index routes output as flat `.html` files (like `file`),
+	// while index routes output as `dir/index.html` (like `directory`).
+	const effectiveFormat =
+		format === 'preserve' ? (isIndex ? 'directory' : 'file') : format;
+	switch (effectiveFormat) {
+		case 'directory': {
 			ending = trailingSlash === 'never' ? '' : '/';
 			break;
 		}
@@ -602,7 +607,7 @@ function getUrlForPath(
 	}
 	let buildPathname: string;
 	if (pathname === '/' || pathname === '') {
-		if (format === 'file') {
+		if (effectiveFormat === 'file') {
 			buildPathname = joinPaths(base, 'index.html');
 		} else {
 			buildPathname = collapseDuplicateTrailingSlashes(base + ending, trailingSlash !== 'never');

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1250,6 +1250,7 @@ export interface AstroUserConfig<
 		 * Setting `build.format` controls what `Astro.url` is set to during the build. When it is:
 		 * - `directory` - The `Astro.url.pathname` will include a trailing slash to mimic folder behavior. (e.g. `/foo/`)
 		 * - `file` - The `Astro.url.pathname` will include `.html`. (e.g. `/foo.html`)
+		 * - `preserve` - The `Astro.url.pathname` matches the generated file for each page: index pages include a trailing slash (e.g. `/foo/`), while non-index pages include `.html` (e.g. `/foo.html`).
 		 *
 		 * This means that when you create relative URLs using `new URL('./relative', Astro.url)`, you will get consistent behavior between dev and build.
 		 *

--- a/packages/astro/test/page-format.test.ts
+++ b/packages/astro/test/page-format.test.ts
@@ -63,6 +63,37 @@ describe('build.format', () => {
 		});
 	});
 
+	describe('preserve', () => {
+		let fixture: Fixture;
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/page-format/',
+				build: {
+					format: 'preserve',
+				},
+				outDir: './dist/page-format-preserve/',
+			});
+		});
+
+		describe('Build', () => {
+			before(async () => {
+				await fixture.build();
+			});
+
+			it('Astro.url pathname is .html for non-index pages', async () => {
+				let html = await fixture.readFile('/nested/page.html');
+				let $ = cheerio.load(html);
+				assert.equal($('#url').text(), '/nested/page.html');
+			});
+
+			it('Astro.url pathname has trailing slash for index pages', async () => {
+				let html = await fixture.readFile('/nested/index.html');
+				let $ = cheerio.load(html);
+				assert.equal($('h2').text(), '/nested/');
+			});
+		});
+	});
+
 	describe('preserve - i18n', () => {
 		let fixture: Fixture;
 		before(async () => {
@@ -120,7 +151,7 @@ describe('build.format', () => {
 			it('relative urls created point to sibling folders', async () => {
 				let html = await fixture.readFile('/en/nested/page.html');
 				let $ = cheerio.load(html);
-				assert.equal($('#another').attr('href'), '/test/en/nested/page/another/');
+				assert.equal($('#another').attr('href'), '/test/en/nested/another/');
 			});
 
 			it('index files are written as index.html', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,12 @@ importers:
         specifier: ^7.1.6
         version: link:../../packages/astro
 
+  examples/repro-17556:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
+
   examples/ssr:
     dependencies:
       '@astrojs/node':


### PR DESCRIPTION
## Changes

- Fixes `Astro.url.pathname` for non-index pages when using `build.format: 'preserve'`. A page like `src/pages/about-me.astro` builds to `dist/about-me.html`, but `Astro.url.pathname` incorrectly returned `/about-me/` (trailing slash) instead of `/about-me.html`, so runtime checks against the pathname (e.g. setting `aria-current="page"` on nav links) never matched.
- `getUrlForPath()` in `generate.ts` treated `'preserve'` identically to `'directory'`, giving every route a trailing-slash pathname. The rest of the build pipeline (`getOutFolder`/`getOutFile`) already branches on `route.isIndex`. This introduces an `effectiveFormat` that resolves `'preserve'` to `'file'` for non-index routes and `'directory'` for index routes, matching the emitted files.

Closes #17556

## Testing

- Adds a `preserve` suite in `packages/astro/test/page-format.test.ts` asserting non-index pages report a `.html` pathname and index pages report a trailing-slash pathname.
- Updates an existing `preserve - i18n` assertion: a relative link from a non-index page now resolves against the flat `.html` URL (`/test/en/nested/another/`) rather than the previous trailing-slash directory URL.

## Docs

- Documents `preserve`'s effect on `Astro.url` in the `build.format` JSDoc (`packages/astro/src/types/public/config.ts`), which generates the "Effect on Astro.url" section of the config reference. No separate docs-repo PR is needed since that page is auto-generated from this source.
