### PR TITLE
Fix Fonts API breaking incremental build caching by embedding ephemeral port in module source

### DIFF
--- a/packages/astro/src/assets/fonts/constants.ts
+++ b/packages/astro/src/assets/fonts/constants.ts
@@ -51,3 +51,8 @@ export const GENERIC_FALLBACK_NAMES = [
 ] as const;
 
 export const FONTS_TYPES_FILE = 'fonts.d.ts';
+
+/** globalThis key used to pass the prerender font server address at runtime
+ * without embedding it in the virtual module's source text, which would make
+ * the incremental-build dependency hash non-deterministic (the port is ephemeral). */
+export const FONTS_PRERENDER_ADDRESS_KEY = '__astro_fonts_prerender_server_address__';

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -17,6 +17,7 @@ import {
 	ASSETS_DIR,
 	CACHE_DIR,
 	DEFAULTS,
+	FONTS_PRERENDER_ADDRESS_KEY,
 	RESOLVED_RUNTIME_FONT_FILE_URL_RESOLVER_VIRTUAL_MODULE_ID,
 	RESOLVED_RUNTIME_VIRTUAL_MODULE_ID,
 	RESOLVED_VIRTUAL_MODULE_ID,
@@ -88,6 +89,10 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 		fontFetcher = null;
 		serverAddress = null;
 		urls = null;
+		// The globalThis key for the prerender server address is intentionally NOT
+		// cleaned up here: cleanup() runs in buildEnd, before the prerender
+		// execution phase reads the address. It is cleaned up in build/index.ts
+		// when the font HTTP server is closed, after prerendering completes.
 	}
 
 	return {
@@ -237,6 +242,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 					});
 				});
 				serverAddress = settings.fontsHttpServer.address() as AddressInfo;
+				(globalThis as any)[FONTS_PRERENDER_ADDRESS_KEY] = serverAddress;
 			}
 		},
 		async configureServer(server) {
@@ -333,6 +339,23 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 								import { SsrRuntimeFontFileUrlResolver } from ${JSON.stringify(new URL('./infra/ssr-runtime-font-file-url-resolver.js', import.meta.url))};
 								export const runtimeFontFileUrlResolver = new SsrRuntimeFontFileUrlResolver({
 									urls: new Set(${JSON.stringify(urls)}),
+								});
+							`,
+						};
+					}
+
+					if (isPrerender) {
+						// Read the address from globalThis at runtime so the compiled
+						// module text is deterministic across builds. The ephemeral
+						// port would otherwise change on every build and invalidate
+						// the incremental-build dependency hash for every route that
+						// uses <Font />. See https://github.com/withastro/astro/issues/17626
+						return {
+							code: `
+								import { RemoteRuntimeFontFileUrlResolver } from ${JSON.stringify(new URL('./infra/remote-runtime-font-file-url-resolver.js', import.meta.url))};
+								export const runtimeFontFileUrlResolver = new RemoteRuntimeFontFileUrlResolver({
+									urls: new Set(${JSON.stringify(urls)}),
+									address: globalThis[${JSON.stringify(FONTS_PRERENDER_ADDRESS_KEY)}],
 								});
 							`,
 						};

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -30,6 +30,7 @@ import { viteBuild } from './static-build.js';
 import type { StaticBuildOptions } from './types.js';
 import { getTimeStat } from './util.js';
 import { warnIfCspResourceFallbackShadowing, warnIfCspWithShiki } from '../messages/runtime.js';
+import { FONTS_PRERENDER_ADDRESS_KEY } from '../../assets/fonts/constants.js';
 
 interface BuildOptions {
 	/**
@@ -254,6 +255,7 @@ export class AstroBuilder {
 				this.logger.debug('assets', 'Failed to close fonts HTTP server:', err);
 			});
 			this.settings.fontsHttpServer = null;
+			delete (globalThis as any)[FONTS_PRERENDER_ADDRESS_KEY];
 		}
 
 		// You're done! Time to clean up.

--- a/packages/astro/test/fixtures/incremental-build-fonts/package.json
+++ b/packages/astro/test/fixtures/incremental-build-fonts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/incremental-build-fonts",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/incremental-build-fonts/src/pages/blog/[slug].astro
+++ b/packages/astro/test/fixtures/incremental-build-fonts/src/pages/blog/[slug].astro
@@ -1,0 +1,21 @@
+---
+import { Font } from 'astro:assets';
+
+export async function getStaticPaths() {
+	return [
+		{ params: { slug: 'post-1' }, props: { title: 'Post 1' }, cacheKey: 'v1' },
+		{ params: { slug: 'post-2' }, props: { title: 'Post 2' }, cacheKey: 'v1' },
+	];
+}
+
+const { title } = Astro.props;
+---
+<html lang="en">
+<head>
+	<title>{title}</title>
+	<Font cssVariable='--font-test' />
+</head>
+<body>
+	<h1>{title}</h1>
+</body>
+</html>

--- a/packages/astro/test/incremental-build-fonts.test.ts
+++ b/packages/astro/test/incremental-build-fonts.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { after, before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('incrementalBuild + fonts (#17626)', () => {
+	const root = new URL('./fixtures/incremental-build-fonts/', import.meta.url);
+	const cacheFile = new URL('node_modules/.astro/incremental-build.json', root);
+	let fixture: Fixture;
+	let hash1: Record<string, string>;
+	let hash2: Record<string, string>;
+
+	before(async () => {
+		fs.rmSync(new URL('dist/', root), { recursive: true, force: true });
+		fs.rmSync(cacheFile, { force: true });
+
+		fixture = await loadFixture({
+			root,
+			experimental: { incrementalBuild: true },
+			fonts: [
+				{
+					provider: (await import('astro/config')).fontProviders.google(),
+					name: 'Roboto',
+					cssVariable: '--font-test',
+				},
+			],
+		});
+
+		await fixture.build();
+		const cache1 = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+		hash1 = {};
+		for (const [key, val] of Object.entries(cache1.routes)) {
+			if ((val as any)?.dependencyHash) hash1[key] = (val as any).dependencyHash;
+		}
+
+		await fixture.build();
+		const cache2 = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+		hash2 = {};
+		for (const [key, val] of Object.entries(cache2.routes)) {
+			if ((val as any)?.dependencyHash) hash2[key] = (val as any).dependencyHash;
+		}
+	});
+
+	after(() => {
+		fs.rmSync(cacheFile, { force: true });
+		fs.rmSync(new URL('dist/', root), { recursive: true, force: true });
+	});
+
+	it('produces stable dependencyHash across builds', () => {
+		const routes = Object.keys(hash1);
+		assert.ok(routes.length > 0, 'Should have at least one route with dependencyHash');
+		for (const route of routes) {
+			assert.equal(hash1[route], hash2[route], `dependencyHash changed for "${route}"`);
+		}
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3540,6 +3540,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/incremental-build-fonts:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/incremental-build-headers:
     dependencies:
       astro:


### PR DESCRIPTION
Closes #17626

## Changes

- The `virtual:astro:assets/fonts/runtime/font-file-url-resolver` virtual module previously embedded the prerender HTTP server's `AddressInfo` (including an OS-assigned ephemeral port) directly as a JSON literal in its compiled source text. Because the port changes on every build, the incremental build plugin's `hashModules()` produced a different `dependencyHash` for every route that transitively imported `<Font />`, silently defeating all caching for any site using the Fonts API from a shared layout.
- Instead of embedding the address literal, the fix stores the server address on `globalThis` under a well-known constant key (`FONTS_PRERENDER_ADDRESS_KEY`) during `buildStart()` and generates module code that reads `globalThis[key]` at prerender execution time. The module text is now identical across builds, making `dependencyHash` stable. The key is deleted from `globalThis` in `build/index.ts` after prerendering completes and the font HTTP server is closed.

## Testing

- Added `packages/astro/test/incremental-build-fonts.test.ts`: runs two consecutive builds of a fixture with `experimental.incrementalBuild: true` and a Google Fonts entry, then asserts that every route's `dependencyHash` in `node_modules/.astro/incremental-build.json` is identical between builds.
- Added `packages/astro/test/fixtures/incremental-build-fonts/` fixture: a dynamic route using `<Font />` with a stable `cacheKey`, the minimal setup to reproduce the issue.

## Docs

No docs update needed — this is a bug fix for experimental features with no API or behavior change visible to users beyond caching now working correctly.
