### PR TITLE
Fix cachekey in incremental

### DIFF
--- a/packages/astro/src/runtime/prerender/static-paths.ts
+++ b/packages/astro/src/runtime/prerender/static-paths.ts
@@ -5,8 +5,17 @@ import type { RouteData } from '../../types/public/internal.js';
 import { stringifyParams } from '../../core/routing/params.js';
 import { getFallbackRoute, routeIsFallback, routeIsRedirect } from '../../core/routing/helpers.js';
 import { callGetStaticPaths } from '../../core/render/route-cache.js';
+import { generateContentHash } from '../../core/encryption.js';
+import { deterministicString } from '../../assets/utils/deterministic-string.js';
 
 export type { PathWithRoute } from '../../types/public/integrations.js';
+
+async function hashCacheKey(cacheKey: unknown): Promise<string | undefined> {
+	if (cacheKey === undefined) return undefined;
+	const input = deterministicString(cacheKey);
+	const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+	return await generateContentHash(hashBuffer);
+}
 
 /**
  * Minimal interface for what StaticPaths needs from an App.
@@ -120,7 +129,7 @@ export class StaticPaths {
 			paths.push({
 				pathname,
 				route,
-				cacheKey: staticPath.cacheKey === undefined ? undefined : String(staticPath.cacheKey),
+				cacheKey: await hashCacheKey(staticPath.cacheKey),
 			});
 		}
 

--- a/packages/astro/test/fixtures/get-static-paths-incremental/package.json
+++ b/packages/astro/test/fixtures/get-static-paths-incremental/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/get-static-paths-incremental",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/get-static-paths-incremental/src/content.config.ts
+++ b/packages/astro/test/fixtures/get-static-paths-incremental/src/content.config.ts
@@ -1,0 +1,23 @@
+// 1. Import utilities from `astro:content`
+import { defineCollection } from 'astro:content';
+
+// 2. Import loader(s)
+import { file } from 'astro/loaders';
+
+// 3. Import Zod
+import { z } from 'astro/zod';
+
+// 4. Define a `loader` and `schema` for each collection
+const blogs = defineCollection({
+  loader: file('./src/data/blog.json'),
+  schema: z.object({
+		id: z.string(),
+		title: z.string(),
+		data:z.array(z.object({
+			content: z.string(),
+		}))
+	}),
+});
+
+// 5. Export a single `collections` object to register your collection(s)
+export const collections = { blogs };

--- a/packages/astro/test/fixtures/get-static-paths-incremental/src/data/blog.json
+++ b/packages/astro/test/fixtures/get-static-paths-incremental/src/data/blog.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "astro-1",
+    "title": "My First Blog Post",
+    "data": [
+      {
+        "content": "This is the content of my first blog post."
+      }
+    ]
+  }
+]

--- a/packages/astro/test/fixtures/get-static-paths-incremental/src/pages/blog/[slug].astro
+++ b/packages/astro/test/fixtures/get-static-paths-incremental/src/pages/blog/[slug].astro
@@ -1,0 +1,30 @@
+---
+import { getCollection, getEntry } from 'astro:content';
+
+export async function getStaticPaths() {
+	const blogs = await getCollection('blogs');
+	
+	return [
+		...blogs.map((blog) => ({
+      params: { slug: blog.id },
+      cacheKey: blog.data.data,
+		}))
+	];
+}
+
+const {  slug } = Astro.params;
+const blog = await getEntry('blogs', slug);
+const data = blog.data.data ?? [];
+---
+<html>
+	<body>
+		<h1>{blog.data.title}</h1>
+{data &&
+data.map((item) => (
+	<div>
+		<p>{item.content}</p>
+	</div>
+))
+}
+	</body>
+</html>

--- a/packages/astro/test/get-static-paths-incremental.test.ts
+++ b/packages/astro/test/get-static-paths-incremental.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { after, before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('getStaticPaths with experimental.incrementalBuild', () => {
+	const root = new URL('./fixtures/get-static-paths-incremental/', import.meta.url);
+	const page = new URL('src/pages/blog/[slug].astro', root);
+	const cachedCopy = new URL('node_modules/.astro/dist/blog/astro-1/index.html', root);
+	let fixture: Fixture;
+	let original: string;
+	let originalJson: string;
+
+	const json = new URL('src/data/blog.json', root);
+
+	before(async () => {
+		fs.rmSync(new URL('dist/', root), { recursive: true, force: true });
+		fs.rmSync(new URL('node_modules/.astro/', root), { recursive: true, force: true });
+		original = fs.readFileSync(page, 'utf-8');
+		originalJson = fs.readFileSync(json, 'utf-8');
+		fixture = await loadFixture({
+			root,
+			output: 'static',
+			experimental: {
+				incrementalBuild: true,
+			},
+		});
+
+		// Build 1: the page emits output and its copy is cached.
+		await fixture.build();
+	});
+
+	after(() => {
+		fs.writeFileSync(page, original);
+		fs.writeFileSync(json, originalJson);
+	});
+
+	it('If a cacheKey field is present, then the cache is used.', async () => {
+		assert.ok(fixture.pathExists('/blog/astro-1/index.html'), 'first build should emit the page');
+		assert.ok(fs.existsSync(cachedCopy), 'first build should cache a copy');
+
+		// Build 2: the page now renders same output (If the cacheKey is not changed,
+		// rendering will proceed; otherwise, there will be no output).
+		const cachedPage = fs.readFileSync(cachedCopy, 'utf-8');
+
+		// change the title of the page to see if the cache is used
+		const title = 'My First Blog Post';
+		fs.writeFileSync(json, originalJson.replace(title, 'My New Blog Post'));
+		await fixture.build();
+
+		assert.ok(cachedPage.includes(title), 'The page still exists; use caching.');
+	});
+
+	it('If the cacheKey value changes, then a re-render will occur.', async () => {
+		assert.ok(fixture.pathExists('/blog/astro-1/index.html'), 'first build should emit the page');
+		assert.ok(fs.existsSync(cachedCopy), 'first build should cache a copy');
+
+		// Build 2: the page now renders same output (If the cacheKey is not changed,
+		// rendering will proceed; otherwise, there will be no output).
+		// const cachedPage = fs.readFileSync(cachedCopy, 'utf-8');
+
+		// change the blog.data(cacheKey) of the page to see if the cache is used
+		const content = 'This is the content of my first blog post.';
+		fs.writeFileSync(json, originalJson.replace(content, 'This is the content of my new blog post.'));
+		await fixture.build();
+
+		const newPage = fs.readFileSync(cachedCopy, 'utf-8');
+
+		assert.ok(
+			!newPage.includes(content),
+			'The cacheKey value has changed; this page should be refreshed.',
+		);
+	});
+});

--- a/packages/astro/test/incremental-build.test.ts
+++ b/packages/astro/test/incremental-build.test.ts
@@ -3,14 +3,25 @@ import fs from 'node:fs';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { type Fixture, loadFixture } from './test-utils.ts';
+import { deterministicString } from '../dist/assets/utils/deterministic-string.js';
+import { generateContentHash } from '../dist/core/encryption.js';
 
 describe('experimental.incrementalBuild', () => {
 	const root = new URL('./fixtures/incremental-build/', import.meta.url);
 	const cacheFile = new URL('node_modules/.astro/incremental-build.json', root);
 	let fixture: Fixture;
+	let cacheKey_v1: string;
+	let cacheKey_v2: string;
 
 	describe('first build', () => {
 		before(async () => {
+			// generate cache keys inside async hook
+			cacheKey_v1 = await generateContentHash(
+				await crypto.subtle.digest('SHA-256', new TextEncoder().encode(deterministicString('v1'))),
+			);
+			cacheKey_v2 = await generateContentHash(
+				await crypto.subtle.digest('SHA-256', new TextEncoder().encode(deterministicString('v2'))),
+			);
 			fs.rmSync(new URL('dist/incremental-build/', root), { recursive: true, force: true });
 			fs.rmSync(cacheFile, { force: true });
 			fixture = await loadFixture({
@@ -52,7 +63,7 @@ describe('experimental.incrementalBuild', () => {
 			assert.ok(blogRoute, 'Blog route should be in cache');
 			assert.ok(blogRoute.dependencyHash, 'Should have a dependency hash');
 			assert.ok(blogRoute.paths['/blog/post-1'], 'post-1 should be tracked');
-			assert.equal(blogRoute.paths['/blog/post-1'].cacheKey, 'v1');
+			assert.equal(blogRoute.paths['/blog/post-1'].cacheKey, cacheKey_v1);
 			assert.equal(cache.routes['src/pages/index.astro'], undefined);
 		});
 	});
@@ -181,9 +192,9 @@ describe('experimental.incrementalBuild', () => {
 		it('updates the cache manifest with the new cacheKey', () => {
 			const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
 			const blogRoute = cache.routes['src/pages/blog/[slug].astro'];
-			assert.equal(blogRoute.paths['/blog/post-2'].cacheKey, 'v2');
+			assert.equal(blogRoute.paths['/blog/post-2'].cacheKey, cacheKey_v2);
 			// Other paths should still have v1
-			assert.equal(blogRoute.paths['/blog/post-1'].cacheKey, 'v1');
+			assert.equal(blogRoute.paths['/blog/post-1'].cacheKey, cacheKey_v1);
 		});
 
 		// Restore original file after tests

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3384,6 +3384,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/get-static-paths-incremental:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/get-static-paths-pages:
     dependencies:
       astro:
@@ -7118,12 +7124,6 @@ importers:
       tsx:
         specifier: ^4.22.0
         version: 4.22.3
-
-  triage/gh-17624:
-    dependencies:
-      astro:
-        specifier: ^7.2.0
-        version: link:../../packages/astro
 
 packages:
 


### PR DESCRIPTION
## Changes

- What does this change?
- Add UT restore issue.
- Improve cache key handling with a hashing function

- [ ] [This doc](https://docs.astro.build/en/reference/experimental-flags/incremental-build/#providing-a-cache-key) must be updated if you accept my PR.

## Testing

Run node test command:

```block
node ./packages/astro/test/get-static-paths-incremental.test.ts 
```

Closed issue: https://github.com/withastro/astro/issues/17635