### PR TITLE
fix(build): Optimize incremental builds with shared content graph hashing

### DIFF
--- a/.changeset/quick-graphs-share.md
+++ b/.changeset/quick-graphs-share.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes incremental builds becoming prohibitively slow for sites with many content entries that share a large dependency graph.

--- a/.changeset/quick-graphs-share.md
+++ b/.changeset/quick-graphs-share.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes incremental builds becoming prohibitively slow for sites with many content entries that share a large dependency graph.
+Fixes incremental builds becoming prohibitively slow for sites with many pages or content entries that share a large dependency graph.

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -27,28 +27,9 @@ interface HashableModuleGraph extends ModuleGraph {
 	getModuleIds(): IterableIterator<string>;
 }
 
-/** Collect the sorted, transitive dependency ids of a module, following static and dynamic imports. */
-function collectTransitiveDeps(graph: ModuleGraph, rootId: string): string[] {
-	const deps = new Set<string>();
-	const queue = [rootId];
-	while (queue.length > 0) {
-		const current = queue.pop()!;
-		if (deps.has(current)) continue;
-
-		const modInfo = graph.getModuleInfo(current);
-		if (isContentDataIncrementalModule(modInfo)) continue;
-
-		deps.add(current);
-		if (!modInfo) continue;
-
-		for (const dep of modInfo.importedIds) {
-			if (!deps.has(dep)) queue.push(dep);
-		}
-		for (const dep of modInfo.dynamicallyImportedIds) {
-			if (!deps.has(dep)) queue.push(dep);
-		}
-	}
-	return [...deps].sort();
+interface TransitiveGraphCache {
+	hashes: Map<string, string>;
+	serverIslandModules: Set<string>;
 }
 
 /** Each placeholder pattern paired with the token that has to be present for it to match. */
@@ -107,7 +88,7 @@ function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
  * Strongly connected components collapse cycles into a DAG, whose hashes can be
  * folded into every importer without walking shared dependencies again for each root.
  */
-function createTransitiveHashCache(graph: HashableModuleGraph): Map<string, string> {
+function createTransitiveGraphCache(graph: HashableModuleGraph): TransitiveGraphCache {
 	const modules = new Map<string, HashableModuleInfo | null>();
 	const dependencies = new Map<string, string[]>();
 	const excludedModules = new Set<string>();
@@ -196,6 +177,7 @@ function createTransitiveHashCache(graph: HashableModuleGraph): Map<string, stri
 	}
 
 	const componentHashes = new Map<number, string>();
+	const componentHasServerIsland = new Map<number, boolean>();
 	const unresolvedDependencies = componentDependencies.map((items) => items.size);
 	const ready = unresolvedDependencies.flatMap((count, index) => (count === 0 ? [index] : []));
 	for (const componentIndex of ready) {
@@ -209,6 +191,15 @@ function createTransitiveHashCache(graph: HashableModuleGraph): Map<string, stri
 			hasher.update(dependencyHash);
 		}
 		componentHashes.set(componentIndex, hasher.digest('hex'));
+		componentHasServerIsland.set(
+			componentIndex,
+			components[componentIndex].some(
+				(id) => (modules.get(id)?.meta?.astro?.serverComponents?.length ?? 0) > 0,
+			) ||
+				[...componentDependencies[componentIndex]].some((dependencyIndex) =>
+					componentHasServerIsland.get(dependencyIndex),
+				),
+		);
 
 		for (const importerIndex of componentImporters[componentIndex]) {
 			unresolvedDependencies[importerIndex]--;
@@ -216,9 +207,19 @@ function createTransitiveHashCache(graph: HashableModuleGraph): Map<string, stri
 		}
 	}
 
-	return new Map(
-		[...componentByModule].map(([id, componentIndex]) => [id, componentHashes.get(componentIndex)!]),
-	);
+	return {
+		hashes: new Map(
+			[...componentByModule].map(([id, componentIndex]) => [
+				id,
+				componentHashes.get(componentIndex)!,
+			]),
+		),
+		serverIslandModules: new Set(
+			[...componentByModule]
+				.filter(([, componentIndex]) => componentHasServerIsland.get(componentIndex))
+				.map(([id]) => id),
+		),
+	};
 }
 
 /**
@@ -226,7 +227,7 @@ function createTransitiveHashCache(graph: HashableModuleGraph): Map<string, stri
  * against every page that uses it, keyed by page component.
  */
 function collectClientEntrypointHashes(
-	graph: ModuleGraph,
+	transitiveHashes: Map<string, string>,
 	entrypointIds: Iterable<string>,
 	pagesByEntrypoint: Map<string, Set<PageBuildData>>,
 	hashesByComponent: Map<string, string[]>,
@@ -235,7 +236,8 @@ function collectClientEntrypointHashes(
 		const pages = pagesByEntrypoint.get(entrypointId);
 		if (!pages?.size) continue;
 
-		const hash = hashModules(graph, collectTransitiveDeps(graph, entrypointId));
+		const hash = transitiveHashes.get(entrypointId);
+		if (!hash) continue;
 		for (const pageData of pages) {
 			let list = hashesByComponent.get(pageData.component);
 			if (!list) {
@@ -260,15 +262,16 @@ function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInte
 	const baseHashes = internals.pageDependencyHashes;
 	if (!baseHashes) return;
 
+	const { hashes: transitiveHashes } = createTransitiveGraphCache(graph);
 	const hashesByComponent = new Map<string, string[]>();
 	collectClientEntrypointHashes(
-		graph,
+		transitiveHashes,
 		internals.discoveredClientOnlyComponents.keys(),
 		internals.pagesByClientOnly,
 		hashesByComponent,
 	);
 	collectClientEntrypointHashes(
-		graph,
+		transitiveHashes,
 		internals.discoveredScripts,
 		internals.pagesByScriptId,
 		hashesByComponent,
@@ -312,20 +315,6 @@ function collectContentEntryHashes(
 }
 
 /**
- * Whether any module in a page's render graph uses a server island. The Astro
- * compiler records `server:defer` usage as `serverComponents` metadata on the
- * module that hosts it, so a page (or one of its layouts/components) that renders
- * an island is detectable from the graph it already walks for hashing.
- */
-function pageContainsServerIsland(graph: ModuleGraph, ids: string[]): boolean {
-	for (const id of ids) {
-		const serverComponents = graph.getModuleInfo(id)?.meta?.astro?.serverComponents;
-		if (serverComponents?.length) return true;
-	}
-	return false;
-}
-
-/**
  * Captures a dependency hash for each prerendered page route during the build.
  *
  * The base hash is derived during the prerender build from the sorted set of all
@@ -351,6 +340,7 @@ export function pluginIncremental(internals: BuildInternals, root: URL): VitePlu
 				return;
 			}
 
+			const transitiveGraph = createTransitiveGraphCache(this);
 			const hashes = new Map<string, string>();
 			const serverIslandComponents = new Set<string>();
 			for (const id of this.getModuleIds()) {
@@ -361,10 +351,12 @@ export function pluginIncremental(internals: BuildInternals, root: URL): VitePlu
 				const pageData = getPageDataByViteID(internals, info.id);
 				if (!pageData) continue;
 
-				const deps = collectTransitiveDeps(this, info.id);
+				const hash = transitiveGraph.hashes.get(info.id);
+				if (!hash) continue;
+
 				// Key by component path (e.g. "src/pages/blog/[slug].astro")
-				hashes.set(pageData.component, hashModules(this, deps));
-				if (pageContainsServerIsland(this, deps)) {
+				hashes.set(pageData.component, hash);
+				if (transitiveGraph.serverIslandModules.has(info.id)) {
 					serverIslandComponents.add(pageData.component);
 				}
 			}
@@ -373,7 +365,7 @@ export function pluginIncremental(internals: BuildInternals, root: URL): VitePlu
 			internals.contentEntryRenderHashes = collectContentEntryHashes(
 				this,
 				root,
-				createTransitiveHashCache(this),
+				transitiveGraph.hashes,
 			);
 			internals.serverIslandPageComponents = serverIslandComponents;
 		},

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -23,6 +23,10 @@ interface ModuleGraph {
 	getFileName(referenceId: string): string;
 }
 
+interface HashableModuleGraph extends ModuleGraph {
+	getModuleIds(): IterableIterator<string>;
+}
+
 /** Collect the sorted, transitive dependency ids of a module, following static and dynamic imports. */
 function collectTransitiveDeps(graph: ModuleGraph, rootId: string): string[] {
 	const deps = new Set<string>();
@@ -99,6 +103,125 @@ function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
 }
 
 /**
+ * Build a transitive hash for every module with one pass over the dependency graph.
+ * Strongly connected components collapse cycles into a DAG, whose hashes can be
+ * folded into every importer without walking shared dependencies again for each root.
+ */
+function createTransitiveHashCache(graph: HashableModuleGraph): Map<string, string> {
+	const modules = new Map<string, HashableModuleInfo | null>();
+	const dependencies = new Map<string, string[]>();
+	const excludedModules = new Set<string>();
+	const pending = [...graph.getModuleIds()];
+	for (const id of pending) {
+		if (modules.has(id)) continue;
+
+		const info = graph.getModuleInfo(id);
+		modules.set(id, info);
+		if (isContentDataIncrementalModule(info)) {
+			excludedModules.add(id);
+			continue;
+		}
+
+		const importedIds = [...(info?.importedIds ?? []), ...(info?.dynamicallyImportedIds ?? [])];
+		dependencies.set(id, importedIds);
+		pending.push(...importedIds);
+	}
+	for (const id of excludedModules) modules.delete(id);
+	for (const [id, importedIds] of dependencies) {
+		dependencies.set(
+			id,
+			importedIds.filter((importedId) => !excludedModules.has(importedId)),
+		);
+	}
+
+	const reverseDependencies = new Map<string, string[]>();
+	for (const id of modules.keys()) reverseDependencies.set(id, []);
+	for (const [id, importedIds] of dependencies) {
+		for (const importedId of importedIds) reverseDependencies.get(importedId)?.push(id);
+	}
+
+	const visited = new Set<string>();
+	const finishOrder: string[] = [];
+	for (const rootId of modules.keys()) {
+		if (visited.has(rootId)) continue;
+		visited.add(rootId);
+		const stack: Array<[string, number]> = [[rootId, 0]];
+		while (stack.length > 0) {
+			const frame = stack[stack.length - 1];
+			const importedIds = dependencies.get(frame[0]) ?? [];
+			if (frame[1] < importedIds.length) {
+				const importedId = importedIds[frame[1]++];
+				if (!visited.has(importedId)) {
+					visited.add(importedId);
+					stack.push([importedId, 0]);
+				}
+			} else {
+				finishOrder.push(frame[0]);
+				stack.pop();
+			}
+		}
+	}
+
+	const componentByModule = new Map<string, number>();
+	const components: string[][] = [];
+	for (const rootId of finishOrder.toReversed()) {
+		if (componentByModule.has(rootId)) continue;
+		const componentIndex = components.length;
+		const component: string[] = [];
+		const stack = [rootId];
+		componentByModule.set(rootId, componentIndex);
+		while (stack.length > 0) {
+			const id = stack.pop()!;
+			component.push(id);
+			for (const importerId of reverseDependencies.get(id) ?? []) {
+				if (!componentByModule.has(importerId)) {
+					componentByModule.set(importerId, componentIndex);
+					stack.push(importerId);
+				}
+			}
+		}
+		components.push(component.sort());
+	}
+
+	const componentDependencies = components.map(() => new Set<number>());
+	const componentImporters = components.map(() => new Set<number>());
+	for (const [id, importedIds] of dependencies) {
+		const componentIndex = componentByModule.get(id)!;
+		for (const importedId of importedIds) {
+			const dependencyIndex = componentByModule.get(importedId)!;
+			if (dependencyIndex === componentIndex) continue;
+			componentDependencies[componentIndex].add(dependencyIndex);
+			componentImporters[dependencyIndex].add(componentIndex);
+		}
+	}
+
+	const componentHashes = new Map<number, string>();
+	const unresolvedDependencies = componentDependencies.map((items) => items.size);
+	const ready = unresolvedDependencies.flatMap((count, index) => (count === 0 ? [index] : []));
+	for (const componentIndex of ready) {
+		const hasher = crypto.createHash('sha256');
+		hasher.update(hashModules(graph, components[componentIndex]));
+		const dependencyHashes = [...componentDependencies[componentIndex]]
+			.map((dependencyIndex) => componentHashes.get(dependencyIndex)!)
+			.sort();
+		for (const dependencyHash of dependencyHashes) {
+			hasher.update('\n');
+			hasher.update(dependencyHash);
+		}
+		componentHashes.set(componentIndex, hasher.digest('hex'));
+
+		for (const importerIndex of componentImporters[componentIndex]) {
+			unresolvedDependencies[importerIndex]--;
+			if (unresolvedDependencies[importerIndex] === 0) ready.push(importerIndex);
+		}
+	}
+
+	return new Map(
+		[...componentByModule].map(([id, componentIndex]) => [id, componentHashes.get(componentIndex)!]),
+	);
+}
+
+/**
  * Hash the transitive graph of each client entrypoint and accumulate the result
  * against every page that uses it, keyed by page component.
  */
@@ -133,7 +256,7 @@ function collectClientEntrypointHashes(
  * build we hash each entrypoint's transitive graph and fold it into the dependency
  * hash of every route that uses it.
  */
-function foldClientDependencies(graph: ModuleGraph, internals: BuildInternals): void {
+function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInternals): void {
 	const baseHashes = internals.pageDependencyHashes;
 	if (!baseHashes) return;
 
@@ -172,8 +295,9 @@ function foldClientDependencies(graph: ModuleGraph, internals: BuildInternals): 
  * entry's graph into another route's hash.
  */
 function collectContentEntryHashes(
-	graph: ModuleGraph & { getModuleIds(): IterableIterator<string> },
+	graph: HashableModuleGraph,
 	root: URL,
+	transitiveHashes: Map<string, string>,
 ): Map<string, string> {
 	const entryHashes = new Map<string, string>();
 	for (const id of graph.getModuleIds()) {
@@ -181,8 +305,8 @@ function collectContentEntryHashes(
 		// e.g. "/abs/src/content/docs/one.mdx?astroPropagatedAssets" -> render module id.
 		const renderModuleId = removeQueryString(id);
 		const key = rootRelativePath(root, renderModuleId, false);
-		const deps = collectTransitiveDeps(graph, renderModuleId);
-		entryHashes.set(key, hashModules(graph, deps));
+		const hash = transitiveHashes.get(renderModuleId);
+		if (hash) entryHashes.set(key, hash);
 	}
 	return entryHashes;
 }
@@ -246,7 +370,11 @@ export function pluginIncremental(internals: BuildInternals, root: URL): VitePlu
 			}
 
 			internals.pageDependencyHashes = hashes;
-			internals.contentEntryRenderHashes = collectContentEntryHashes(this, root);
+			internals.contentEntryRenderHashes = collectContentEntryHashes(
+				this,
+				root,
+				createTransitiveHashCache(this),
+			);
 			internals.serverIslandPageComponents = serverIslandComponents;
 		},
 	};

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -96,6 +96,27 @@ function contentEntryHashes(
 	return internals.contentEntryRenderHashes as Map<string, string>;
 }
 
+function pageDependencyHashes(
+	modules: Map<string, ReturnType<typeof moduleInfo>>,
+	pagesByViteID: Map<string, { component: string }>,
+	onGetModuleInfo?: () => void,
+) {
+	const internals = { pagesByViteID } as any;
+	const plugin = pluginIncremental(internals, ROOT) as any;
+	plugin.generateBundle.call({
+		environment: { name: 'prerender' },
+		getModuleIds: () => modules.keys(),
+		getModuleInfo: (id: string) => {
+			onGetModuleInfo?.();
+			return modules.get(id) ?? null;
+		},
+		getFileName: () => {
+			throw new Error('Unexpected asset reference');
+		},
+	});
+	return internals.pageDependencyHashes as Map<string, string>;
+}
+
 describe('pluginIncremental', () => {
 	describe('dependency hash', () => {
 		it('is stable when the same images are emitted with different handles', () => {
@@ -142,16 +163,57 @@ describe('pluginIncremental', () => {
 			assert.equal(first, second);
 			assert.match(first, /^[0-9a-f]{64}$/);
 		});
+
+		it('hashes a shared graph once for many pages', () => {
+			const modules = new Map<string, ReturnType<typeof moduleInfo>>();
+			const pagesByViteID = new Map<string, { component: string }>();
+			const sharedCount = 100;
+			const pageCount = 100;
+			for (let index = 0; index < sharedCount; index++) {
+				const id = `/project/src/components/shared-${index}.ts`;
+				const importedIds =
+					index + 1 < sharedCount ? [`/project/src/components/shared-${index + 1}.ts`] : [];
+				modules.set(id, moduleInfo(id, { code: String(index), importedIds }));
+			}
+			for (let index = 0; index < pageCount; index++) {
+				const id = `/project/src/pages/page-${index}.astro`;
+				modules.set(
+					id,
+					moduleInfo(id, {
+						importedIds: ['/project/src/components/shared-0.ts'],
+						importers: [VIRTUAL_PAGE_RESOLVED_MODULE_ID],
+					}),
+				);
+				pagesByViteID.set(id, { component: `src/pages/page-${index}.astro` });
+			}
+
+			let getModuleInfoCalls = 0;
+			const hashes = pageDependencyHashes(modules, pagesByViteID, () => getModuleInfoCalls++);
+			assert.equal(hashes.size, pageCount);
+			assert.ok(getModuleInfoCalls <= modules.size * 4, `made ${getModuleInfoCalls} graph lookups`);
+		});
 	});
 
 	describe('content entry hash', () => {
 		it('invalidates every entry that imports a changed shared dependency', () => {
 			const shared = '/project/src/components/shared.astro';
 			const firstModules = new Map([
-				['/project/src/content/one.mdx', moduleInfo('/project/src/content/one.mdx', { importedIds: [shared] })],
-				['/project/src/content/one.mdx?astroPropagatedAssets', moduleInfo('/project/src/content/one.mdx?astroPropagatedAssets')],
-				['/project/src/content/two.mdx', moduleInfo('/project/src/content/two.mdx', { importedIds: [shared] })],
-				['/project/src/content/two.mdx?astroPropagatedAssets', moduleInfo('/project/src/content/two.mdx?astroPropagatedAssets')],
+				[
+					'/project/src/content/one.mdx',
+					moduleInfo('/project/src/content/one.mdx', { importedIds: [shared] }),
+				],
+				[
+					'/project/src/content/one.mdx?astroPropagatedAssets',
+					moduleInfo('/project/src/content/one.mdx?astroPropagatedAssets'),
+				],
+				[
+					'/project/src/content/two.mdx',
+					moduleInfo('/project/src/content/two.mdx', { importedIds: [shared] }),
+				],
+				[
+					'/project/src/content/two.mdx?astroPropagatedAssets',
+					moduleInfo('/project/src/content/two.mdx?astroPropagatedAssets'),
+				],
 				[shared, moduleInfo(shared, { code: 'first' })],
 			]);
 			const secondModules = new Map(firstModules);
@@ -185,7 +247,8 @@ describe('pluginIncremental', () => {
 			const entryCount = 100;
 			for (let index = 0; index < sharedCount; index++) {
 				const id = `/project/src/components/shared-${index}.ts`;
-				const importedIds = index + 1 < sharedCount ? [`/project/src/components/shared-${index + 1}.ts`] : [];
+				const importedIds =
+					index + 1 < sharedCount ? [`/project/src/components/shared-${index + 1}.ts`] : [];
 				modules.set(id, moduleInfo(id, { code: String(index), importedIds }));
 			}
 			for (let index = 0; index < entryCount; index++) {

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -76,6 +76,26 @@ function dependencyHash(
 	return internals.pageDependencyHashes.get(COMPONENT);
 }
 
+function contentEntryHashes(
+	modules: Map<string, ReturnType<typeof moduleInfo>>,
+	onGetModuleInfo?: () => void,
+) {
+	const internals = { pagesByViteID: new Map() } as any;
+	const plugin = pluginIncremental(internals, ROOT) as any;
+	plugin.generateBundle.call({
+		environment: { name: 'prerender' },
+		getModuleIds: () => modules.keys(),
+		getModuleInfo: (id: string) => {
+			onGetModuleInfo?.();
+			return modules.get(id) ?? null;
+		},
+		getFileName: () => {
+			throw new Error('Unexpected asset reference');
+		},
+	});
+	return internals.contentEntryRenderHashes as Map<string, string>;
+}
+
 describe('pluginIncremental', () => {
 	describe('dependency hash', () => {
 		it('is stable when the same images are emitted with different handles', () => {
@@ -121,6 +141,63 @@ describe('pluginIncremental', () => {
 			const second = dependencyHash(code, {});
 			assert.equal(first, second);
 			assert.match(first, /^[0-9a-f]{64}$/);
+		});
+	});
+
+	describe('content entry hash', () => {
+		it('invalidates every entry that imports a changed shared dependency', () => {
+			const shared = '/project/src/components/shared.astro';
+			const firstModules = new Map([
+				['/project/src/content/one.mdx', moduleInfo('/project/src/content/one.mdx', { importedIds: [shared] })],
+				['/project/src/content/one.mdx?astroPropagatedAssets', moduleInfo('/project/src/content/one.mdx?astroPropagatedAssets')],
+				['/project/src/content/two.mdx', moduleInfo('/project/src/content/two.mdx', { importedIds: [shared] })],
+				['/project/src/content/two.mdx?astroPropagatedAssets', moduleInfo('/project/src/content/two.mdx?astroPropagatedAssets')],
+				[shared, moduleInfo(shared, { code: 'first' })],
+			]);
+			const secondModules = new Map(firstModules);
+			secondModules.set(shared, moduleInfo(shared, { code: 'second' }));
+
+			const first = contentEntryHashes(firstModules);
+			const second = contentEntryHashes(secondModules);
+			assert.notEqual(first.get('src/content/one.mdx'), second.get('src/content/one.mdx'));
+			assert.notEqual(first.get('src/content/two.mdx'), second.get('src/content/two.mdx'));
+		});
+
+		it('handles cycles deterministically', () => {
+			const entry = '/project/src/content/one.mdx';
+			const a = '/project/src/components/a.ts';
+			const b = '/project/src/components/b.ts';
+			const modules = new Map([
+				[entry, moduleInfo(entry, { importedIds: [a] })],
+				[`${entry}?astroPropagatedAssets`, moduleInfo(`${entry}?astroPropagatedAssets`)],
+				[a, moduleInfo(a, { code: 'a', importedIds: [b] })],
+				[b, moduleInfo(b, { code: 'b', importedIds: [a] })],
+			]);
+
+			const first = contentEntryHashes(modules).get('src/content/one.mdx');
+			const second = contentEntryHashes(new Map([...modules].reverse())).get('src/content/one.mdx');
+			assert.equal(first, second);
+		});
+
+		it('hashes a shared graph once for many content entries', () => {
+			const modules = new Map<string, ReturnType<typeof moduleInfo>>();
+			const sharedCount = 100;
+			const entryCount = 100;
+			for (let index = 0; index < sharedCount; index++) {
+				const id = `/project/src/components/shared-${index}.ts`;
+				const importedIds = index + 1 < sharedCount ? [`/project/src/components/shared-${index + 1}.ts`] : [];
+				modules.set(id, moduleInfo(id, { code: String(index), importedIds }));
+			}
+			for (let index = 0; index < entryCount; index++) {
+				const id = `/project/src/content/entry-${index}.mdx`;
+				modules.set(id, moduleInfo(id, { importedIds: ['/project/src/components/shared-0.ts'] }));
+				modules.set(`${id}?astroPropagatedAssets`, moduleInfo(`${id}?astroPropagatedAssets`));
+			}
+
+			let getModuleInfoCalls = 0;
+			const hashes = contentEntryHashes(modules, () => getModuleInfoCalls++);
+			assert.equal(hashes.size, entryCount);
+			assert.ok(getModuleInfoCalls <= modules.size * 3, `made ${getModuleInfoCalls} graph lookups`);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

### Prevent OOM with optimal hashing algorithm

Optimizes experimental cache from **O(R × G)** to **O(G × R)** using a [Merkle-style hashing algorithm](https://en.wikipedia.org/wiki/Merkle_tree) to **content roots** that heavily share dependencies. 

- `R` = # of roots. (e.g. 8,000 content pages)
- `G` = graph size.

```mermaid
flowchart LR
    subgraph Before["Before: O(R × G)"]
        P1["Entry 1"] --> G1["Walk graph"]
        P2["Entry 2"] --> G2["Walk graph"]
        P3["Entry 3"] --> G3["Walk graph"]
    end

    subgraph After["After: O(G + R)"]
        G["Analyze graph once"] --> H["Hash cache"]
        H --> R1["Entry 1: O(1) lookup"]
        H --> R2["Entry 2: O(1) lookup"]
        H --> R3["Entry 3: O(1) lookup"]
    end
```

### Fixes `astro-icon`

`\0virtual:astro-icon` would invalidate entire module graphs because Rolldown checked by `lastModified` (which came from _when the collection was generated, not actual changes).

By removing `lastModified`, hashing correctly keys off the equality of the `icons.*` instead.

### Fixes OOM for Astro Islands

Server-island detection still walked the full shared graph once per page.  This caused any page with an island to regress back to the **O(R × G)** perf.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

The performance degradation was discovered on my [fork of cloudflare-docs](https://github.com/cloudflare/cloudflare-docs/compare/production...ericclemmons:cloudflare-docs:production) where I enabled `incrementalBuild`. ~10m builds now timed out at 30 minutes.
<img width="957" height="450" alt="Screenshot 2026-08-07 at 5 02 13 PM" src="https://github.com/user-attachments/assets/61aab6bf-0cfa-4ff5-bf65-62a9df7c4420" />
<img width="993" height="501" alt="Screenshot 2026-08-07 at 5 02 26 PM" src="https://github.com/user-attachments/assets/d344572c-6cee-4efc-aed5-592e66d7ceb4" />
<img width="990" height="658" alt="Screenshot 2026-08-07 at 5 02 30 PM" src="https://github.com/user-attachments/assets/e6f6cd5b-454d-4910-a284-2267e258568b" />

Once I used this PR, the build is able to run again:
<img width="997" height="512" alt="Screenshot 2026-08-07 at 5 03 56 PM" src="https://github.com/user-attachments/assets/f6120ad1-e9ae-4e3d-84cf-505a19c115e0" />

Then, testing an empty commit (to see if incremental builds continued working):
<img width="1001" height="643" alt="Screenshot 2026-08-07 at 5 04 52 PM" src="https://github.com/user-attachments/assets/84d250cd-707f-48e2-9d22-ad0e6e45beae" />
<img width="976" height="576" alt="Screenshot 2026-08-07 at 5 05 03 PM" src="https://github.com/user-attachments/assets/48b4e76c-63f6-4442-b318-0839ea78a38e" />




## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
