### PR TITLE
fix(incremental): use resolved file names for imported assets in the dependency hash

### DIFF
--- a/.changeset/tidy-jokes-count.md
+++ b/.changeset/tidy-jokes-count.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `experimental.incrementalBuild` re-rendering unchanged routes that import more than one asset. The route's dependency hash depended on the order the assets finished building, so two builds of identical sources could produce different hashes. The hash is now based on the file name each asset resolves to.

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -20,6 +20,7 @@ interface HashableModuleInfo {
 
 interface ModuleGraph {
 	getModuleInfo(id: string): HashableModuleInfo | null;
+	getFileName(referenceId: string): string;
 }
 
 /** Collect the sorted, transitive dependency ids of a module, following static and dynamic imports. */
@@ -46,11 +47,42 @@ function collectTransitiveDeps(graph: ModuleGraph, rootId: string): string[] {
 	return [...deps].sort();
 }
 
+/** Each placeholder pattern paired with the token that has to be present for it to match. */
+const ASSET_PLACEHOLDERS = [
+	{ token: '__ASTRO_ASSET_IMAGE__', pattern: /__ASTRO_ASSET_IMAGE__([\w$]+)__(?:_(.*?)__)?/g },
+	{ token: '__VITE_ASSET__', pattern: /__VITE_ASSET__([\w$]+)__(?:\$_(.*?)__)?/g },
+];
+
+/**
+ * Replace the emit handles of imported assets with the file names they resolve
+ * to. Handles are assigned by the bundler in the order modules finish
+ * transforming, so two builds of the same sources can hand the same asset a
+ * different handle, while the file name it resolves to is content-hashed and
+ * stable. If a handle does not resolve to a file, the placeholder is left as
+ * it is; the worst case is an unnecessary re-render, not a stale one.
+ */
+function resolveAssetPlaceholders(graph: ModuleGraph, code: string): string {
+	let resolved = code;
+	for (const { token, pattern } of ASSET_PLACEHOLDERS) {
+		if (!resolved.includes(token)) continue;
+		resolved = resolved.replace(pattern, (placeholder, handle, postfix = '') => {
+			try {
+				return graph.getFileName(handle) + postfix;
+			} catch {
+				return placeholder;
+			}
+		});
+	}
+	return resolved;
+}
+
 /**
  * Hash a sorted set of module ids together with each module's compiled output.
  * Hashing the transformed `code` from the bundle (rather than the source file on
  * disk) reflects what actually ships and covers virtual modules, which have no
- * file on disk but still carry generated code.
+ * file on disk but still carry generated code. Emitted-asset placeholders in
+ * that code are resolved to their file names first, since the handles
+ * themselves are not stable between builds.
  */
 function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
 	const hasher = crypto.createHash('sha256');
@@ -59,7 +91,7 @@ function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
 		hasher.update('\n');
 		const code = graph.getModuleInfo(id)?.code;
 		if (code != null) {
-			hasher.update(code);
+			hasher.update(resolveAssetPlaceholders(graph, code));
 		}
 		hasher.update('\n');
 	}

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { pluginIncremental } from '../../../dist/core/build/plugins/plugin-incremental.js';
+import { VIRTUAL_PAGE_RESOLVED_MODULE_ID } from '../../../dist/vite-plugin-pages/const.js';
+
+const ROOT = new URL('file:///project/');
+const PAGE_ID = '/project/src/pages/[slug].astro';
+const COMPONENT = 'src/pages/[slug].astro';
+const RED = '/project/src/assets/red.png';
+const BLUE = '/project/src/assets/blue.png';
+const VIDEO = '/project/src/assets/clip.mp4';
+
+const HANDLE_ONE = 'VRAku6fjghkApIISiBWPzg';
+const HANDLE_TWO = 'WPGYjwIlzWVNM1bYhOc83w';
+
+function moduleInfo(
+	id: string,
+	{ code = '', importedIds = [] as string[], importers = [] as string[] } = {},
+) {
+	return {
+		id,
+		code,
+		importedIds,
+		importers,
+		dynamicallyImportedIds: [],
+		dynamicImporters: [] as string[],
+		meta: {},
+	};
+}
+
+function imageCode(handle: string) {
+	return `export default {"src":"__ASTRO_ASSET_IMAGE__${handle}__","width":1,"height":1}`;
+}
+
+function assetCode(handle: string) {
+	return `export default "__VITE_ASSET__${handle}__"`;
+}
+
+function pluginContext(
+	codeByModule: Record<string, string>,
+	fileNames: Record<string, string>,
+	importedIds: string[],
+) {
+	const modules = new Map([
+		[
+			PAGE_ID,
+			moduleInfo(PAGE_ID, {
+				code: 'export default page',
+				importedIds,
+				importers: [VIRTUAL_PAGE_RESOLVED_MODULE_ID],
+			}),
+		],
+		...importedIds.map((id) => [id, moduleInfo(id, { code: codeByModule[id] })] as const),
+	]);
+
+	return {
+		environment: { name: 'prerender' },
+		getModuleIds: () => modules.keys(),
+		getModuleInfo: (id: string) => modules.get(id) ?? null,
+		getFileName: (handle: string) => {
+			const fileName = fileNames[handle];
+			if (!fileName) throw new Error(`Unknown reference id ${handle}`);
+			return fileName;
+		},
+	};
+}
+
+function dependencyHash(
+	codeByModule: Record<string, string>,
+	fileNames: Record<string, string>,
+	importedIds = Object.keys(codeByModule),
+) {
+	const internals = { pagesByViteID: new Map([[PAGE_ID, { component: COMPONENT }]]) } as any;
+	const plugin = pluginIncremental(internals, ROOT) as any;
+	plugin.generateBundle.call(pluginContext(codeByModule, fileNames, importedIds));
+	return internals.pageDependencyHashes.get(COMPONENT);
+}
+
+describe('pluginIncremental', () => {
+	describe('dependency hash', () => {
+		it('is stable when the same images are emitted with different handles', () => {
+			const first = dependencyHash(
+				{ [RED]: imageCode(HANDLE_ONE), [BLUE]: imageCode(HANDLE_TWO) },
+				{ [HANDLE_ONE]: '_astro/red.aaaa.png', [HANDLE_TWO]: '_astro/blue.bbbb.png' },
+			);
+			const second = dependencyHash(
+				{ [RED]: imageCode(HANDLE_TWO), [BLUE]: imageCode(HANDLE_ONE) },
+				{ [HANDLE_TWO]: '_astro/red.aaaa.png', [HANDLE_ONE]: '_astro/blue.bbbb.png' },
+			);
+			assert.equal(first, second);
+		});
+
+		it('is stable when the same non-image assets are emitted with different handles', () => {
+			const first = dependencyHash(
+				{ [RED]: imageCode(HANDLE_ONE), [VIDEO]: assetCode(HANDLE_TWO) },
+				{ [HANDLE_ONE]: '_astro/red.aaaa.png', [HANDLE_TWO]: '_astro/clip.cccc.mp4' },
+			);
+			const second = dependencyHash(
+				{ [RED]: imageCode(HANDLE_TWO), [VIDEO]: assetCode(HANDLE_ONE) },
+				{ [HANDLE_TWO]: '_astro/red.aaaa.png', [HANDLE_ONE]: '_astro/clip.cccc.mp4' },
+			);
+			assert.equal(first, second);
+		});
+
+		it('changes when an imported image resolves to a different file name', () => {
+			const code = { [RED]: imageCode(HANDLE_ONE), [BLUE]: imageCode(HANDLE_TWO) };
+			const first = dependencyHash(code, {
+				[HANDLE_ONE]: '_astro/red.aaaa.png',
+				[HANDLE_TWO]: '_astro/blue.bbbb.png',
+			});
+			const second = dependencyHash(code, {
+				[HANDLE_ONE]: '_astro/red.dddd.png',
+				[HANDLE_TWO]: '_astro/blue.bbbb.png',
+			});
+			assert.notEqual(first, second);
+		});
+
+		it('keeps hashing when a handle does not resolve to a file', () => {
+			const code = { [RED]: imageCode(HANDLE_ONE) };
+			const first = dependencyHash(code, {});
+			const second = dependencyHash(code, {});
+			assert.equal(first, second);
+			assert.match(first, /^[0-9a-f]{64}$/);
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- closes #17615
- With `experimental.incrementalBuild`, a route that imports more than one asset was sometimes re-rendered even though nothing about it changed. An imported image's module code carries an `__ASTRO_ASSET_IMAGE__<handle>__` placeholder, other assets carry Vite's `__VITE_ASSET__<handle>__`, and the handle comes from `emitFile` in the order the modules finish transforming, so two builds of the same sources can swap the handles around. The route hash then changes while the output stays byte-for-byte identical.
- Before hashing a module, the placeholders are replaced with the file name each handle resolves to. Those names are content-hashed, so the hash stays stable across builds and still changes when an asset's contents change. Replacing the placeholder with a fixed token would also stop the churn, but then an image edited without a dimension change would leave the hash untouched and the restored HTML would point at a file name the build no longer emits.

## Testing

New unit tests in `test/units/build/plugin-incremental.test.ts` drive the plugin with swapped emit handles, for images and for other assets, and assert the hash is unchanged, plus the reverse case where a different resolved file name does change it. Also confirmed against the reproduction in the issue, where 50 builds now produce the same hash, and against a variant of it importing a video and a PDF rather than images.

## Docs

No user-facing behavior change, so nothing to document.