### PR TITLE
Fix googleicons() returning the full font when multiple experimental.glyphs are specified

### DIFF
--- a/.changeset/fix-googleicons-glyphs.md
+++ b/.changeset/fix-googleicons-glyphs.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `fontProviders.googleicons()` returning the full icon font (~3.9MB) instead of only the requested glyphs when multiple `experimental.glyphs` are specified

--- a/packages/astro/src/assets/fonts/providers/index.ts
+++ b/packages/astro/src/assets/fonts/providers/index.ts
@@ -113,8 +113,25 @@ function googleicons(): FontProvider<GoogleiconsFamilyOptions | undefined> {
 		async init(context) {
 			initializedProvider = await provider(context);
 		},
-		async resolveFont({ familyName, ...rest }) {
-			return await initializedProvider?.resolveFont(familyName, rest);
+		async resolveFont({ familyName, options, ...rest }) {
+			// Workaround for https://github.com/unjs/unifont/issues/336
+			// unifont joins glyphs with .join("") instead of .join(","), producing
+			// an invalid `icon_names` query param that causes Google to return the
+			// full font. Pre-joining into a single element sidesteps the bug.
+			const patchedOptions =
+				options?.experimental?.glyphs && options.experimental.glyphs.length > 1
+					? {
+							...options,
+							experimental: {
+								...options.experimental,
+								glyphs: [options.experimental.glyphs.join(',')],
+							},
+						}
+					: options;
+			return await initializedProvider?.resolveFont(familyName, {
+				options: patchedOptions,
+				...rest,
+			});
 		},
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();

--- a/packages/astro/test/units/assets/fonts/googleicons-glyphs.test.ts
+++ b/packages/astro/test/units/assets/fonts/googleicons-glyphs.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { fontProviders } from '../../../../dist/config/entrypoint.js';
+
+describe('googleicons glyphs workaround (unifont#336)', () => {
+	// The googleicons provider wraps unifont and pre-joins multiple glyphs
+	// into a single comma-separated string before passing to unifont. This
+	// works around unifont's .join("") bug which concatenates icon names
+	// without a separator.
+	//
+	// We can't fully test the transformation without hitting the network
+	// (init() fetches Google's metadata), so we verify that resolveFont
+	// handles all option shapes without errors when the provider is
+	// uninitialized (returns undefined).
+
+	it('handles multiple glyphs without error', async () => {
+		const provider = fontProviders.googleicons();
+		const result = await provider.resolveFont({
+			familyName: 'Material Symbols Outlined',
+			weights: ['400'],
+			styles: ['normal'],
+			subsets: ['latin'],
+			formats: ['woff2'],
+			options: {
+				experimental: {
+					glyphs: ['add_shopping_cart', 'remove_shopping_cart', 'home'],
+				},
+			},
+		});
+		// Without init(), returns undefined — no crash means the patching logic is safe
+		assert.equal(result, undefined);
+	});
+
+	it('handles single glyph without error', async () => {
+		const provider = fontProviders.googleicons();
+		const result = await provider.resolveFont({
+			familyName: 'Material Symbols Outlined',
+			weights: ['400'],
+			styles: ['normal'],
+			subsets: ['latin'],
+			formats: ['woff2'],
+			options: {
+				experimental: {
+					glyphs: ['add_shopping_cart'],
+				},
+			},
+		});
+		assert.equal(result, undefined);
+	});
+
+	it('handles undefined options without error', async () => {
+		const provider = fontProviders.googleicons();
+		const result = await provider.resolveFont({
+			familyName: 'Material Symbols Outlined',
+			weights: ['400'],
+			styles: ['normal'],
+			subsets: ['latin'],
+			formats: ['woff2'],
+			options: undefined,
+		});
+		assert.equal(result, undefined);
+	});
+
+	it('handles empty glyphs array without error', async () => {
+		const provider = fontProviders.googleicons();
+		const result = await provider.resolveFont({
+			familyName: 'Material Symbols Outlined',
+			weights: ['400'],
+			styles: ['normal'],
+			subsets: ['latin'],
+			formats: ['woff2'],
+			options: {
+				experimental: {
+					glyphs: [],
+				},
+			},
+		});
+		assert.equal(result, undefined);
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes `fontProviders.googleicons()` downloading the entire ~3.9MB Google Icons font instead of only the requested glyphs when `experimental.glyphs` contains more than one name. The root cause is a bug in unifont ([unjs/unifont#336](https://github.com/unjs/unifont/issues/336)) where glyph names are joined with `.join("")` (no separator), producing an invalid `icon_names` query parameter that causes Google's API to silently return the full font. The workaround pre-joins multiple glyphs into a single comma-separated string before passing them to unifont, so unifont's `.join("")` produces the correct value.

## Testing

- Adds `packages/astro/test/units/assets/fonts/googleicons-glyphs.test.ts` covering the `resolveFont` call with multiple glyphs, a single glyph, undefined options, and an empty glyphs array — verifying the patching logic doesn't throw for any of these shapes.

## Docs

- No docs update needed; `experimental.glyphs` behavior is unchanged from the user's perspective — this restores the documented subsetting behavior.

Closes #17565