### PR TITLE
Fix CSP violation when using clientPrerender with speculation rules

### DIFF
--- a/.changeset/bumpy-drinks-doubt.md
+++ b/.changeset/bumpy-drinks-doubt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a CSP violation when using both `security.csp` and `experimental.clientPrerender` with `data-astro-prefetch` links. The dynamically injected `<script type="speculationrules">` now uses a static `"source": "document"` approach with a CSS selector, producing a deterministic payload that is hashed and included in the CSP `script-src` directive at build time.

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -204,6 +204,8 @@ export type SSRManifestCSP = {
 		resources: CspResourceEntry[];
 		hashes: CspHashEntry[];
 	};
+	/** Static speculation rules JSON to inject in the head when CSP + clientPrerender are both enabled. */
+	speculationRulesContent?: string;
 };
 
 export interface SSRManifestSession extends BaseSessionConfig {

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -28,7 +28,8 @@ import {
 	trackStyleHashes,
 } from '../../csp/common.js';
 import { partitionByKind } from '../../csp/runtime.js';
-import { encodeKey } from '../../encryption.js';
+import { generateSpeculationRulesContent } from '../../../prefetch/speculation-rules.js';
+import { encodeKey, generateCspDigest } from '../../encryption.js';
 import { fileExtension, joinPaths, prependForwardSlash } from '../../path.js';
 import { DEFAULT_COMPONENTS } from '../../routing/default.js';
 import { getOutFile, getOutFolder } from '../common.js';
@@ -324,6 +325,20 @@ async function buildManifest(
 			...(await trackStyleHashes(internals, settings, algorithm)),
 		];
 
+		// When both CSP and clientPrerender are enabled, generate a static speculation rules
+		// script whose hash can be included in the CSP policy. Dynamic per-URL injection would
+		// produce unpredictable hashes that cannot be whitelisted at build time.
+		let speculationRulesContent: string | undefined;
+		if (settings.config.experimental.clientPrerender && settings.config.prefetch) {
+			const prefetchAll =
+				typeof settings.config.prefetch === 'object'
+					? (settings.config.prefetch.prefetchAll ?? false)
+					: false;
+			speculationRulesContent = generateSpeculationRulesContent(prefetchAll);
+			const speculationRulesHash = await generateCspDigest(speculationRulesContent, algorithm);
+			scriptHashes.push(speculationRulesHash);
+		}
+
 		const scriptDirective = {
 			resources: getScriptResources(cspConfig),
 			hashes: scriptHashes,
@@ -348,6 +363,7 @@ async function buildManifest(
 			styleResources: styleDefault.resources,
 			scriptDirective,
 			styleDirective,
+			speculationRulesContent,
 		};
 	}
 

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -453,6 +453,7 @@ export class FetchState implements AstroFetchState {
 				resources: manifest.csp?.styleDirective ? [...manifest.csp.styleDirective.resources] : [],
 				hashes: manifest.csp?.styleDirective ? [...manifest.csp.styleDirective.hashes] : [],
 			},
+			speculationRulesContent: manifest.csp?.speculationRulesContent,
 			internalFetchHeaders: manifest.internalFetchHeaders,
 		};
 

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -225,9 +225,15 @@ export function prefetch(url: string, opts?: PrefetchOptions) {
 	if (!canPrefetchUrl(url, ignoreSlowConnection)) return;
 	prefetchedUrls.add(url);
 
-	// Prefetch with speculationrules if `clientPrerender` is enabled and supported
+	// Prefetch with speculationrules if `clientPrerender` is enabled and supported.
+	// Skip dynamic injection when a static document-source speculation rules script is already
+	// in the page (injected at build time for CSP compatibility).
 	// NOTE: This condition is tree-shaken if `clientPrerender` is false as its a static value
-	if (clientPrerender && HTMLScriptElement.supports?.('speculationrules')) {
+	if (
+		clientPrerender &&
+		HTMLScriptElement.supports?.('speculationrules') &&
+		!hasStaticSpeculationRules()
+	) {
 		debug?.(`[astro] Prefetching ${url} with <script type="speculationrules">`);
 		appendSpeculationRules(url, opts?.eagerness ?? 'immediate');
 	}
@@ -338,6 +344,32 @@ function onPageLoad(cb: () => void) {
 			}
 		}
 	}).observe(document.body, { childList: true, subtree: true });
+}
+
+/** Cached result of static speculation rules detection. */
+let _hasStaticRules: boolean | undefined;
+
+/**
+ * Returns `true` when a `<script type="speculationrules">` using `"source": "document"`
+ * is already present in the page (injected server-side for CSP compatibility).
+ * The browser handles URL matching via CSS selectors in that case, so per-URL
+ * dynamic injection is unnecessary.
+ */
+function hasStaticSpeculationRules(): boolean {
+	if (_hasStaticRules === undefined) {
+		_hasStaticRules = Array.from(document.querySelectorAll('script[type="speculationrules"]')).some(
+			(el) => {
+				try {
+					const rules = JSON.parse(el.textContent ?? '');
+					const entries = [...(rules.prerender ?? []), ...(rules.prefetch ?? [])];
+					return entries.some((entry: any) => entry.source === 'document');
+				} catch {
+					return false;
+				}
+			},
+		);
+	}
+	return _hasStaticRules;
 }
 
 /**

--- a/packages/astro/src/prefetch/speculation-rules.ts
+++ b/packages/astro/src/prefetch/speculation-rules.ts
@@ -1,0 +1,24 @@
+/**
+ * Generates static speculation rules JSON using `"source": "document"` with CSS selector matching.
+ * This produces a deterministic payload that can be hashed at build time for CSP compatibility,
+ * unlike the dynamic per-URL `"source": "list"` approach in `appendSpeculationRules()`.
+ */
+export function generateSpeculationRulesContent(prefetchAll: boolean): string {
+	const selector = prefetchAll ? 'a' : 'a[data-astro-prefetch]';
+	return JSON.stringify({
+		prerender: [
+			{
+				source: 'document',
+				where: { selector_matches: selector },
+				eagerness: 'moderate',
+			},
+		],
+		prefetch: [
+			{
+				source: 'document',
+				where: { selector_matches: selector },
+				eagerness: 'moderate',
+			},
+		],
+	});
+}

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -71,6 +71,19 @@ export function renderAllHeadContent(result: SSRResult) {
 	const sep = result.compressHTML === true || result.compressHTML === 'jsx' ? '' : '\n';
 	content += styles.join(sep) + links.join(sep) + scripts.join(sep);
 
+	// Inject static speculation rules when CSP + clientPrerender are both enabled.
+	// The content is pre-hashed at build time and included in the CSP script-src directive.
+	if (result.speculationRulesContent) {
+		content += renderElement(
+			'script',
+			{
+				props: { type: 'speculationrules' },
+				children: result.speculationRulesContent,
+			},
+			false,
+		);
+	}
+
 	content += result._metadata.extraHead.join('');
 
 	return markHTMLString(content);

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -252,6 +252,8 @@ export interface SSRResult {
 	isStrictDynamic: SSRManifestCSP['isStrictDynamic'];
 	scriptDirective: SSRManifestCSP['scriptDirective'];
 	styleDirective: SSRManifestCSP['styleDirective'];
+	/** Static speculation rules JSON to inject in the head when CSP + clientPrerender are both enabled. */
+	speculationRulesContent?: string;
 	internalFetchHeaders?: Record<string, string>;
 }
 

--- a/packages/astro/test/units/csp/speculation-rules.test.ts
+++ b/packages/astro/test/units/csp/speculation-rules.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { generateSpeculationRulesContent } from '../../../dist/prefetch/speculation-rules.js';
+import { generateCspDigest } from '../../../dist/core/encryption.js';
+
+describe('speculation rules CSP integration', () => {
+	it('generates document-source speculation rules with data-astro-prefetch selector', () => {
+		const content = generateSpeculationRulesContent(false);
+		const parsed = JSON.parse(content);
+		assert.equal(parsed.prerender[0].source, 'document');
+		assert.equal(parsed.prerender[0].where.selector_matches, 'a[data-astro-prefetch]');
+		assert.equal(parsed.prefetch[0].source, 'document');
+		assert.equal(parsed.prefetch[0].where.selector_matches, 'a[data-astro-prefetch]');
+	});
+
+	it('uses "a" selector when prefetchAll is true', () => {
+		const content = generateSpeculationRulesContent(true);
+		const parsed = JSON.parse(content);
+		assert.equal(parsed.prerender[0].where.selector_matches, 'a');
+		assert.equal(parsed.prefetch[0].where.selector_matches, 'a');
+	});
+
+	it('produces a deterministic hash for CSP', async () => {
+		const content1 = generateSpeculationRulesContent(false);
+		const content2 = generateSpeculationRulesContent(false);
+		assert.equal(content1, content2);
+
+		const hash = await generateCspDigest(content1, 'SHA-256');
+		assert.equal(typeof hash, 'string');
+		assert.ok(hash.length > 0);
+
+		// Same content always produces same hash
+		const hash2 = await generateCspDigest(content2, 'SHA-256');
+		assert.equal(hash, hash2);
+	});
+});


### PR DESCRIPTION
## Changes

- When both `security.csp` and `experimental.clientPrerender` are enabled, Astro now injects a single static `<script type="speculationrules">` at render time using `"source": "document"` with a CSS selector (`a[data-astro-prefetch]` or `a` when `prefetchAll` is enabled). This produces a deterministic payload whose hash can be computed at build time and added to the CSP `script-src` directive.
- The client-side prefetch code detects existing document-source speculation rules in the DOM and skips dynamic per-URL injection, which would generate unwhitelistable hashes.

Closes #17599

## Testing

- New unit test file `packages/astro/test/units/csp/speculation-rules.test.ts` covering `generateSpeculationRulesContent()` output shape and hash determinism.

## Docs

- No docs update needed; this fixes a bug in the interaction between two existing features without changing any user-facing API or configuration.
