### PR TITLE
fix(test): provide experimental config in Cloudflare session-false test

### DIFF
--- a/packages/integrations/cloudflare/test/session-false.test.ts
+++ b/packages/integrations/cloudflare/test/session-false.test.ts
@@ -32,6 +32,7 @@ async function runConfigSetup(session: unknown) {
 			outDir: new URL('./dist/', root),
 			cacheDir: new URL('./.astro/', root),
 			build: { client: new URL('./dist/client/', root), server: new URL('./dist/server/', root) },
+			experimental: { collectionStorage: 'single-file' },
 			vite: {},
 		},
 		logger: {


### PR DESCRIPTION
## Changes

Fixes the three `@astrojs/cloudflare` `session-false` tests failing on `main` and blocking #17558.

The adapter's `astro:config:setup` gained an unguarded read of `config.experimental.collectionStorage` in #17543 (`src/index.ts:289`). `session-false.test.ts` calls that hook with a mock config that has no `experimental` key, so it threw `TypeError: Cannot read properties of undefined (reading 'collectionStorage')`. This PR adds the missing key to the mock:

```js
experimental: { collectionStorage: 'single-file' },
```

A resolved `AstroConfig` always has it, since the schema defaults it to `'single-file'`, so the mock was incomplete rather than the adapter.

## Testing

* Fixed the failing Cloudflare tests.
* Node and Netlify are unaffected since their mocks don't read `experimental`.

## Docs

None needed, test-only change. No changeset for the same reason.