### PR TITLE
fix: load the default Markdown processor lazily

### DIFF
--- a/.changeset/lazy-markdown-processor.md
+++ b/.changeset/lazy-markdown-processor.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Loads the default Sätteri Markdown processor lazily so it is only resolved when Markdown is actually rendered. Previously it was imported at the top of the config schema and pulled into the module graph on every `astro dev`/`build`, which broke builds on platforms where Sätteri's optional native binary is not installed even when the project had no Markdown files.

--- a/packages/astro/src/core/config/schemas/base.ts
+++ b/packages/astro/src/core/config/schemas/base.ts
@@ -6,7 +6,6 @@ import type {
 	ShikiConfig,
 } from '@astrojs/internal-helpers/markdown';
 import { syntaxHighlightDefaults } from '@astrojs/internal-helpers/markdown';
-import { satteri } from '@astrojs/markdown-satteri';
 import type { MarkdownProcessor } from '../../../markdown/index.js';
 import type { OutgoingHttpHeaders } from 'node:http';
 import { type BuiltinTheme, bundledThemes } from 'shiki';
@@ -89,6 +88,20 @@ const smartypantsOptionsSchema: z.ZodType<Smartypants> = z.object({
 	}),
 	quotes: z.boolean().default(true),
 });
+
+// Dynamic import so Sätteri's optional native binaries aren't pulled into
+// the graph for projects with no Markdown.
+function createDefaultMarkdownProcessor(): MarkdownProcessor {
+	const processor: MarkdownProcessor = {
+		name: 'satteri',
+		options: { mdastPlugins: [], hastPlugins: [], features: {} },
+		async createRenderer(shared) {
+			const { satteri } = await import('@astrojs/markdown-satteri');
+			return satteri(processor.options).createRenderer(shared);
+		},
+	};
+	return processor;
+}
 
 export const AstroConfigSchema = z.object({
 	root: z
@@ -393,7 +406,7 @@ export const AstroConfigSchema = z.object({
 				// A factory (not a shared value) so every config gets its own processor —
 				// integrations extend the pipeline by mutating `processor.options`, which
 				// would otherwise leak across configs built in the same process.
-				.default(() => satteri()),
+				.default(() => createDefaultMarkdownProcessor()),
 		})
 		.prefault({}),
 	vite: z

--- a/packages/astro/test/units/config/config-validate.test.ts
+++ b/packages/astro/test/units/config/config-validate.test.ts
@@ -669,6 +669,16 @@ describe('Config Validation', () => {
 		});
 	});
 
+	describe('markdown default processor', () => {
+		it('defaults to the Sätteri processor without eagerly importing it', async () => {
+			const result = await validateConfig({});
+			// `@astrojs/markdown-satteri` is loaded on demand from `createRenderer`, so the
+			// default has to resolve to the Sätteri processor for Markdown to render.
+			assert.equal(result.markdown.processor.name, 'satteri');
+			assert.equal(typeof result.markdown.processor.createRenderer, 'function');
+		});
+	});
+
 	describe('devToolbar', () => {
 		it('should allow valid placement values', async () => {
 			for (const placement of ['bottom-left', 'bottom-center', 'bottom-right']) {


### PR DESCRIPTION
## Changes

Astro's config schema imported `@astrojs/markdown-satteri` at the top level, so Sätteri and its optional platform-specific native binaries landed in the module graph on every `astro dev`/`build`, even for projects with no Markdown files. When npm skips the unavailable optional binary for the host platform (for example Windows without `@bruits/satteri-wasm32-wasi`), the bundler then can't resolve it and the build crashes.

This puts the default processor behind a dynamic import, so `@astrojs/markdown-satteri` is only resolved when Markdown actually gets rendered. A project with no Markdown never pulls it into the graph.

## Testing

I added a unit test checking that the default `markdown.processor` still resolves to the Sätteri processor. The existing `markdown.processor` integration test already covers rendering with the default, and it plus the full unit suite pass. The Windows build crash from the report needs the missing optional binary, so it can't be reproduced on Linux CI.

## Docs

No user-facing behavior change, so no docs needed.

Fixes #17585
