### PR TITLE
Validate content collection reference() IDs after sync

### DIFF
--- a/.changeset/hungry-tips-enjoy.md
+++ b/.changeset/hungry-tips-enjoy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression where content collection `reference()` fields silently accepted entry IDs that don't exist, such as an ID that doesn't match a loader's slugified version of it. Astro now logs an error for references that point to a missing entry after all loaders finish syncing.

--- a/packages/astro/src/content/content-layer.ts
+++ b/packages/astro/src/content/content-layer.ts
@@ -347,6 +347,7 @@ export class ContentLayer {
 				}
 			}),
 		);
+		this.#validateReferences(contentConfig.config.collections, logger);
 		await fs.mkdir(this.#settings.config.cacheDir, { recursive: true });
 		await fs.mkdir(this.#settings.dotAstroDir, { recursive: true });
 		const assetImportsFile = new URL(ASSET_IMPORTS_FILE, this.#settings.dotAstroDir);
@@ -357,6 +358,79 @@ export class ContentLayer {
 		logger.info('Synced content');
 		if (this.#settings.config.experimental.contentIntellisense) {
 			await this.regenerateCollectionFileManifest();
+		}
+	}
+
+	/**
+	 * After all loaders complete, walks every entry's data to find reference objects
+	 * (`{ id, collection }`) and checks that the referenced entry exists in the store.
+	 * This replaces the inline Zod validation that was removed in the Zod 4 upgrade.
+	 */
+	#validateReferences(collections: Record<string, any>, logger: { error(message: string): void }) {
+		const collectionNames = new Set(Object.keys(collections));
+		for (const collectionName of collectionNames) {
+			for (const entry of this.#store.values(collectionName)) {
+				if (entry?.data) {
+					this.#findInvalidReferences(
+						entry.data,
+						collectionNames,
+						collectionName,
+						entry.id,
+						logger,
+						'',
+					);
+				}
+			}
+		}
+	}
+
+	#findInvalidReferences(
+		value: unknown,
+		collectionNames: Set<string>,
+		ownerCollection: string,
+		ownerId: string,
+		logger: { error(message: string): void },
+		path: string,
+	) {
+		if (value == null || typeof value !== 'object') return;
+
+		if (Array.isArray(value)) {
+			for (let i = 0; i < value.length; i++) {
+				this.#findInvalidReferences(
+					value[i],
+					collectionNames,
+					ownerCollection,
+					ownerId,
+					logger,
+					`${path}[${i}]`,
+				);
+			}
+			return;
+		}
+
+		const obj = value as Record<string, unknown>;
+		// A reference object has `id` (or `slug`) and `collection` string fields
+		if (typeof obj.collection === 'string' && collectionNames.has(obj.collection)) {
+			const refId =
+				typeof obj.id === 'string' ? obj.id : typeof obj.slug === 'string' ? obj.slug : undefined;
+			if (refId !== undefined && !this.#store.has(obj.collection, refId)) {
+				const fieldPath = path ? ` (field: ${path})` : '';
+				logger.error(
+					`Invalid content reference: entry "${ownerId}" in collection "${ownerCollection}"${fieldPath} references "${refId}" in collection "${obj.collection}", but that entry does not exist.`,
+				);
+			}
+			return;
+		}
+
+		for (const [key, val] of Object.entries(obj)) {
+			this.#findInvalidReferences(
+				val,
+				collectionNames,
+				ownerCollection,
+				ownerId,
+				logger,
+				path ? `${path}.${key}` : key,
+			);
 		}
 	}
 

--- a/packages/astro/test/units/content-layer/data-transforms.test.ts
+++ b/packages/astro/test/units/content-layer/data-transforms.test.ts
@@ -515,6 +515,140 @@ describe('Content Layer - Data Transforms', () => {
 		assert.equal(result2.data.category, 'general');
 	});
 
+	it('logs error for invalid reference after sync', async () => {
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root);
+		const errors: string[] = [];
+		const logger = new AstroLogger({
+			destination: {
+				write: (msg: any) => {
+					errors.push(msg.message ?? String(msg));
+				},
+			},
+			level: 'info',
+		});
+
+		const authorsLoader = {
+			name: 'authors-loader',
+			load: async (context: any) => {
+				const parsed = await context.parseData({
+					id: 'john-doe',
+					data: { id: 'john-doe', name: 'John Doe' },
+				});
+				await context.store.set({ id: 'john-doe', data: parsed });
+			},
+		};
+
+		const postsLoader = {
+			name: 'posts-loader',
+			load: async (context: any) => {
+				const parsed = await context.parseData({
+					id: 'my-post',
+					data: { id: 'my-post', title: 'My Post', author: 'John-Doe' },
+				});
+				await context.store.set({ id: 'my-post', data: parsed });
+			},
+		};
+
+		const collections = {
+			authors: defineCollection({
+				loader: authorsLoader,
+				schema: z.object({ id: z.string(), name: z.string() }),
+			}),
+			posts: defineCollection({
+				loader: postsLoader,
+				schema: z.object({
+					id: z.string(),
+					title: z.string(),
+					author: reference('authors'),
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		// The reference "John-Doe" should trigger an error because the actual id is "john-doe"
+		const errorMessages = errors.join('\n');
+		assert.ok(
+			errorMessages.includes('John-Doe') && errorMessages.includes('does not exist'),
+			`Expected error about invalid reference "John-Doe", got: ${errorMessages}`,
+		);
+	});
+
+	it('does not log error for valid references after sync', async () => {
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root);
+		const errors: string[] = [];
+		const logger = new AstroLogger({
+			destination: {
+				write: (msg: any) => {
+					errors.push(msg.message ?? String(msg));
+				},
+			},
+			level: 'info',
+		});
+
+		const authorsLoader = {
+			name: 'authors-loader',
+			load: async (context: any) => {
+				const parsed = await context.parseData({
+					id: 'john-doe',
+					data: { id: 'john-doe', name: 'John Doe' },
+				});
+				await context.store.set({ id: 'john-doe', data: parsed });
+			},
+		};
+
+		const postsLoader = {
+			name: 'posts-loader',
+			load: async (context: any) => {
+				const parsed = await context.parseData({
+					id: 'my-post',
+					data: { id: 'my-post', title: 'My Post', author: 'john-doe' },
+				});
+				await context.store.set({ id: 'my-post', data: parsed });
+			},
+		};
+
+		const collections = {
+			authors: defineCollection({
+				loader: authorsLoader,
+				schema: z.object({ id: z.string(), name: z.string() }),
+			}),
+			posts: defineCollection({
+				loader: postsLoader,
+				schema: z.object({
+					id: z.string(),
+					title: z.string(),
+					author: reference('authors'),
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		// No errors about invalid references
+		const errorMessages = errors.join('\n');
+		assert.ok(
+			!errorMessages.includes('does not exist'),
+			`Unexpected reference error: ${errorMessages}`,
+		);
+	});
+
 	it('transforms numeric ids to strings', async () => {
 		const store = new MutableDataStore();
 		const settings = createMinimalSettings(root);


### PR DESCRIPTION
## Changes

- `reference()` fields in content collections no longer silently accept entry IDs that don't exist in the store. After all loaders finish syncing, `ContentLayer` now walks every entry's data to find reference objects (`{ id, collection }`) and logs an error for any that point to a missing entry. This catches cases like `author: "John-Doe"` where the `glob()` loader slugified the actual entry ID to `john-doe`.
- This is a regression from the Zod 4 upgrade (PR #14956), which removed the inline Zod validation that previously caught invalid references. Inline validation can't be restored because loaders run in parallel and the referenced collection may not be populated yet, so validation runs post-sync instead.

Closes #17322

## Testing

- Two new unit tests in `packages/astro/test/units/content-layer/data-transforms.test.ts`: one verifying that an invalid reference (`John-Doe` where only `john-doe` exists) produces an error log, and one verifying that a valid reference produces no error.

## Docs

- No docs update needed; this restores previously documented behavior that was accidentally removed.
