### PR TITLE
fix(transitions): snapshot script collection before iterating in runScripts

### DIFF
--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -131,7 +131,7 @@ function runScripts() {
 	// inline module scripts cannot be awaited for with onload.
 	// Thus to be able to wait for the execution of all scripts, we make sure that the last inline module script
 	// is always followed by an external module script
-	for (const script of document.getElementsByTagName('script')) {
+	for (const script of Array.from(document.getElementsByTagName('script'))) {
 		script.dataset.astroExec === undefined &&
 			script.getAttribute('type') === 'module' &&
 			(needsWaitForInlineModuleScript = script.getAttribute('src') === null);
@@ -142,7 +142,7 @@ function runScripts() {
 			`<script type="module" src="data:application/javascript,"/>`,
 		);
 
-	for (const script of document.getElementsByTagName('script')) {
+	for (const script of Array.from(document.getElementsByTagName('script'))) {
 		if (script.dataset.astroExec === '') continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
@@ -681,7 +681,7 @@ if (inBrowser) {
 			);
 		}
 	}
-	for (const script of document.getElementsByTagName('script')) {
+	for (const script of Array.from(document.getElementsByTagName('script'))) {
 		detectScriptExecuted(script);
 		script.dataset.astroExec = '';
 	}


### PR DESCRIPTION
`getElementsByTagName` returns a live `HTMLCollection`. When new scripts are
appended to the DOM inside the loop body — specifically the sentinel
`data:application/javascript` module injected at line 142 — the collection
grows mid-iteration and subsequently added scripts are skipped (the iterator
index advances past them before they are visited).

Convert to a static snapshot with `Array.from()` before each loop so every
script is visited exactly once.

**Affected loops** (`runScripts()` is called on every page transition):
- First pass at line 131 — detects whether a sentinel is needed
- Second pass at line 142 — runs/re-runs scripts
- Initialisation pass at line 681 — marks scripts already executed