### PR TITLE
Fix Content Layer build crash when neotraverse 0.6.x is hoisted by another dependency

### DIFF
--- a/.changeset/hip-gifts-try.md
+++ b/.changeset/hip-gifts-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a Content Layer build crash that could occur when another dependency causes an older version of `neotraverse` to be hoisted to the project root

--- a/packages/astro/src/vite-plugin-environment/index.ts
+++ b/packages/astro/src/vite-plugin-environment/index.ts
@@ -26,6 +26,9 @@ const ALWAYS_NOEXTERNAL = [
 	'@nanostores/preact',
 	// fontsource packages are CSS that need to be processed
 	'@fontsource/*',
+	// Must be bundled so the prerender output resolves Astro's own copy, not an
+	// older hoisted version from another dependency. See https://github.com/withastro/astro/issues/17508
+	'neotraverse',
 ];
 
 interface Payload {


### PR DESCRIPTION
Closes #17508

## Changes

- Adds `neotraverse` to the `ALWAYS_NOEXTERNAL` list in `vite-plugin-environment/index.ts`, forcing it to be bundled into the prerender output instead of emitted as a bare external import.
- Before this fix, if any other package in the dependency tree required `neotraverse@^0.6.x`, npm would hoist that older copy to the project root. The prerender bundle (written to `dist/.prerender/`, outside `node_modules/astro`) would then resolve the bare `import { forEach } from "neotraverse"` to the hoisted 0.6.x copy — which doesn't export `forEach` — crashing the build. Bundling `neotraverse` ensures Astro's own copy is always used regardless of what's hoisted in the project.

## Testing

- No new tests added; the fix is a one-line config addition. Existing Content Layer integration tests cover the affected code paths and confirm no regression.

## Docs

- No docs update needed; this is an internal dependency resolution fix with no user-facing API changes.
