### PR TITLE
docs: slightly reword session options description

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1667,6 +1667,7 @@ export interface AstroUserConfig<
 	/**
 	 * @docs
 	 * @kind heading
+	 * @type {object | false}
 	 * @version 5.7.0
 	 * @name Session Options
 	 * @description
@@ -1690,7 +1691,7 @@ export interface AstroUserConfig<
 	 *
 	 * Session drivers are configured at build time. This means environment variables used in the driver configuration are inlined. You must create your own driver entrypoint to [override the configuration at runtime](https://docs.astro.build/en/guides/sessions/#overriding-the-configuration-at-runtime).
 	 *
-	 * Set to `false` to opt out of session support entirely. With `session: false`, the session runtime is excluded from the SSR bundle, adapters skip wiring their default session driver, and `Astro.session` (and `context.session`) is `undefined` — the same as a project without sessions configured. Useful for serverless and edge runtimes where bundle parse time is sensitive.
+	 * Since Astro v7.2.0, you can opt out of session support by setting the option to `false`. When sessions are disabled, the session runtime is excluded from the SSR bundle, and adapters skip wiring their default session driver. This is useful for serverless and edge runtimes where bundle parse time is sensitive.
 	 *
 	 * ```js title="astro.config.mjs"
 	 * import { defineConfig } from 'astro/config';


### PR DESCRIPTION
## Changes

We got a [PR in docs](https://github.com/withastro/docs/pull/14340) to update the configuration reference for 7.2, and I noticed I forgot to review one core PR. Current preview is here: https://ci-docgen.previews.docs.astro.build/en/reference/configuration-reference/#session-options

- We should have a type on "Session options" now we can set `session` to `false`
- The `Astro.session` part with the em-dash sounds really AI generated to me (ie. too verbose without providing any real utility) and, in the Configuration reference, we never specify that `Astro.x`  (or `context.x`) might be `undefined`. (e.g. [`security.csp`](https://docs.astro.build/en/reference/configuration-reference/#securitycsp) when [`Astro.csp`](https://docs.astro.build/en/reference/api-reference/#csp) can be `undefined`). If we were to mention this point, it shouldn't be limited to the `session: false` case (which also applies when there is no configuration), and other entries would need to be updated as well.
- People that are not yet on 7.2 should be aware this is not available for them

## Testing

N/A

## Docs

This is docs.
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
