### PR TITLE
fix(cloudflare): warn when the default SESSION KV binding will be auto-provisioned

### DIFF
--- a/.changeset/lucky-moons-provision.md
+++ b/.changeset/lucky-moons-provision.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Warns at build time when the default `SESSION` KV binding will be auto-provisioned on deploy
+
+The adapter injects a `SESSION` KV binding with no `id`, which `wrangler deploy` treats as a request to provision a new KV namespace. If your API token lacks the `Workers KV Storage: Edit` permission, the deploy fails with an opaque `Authentication error [code: 10000]` well after the build succeeded.
+
+`astro build` now warns when this binding is about to be provisioned, pointing at both escape hatches: declaring `kv_namespaces` in your Wrangler config to use an existing namespace, or setting `session: false` in your Astro config to skip sessions entirely. No warning is emitted if you already declared the binding yourself, if sessions are disabled, or during `astro dev`.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -208,6 +208,8 @@ export default function createIntegration({
 						imagesBindingName:
 							needsImagesBinding || needsImagesBindingForDev ? imagesBindingName : false,
 						needsWorkerCache,
+						// Only relevant ahead of a deploy; `dev` never provisions anything.
+						logger: command === 'build' ? logger : undefined,
 					}),
 					...(prerenderEnvironment === 'workerd' && {
 						experimental: {

--- a/packages/integrations/cloudflare/src/wrangler.ts
+++ b/packages/integrations/cloudflare/src/wrangler.ts
@@ -1,4 +1,5 @@
 import type { PluginConfig, WorkerConfig } from '@cloudflare/vite-plugin';
+import type { AstroIntegrationLogger } from 'astro';
 
 export const DEFAULT_SESSION_KV_BINDING_NAME = 'SESSION';
 export const DEFAULT_IMAGES_BINDING_NAME = 'IMAGES';
@@ -16,6 +17,11 @@ interface CloudflareConfigOptions {
 	needsSessionKVBinding?: boolean;
 	imagesBindingName?: string | false | undefined;
 	needsWorkerCache?: boolean;
+	/**
+	 * When set, warns once if the session KV binding is injected without an `id`,
+	 * since `wrangler deploy` will then provision a new KV namespace.
+	 */
+	logger?: AstroIntegrationLogger | undefined;
 }
 
 type KVNamespace = NonNullable<WorkerConfig['kv_namespaces']>[number];
@@ -34,6 +40,9 @@ export function cloudflareConfigCustomizer(
 			? undefined
 			: (options?.imagesBindingName ?? DEFAULT_IMAGES_BINDING_NAME);
 	const needsWorkerCache = options?.needsWorkerCache ?? false;
+	// The customizer runs once per worker (entry, prerender, previews), so the
+	// provisioning notice is deduplicated to a single warning per build.
+	let hasWarnedAboutProvisioning = false;
 
 	const customizer = (config: Partial<WorkerConfig>): Partial<WorkerConfig> => {
 		const getNonInheritableBindings = (
@@ -43,12 +52,24 @@ export function cloudflareConfigCustomizer(
 				(kv: KVNamespace) => kv.binding === sessionKVBindingName,
 			);
 			const hasImagesBinding = nonInheritableConfig?.images?.binding !== undefined;
+			const injectsSessionBinding = needsSessionKVBinding && !hasSessionBinding;
+
+			// The injected binding has no `id`, which wrangler reads as a request to
+			// provision a namespace on deploy. That needs a token with
+			// "Workers KV Storage: Edit", so surface it at build time rather than
+			// letting the deploy fail with an opaque authentication error.
+			if (injectsSessionBinding && options?.logger && !hasWarnedAboutProvisioning) {
+				hasWarnedAboutProvisioning = true;
+				options.logger.warn(
+					`The "${sessionKVBindingName}" KV binding has no \`id\`, so \`wrangler deploy\` will provision a new KV namespace. ` +
+						`This requires an API token with the "Workers KV Storage: Edit" permission.\n` +
+						`  To use an existing namespace, add \`kv_namespaces: [{ binding: "${sessionKVBindingName}", id: "<id>" }]\` to your Wrangler config.\n` +
+						`  To skip sessions entirely, set \`session: false\` in your Astro config.`,
+				);
+			}
 
 			return {
-				kv_namespaces:
-					!needsSessionKVBinding || hasSessionBinding
-						? undefined
-						: [{ binding: sessionKVBindingName }],
+				kv_namespaces: injectsSessionBinding ? [{ binding: sessionKVBindingName }] : undefined,
 				images:
 					hasImagesBinding || !imagesBindingName
 						? undefined

--- a/packages/integrations/cloudflare/test/session-false.test.ts
+++ b/packages/integrations/cloudflare/test/session-false.test.ts
@@ -100,4 +100,56 @@ describe('@astrojs/cloudflare session: false', () => {
 			);
 		});
 	});
+
+	describe('provisioning warning', () => {
+		const collectWarnings = () => {
+			const warnings: string[] = [];
+			const logger = {
+				info: () => {},
+				warn: (message: string) => warnings.push(message),
+				error: () => {},
+				debug: () => {},
+			} as any;
+			return { warnings, logger };
+		};
+
+		it('warns that the deploy will provision a KV namespace', () => {
+			const { warnings, logger } = collectWarnings();
+			cloudflareConfigCustomizer({ needsSessionKVBinding: true, logger })({});
+
+			assert.equal(warnings.length, 1, 'expected exactly one warning');
+			assert.match(warnings[0], /provision a new KV namespace/);
+			assert.match(warnings[0], /Workers KV Storage: Edit/);
+		});
+
+		it('warns only once across multiple workers', () => {
+			const { warnings, logger } = collectWarnings();
+			const customize = cloudflareConfigCustomizer({ needsSessionKVBinding: true, logger });
+			customize({});
+			customize({});
+
+			assert.equal(warnings.length, 1, 'expected the warning to be deduplicated');
+		});
+
+		it('does not warn when the user declared the binding', () => {
+			const { warnings, logger } = collectWarnings();
+			cloudflareConfigCustomizer({ needsSessionKVBinding: true, logger })({
+				kv_namespaces: [{ binding: DEFAULT_SESSION_KV_BINDING_NAME, id: 'abc123' }],
+				previews: { kv_namespaces: [{ binding: DEFAULT_SESSION_KV_BINDING_NAME, id: 'abc123' }] },
+			} as any);
+
+			assert.deepEqual(warnings, []);
+		});
+
+		it('does not warn when sessions are disabled', () => {
+			const { warnings, logger } = collectWarnings();
+			cloudflareConfigCustomizer({ needsSessionKVBinding: false, logger })({});
+
+			assert.deepEqual(warnings, []);
+		});
+
+		it('does not warn without a logger', () => {
+			assert.doesNotThrow(() => cloudflareConfigCustomizer({ needsSessionKVBinding: true })({}));
+		});
+	});
 });


### PR DESCRIPTION
## Changes

- The adapter injects a `SESSION` KV binding with no `id`, which Wrangler treats as a
  request to auto-provision a namespace on deploy. That needs an API token with
  `Workers KV Storage: Edit`, so deploys without it fail with a generic
  `Authentication error [code: 10000]` against `/storage/kv/namespaces` — **after the
  build already succeeded**, and with nothing in the message pointing back at sessions.
- `astro build` now warns when that binding is about to be provisioned, naming the
  permission and both escape hatches:

  ```
  [@astrojs/cloudflare] The "SESSION" KV binding has no `id`, so `wrangler deploy` will
  provision a new KV namespace. This requires an API token with the "Workers KV Storage:
  Edit" permission.
    To use an existing namespace, add `kv_namespaces: [{ binding: "SESSION", id: "<id>" }]`
    to your Wrangler config.
    To skip sessions entirely, set `session: false` in your Astro config.
  ```

- Silent when the user already declared the binding, when `session: false`, and during
  `dev` (which never provisions anything). Deduplicated to one warning per build, since
  the customizer runs once per worker (entry, prerender, previews).
- **No change to the emitted Wrangler config.** The existing
  `!needsSessionKVBinding || hasSessionBinding` ternary is extracted into a named
  `injectsSessionBinding` so the warning condition and the emission condition can't
  drift apart, but the output is identical.
- The warning lives in `cloudflareConfigCustomizer` rather than the `astro:config:setup`
  hook because that's the only place that knows whether an id-less binding is *actually*
  being emitted — warning from `index.ts` would also fire for users who correctly
  declared `SESSION` with an `id`.

Closes #17640

## Testing

Five cases added to the existing `test/session-false.test.ts`, which already covers the
sibling `session: false` behavior: warns with both key phrases, dedupes across workers,
silent when user-declared, silent when sessions disabled, and doesn't throw without a
logger.

Being upfront about verification: the suite imports from `dist/`, so it needs a full
monorepo install and build, which I did not run locally. I verified the logic by
compiling `wrangler.ts` standalone and running the same assertions plus three
regressions asserting binding emission is unchanged (8/8 passing). The committed test
file itself has therefore not been executed, and `tsc -b` is unconfirmed — I'd
appreciate CI confirming both.

## Docs

No docs change needed: this adds no API or config surface, and the new `logger` option
is internal to the customizer.

That said, the underlying gotcha — that a default-on adapter feature makes `deploy`
require `Workers KV Storage: Edit` — isn't currently called out on the Cloudflare
sessions docs page, and arguably should be.

/cc @withastro/maintainers-docs for feedback!
