### PR TITLE
Fix middleware HMR not reloading when imported modules change

### DIFF
--- a/.changeset/happy-camels-open.md
+++ b/.changeset/happy-camels-open.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes middleware HMR not responding to changes in imported modules. Previously, editing a file imported by `middleware.ts` would not trigger a middleware reload — only direct edits to the middleware file itself were detected. The middleware now correctly reloads when any of its transitive dependencies change.

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -1,9 +1,11 @@
 import { fileURLToPath } from 'node:url';
 import {
 	normalizePath as viteNormalizePath,
+	type EnvironmentModuleNode,
 	type ViteDevServer,
 	type Plugin as VitePlugin,
 } from 'vite';
+import { isAstroServerEnvironment } from '../../environments.js';
 import { getServerOutputDirectory } from '../../prerender/utils.js';
 import type { AstroSettings } from '../../types/astro.js';
 import { addRolldownInput } from '../build/add-rolldown-input.js';
@@ -68,6 +70,23 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 				}
 			});
 		},
+		hotUpdate: {
+			handler({ modules }) {
+				if (!isAstroServerEnvironment(this.environment)) return;
+
+				const middlewareVirtualMod =
+					this.environment.moduleGraph.getModuleById(MIDDLEWARE_RESOLVED_MODULE_ID);
+				if (!middlewareVirtualMod) return;
+
+				for (const mod of modules) {
+					if (isTransitiveImporterOf(mod, MIDDLEWARE_RESOLVED_MODULE_ID)) {
+						this.environment.moduleGraph.invalidateModule(middlewareVirtualMod);
+						this.environment.hot.send('astro:middleware-updated', {});
+						return;
+					}
+				}
+			},
+		},
 		resolveId: {
 			filter: {
 				id: new RegExp(`^${MIDDLEWARE_MODULE_ID}$`),
@@ -127,6 +146,24 @@ export const onRequest = sequence(
 			},
 		},
 	};
+}
+
+/**
+ * Walks up the `importers` chain from `mod` to check whether the module
+ * with the given `targetId` transitively imports it.
+ */
+export function isTransitiveImporterOf(
+	mod: EnvironmentModuleNode,
+	targetId: string,
+	seen = new Set<EnvironmentModuleNode>(),
+): boolean {
+	if (seen.has(mod)) return false;
+	seen.add(mod);
+	for (const importer of mod.importers) {
+		if (importer.id === targetId) return true;
+		if (isTransitiveImporterOf(importer, targetId, seen)) return true;
+	}
+	return false;
 }
 
 function createMiddlewareImports(

--- a/packages/astro/test/units/middleware/middleware-hmr-imports.test.ts
+++ b/packages/astro/test/units/middleware/middleware-hmr-imports.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isTransitiveImporterOf } from '../../../dist/core/middleware/vite-plugin.js';
+
+/**
+ * Minimal mock of EnvironmentModuleNode with just the fields
+ * that isTransitiveImporterOf uses (id and importers).
+ */
+function createMockNode(id: string, importers: any[] = []): any {
+	return { id, importers };
+}
+
+describe('isTransitiveImporterOf', () => {
+	it('returns true when the module is directly imported by the target', () => {
+		const target = createMockNode('virtual:middleware');
+		const mod = createMockNode('utils/misc.ts', [target]);
+		assert.ok(isTransitiveImporterOf(mod, 'virtual:middleware'));
+	});
+
+	it('returns true when the module is transitively imported by the target', () => {
+		const target = createMockNode('virtual:middleware');
+		const middleware = createMockNode('middleware.ts', [target]);
+		const mod = createMockNode('utils/misc.ts', [middleware]);
+		assert.ok(isTransitiveImporterOf(mod, 'virtual:middleware'));
+	});
+
+	it('returns false when the module is not in the import chain of the target', () => {
+		const unrelated = createMockNode('pages/index.astro');
+		const mod = createMockNode('utils/misc.ts', [unrelated]);
+		assert.ok(!isTransitiveImporterOf(mod, 'virtual:middleware'));
+	});
+
+	it('handles circular imports without infinite recursion', () => {
+		const a = createMockNode('a.ts');
+		const b = createMockNode('b.ts', [a]);
+		// Create circular reference: a imports b, b imports a
+		a.importers = [b];
+		assert.ok(!isTransitiveImporterOf(a, 'virtual:middleware'));
+	});
+
+	it('returns false when the module has no importers', () => {
+		const mod = createMockNode('utils/misc.ts');
+		assert.ok(!isTransitiveImporterOf(mod, 'virtual:middleware'));
+	});
+
+	it('returns true through deeply nested import chains', () => {
+		const target = createMockNode('virtual:middleware');
+		const level1 = createMockNode('middleware.ts', [target]);
+		const level2 = createMockNode('utils/index.ts', [level1]);
+		const level3 = createMockNode('utils/helpers.ts', [level2]);
+		assert.ok(isTransitiveImporterOf(level3, 'virtual:middleware'));
+	});
+});


### PR DESCRIPTION
## Changes

- Middleware now reloads during HMR when any of its transitive dependencies change, not only when `middleware.ts` itself is edited.
- Adds a `hotUpdate` hook to the middleware Vite plugin that walks each updated module's `importers` chain. When a changed module is a transitive dependency of the middleware virtual module, the hook invalidates it and sends the `astro:middleware-updated` event to clear the pipeline cache.

## Testing

- Adds `packages/astro/test/units/middleware/middleware-hmr-imports.test.ts` with 6 unit tests covering the new `isTransitiveImporterOf` helper: direct imports, multi-level transitive chains, unrelated modules, circular references, empty importer lists, and deeply nested chains.

## Docs

- No docs update needed; this restores expected HMR behavior with no API changes.

Closes #17590