### PR TITLE
fix(vercel): prevent EEXIST crash when output/server directory already exists

### DIFF
--- a/.changeset/thin-donuts-cheer.md
+++ b/.changeset/thin-donuts-cheer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Prevents `astro build` from crashing with `EEXIST` when `.vercel/output/server/` already exists by creating it with `{ recursive: true }`, matching the sibling `static/` directory call

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -407,13 +407,13 @@ export default function vercelAdapter({
 				const outDir = new URL('./.vercel/output/', _config.root);
 				if (staticDir) {
 					if (existsSync(staticDir)) {
-						emptyDir(staticDir);
+						await emptyDir(staticDir);
 					}
 					mkdirSync(new URL('./.vercel/output/static/', _config.root), {
 						recursive: true,
 					});
 
-					mkdirSync(new URL('./.vercel/output/server/', _config.root));
+					mkdirSync(new URL('./.vercel/output/server/', _config.root), { recursive: true });
 
 					if (_buildOutput !== 'static') {
 						cpSync(_config.build.server, new URL('./.vercel/output/_functions/', _config.root), {


### PR DESCRIPTION
## Changes

- `@astrojs/vercel` creates `.vercel/output/server/` with a plain `mkdirSync`, so `astro build` crashes with `EEXIST` when that directory already exists, for example when two builds run against the same project root. This creates it with `{ recursive: true }`, the same way the `static/` directory one line above is already created.
- It also awaits `emptyDir(staticDir)`, which was fire-and-forget before and could race the copy calls that follow it.

Fixes #17568

## Testing

The existing `@astrojs/vercel` test suite passes. Reproducing the race needs two overlapping builds sharing one project root, which the current integration harness has no way to set up, so I did not add a new test.

## Docs

No docs changes. This is an internal bug fix with no change to the public API.
