### PR TITLE
fix(node): find SSR fallback after prerendered route

### DIFF
--- a/.changeset/orange-doors-agree.md
+++ b/.changeset/orange-doors-agree.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes middleware mode routing when a prerendered dynamic route sorts before an on-demand fallback

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -106,11 +106,14 @@ export function createAppHandler(app: BaseApp, options: Options): RequestHandler
 			return;
 		}
 
-		// Redirects are considered prerendered routes in static mode, but we want to
-		// handle them dynamically, so prerendered routes are included here.
-		const routeData = app.match(request, true);
-		// But we still want to skip prerendered pages.
-		if (routeData && !(routeData.type === 'page' && routeData.prerender)) {
+		// Include prerendered routes so static-mode redirects remain dynamic.
+		let routeData = app.match(request, true);
+		// Normal matching can select a lower-priority on-demand route when a prerendered page
+		// matches first.
+		if (routeData?.type === 'page' && routeData.prerender) {
+			routeData = app.match(request);
+		}
+		if (routeData) {
 			const response = await als.run(request.url, () =>
 				app.render(request, {
 					addCookieHeader: true,

--- a/packages/integrations/node/test/fixtures/node-middleware/src/pages/articles/[...slug].astro
+++ b/packages/integrations/node/test/fixtures/node-middleware/src/pages/articles/[...slug].astro
@@ -1,0 +1,5 @@
+---
+export const prerender = false;
+
+return Astro.redirect('/articles/known-article');
+---

--- a/packages/integrations/node/test/fixtures/node-middleware/src/pages/articles/[slug].astro
+++ b/packages/integrations/node/test/fixtures/node-middleware/src/pages/articles/[slug].astro
@@ -1,0 +1,9 @@
+---
+export const prerender = true;
+
+export function getStaticPaths() {
+	return [{ params: { slug: 'known-article' } }];
+}
+---
+
+<h1>Known article</h1>

--- a/packages/integrations/node/test/node-middleware.test.ts
+++ b/packages/integrations/node/test/node-middleware.test.ts
@@ -55,12 +55,23 @@ describe('behavior from middleware, middleware with express', () => {
 		fixture = await loadFixture({
 			root: './fixtures/node-middleware/',
 			output: 'server',
+			outDir: './dist/middleware-express',
 			adapter: nodejs({ mode: 'middleware' }),
 		});
 		await fixture.build();
 		const { handler } = await fixture.loadAdapterEntryModule();
 		const app = express();
+		app.use(
+			express.static(
+				fileURLToPath(
+					new URL('./fixtures/node-middleware/dist/middleware-express/client', import.meta.url),
+				),
+			),
+		);
 		app.use(handler);
+		app.use((_request, response) => {
+			response.status(404).send('CUSTOM_404');
+		});
 		server = app.listen(8889);
 	});
 
@@ -125,6 +136,15 @@ describe('behavior from middleware, middleware with express', () => {
 
 		body = $('body');
 		assert.equal(body.text().includes('bar'), true);
+	});
+
+	it('should fall through a prerendered dynamic route to an SSR fallback', async () => {
+		const res = await fetch('http://localhost:8889/articles/unknown', {
+			redirect: 'manual',
+		});
+
+		assert.equal(res.status, 302);
+		assert.equal(res.headers.get('location'), '/articles/known-article');
 	});
 });
 


### PR DESCRIPTION
## Changes

- Fixes Node middleware mode returning 404 when prerendered dynamic route matches before a valid on-demand fallback.
- Preserves dynamic redirect handling by retrying normal route matching only when the initial match is a prerendered page.

Fixes https://github.com/withastro/astro/issues/17580

## Context

The problematic middleware path was introduced by [#15164](https://github.com/withastro/astro/pull/15164). After [#14441](https://github.com/withastro/astro/pull/14441) began including prerendered routes to keep redirects dynamic, the handler skipped a matching prerendered page by immediately calling `next()`. This prevented lower-priority on-demand routes from being considered. [#16878](https://github.com/withastro/astro/pull/16878) later added this fallthrough to Astro's normal matcher, but middleware mode bypassed it by using inclusive matching.

## Testing

- Adds an Express middleware regression fixture with a prerendered `[slug]` route and an on-demand `[...slug]` fallback.

## Docs

Fixes existing routing behavior without changing the public API.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
