### PR TITLE
Fix dynamic redirect routes ignoring configured status code in underscore-redirects

### DIFF
--- a/.changeset/fix-dynamic-redirect-status.md
+++ b/.changeset/fix-dynamic-redirect-status.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/underscore-redirects': patch
+---
+
+Fixes dynamic redirect routes to honour user-configured status codes instead of hardcoding 301. Previously, a redirect configured with `{ destination: '/new', status: 302 }` would be emitted as 301 in the `_redirects` file when the route was dynamic.

--- a/packages/underscore-redirects/src/astro.ts
+++ b/packages/underscore-redirects/src/astro.ts
@@ -153,7 +153,7 @@ export function createRedirectsFromAstroRoutes({
 					dynamic: true,
 					input: `${base}${pattern}`,
 					target,
-					status: route.type === 'redirect' ? 301 : 200,
+					status: route.type === 'redirect' ? getRedirectStatus(route) : 200,
 					weight: 1,
 				});
 			} else {

--- a/packages/underscore-redirects/test/astro.test.ts
+++ b/packages/underscore-redirects/test/astro.test.ts
@@ -48,6 +48,77 @@ describe('Astro', () => {
 		assert.deepEqual(getTrailingSlashPaths('/path', 'never'), ['/path']);
 		assert.deepEqual(getTrailingSlashPaths('/path/', 'never'), ['/path']);
 	});
+	it('Dynamic redirect honours configured status', () => {
+		const route = {
+			pattern: '/old/[id]',
+			pathname: undefined,
+			segments: [
+				[{ content: 'old', dynamic: false, spread: false }],
+				[{ content: 'id', dynamic: true, spread: false }],
+			],
+			type: 'redirect',
+			redirect: { destination: '/new/:id', status: 302 },
+			redirectRoute: {
+				pattern: '/new/[id]',
+				segments: [
+					[{ content: 'new', dynamic: false, spread: false }],
+					[{ content: 'id', dynamic: true, spread: false }],
+				],
+			},
+			entrypoint: '/old/[id]',
+			isPrerendered: true,
+			origin: 'internal',
+		} as unknown as IntegrationResolvedRoute;
+
+		const redirects = createRedirectsFromAstroRoutes({
+			config: {
+				build: { format: 'directory' },
+				trailingSlash: 'never',
+			} as AstroConfig,
+			routeToDynamicTargetMap: new Map([[route, '']]),
+			dir: new URL(import.meta.url),
+			buildOutput: 'server',
+			assets: new Map([['/old/[id]', [new URL('./old/index.html', import.meta.url)]]]),
+		});
+
+		assert.equal(redirects.definitions[0].status, 302);
+	});
+
+	it('Dynamic redirect defaults to 301 when redirect is a string', () => {
+		const route = {
+			pattern: '/old/[id]',
+			pathname: undefined,
+			segments: [
+				[{ content: 'old', dynamic: false, spread: false }],
+				[{ content: 'id', dynamic: true, spread: false }],
+			],
+			type: 'redirect',
+			redirect: '/new/:id',
+			redirectRoute: {
+				pattern: '/new/[id]',
+				segments: [
+					[{ content: 'new', dynamic: false, spread: false }],
+					[{ content: 'id', dynamic: true, spread: false }],
+				],
+			},
+			entrypoint: '/old/[id]',
+			isPrerendered: true,
+			origin: 'internal',
+		} as unknown as IntegrationResolvedRoute;
+
+		const redirects = createRedirectsFromAstroRoutes({
+			config: {
+				build: { format: 'directory' },
+				trailingSlash: 'never',
+			} as AstroConfig,
+			routeToDynamicTargetMap: new Map([[route, '']]),
+			dir: new URL(import.meta.url),
+			buildOutput: 'server',
+			assets: new Map([['/old/[id]', [new URL('./old/index.html', import.meta.url)]]]),
+		});
+
+		assert.equal(redirects.definitions[0].status, 301);
+	});
 });
 
 function createIntegrationRoute(pattern: string, pathname = pattern): IntegrationResolvedRoute {


### PR DESCRIPTION
## Changes

- Dynamic redirect routes in `createRedirectsFromAstroRoutes` now honour the user-configured status code. Previously, the dynamic branch hardcoded `301` (`route.type === 'redirect' ? 301 : 200`), so a redirect configured as `{ destination: '/new', status: 302 }` would be written as `301` in the `_redirects` file. The static branch already called `getRedirectStatus(route)` correctly; this applies the same call to the dynamic branch.
- Since `301` is cached essentially permanently by browsers, an incorrect status is very difficult to reverse in production.

Closes #17619

## Testing

- Two new test cases in `packages/underscore-redirects/test/astro.test.ts`: one verifies that a dynamic redirect with `{ destination, status: 302 }` emits `302`, the other verifies that a string-form redirect still defaults to `301`.

## Docs

- No docs update needed — this restores already-documented behavior (configured status is respected).