### PR TITLE
Fix glob() loader silently dropping entries with a numeric slug after the first sync

### DIFF
--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -47,7 +47,7 @@ interface GlobOptions {
 
 function generateIdDefault({ entry, base, data }: GenerateIdOptions, isLegacy?: boolean): string {
 	if (data.slug) {
-		return data.slug as string;
+		return String(data.slug);
 	}
 	const entryURL = new URL(encodeURI(entry), base);
 	if (isLegacy) {
@@ -94,8 +94,11 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 	}
 
 	const isLegacy = !!globOptions[secretLegacyFlag];
-	const generateId =
+	const userGenerateId =
 		globOptions?.generateId ?? ((opts: GenerateIdOptions) => generateIdDefault(opts, isLegacy));
+	// Coerce to string so numeric ids from YAML don't cause Set strict-equality mismatches
+	// against string store keys in the untouched-entries cleanup. See #17624.
+	const generateId = (opts: GenerateIdOptions) => String(userGenerateId(opts));
 
 	const fileToIdMap = new Map<string, string>();
 

--- a/packages/astro/test/fixtures/content-layer/src/content/space/numeric-slug.md
+++ b/packages/astro/test/fixtures/content-layer/src/content/space/numeric-slug.md
@@ -1,0 +1,6 @@
+---
+title: Numeric Slug Entry
+slug: 20260624
+---
+
+Entry with an unquoted numeric slug value.

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -64,6 +64,44 @@ describe('Glob Loader', () => {
 		assert.equal(columbia.filePath!.replace(/\\/g, '/'), 'src/content/space/columbia.md');
 	});
 
+	it('retains entries with numeric slug across multiple syncs', async () => {
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root, {
+			contentEntryTypes: [createMarkdownEntryType()],
+		});
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'silent',
+		});
+
+		const collections = {
+			spacecraft: defineCollection({
+				loader: glob({ pattern: '*.md', base: 'src/content/space' }),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		// First sync
+		await contentLayer.sync();
+		const numericEntry1 = store.values('spacecraft').find((e) => e.id === '20260624');
+		assert.ok(numericEntry1, 'Numeric slug entry should exist after first sync');
+		const count1 = store.values('spacecraft').length;
+
+		// Second sync — the bug caused entries with numeric slugs to be dropped here
+		await contentLayer.sync();
+		const numericEntry2 = store.values('spacecraft').find((e) => e.id === '20260624');
+		assert.ok(numericEntry2, 'Numeric slug entry should persist after second sync');
+		const count2 = store.values('spacecraft').length;
+
+		assert.equal(count1, count2, 'Entry count should be stable across syncs');
+	});
+
 	it('handles negative matches in glob pattern', async () => {
 		const store = new MutableDataStore();
 		const settings = createMinimalSettings(root, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7119,6 +7119,12 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
+  triage/gh-17624:
+    dependencies:
+      astro:
+        specifier: ^7.2.0
+        version: link:../../packages/astro
+
 packages:
 
   '@anthropic-ai/sdk@0.91.1':


### PR DESCRIPTION
Closes #17624

## Changes

- Entries whose frontmatter `slug` is an unquoted YAML number (e.g. `slug: 20260624`) now survive repeated syncs. YAML parses an unquoted number as a JS `number`, but the `untouchedEntries` Set holds string keys from the store. The `Set.delete` call used strict equality, so `delete(20260624)` was a no-op against `"20260624"`, leaving the entry marked "untouched" and deleted in the cleanup pass on every sync after the first.
- `generateIdDefault()` now calls `String(data.slug)` instead of relying on the `as string` type assertion, which was compile-time-only and did nothing at runtime.
- The `generateId` wrapper also coerces the return value with `String()` so custom `generateId` callbacks returning non-string values are handled defensively as well.

## Testing

- Added a unit test in `packages/astro/test/units/content-layer/glob-loader.test.ts` that calls `contentLayer.sync()` twice and asserts the numeric-slug entry (`id === '20260624'`) is present after both syncs and that the entry count is stable.
- Added a fixture file `src/content/space/numeric-slug.md` with `slug: 20260624` to back the new test case.

## Docs

No docs update needed — this is a bug fix for an internal ID coercion issue with no API surface change.