### PR TITLE
Support detect devEngines for installs

### DIFF
--- a/.changeset/shiny-plums-brush.md
+++ b/.changeset/shiny-plums-brush.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/upgrade': patch
+'astro': patch
+---
+
+Supports the `devEngines` field in package.json when detecting the package manager for install commands

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -772,7 +772,7 @@ async function tryToInstallIntegrations({
 		cwd,
 		// Include the `install-metadata` strategy to have the package manager that's
 		// used for installation take precedence
-		strategies: ['install-metadata', 'lockfile', 'packageManager-field'],
+		strategies: ['install-metadata', 'lockfile', 'packageManager-field', 'devEngines-field'],
 	});
 	logger.debug('add', `package manager: "${packageManager?.name}"`);
 	if (!packageManager) return 'none';

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -66,7 +66,7 @@ async function installPackage(
 		cwd,
 		// Include the `install-metadata` strategy to have the package manager that's
 		// used for installation take precedence
-		strategies: ['install-metadata', 'lockfile', 'packageManager-field'],
+		strategies: ['install-metadata', 'lockfile', 'packageManager-field', 'devEngines-field'],
 	});
 	const installCommand = resolveCommand(packageManager?.agent ?? 'npm', 'add', []);
 	if (!installCommand) return false;

--- a/packages/upgrade/src/actions/context.ts
+++ b/packages/upgrade/src/actions/context.ts
@@ -41,7 +41,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 	const packageManager = (await detect({
 		// Include the `install-metadata` strategy to have the package manager that's
 		// used for installation take precedence
-		strategies: ['install-metadata', 'lockfile', 'packageManager-field'],
+		strategies: ['install-metadata', 'lockfile', 'packageManager-field', 'devEngines-field'],
 	})) ?? { agent: 'npm', name: 'npm' };
 	const { _: [version = 'latest'] = [], '--help': help = false, '--dry-run': dryRun } = flags;
 


### PR DESCRIPTION
## Changes

`package-manager-detector` recently supported the `devEngines` field, but for our custom `strategies` option passing, we redefine the list and didn't include the `devEngines-field` option, so this PR includes it.

Its default value had `devEngines-field`.

## Testing

Didn't test as should be a simple change

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Added a changeset.