### PR TITLE
Fix incremental build cache invalidated on every build when fonts API is used

### DIFF
--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from 'node:net';
 import { isAbsolute } from 'node:path';
 import colors from 'piccolore';
 import type { Plugin } from 'vite';
+import { createSkipIncrementalMetadata } from '../../core/build/incremental-metadata.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../core/constants.js';
 import { getAlgorithm, shouldTrackCspHashes } from '../../core/csp/common.js';
 import { generateCspDigest } from '../../core/encryption.js';
@@ -335,6 +336,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 									urls: new Set(${JSON.stringify(urls)}),
 								});
 							`,
+							meta: createSkipIncrementalMetadata(),
 						};
 					}
 
@@ -346,6 +348,7 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 								address: ${JSON.stringify(serverAddress)},
 							});
 						`,
+						meta: createSkipIncrementalMetadata(),
 					};
 				}
 			},

--- a/packages/astro/src/core/build/incremental-metadata.ts
+++ b/packages/astro/src/core/build/incremental-metadata.ts
@@ -1,7 +1,7 @@
 export const ASTRO_INCREMENTAL_META_KEY = 'astroIncremental';
 
 interface AstroIncrementalMetadata {
-	kind: 'content-data';
+	kind: 'content-data' | 'skip';
 }
 
 export function createContentDataIncrementalMetadata() {
@@ -12,9 +12,30 @@ export function createContentDataIncrementalMetadata() {
 	};
 }
 
+/**
+ * Marks a module so that `collectTransitiveDeps` will exclude it (and its
+ * subtree) from the dependency hash. Use this for virtual modules whose
+ * generated code contains build-ephemeral values (e.g. a random port) that
+ * would otherwise bust the incremental cache on every build.
+ */
+export function createSkipIncrementalMetadata() {
+	return {
+		[ASTRO_INCREMENTAL_META_KEY]: {
+			kind: 'skip' as const,
+		},
+	};
+}
+
 export function isContentDataIncrementalModule(
 	info: { meta?: Record<string, any> } | null | undefined,
 ): boolean {
 	const metadata = info?.meta?.[ASTRO_INCREMENTAL_META_KEY] as AstroIncrementalMetadata | undefined;
 	return metadata?.kind === 'content-data';
+}
+
+export function isSkippedIncrementalModule(
+	info: { meta?: Record<string, any> } | null | undefined,
+): boolean {
+	const metadata = info?.meta?.[ASTRO_INCREMENTAL_META_KEY] as AstroIncrementalMetadata | undefined;
+	return metadata?.kind === 'skip';
 }

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -6,7 +6,10 @@ import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../constants.js';
 import { removeQueryString } from '../../path.js';
 import { rootRelativePath } from '../../viteUtils.js';
 import { moduleIsTopLevelPage } from '../graph.js';
-import { isContentDataIncrementalModule } from '../incremental-metadata.js';
+import {
+	isContentDataIncrementalModule,
+	isSkippedIncrementalModule,
+} from '../incremental-metadata.js';
 import type { BuildInternals } from '../internal.js';
 import { getPageDataByViteID } from '../internal.js';
 import type { PageBuildData } from '../types.js';
@@ -33,6 +36,7 @@ function collectTransitiveDeps(graph: ModuleGraph, rootId: string): string[] {
 
 		const modInfo = graph.getModuleInfo(current);
 		if (isContentDataIncrementalModule(modInfo)) continue;
+		if (isSkippedIncrementalModule(modInfo)) continue;
 
 		deps.add(current);
 		if (!modInfo) continue;

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { createSkipIncrementalMetadata } from '../../../dist/core/build/incremental-metadata.js';
 import { pluginIncremental } from '../../../dist/core/build/plugins/plugin-incremental.js';
 import { VIRTUAL_PAGE_RESOLVED_MODULE_ID } from '../../../dist/vite-plugin-pages/const.js';
 
@@ -15,7 +16,12 @@ const HANDLE_TWO = 'WPGYjwIlzWVNM1bYhOc83w';
 
 function moduleInfo(
 	id: string,
-	{ code = '', importedIds = [] as string[], importers = [] as string[] } = {},
+	{
+		code = '',
+		importedIds = [] as string[],
+		importers = [] as string[],
+		meta = {} as Record<string, any>,
+	} = {},
 ) {
 	return {
 		id,
@@ -24,7 +30,7 @@ function moduleInfo(
 		importers,
 		dynamicallyImportedIds: [],
 		dynamicImporters: [] as string[],
-		meta: {},
+		meta,
 	};
 }
 
@@ -40,6 +46,7 @@ function pluginContext(
 	codeByModule: Record<string, string>,
 	fileNames: Record<string, string>,
 	importedIds: string[],
+	metaByModule: Record<string, Record<string, any>> = {},
 ) {
 	const modules = new Map([
 		[
@@ -50,7 +57,9 @@ function pluginContext(
 				importers: [VIRTUAL_PAGE_RESOLVED_MODULE_ID],
 			}),
 		],
-		...importedIds.map((id) => [id, moduleInfo(id, { code: codeByModule[id] })] as const),
+		...importedIds.map(
+			(id) => [id, moduleInfo(id, { code: codeByModule[id], meta: metaByModule[id] })] as const,
+		),
 	]);
 
 	return {
@@ -69,10 +78,11 @@ function dependencyHash(
 	codeByModule: Record<string, string>,
 	fileNames: Record<string, string>,
 	importedIds = Object.keys(codeByModule),
+	metaByModule: Record<string, Record<string, any>> = {},
 ) {
 	const internals = { pagesByViteID: new Map([[PAGE_ID, { component: COMPONENT }]]) } as any;
 	const plugin = pluginIncremental(internals, ROOT) as any;
-	plugin.generateBundle.call(pluginContext(codeByModule, fileNames, importedIds));
+	plugin.generateBundle.call(pluginContext(codeByModule, fileNames, importedIds, metaByModule));
 	return internals.pageDependencyHashes.get(COMPONENT);
 }
 
@@ -121,6 +131,25 @@ describe('pluginIncremental', () => {
 			const second = dependencyHash(code, {});
 			assert.equal(first, second);
 			assert.match(first, /^[0-9a-f]{64}$/);
+		});
+
+		it('is stable when a skipped module changes its code between builds', () => {
+			const RESOLVER = '\0virtual:astro:assets/fonts/runtime/font-file-url-resolver';
+			const skipMeta = createSkipIncrementalMetadata();
+
+			const first = dependencyHash(
+				{ [RED]: imageCode(HANDLE_ONE), [RESOLVER]: 'address: "127.0.0.1:40001"' },
+				{ [HANDLE_ONE]: '_astro/red.aaaa.png' },
+				[RED, RESOLVER],
+				{ [RESOLVER]: skipMeta },
+			);
+			const second = dependencyHash(
+				{ [RED]: imageCode(HANDLE_ONE), [RESOLVER]: 'address: "127.0.0.1:55123"' },
+				{ [HANDLE_ONE]: '_astro/red.aaaa.png' },
+				[RED, RESOLVER],
+				{ [RESOLVER]: skipMeta },
+			);
+			assert.equal(first, second);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- `experimental.incrementalBuild` now correctly caches pages when `fonts` is configured. The `virtual:astro:assets/fonts/runtime/font-file-url-resolver` virtual module embeds an ephemeral HTTP server port (assigned by the OS on each build); because `collectTransitiveDeps()` included this module in the dependency hash, `dependencyHash` changed on every build and `IncrementalBuildCache.canSkip()` always returned `false`.
- Adds a `'skip'` kind to `AstroIncrementalMetadata`, with `createSkipIncrementalMetadata()` and `isSkippedIncrementalModule()` helpers. `collectTransitiveDeps()` now skips modules carrying this metadata, following the same pattern as the existing `content-data` skip. Font configuration changes are still detected through `virtual:astro:assets/fonts/internal`, which carries the actual font data and remains in the hash.
- Both return paths of the font-file-url-resolver `load` handler in `vite-plugin-fonts.ts` are marked with `createSkipIncrementalMetadata()`.

## Testing

- New unit test in `packages/astro/test/units/build/plugin-incremental.test.ts`: "is stable when a skipped module changes its code between builds" — verifies that a module tagged with `skip` metadata does not affect the dependency hash even when its generated code changes between builds.

## Docs

- No docs update needed; this restores behavior that `experimental.incrementalBuild` already documents.

Closes #17642