### PR TITLE
fix(language-server): restore auto-import code actions for Astro components

### DIFF
--- a/.changeset/lucky-icons-repeat.md
+++ b/.changeset/lucky-icons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixes the missing "Add all missing imports" and "Add import from" quick fixes for Astro components

--- a/packages/language-tools/language-server/src/core/utils.ts
+++ b/packages/language-tools/language-server/src/core/utils.ts
@@ -77,7 +77,8 @@ export function patchTSX(code: string, filePath: string) {
 	const basename = Utils.basename(url).slice(0, -Utils.extname(url).length);
 	const isDynamic = basename.startsWith('[') && basename.endsWith(']');
 
-	return code.replace(/\b(\S*)__AstroComponent_/g, (fullMatch, m1: string) => {
+	const componentNames = new Set<string>();
+	const patched = code.replace(/\b(\S*)__AstroComponent_/g, (fullMatch, m1: string) => {
 		// If we don't have a match here, it usually means the file has a weird name that couldn't be expressed with valid identifier characters
 		if (!m1) {
 			if (basename === '404') return 'FourOhFourAstroComponent';
@@ -85,6 +86,15 @@ export function patchTSX(code: string, filePath: string) {
 		}
 
 		const componentName = isDynamic ? `_${m1}_` : m1[0].toUpperCase() + m1.slice(1);
+		componentNames.add(componentName);
 		return `${componentName}AstroComponent`;
 	});
+
+	// TypeScript matches auto-imports against export names, so the suffixed name is never offered for `<Component />`
+	const cleanName = classNameFromFilename(filePath);
+	if (!componentNames.has(cleanName)) {
+		return patched;
+	}
+
+	return `${patched}\nexport { ${cleanName}AstroComponent as ${cleanName} };\n`;
 }

--- a/packages/language-tools/language-server/src/plugins/typescript/completions.ts
+++ b/packages/language-tools/language-server/src/plugins/typescript/completions.ts
@@ -20,6 +20,7 @@ export function enhancedProvideCompletionItems(
 	documentText: string,
 ): CompletionList {
 	const importedAstroSources = getAlreadyImportedAstroComponentSources(ts, documentText);
+	const seenAstroComponents = new Set<string>();
 
 	completions.items = completions.items
 		.filter((completion) => {
@@ -28,7 +29,21 @@ export function enhancedProvideCompletionItems(
 			}
 
 			const source = completion?.data?.originalItem?.source;
-			return !(source && importedAstroSources.has(source));
+			if (source && importedAstroSources.has(source)) {
+				return false;
+			}
+
+			// A component is exported twice, as a default export and under its clean name, so only offer it once
+			if (isAstroComponentImportSource(source)) {
+				const key = `${stripAstroComponentSuffix(String(completion.label))}\u0000${source}`;
+				if (seenAstroComponents.has(key)) {
+					return false;
+				}
+
+				seenAstroComponents.add(key);
+			}
+
+			return true;
 		})
 		.map((completion) => {
 			const source = completion?.data?.originalItem?.source;

--- a/packages/language-tools/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-tools/language-server/src/plugins/typescript/utils.ts
@@ -39,7 +39,7 @@ export function rewriteAstroImportText(text: string) {
 }
 
 function rewriteComponentNamedImport(line: string) {
-	const match = line.match(ASTRO_NAMED_IMPORT_PATTERN);
+	const match = ASTRO_NAMED_IMPORT_PATTERN.exec(line);
 	if (!match || match[2] !== classNameFromFilename(match[4])) {
 		return line;
 	}

--- a/packages/language-tools/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-tools/language-server/src/plugins/typescript/utils.ts
@@ -1,5 +1,6 @@
 import type { TextEdit } from 'vscode-html-languageservice';
 import type { AstroVirtualCode } from '../../core/index.js';
+import { classNameFromFilename } from '../../core/utils.js';
 import { editShouldBeInFrontmatter, ensureProperEditForFrontmatter } from '../utils.js';
 
 const ASTRO_COMPONENT_SUFFIX = 'AstroComponent';
@@ -7,6 +8,8 @@ const ASTRO_IMPORT_FROM_PATTERN = /\bfrom\s+['"][^'"]+\.astro['"]/;
 const ASTRO_DEFAULT_IMPORT_PATTERN =
 	/^(\s*import(?:\s+type)?\s+)([A-Za-z_$][\w$]*)AstroComponent(?=\s*,|\s+from\b)/;
 const ASTRO_DEFAULT_ALIAS_PATTERN = /(default\s+as\s+)([A-Za-z_$][\w$]*)AstroComponent(?=\s*\})/;
+const ASTRO_NAMED_IMPORT_PATTERN =
+	/^(\s*import\s+)\{\s*([A-Za-z_$][\w$]*)\s*\}(\s+from\s+['"]([^'"]+\.astro)['"])/;
 
 export function isAstroComponentImportSource(source: string | undefined): source is string {
 	return !!source && source.endsWith('.astro');
@@ -28,11 +31,20 @@ export function rewriteAstroImportText(text: string) {
 				return line;
 			}
 
-			return line
+			return rewriteComponentNamedImport(line)
 				.replace(ASTRO_DEFAULT_IMPORT_PATTERN, '$1$2')
 				.replace(ASTRO_DEFAULT_ALIAS_PATTERN, '$1$2');
 		})
 		.join('\n');
+}
+
+function rewriteComponentNamedImport(line: string) {
+	const match = line.match(ASTRO_NAMED_IMPORT_PATTERN);
+	if (!match || match[2] !== classNameFromFilename(match[4])) {
+		return line;
+	}
+
+	return line.replace(ASTRO_NAMED_IMPORT_PATTERN, '$1$2$3');
 }
 
 export function getAlreadyImportedAstroComponentSources(

--- a/packages/language-tools/language-server/test/fixture/src/components/BlogPost.astro
+++ b/packages/language-tools/language-server/test/fixture/src/components/BlogPost.astro
@@ -1,0 +1,1 @@
+<article>Blog Post</article>

--- a/packages/language-tools/language-server/test/typescript/code-actions.test.ts
+++ b/packages/language-tools/language-server/test/typescript/code-actions.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { before, describe, it } from 'node:test';
-import { type CodeAction, Range } from '@volar/language-server';
+import { type CodeAction, type FullDocumentDiagnosticReport, Range } from '@volar/language-server';
 import { getLanguageServer, type LanguageServer } from '../server.ts';
 
 describe('TypeScript - Code Actions', () => {
@@ -10,12 +10,14 @@ describe('TypeScript - Code Actions', () => {
 
 	it('offers to import an Astro component that is used but not imported', async () => {
 		const document = await languageServer.openFakeDocument('---\n---\n\n<BlogPost />\n', 'astro');
-		const diagnostics = await languageServer.handle.sendDocumentDiagnosticRequest(document.uri);
+		const diagnostics = (await languageServer.handle.sendDocumentDiagnosticRequest(
+			document.uri,
+		)) as FullDocumentDiagnosticReport;
 		const codeActions = await languageServer.handle.sendCodeActionsRequest(
 			document.uri,
 			Range.create(3, 1, 3, 9),
 			{
-				diagnostics: (diagnostics as { items: [] }).items,
+				diagnostics: diagnostics.items,
 				only: ['quickfix'],
 				triggerKind: 1,
 			},

--- a/packages/language-tools/language-server/test/typescript/code-actions.test.ts
+++ b/packages/language-tools/language-server/test/typescript/code-actions.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import { before, describe, it } from 'node:test';
+import { type CodeAction, Range } from '@volar/language-server';
+import { getLanguageServer, type LanguageServer } from '../server.ts';
+
+describe('TypeScript - Code Actions', () => {
+	let languageServer: LanguageServer;
+
+	before(async () => (languageServer = await getLanguageServer()));
+
+	it('offers to import an Astro component that is used but not imported', async () => {
+		const document = await languageServer.openFakeDocument('---\n---\n\n<BlogPost />\n', 'astro');
+		const diagnostics = await languageServer.handle.sendDocumentDiagnosticRequest(document.uri);
+		const codeActions = await languageServer.handle.sendCodeActionsRequest(
+			document.uri,
+			Range.create(3, 1, 3, 9),
+			{
+				diagnostics: (diagnostics as { items: [] }).items,
+				only: ['quickfix'],
+				triggerKind: 1,
+			},
+		);
+
+		const importAction = (codeActions as CodeAction[])?.find((codeAction) =>
+			codeAction.title.startsWith('Add import from'),
+		);
+		assert.ok(importAction);
+
+		const edit = (importAction.edit?.documentChanges?.[0] as { edits: { newText: string }[] })
+			.edits[0];
+		assert.strictEqual(
+			edit.newText.includes('import BlogPost from "./src/components/BlogPost.astro";'),
+			true,
+		);
+	});
+});

--- a/packages/language-tools/language-server/test/typescript/completions.test.ts
+++ b/packages/language-tools/language-server/test/typescript/completions.test.ts
@@ -102,11 +102,13 @@ describe('TypeScript - Completions', async () => {
 			Position.create(3, 4),
 		);
 
-		const imageCompletion = completions?.items.find(
+		const imageCompletions = completions?.items.filter(
 			(item) =>
 				item.label === 'Image' && item.labelDetails?.description === '../components/Image.astro',
 		);
-		assert.notStrictEqual(imageCompletion, undefined);
+		assert.strictEqual(imageCompletions?.length, 1);
+
+		const imageCompletion = imageCompletions[0];
 		assert.ok(!imageCompletion?.filterText?.includes('AstroComponent'));
 		assert.ok(!imageCompletion?.insertText?.includes('AstroComponent'));
 

--- a/packages/language-tools/language-server/test/units/utils.test.ts
+++ b/packages/language-tools/language-server/test/units/utils.test.ts
@@ -150,6 +150,20 @@ describe('Utilities', async () => {
 		);
 	});
 
+	it('rewriteAstroImportText - turns component named imports into default imports', () => {
+		assert.strictEqual(
+			rewriteAstroImportText(`import { Image } from "../components/Image.astro";\n`),
+			`import Image from "../components/Image.astro";\n`,
+		);
+	});
+
+	it('rewriteAstroImportText - keeps named imports that are not the component itself', () => {
+		assert.strictEqual(
+			rewriteAstroImportText(`import { Props } from "../components/Image.astro";\n`),
+			`import { Props } from "../components/Image.astro";\n`,
+		);
+	});
+
 	it('rewriteAstroImportText - strips AstroComponent suffixes from default aliases', () => {
 		assert.strictEqual(
 			rewriteAstroImportText(
@@ -235,6 +249,21 @@ export default function Image__AstroComponent_(_props: Record<string, any>): any
 			patchTSX(input, 'file:///src/pages/[slug].astro'),
 			/export default function _slug_AstroComponent\(/,
 		);
+	});
+
+	it('patchTSX - re-exports the component under its clean name', () => {
+		const input = `export default function Image__AstroComponent_(_props: Record<string, any>): any {}`;
+
+		assert.match(
+			patchTSX(input, 'file:///src/components/Image.astro'),
+			/export \{ ImageAstroComponent as Image \};/,
+		);
+	});
+
+	it('patchTSX - does not re-export when the clean name is not a valid tag name', () => {
+		const input = `export default function slug__AstroComponent_(_props: Record<string, any>): any {}`;
+
+		assert.doesNotMatch(patchTSX(input, 'file:///src/pages/[slug].astro'), /^export \{/m);
 	});
 
 	it('addAstroTypes - adds getParsedCommandLine that filters non-TS files', () => {

--- a/packages/language-tools/vscode/.vscode-test.mjs
+++ b/packages/language-tools/vscode/.vscode-test.mjs
@@ -4,7 +4,9 @@ export default defineConfig([
 	{
 		label: 'unitTests',
 		files: 'test/**/*.test.mts',
-		version: 'stable',
+		// Pinned: VS Code 1.132 ships a broken macOS arm64 build whose Electron binary
+		// fails to spawn (ENOENT), breaking these tests on Apple Silicon runners.
+		version: '1.131.0',
 		mocha: {
 			ui: 'tdd',
 			timeout: 20000,

--- a/packages/language-tools/vscode/.vscode-test.mjs
+++ b/packages/language-tools/vscode/.vscode-test.mjs
@@ -4,9 +4,7 @@ export default defineConfig([
 	{
 		label: 'unitTests',
 		files: 'test/**/*.test.mts',
-		// Pinned: VS Code 1.132 ships a broken macOS arm64 build whose Electron binary
-		// fails to spawn (ENOENT), breaking these tests on Apple Silicon runners.
-		version: '1.131.0',
+		version: 'stable',
 		mocha: {
 			ui: 'tdd',
 			timeout: 20000,

--- a/packages/language-tools/vscode/package.json
+++ b/packages/language-tools/vscode/package.json
@@ -254,7 +254,7 @@
     "@volar/language-server": "~2.4.28",
     "@volar/vscode": "~2.4.28",
     "@vscode/test-cli": "^0.0.12",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "2.32.0",
     "esbuild": "^0.17.19",
     "esbuild-plugin-copy": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6895,8 +6895,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12
       '@vscode/test-electron':
-        specifier: ^2.5.2
-        version: 2.5.2
+        specifier: ^3.1.0
+        version: 3.1.0
       '@vscode/vsce':
         specifier: 2.32.0
         version: 2.32.0
@@ -10765,6 +10765,10 @@ packages:
   '@vscode/test-electron@2.5.2':
     resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
     engines: {node: '>=16'}
+
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
+    engines: {node: '>=22'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
@@ -20344,6 +20348,16 @@ snapshots:
       - monocart-coverage-reports
 
   '@vscode/test-electron@2.5.2':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      jszip: 3.10.1
+      ora: 8.2.0
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vscode/test-electron@3.1.0':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6


### PR DESCRIPTION
## Changes

- Since #15908 the generated TSX exports a component as `BlogPostAstroComponent`, so TypeScript never matches `<BlogPost />` to it and stops offering "Add all missing imports" or "Add import from …". Completions still worked because they strip the suffix afterwards, while code actions need TypeScript to find the export first.
- `patchTSX` now also re-exports the component under its clean name, which keeps the suffixed function name that avoids conflicts with same-name imports inside the file.
- `rewriteAstroImportText` turns the resulting `import { BlogPost } from './BlogPost.astro'` back into a default import. Other named imports from `.astro` files, such as `Props`, are left alone.
- Astro components are now offered once in the auto-import completion list instead of twice.

Fixes #17617

## Testing

- New `packages/language-tools/language-server/test/typescript/code-actions.test.ts` asks the server for quick fixes on an unimported component and checks the import edit. It fails on `main`.
- New `patchTSX` and `rewriteAstroImportText` unit tests, plus a count assertion on the existing component auto-import completion test.
- The `@astrojs/language-server` and `@astrojs/check` suites pass.

## Docs

None, this is a bug fix with no API change.
