### PR TITLE
fix(assets): add AbortSignal timeout to remote image fetch

### DIFF
--- a/packages/astro/src/assets/utils/redirectValidation.ts
+++ b/packages/astro/src/assets/utils/redirectValidation.ts
@@ -79,7 +79,7 @@ export async function fetchWithRedirects(options: FetchRedirectOptions): Promise
 
 	const urlString = typeof url === 'string' ? url : url.toString();
 	const req = new Request(url, { headers });
-	const res = await fetchFn(req, { redirect: 'manual' });
+	const res = await fetchFn(req, { redirect: 'manual', signal: AbortSignal.timeout(10_000) });
 
 	// Handle redirects (301, 302, 303, 307, 308 are actual redirects, not 304 Not Modified)
 	if ([301, 302, 303, 307, 308].includes(res.status)) {


### PR DESCRIPTION
The remote image fetch in redirectValidation.ts passes no signal or timeout to fetchFn. A slow or unresponsive image origin server will stall the fetch indefinitely - blocking SSR responses in production and the dev server during development. Added AbortSignal.timeout(10_000) to the fetch options so the call aborts after 10 seconds rather than hanging forever.