### PR TITLE
test: skip type check tests in ecosystem-ci

### DIFF
--- a/packages/astro/test/cli.test.ts
+++ b/packages/astro/test/cli.test.ts
@@ -73,6 +73,8 @@ describe('astro cli', () => {
 	});
 
 	it('astro check no errors', {
+		// type definitions are not generated for ecosystem CI
+		skip: !!process.env.ECOSYSTEM_CI,
 		timeout: 35000,
 	}, async () => {
 		const projectRootURL = new URL('./fixtures/astro-check-no-errors/', import.meta.url);
@@ -87,6 +89,8 @@ describe('astro cli', () => {
 	});
 
 	it('astro check has errors', {
+		// type definitions are not generated for ecosystem CI
+		skip: !!process.env.ECOSYSTEM_CI,
 		timeout: 35000,
 	}, async () => {
 		const projectRootURL = new URL('./fixtures/astro-check-errors/', import.meta.url);

--- a/packages/astro/test/content-collections-type-inference.test.ts
+++ b/packages/astro/test/content-collections-type-inference.test.ts
@@ -51,7 +51,10 @@ describe('Content collection type inference', () => {
 		);
 	});
 
-	it('type-checks correctly against the generated types', () => {
+	it('type-checks correctly against the generated types', {
+		// type definitions are not generated for ecosystem CI
+		skip: !!process.env.ECOSYSTEM_CI,
+	}, () => {
 		// Run tsc on the fixture to verify the type assertions in src/type-checks.ts
 		// pass against the real generated content.d.ts.
 		//


### PR DESCRIPTION
## Changes

Skip the failing type check tests in ecosystem-ci. This will make ecosystem-ci pass.

I think it is better to make the tests pass so we can easily catch regressions. If we want to catch regressions for types, we can enable these tests later when it passes.

I didn't add a changeset as this is completely an internal change.

## Testing

I ran ecosystem-ci against my fork by running `node ecosystem-ci.ts astro` in the local modified ecosystem-ci repo.

## Docs

No docs change as this is an internal change.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
