### PR TITLE
Fix type error when using app.use(cf()) from @astrojs/cloudflare/hono

### DIFF
--- a/.changeset/solid-steaks-enjoy.md
+++ b/.changeset/solid-steaks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a type-checking error when using `app.use(cf())` from `@astrojs/cloudflare/hono` in projects with `wrangler types`-generated `ExecutionContext` declarations

--- a/packages/integrations/cloudflare/src/hono.ts
+++ b/packages/integrations/cloudflare/src/hono.ts
@@ -33,7 +33,11 @@ type HonoCloudflareContextLike = {
 		raw: Request;
 	};
 	env: Env;
-	executionCtx: ExecutionContext;
+	executionCtx: {
+		waitUntil(promise: Promise<unknown>): void;
+		passThroughOnException(): void;
+		props: unknown;
+	};
 	get?: (key: string) => unknown;
 	set?: (key: string, value: unknown) => void;
 };


### PR DESCRIPTION
## Changes

- `app.use(cf())` from `@astrojs/cloudflare/hono` now type-checks correctly in projects that use `wrangler types`. Previously, `HonoCloudflareContextLike` declared `executionCtx: ExecutionContext`, binding it to the global `ExecutionContext` type. When `wrangler types` generates `worker-configuration.d.ts`, that global gains required members (`tracing`, `exports`) that Hono's own `ExecutionContext` doesn't have, making the handler contravariant-incompatible with `MiddlewareHandler`.
- Replaces `executionCtx: ExecutionContext` with an inline structural type listing only the three members actually consumed downstream (`waitUntil`, `passThroughOnException`, `props`). This matches the approach `astro/hono` already uses for its duck-typed context, and the narrowed type remains assignable to internal callers (`cfFetch`, `createLocals`) without any casts.

## Testing

- No new automated test — the mismatch only surfaces when the user's `wrangler types`-generated `ExecutionContext` global is in scope, which the package's own test compilation doesn't exercise (it compiles against `@cloudflare/workers-types`, whose `ExecutionContext` has fewer/optional members). The fix was verified against the reporter's repro at https://github.com/iseraph-dev/repro-astro-cf-hono-types, where `astro check` goes from 1 error to 0.

## Docs

- No docs change needed — this is a type-only fix with no behavior or API surface change.

Closes #17593