### PR TITLE
Preserve cookies set by custom 404/500 error pages

### DIFF
--- a/.changeset/hip-tools-tie.md
+++ b/.changeset/hip-tools-tie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes cookies set via `Astro.cookies.set()` inside a custom `404.astro` or `500.astro` error page being silently dropped from the final response

--- a/packages/astro/src/core/errors/default-handler.ts
+++ b/packages/astro/src/core/errors/default-handler.ts
@@ -219,9 +219,11 @@ function mergeResponses(
 		seen.add(name.toLowerCase());
 	}
 	// Add new response headers that weren't already set by the original response,
-	// but skip content-type since the error page must return text/html
+	// but skip content-type since the error page must return text/html.
+	// set-cookie is special: it's a multi-value header, so we always append.
 	for (const [name, value] of newResponseHeaders) {
-		if (!seen.has(name.toLowerCase())) {
+		const lower = name.toLowerCase();
+		if (!seen.has(lower) || lower === 'set-cookie') {
 			newHeaders.append(name, value);
 		}
 	}
@@ -243,9 +245,7 @@ function mergeResponses(
 	if (originalCookies) {
 		// If both responses have cookies, merge new response cookies into original
 		if (newCookies) {
-			for (const cookieValue of newCookies.consume()) {
-				originalResponse.headers.append('set-cookie', cookieValue);
-			}
+			originalCookies.merge(newCookies);
 		}
 		attachCookiesToResponse(mergedResponse, originalCookies);
 	} else if (newCookies) {

--- a/packages/astro/test/error-page-cookies.test.ts
+++ b/packages/astro/test/error-page-cookies.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.ts';
+import { type App, type Fixture, loadFixture } from './test-utils.ts';
+
+describe('Error page cookies', () => {
+	let fixture: Fixture;
+	let app: App;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/error-page-cookies/',
+			output: 'server',
+			adapter: testAdapter(),
+		});
+		await fixture.build({});
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it('preserves cookies from the 500 error page when original page throws', async () => {
+		const request = new Request('http://example.com/');
+		const response = await app.render(request, { addCookieHeader: true });
+
+		assert.equal(response.status, 500);
+
+		const setCookieHeaders = response.headers.getSetCookie();
+		const hasFlash = setCookieHeaders.some((c) => c.includes('flash=boom'));
+		assert.ok(hasFlash, `Expected flash=boom cookie, got: ${JSON.stringify(setCookieHeaders)}`);
+	});
+
+	it('preserves cookies from the 500 error page when no original cookies exist', async () => {
+		const request = new Request('http://example.com/only-error-cookie');
+		const response = await app.render(request, { addCookieHeader: true });
+
+		assert.equal(response.status, 500);
+
+		const setCookieHeaders = response.headers.getSetCookie();
+		const hasFlash = setCookieHeaders.some((c) => c.includes('flash=boom'));
+		assert.ok(hasFlash, `Expected flash=boom cookie, got: ${JSON.stringify(setCookieHeaders)}`);
+	});
+
+	it('preserves cookies from both middleware and the 404 error page', async () => {
+		const request = new Request('http://example.com/does-not-exist');
+		const response = await app.render(request, { addCookieHeader: true });
+
+		assert.equal(response.status, 404);
+
+		const setCookieHeaders = response.headers.getSetCookie();
+		const hasSid = setCookieHeaders.some((c) => c.includes('sid=abc'));
+		const hasNotFound = setCookieHeaders.some((c) => c.includes('not_found=true'));
+
+		assert.ok(hasSid, `Expected sid=abc cookie, got: ${JSON.stringify(setCookieHeaders)}`);
+		assert.ok(
+			hasNotFound,
+			`Expected not_found=true cookie, got: ${JSON.stringify(setCookieHeaders)}`,
+		);
+	});
+});

--- a/packages/astro/test/fixtures/error-page-cookies/src/middleware.ts
+++ b/packages/astro/test/fixtures/error-page-cookies/src/middleware.ts
@@ -1,0 +1,6 @@
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware(async (ctx, next) => {
+	ctx.cookies.set('sid', 'abc');
+	return next();
+});

--- a/packages/astro/test/fixtures/error-page-cookies/src/pages/404.astro
+++ b/packages/astro/test/fixtures/error-page-cookies/src/pages/404.astro
@@ -1,0 +1,8 @@
+---
+Astro.cookies.set('not_found', 'true');
+---
+<html>
+<body>
+<h1>404 Not Found</h1>
+</body>
+</html>

--- a/packages/astro/test/fixtures/error-page-cookies/src/pages/500.astro
+++ b/packages/astro/test/fixtures/error-page-cookies/src/pages/500.astro
@@ -1,0 +1,8 @@
+---
+Astro.cookies.set('flash', 'boom');
+---
+<html>
+<body>
+<h1>500 Error</h1>
+</body>
+</html>

--- a/packages/astro/test/fixtures/error-page-cookies/src/pages/index.astro
+++ b/packages/astro/test/fixtures/error-page-cookies/src/pages/index.astro
@@ -1,0 +1,4 @@
+---
+Astro.cookies.set('sid', 'abc');
+throw new Error('boom');
+---

--- a/packages/astro/test/fixtures/error-page-cookies/src/pages/only-error-cookie.astro
+++ b/packages/astro/test/fixtures/error-page-cookies/src/pages/only-error-cookie.astro
@@ -1,0 +1,3 @@
+---
+throw new Error('no cookies set here');
+---


### PR DESCRIPTION
Closes #17329

## Changes

- Cookies set via `Astro.cookies.set()` inside a custom `404.astro` or `500.astro` are now correctly included in the final response. Previously they were silently dropped.
- Two bugs in `mergeResponses` (`packages/astro/src/core/errors/default-handler.ts`): (1) when both the original and error page had `AstroCookies`, the error page's cookies were appended to `originalResponse.headers` — an object already copied into `newHeaders` and no longer connected to the merged response — so they went nowhere; fixed by replacing the loop with `originalCookies.merge(newCookies)`. (2) the `seen`-set guard that deduplicates merged headers treated `set-cookie` as a single-value header, blocking error-page cookies when the original response already set one; fixed by always appending `set-cookie` entries.

## Testing

- Added `packages/astro/test/error-page-cookies.test.ts` with three cases: error page cookies survive when the original page throws, error page cookies survive when no original cookies exist, and both middleware and 404 error page cookies are preserved together.

## Docs

- No docs update needed. This restores the behavior that `Astro.cookies.set()` is documented to provide; no API surface changed.
