### PR TITLE
Fix vendor prefix stripping in default static builds caused by cssTarget inheriting esnext

### DIFF
--- a/packages/astro/src/core/build/vite-build-config.ts
+++ b/packages/astro/src/core/build/vite-build-config.ts
@@ -55,6 +55,12 @@ export function createViteBuildConfig(opts: CreateViteBuildConfigOptions): vite.
 		logLevel: viteConfig.logLevel ?? 'error',
 		build: {
 			target: 'esnext',
+			// Vite defaults cssTarget to build.target when unset. Since we set
+			// build.target to 'esnext' (for Node-side JS), that would cause
+			// Lightning CSS to receive empty browser targets and strip all vendor
+			// prefixes from CSS that is actually served to browsers. Use Vite's
+			// baseline-widely-available browser targets so prefixes are preserved.
+			cssTarget: ['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4'],
 			// Vite defaults cssMinify to false in SSR by default, but we want to minify it
 			// as the CSS generated are used and served to the client.
 			cssMinify: viteConfig.build?.minify == null ? true : !!viteConfig.build?.minify,

--- a/packages/astro/test/units/build/vite-build-config.test.ts
+++ b/packages/astro/test/units/build/vite-build-config.test.ts
@@ -263,6 +263,30 @@ describe('createViteBuildConfig', () => {
 			assert.equal(config2.envPrefix, 'CUSTOM_');
 		});
 
+		it('sets cssTarget to browser-oriented defaults instead of inheriting esnext', async () => {
+			const settings = await createBasicSettings();
+			const config = buildConfig({ settings });
+			assert.ok(Array.isArray(config.build?.cssTarget), 'cssTarget should be an array');
+			const targets = config.build!.cssTarget as string[];
+			assert.ok(
+				targets.some((t) => t.startsWith('safari')),
+				'cssTarget should include safari',
+			);
+			assert.ok(
+				!targets.includes('esnext'),
+				'cssTarget should not include esnext (which produces empty Lightning CSS targets)',
+			);
+		});
+
+		it('allows user to override cssTarget', async () => {
+			const settings = await createBasicSettings();
+			const config = buildConfig({
+				settings,
+				viteConfig: { build: { cssTarget: 'safari11' } },
+			});
+			assert.equal(config.build?.cssTarget, 'safari11');
+		});
+
 		it('sets cssMinify based on vite build.minify', async () => {
 			const settings = await createBasicSettings();
 


### PR DESCRIPTION
## Changes

- In `vite-build-config.ts`, Astro sets `build.target: 'esnext'` for the static/prerender build so Node-side JS can use modern syntax. Vite then defaults `cssTarget` to `build.target` when unset, causing Lightning CSS to receive an empty `targets: {}` (since `convertTargets` discards `'esnext'`). Lightning CSS treats empty targets as "no browser needs compatibility" and strips vendor prefixes — including `-webkit-box-decoration-break`, which Safari still requires. Affected every Astro 7 user with default settings and no explicit `cssTarget`.
- Adds an explicit `cssTarget: ['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4']` (Vite's `baseline-widely-available` browser set) before the `...viteConfig.build` spread, so the JS-oriented target no longer leaks into CSS processing. User-provided `cssTarget` continues to take priority.

## Testing

- Added two unit tests to `packages/astro/test/units/build/vite-build-config.test.ts`: one verifying the default `cssTarget` is a browser-oriented array (includes `safari`, excludes `esnext`), and one verifying a user-provided `cssTarget` overrides the default.

## Docs

- No docs update needed — this restores correct behavior for the default configuration with no API changes.

Closes #17647