### PR TITLE
Fix @astrojs/cloudflare peer dependency range to require astro >=7.2.0

### DIFF
--- a/.changeset/fix-cloudflare-peer-dep.md
+++ b/.changeset/fix-cloudflare-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes the `astro` peer dependency range from `^7.0.0` to `^7.2.0`. The adapter imports symbols (`beginContentEntryCollection`, `beginImageCollection`, `endContentEntryCollection`, `endImageCollection`) from `astro/app` that were added in Astro 7.2.0, so earlier versions fail at build time with a `MISSING_EXPORT` error.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -51,7 +51,7 @@
     "vite": "^8.0.13"
   },
   "peerDependencies": {
-    "astro": "^7.0.0",
+    "astro": "^7.2.0",
     "wrangler": "^4.83.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Changes

- Bumps the `astro` peer dependency in `@astrojs/cloudflare` from `^7.0.0` to `^7.2.0`. The adapter imports `beginContentEntryCollection`, `beginImageCollection`, `endContentEntryCollection`, and `endImageCollection` from `astro/app`, which were added in 7.2.0. The wider range allowed npm to silently resolve `astro@7.1.x`, causing a cryptic `MISSING_EXPORT` build failure with no install-time warning.

Closes #17622

## Testing

- No new tests added — the fix is a manifest correction; existing adapter tests cover the affected code paths.

## Docs

- No docs update needed; this corrects a peer dependency declaration, not a user-facing API.
