### PR TITLE
Handle malformed port in Host header without crashing

### DIFF
--- a/.changeset/orange-peas-dress.md
+++ b/.changeset/orange-peas-dress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a crash when a request arrives with a malformed port in the `Host` header (for example `example.com:65536` or `example.com:8080:8080`). Such a host made the constructed request URL invalid, and the fallback that was meant to recover reused the same invalid host and threw again. The request URL now degrades to a host the server controls when the incoming host cannot be parsed, so the request is handled instead of erroring.

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -75,12 +75,7 @@ export function createRequestFromNodeRequest(
 					? `localhost:${serverPort}`
 					: 'localhost';
 
-	let url: URL;
-	try {
-		url = new URL(`${protocol}://${hostname}${req.url}`);
-	} catch {
-		url = new URL(`${protocol}://${hostname}`);
-	}
+	const url = buildRequestUrl(protocol, hostname, req.url, serverPort);
 
 	const options: RequestInit = {
 		method: req.method || 'GET',
@@ -175,15 +170,7 @@ export function createRequest(
 		validated.port ??
 		(!validated.host && !validatedHostname && serverPort ? String(serverPort) : undefined);
 
-	let url: URL;
-	try {
-		const hostnamePort = getHostnamePort(hostname, port);
-		url = new URL(`${protocol}://${hostnamePort}${req.url}`);
-	} catch {
-		// Fallback using validated hostname to prevent SSRF
-		const hostnamePort = getHostnamePort(hostname, port);
-		url = new URL(`${protocol}://${hostnamePort}`);
-	}
+	const url = buildRequestUrl(protocol, getHostnamePort(hostname, port), req.url, serverPort);
 
 	const options: RequestInit = {
 		method: req.method || 'GET',
@@ -399,6 +386,33 @@ function getHostnamePort(hostname: string | string[] | undefined, port?: string)
 	const portInHostname = typeof hostname === 'string' && /:\d+$/.test(hostname);
 	const hostnamePort = portInHostname ? hostname : `${hostname}${port ? `:${port}` : ''}`;
 	return hostnamePort;
+}
+
+/**
+ * Builds the request URL from a client-supplied host, which may contain an
+ * unparseable port (e.g. `example.com:65536`). Parsing degrades in steps so
+ * that construction always yields a URL:
+ *
+ * 1. Full URL including the request path.
+ * 2. Origin only, dropping a request path that alone made the URL invalid.
+ * 3. A host the server controls, when the host itself is unparseable — using
+ *    the listening port when known so the origin still carries the right port.
+ */
+function buildRequestUrl(
+	protocol: string,
+	hostnamePort: string,
+	requestPath: string | undefined,
+	serverPort?: number,
+): URL {
+	const path = requestPath ?? '';
+	if (URL.canParse(`${protocol}://${hostnamePort}${path}`)) {
+		return new URL(`${protocol}://${hostnamePort}${path}`);
+	}
+	if (URL.canParse(`${protocol}://${hostnamePort}`)) {
+		return new URL(`${protocol}://${hostnamePort}`);
+	}
+	const fallbackHost = serverPort ? `localhost:${serverPort}` : 'localhost';
+	return new URL(`${protocol}://${fallbackHost}`);
 }
 
 function makeRequestHeaders(req: NodeRequest): Headers {

--- a/packages/astro/src/core/app/validate-headers.ts
+++ b/packages/astro/src/core/app/validate-headers.ts
@@ -31,10 +31,14 @@ interface ParsedHost {
 }
 
 /**
- * Parse a host string into hostname and port components.
+ * Parse a host string into hostname and port components. Returns `undefined`
+ * for a host that carries more than a single `hostname:port` pair (e.g.
+ * `example.com:8080:8080`), which is not a valid host and would otherwise be
+ * accepted by inspecting only the first two segments.
  */
-function parseHost(host: string): ParsedHost {
+function parseHost(host: string): ParsedHost | undefined {
 	const parts = host.split(':');
+	if (parts.length > 2) return undefined;
 	return {
 		hostname: parts[0],
 		port: parts[1],
@@ -78,7 +82,10 @@ export function validateHost(
 	const sanitized = sanitizeHost(host);
 	if (!sanitized) return undefined;
 
-	const { hostname, port } = parseHost(sanitized);
+	const parsed = parseHost(sanitized);
+	if (!parsed) return undefined;
+
+	const { hostname, port } = parsed;
 	if (matchesAllowedDomains(hostname, protocol, port, allowedDomains)) {
 		return sanitized;
 	}
@@ -145,8 +152,9 @@ export function validateForwardedHeaders(
 	if (forwardedHost && forwardedHost.length > 0 && allowedDomains && allowedDomains.length > 0) {
 		const protoForValidation = result.protocol || 'https';
 		const sanitized = sanitizeHost(forwardedHost);
-		if (sanitized) {
-			const { hostname, port: portFromHost } = parseHost(sanitized);
+		const parsed = sanitized ? parseHost(sanitized) : undefined;
+		if (sanitized && parsed) {
+			const { hostname, port: portFromHost } = parsed;
 			const portForValidation = result.port || portFromHost;
 			if (matchesAllowedDomains(hostname, protoForValidation, portForValidation, allowedDomains)) {
 				result.host = sanitized;

--- a/packages/astro/test/units/app/node.test.ts
+++ b/packages/astro/test/units/app/node.test.ts
@@ -416,6 +416,21 @@ describe('node', () => {
 				assert.equal(result.url, 'https://example.com:3000/');
 			});
 
+			it('rejects Host header with a duplicated port', () => {
+				const result = createRequest(
+					{
+						...mockNodeRequest,
+						headers: {
+							host: 'example.com:8080:8080',
+						},
+					},
+					{ allowedDomains: [{ hostname: 'example.com' }] },
+				);
+				// A host carrying two ports is invalid and must not validate,
+				// so it falls back to localhost rather than being interpolated verbatim.
+				assert.equal(result.url, 'https://localhost/');
+			});
+
 			it('accepts Host header with wildcard pattern in allowedDomains', () => {
 				const result = createRequest(
 					{
@@ -919,6 +934,41 @@ describe('node', () => {
 					},
 				});
 				assert.equal((result as any)[Symbol.for('astro.clientAddress')], '2.2.2.2');
+			});
+		});
+
+		describe('malformed host header', () => {
+			// A Host header with an unparseable port makes the interpolated URL
+			// invalid. The construction must not throw: it falls back to a host the
+			// server controls so callers always receive a Request.
+			const malformedHosts = [
+				'example.com:65536',
+				'example.com:99999',
+				'example.com:abc',
+				'example.com:443:443',
+				'example.com:-1',
+			];
+
+			for (const host of malformedHosts) {
+				it(`does not throw for host "${host}"`, () => {
+					const build = () =>
+						createRequestFromNodeRequest({
+							...mockNodeRequest,
+							socket: { encrypted: false, remoteAddress: '2.2.2.2' },
+							headers: { host },
+						});
+					assert.doesNotThrow(build);
+					assert.ok(URL.canParse(build().url));
+				});
+			}
+
+			it('preserves a valid host with the maximum port', () => {
+				const result = createRequestFromNodeRequest({
+					...mockNodeRequest,
+					socket: { encrypted: false, remoteAddress: '2.2.2.2' },
+					headers: { host: 'example.com:65535' },
+				});
+				assert.equal(new URL(result.url).host, 'example.com:65535');
 			});
 		});
 	});

--- a/packages/integrations/node/test/static-headers.test.ts
+++ b/packages/integrations/node/test/static-headers.test.ts
@@ -1,7 +1,26 @@
 import * as assert from 'node:assert/strict';
+import net from 'node:net';
 import { after, before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
 import { type Fixture, loadFixture, waitServerListen, type AdapterServer } from './test-utils.ts';
+
+/**
+ * Sends a raw HTTP request with a hand-written Host header and resolves with
+ * the status line. `fetch` rewrites the Host header, so a socket is the only
+ * way to exercise a client-supplied host with a malformed port.
+ */
+function requestWithHost(host: string, port: number, hostHeader: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const socket = net.connect(port, host, () => {
+			socket.write(`GET / HTTP/1.1\r\nHost: ${hostHeader}\r\nConnection: close\r\n\r\n`);
+		});
+		let body = '';
+		socket.setEncoding('utf8');
+		socket.on('data', (chunk) => (body += chunk));
+		socket.on('end', () => resolve(body.split('\r\n')[0] ?? ''));
+		socket.on('error', reject);
+	});
+}
 
 type StaticHeaderEntry = { pathname: string; headers: Array<{ key: string; value: string }> };
 
@@ -72,6 +91,15 @@ describe('Static headers', () => {
 			cps.includes('script-src'),
 			'should contain script-src directive due to server island',
 		);
+	});
+
+	it('survives a request with a malformed port in the Host header', async () => {
+		// A malformed port makes the URL unparseable while the static handler
+		// builds a Request to look up per-route headers. The request must not
+		// take the process down; a follow-up request must still be served.
+		await requestWithHost(server.host ?? '127.0.0.1', server.port, 'example.com:65536');
+		const res = await fetch(`http://${server.host}:${server.port}/`);
+		assert.equal(res.status, 200);
 	});
 });
 


### PR DESCRIPTION
## Changes

- Fixes a crash in the Node adapter when a request arrives with a malformed port in the `Host` header (e.g. `example.com:65536`, `example.com:8080:8080`). The bad host made the request URL invalid, and the existing `catch` fallback rebuilt the URL from the same host and threw again.
- `buildRequestUrl` (shared by `createRequestFromNodeRequest` and `createRequest`) now degrades in steps — full URL, origin only, then a server-controlled host (`localhost`, with the listening port when known) — so URL construction never throws.
- `parseHost` now rejects a host with more than one `hostname:port` pair, which previously passed by inspecting only the first two colon-separated segments.

## Testing

- Unit tests in `node.test.ts` covering malformed hosts through `createRequestFromNodeRequest` (no throw, parseable URL) plus a valid max-port control, and a `createRequest` case asserting a duplicated-port host is rejected.
- An end-to-end `@astrojs/node` test that drives a standalone server, sends a crafted `Host` over a raw socket, and asserts a follow-up request still succeeds.

## Docs

- No docs update needed; this is an internal reliability fix with no API change.
