### PR TITLE
Fix middleware hmr behaviour

### DIFF
--- a/.changeset/calm-shrimps-peel.md
+++ b/.changeset/calm-shrimps-peel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes middleware HMR not responding to changes in imported modules. Previously, only direct edits to the middleware file would trigger a reload.

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -1,9 +1,4 @@
-import { fileURLToPath } from 'node:url';
-import {
-	normalizePath as viteNormalizePath,
-	type ViteDevServer,
-	type Plugin as VitePlugin,
-} from 'vite';
+import type { Plugin as VitePlugin } from 'vite';
 import { getServerOutputDirectory } from '../../prerender/utils.js';
 import type { AstroSettings } from '../../types/astro.js';
 import { addRolldownInput } from '../build/add-rolldown-input.js';
@@ -13,6 +8,7 @@ import { ASTRO_VITE_ENVIRONMENT_NAMES, MIDDLEWARE_PATH_SEGMENT_NAME } from '../c
 import { MissingMiddlewareForInternationalization } from '../errors/errors-data.js';
 import { AstroError } from '../errors/index.js';
 import { normalizePath } from '../viteUtils.js';
+import { isAstroServerEnvironment } from '../../environments.js';
 
 // This module name is used in Cloudflare's optimizedDeps configuration,
 // if th name changes that needs to be updated as well.
@@ -33,8 +29,6 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 		settings.middlewares.pre.length > 0 || settings.middlewares.post.length > 0;
 	let userMiddlewareIsPresent = false;
 
-	const normalizedSrcDir = viteNormalizePath(fileURLToPath(settings.config.srcDir));
-
 	return {
 		name: '@astro/plugin-middleware',
 		applyToEnvironment(environment) {
@@ -44,29 +38,18 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 				environment.name === ASTRO_VITE_ENVIRONMENT_NAMES.prerender
 			);
 		},
-		configureServer(server: ViteDevServer) {
-			server.watcher.on('change', (path) => {
-				const normalizedPath = viteNormalizePath(path);
-				// Check if the changed file is a middleware file under srcDir
-				if (!normalizedPath.startsWith(normalizedSrcDir)) return;
-				const relativePath = normalizedPath.slice(normalizedSrcDir.length);
-				if (!isMiddlewarePath(relativePath)) return;
+		hotUpdate: {
+			handler() {
+				if (!isAstroServerEnvironment(this.environment)) return;
 
-				for (const name of [
-					ASTRO_VITE_ENVIRONMENT_NAMES.ssr,
-					ASTRO_VITE_ENVIRONMENT_NAMES.astro,
-				] as const) {
-					const environment = server.environments[name];
-					if (!environment) continue;
+				const middlewareVirtualMod = this.environment.moduleGraph.getModuleById(
+					MIDDLEWARE_RESOLVED_MODULE_ID,
+				);
+				if (!middlewareVirtualMod) return;
 
-					const virtualMod = environment.moduleGraph.getModuleById(MIDDLEWARE_RESOLVED_MODULE_ID);
-					if (virtualMod) {
-						environment.moduleGraph.invalidateModule(virtualMod);
-					}
-
-					environment.hot.send('astro:middleware-updated', {});
-				}
-			});
+				this.environment.moduleGraph.invalidateModule(middlewareVirtualMod);
+				this.environment.hot.send('astro:middleware-updated', {});
+			},
 		},
 		resolveId: {
 			filter: {

--- a/packages/astro/test/fixtures/hmr-middleware/astro.config.mjs
+++ b/packages/astro/test/fixtures/hmr-middleware/astro.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({});

--- a/packages/astro/test/fixtures/hmr-middleware/package.json
+++ b/packages/astro/test/fixtures/hmr-middleware/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/hmr-middleware",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/hmr-middleware/src/middleware.js
+++ b/packages/astro/test/fixtures/hmr-middleware/src/middleware.js
@@ -1,0 +1,16 @@
+import { defineMiddleware } from "astro:middleware";
+import { MiscUtils } from "./utils/misc";
+
+let executed = 0;
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  context.locals.utils = new MiscUtils();
+
+	// add newline here
+  executed += 1;
+
+	return next().then((res) => {
+		res.headers.set("x-test-executed", executed);
+		res.headers.set("x-test-other-count", context.locals.utils.nestedImportCount())
+	});
+});

--- a/packages/astro/test/fixtures/hmr-middleware/src/pages/index.astro
+++ b/packages/astro/test/fixtures/hmr-middleware/src/pages/index.astro
@@ -1,0 +1,17 @@
+---
+const title = Astro.locals.utils.arrayToString(["Hello", "Astro"]);
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" /> 
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>{title}</title>
+	</head>
+	<body>
+		<h1>{title}</h1>
+	</body>
+</html>

--- a/packages/astro/test/fixtures/hmr-middleware/src/utils/misc.js
+++ b/packages/astro/test/fixtures/hmr-middleware/src/utils/misc.js
@@ -1,0 +1,11 @@
+import { getCount } from "./other";
+
+export class MiscUtils {
+	nestedImportCount() {
+		return getCount();
+	}
+
+  arrayToString(arr) {
+    return arr.join(" ");
+  }
+}

--- a/packages/astro/test/fixtures/hmr-middleware/src/utils/other.js
+++ b/packages/astro/test/fixtures/hmr-middleware/src/utils/other.js
@@ -1,0 +1,6 @@
+let count = 0;
+
+export const getCount = () => {
+	count += 1;
+	return count;
+}

--- a/packages/astro/test/middleware.test.ts
+++ b/packages/astro/test/middleware.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
-import { after, before, describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.ts';
@@ -194,5 +194,86 @@ describe('Middleware with tailwind', () => {
 			.replace(/\s/g, '')
 			.replace('/n', '');
 		assert.equal(bundledCSS.includes('--tw'), true);
+	});
+});
+
+describe('Middleware HMR', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+
+	beforeEach(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/hmr-middleware/',
+			outDir: './dist/middleware-middleware-hmr/',
+		});
+
+		devServer = await fixture.startDevServer();
+	});
+
+	afterEach(async () => {
+		await devServer.stop();
+		fixture.resetAllFiles();
+	});
+
+	const fetchAndAssertTwice = async () => {
+		let response = await fixture.fetch('/');
+		assert.equal(response.headers.get('x-test-executed'), '1');
+		assert.equal(response.headers.get('x-test-other-count'), '1');
+
+		response = await fixture.fetch('/');
+		assert.equal(response.headers.get('x-test-executed'), '2');
+		assert.equal(response.headers.get('x-test-other-count'), '2');
+
+		return response;
+	};
+
+	it('should perform HMR on middleware.js', async () => {
+		await fetchAndAssertTwice();
+
+		await fixture.editFile('./src/middleware.js', (original) =>
+			original.replace('add newline here', 'add newline here\n'),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		// src/middleware.js should reload
+		// src/utils/other.js shouldn't reload
+		const response = await fixture.fetch('/');
+		assert.equal(response.headers.get('x-test-executed'), '1');
+		assert.equal(response.headers.get('x-test-other-count'), '3');
+	});
+
+	it('should perform HMR on modules imported by middleware.js', async () => {
+		let response = await fetchAndAssertTwice();
+		assert.ok((await response.text()).includes('Hello Astro'));
+
+		await fixture.editFile('./src/utils/misc.js', (original) =>
+			original.replace('join(" ")', 'join(" - ")'),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		// src/utils/misc.js should reload, as should src/middleware.js
+		// src/pages/index.astro should therefore receive the new instance of MiscUtils
+		// src/utils/other.js shouldn't reload
+		response = await fixture.fetch('/');
+		assert.equal(response.headers.get('x-test-executed'), '1');
+		assert.equal(response.headers.get('x-test-other-count'), '3');
+		assert.ok((await response.text()).includes('Hello - Astro'));
+	});
+
+	it('should perform HMR on nested modules imported by middleware.js', async () => {
+		await fetchAndAssertTwice();
+
+		await fixture.editFile('./src/utils/other.js', (original) =>
+			original.replace('let count = 0;', 'let count = 0;\n//foo\n'),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		// src/utils/other.js should reload, as should src/middleware.js
+		const response = await fixture.fetch('/');
+		assert.equal(response.headers.get('x-test-executed'), '1');
+		assert.equal(response.headers.get('x-test-other-count'), '1');
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3408,6 +3408,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/hmr-middleware:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/hmr-new-page:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Fixes the previous attempt to get HMR working for middleware. Now any imports (and transitive imports) in `middleware.ts` can trigger HMR for `middleware.ts`, instead of just itself.

This is meant to be a cleaner and better-tested version of https://github.com/withastro/astro/pull/17597

Closes https://github.com/withastro/astro/issues/17590

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

3 tests added to `packages/astro/test/middleware.test.ts`, covering the 3 main HMR cases

1. `middleware.ts` is modified
2. A module imported by `middleware.ts` is modified
3. A transitive dependency (a module imported by a module imported by `middleware.ts`) is modified

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs update needed. This PR fixes a bug in HMR behavior, with no API changes.
