### PR TITLE
fix(content): support non-cloneable values in content collection data

### DIFF
--- a/.changeset/shiny-moons-clone.md
+++ b/.changeset/shiny-moons-clone.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `getCollection()` and `getEntry()` throwing `DataCloneError` when a content collection schema produces values that `structuredClone` cannot handle, such as `Temporal.PlainDate` or other class instances returned from a Zod `transform()`. Image reference replacement now clones only the plain objects and arrays it may modify, passing all other values through by reference.

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -530,21 +530,21 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  */
 function cloneContainers<T>(value: T, seen = new WeakMap<object, unknown>()): T {
 	if (Array.isArray(value)) {
-		const existing = seen.get(value);
-		if (existing) {
-			return existing as T;
+		const cached = seen.get(value);
+		if (cached !== undefined) {
+			return cached as T;
 		}
-		const copy: unknown[] = [];
+		const copy = new Array(value.length);
 		seen.set(value, copy);
-		for (const item of value) {
-			copy.push(cloneContainers(item, seen));
+		for (let index = 0; index < value.length; index++) {
+			copy[index] = cloneContainers(value[index], seen);
 		}
 		return copy as T;
 	}
 	if (isPlainObject(value)) {
-		const existing = seen.get(value);
-		if (existing) {
-			return existing as T;
+		const cached = seen.get(value);
+		if (cached !== undefined) {
+			return cached as T;
 		}
 		const copy: Record<string, unknown> = {};
 		seen.set(value, copy);

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -512,12 +512,56 @@ async function updateImageReferencesInBody(html: string, fileName: string) {
 	});
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Clones the structural containers (plain objects and arrays) of a value, passing
+ * every other value through by reference. Image reference replacement only ever
+ * rewrites strings nested in plain objects and arrays, so those are the only
+ * containers that must be copied to avoid mutating the data store. Cloning the
+ * rest with `structuredClone` would throw on non-cloneable values such as
+ * `Temporal.PlainDate` or class instances produced by Zod transforms.
+ */
+function cloneContainers<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+	if (Array.isArray(value)) {
+		const existing = seen.get(value);
+		if (existing) {
+			return existing as T;
+		}
+		const copy: unknown[] = [];
+		seen.set(value, copy);
+		for (const item of value) {
+			copy.push(cloneContainers(item, seen));
+		}
+		return copy as T;
+	}
+	if (isPlainObject(value)) {
+		const existing = seen.get(value);
+		if (existing) {
+			return existing as T;
+		}
+		const copy: Record<string, unknown> = {};
+		seen.set(value, copy);
+		for (const [key, entry] of Object.entries(value)) {
+			copy[key] = cloneContainers(entry, seen);
+		}
+		return copy as T;
+	}
+	return value;
+}
+
 export function updateImageReferencesInData<T extends Record<string, unknown>>(
 	data: T,
 	fileName?: string,
 	imageAssetMap?: Map<string, ImageMetadata>,
 ): T {
-	const copy = structuredClone(data);
+	const copy = cloneContainers(data);
 	forEach(copy, function (ctx, val) {
 		if (typeof val === 'string' && val.startsWith(IMAGE_IMPORT_PREFIX)) {
 			const src = val.replace(IMAGE_IMPORT_PREFIX, '');

--- a/packages/astro/test/units/content-collections/image-references.test.ts
+++ b/packages/astro/test/units/content-collections/image-references.test.ts
@@ -122,4 +122,35 @@ describe('updateImageReferencesInData', () => {
 		assert.equal(result.flags.has('showCover'), false);
 		assert.equal(result.flags.size, 2);
 	});
+
+	it('preserves non-structuredClone-compatible values (see #17589)', () => {
+		// Stand-in for values like Temporal.PlainDate that structuredClone rejects
+		class PlainDate {
+			iso: string;
+			format = () => this.iso;
+			constructor(iso: string) {
+				this.iso = iso;
+			}
+		}
+		const publishedOn = new PlainDate('2026-08-04');
+		assert.throws(() => structuredClone(publishedOn), { name: 'DataCloneError' });
+
+		const data = { publishedOn, nested: { alsoDate: publishedOn } };
+		const result = updateImageReferencesInData(data, FILE_NAME, new Map());
+		assert.equal(result.publishedOn, publishedOn);
+		assert.equal(result.nested.alsoDate, publishedOn);
+		assert.equal(result.publishedOn.format(), '2026-08-04');
+	});
+
+	it('resolves images without mutating the original data', () => {
+		const data = {
+			image: `${IMAGE_PREFIX}./hero.png`,
+			meta: { caption: 'A hero' },
+		};
+		const map = makeImageMap('./hero.png', heroMeta);
+		const result = updateImageReferencesInData(data, FILE_NAME, map);
+		assert.deepEqual(result.image, heroMeta);
+		assert.equal(data.image, `${IMAGE_PREFIX}./hero.png`);
+		assert.notEqual(result.meta, data.meta);
+	});
 });


### PR DESCRIPTION
## Changes

- Fixes #17589
- `getCollection()` / `getEntry()` threw `DataCloneError` when a collection schema produced values that `structuredClone` cannot handle — e.g. a Zod `transform()` returning `Temporal.PlainDate` or any other class instance.
- The unconditional `structuredClone(data)` in `updateImageReferencesInData()` (introduced in #16701 to preserve `Map`/`Set`) is replaced with a selective clone: only plain objects and arrays — the containers whose nested strings may be rewritten into image metadata — are copied. Everything else (`Map`, `Set`, class instances, `Temporal` objects, …) passes through by reference.
- This is safe because the traversal only ever calls `ctx.update()` on strings prefixed with `__ASTRO_IMAGE_`; non-plain values are never mutation targets, so sharing them between the store data and the returned copy cannot leak mutations.
- Handles circular references among plain containers via a `WeakMap`, matching `structuredClone`'s behavior there.
- Includes a changeset (patch for `astro`).

## Testing

- Added a regression test in `packages/astro/test/units/content-collections/image-references.test.ts` using a class instance as a stand-in for `Temporal.PlainDate` (the test first asserts `structuredClone` rejects it with `DataCloneError`, then that `updateImageReferencesInData` preserves it by reference, including when nested).
- Added a test asserting image resolution still does not mutate the original store data.
- All 13 tests in `image-references.test.ts` pass, including the `Map`/`Set` preservation tests from #16701; the other content-collections unit suites (`get-entry-info`, `get-entry-type`, `mutable-data-store`) also pass.

## Docs

No docs changes needed — this removes an undocumented limitation rather than changing documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)