### PR TITLE
Fix socket listener leak in Node adapter static headers path

### DIFF
--- a/.changeset/tough-lilies-bet.md
+++ b/.changeset/tough-lilies-bet.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes an EventEmitter memory leak when serving static pages over keep-alive connections with `staticHeaders` enabled and CSP (`security.csp`) active

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -6,7 +6,7 @@ import type { BaseApp } from 'astro/app';
 import send from 'send';
 import { resolveClientDir } from './shared.js';
 import type { NodeAppHeadersJson, Options } from './types.js';
-import { createRequestFromNodeRequest } from 'astro/app/node';
+import { createRequestFromNodeRequest, getAbortControllerCleanup } from 'astro/app/node';
 
 /**
  * Resolves a URL path to a filesystem path within the client directory,
@@ -72,6 +72,10 @@ export function createStaticHandler(
 					port: options.port,
 				});
 				const routeData = app.match(request, true);
+				// The Request is only used for route matching above. Clean up the
+				// socket `close` listener that wireAbortController added, otherwise
+				// keep-alive connections accumulate listeners on every request.
+				getAbortControllerCleanup(req)?.();
 				if (routeData && routeData.prerender) {
 					// Headers are stored keyed by base-less route paths (e.g. "/one"), so we
 					// must strip config.base from the incoming URL before matching, just as

--- a/packages/integrations/node/test/static-headers.test.ts
+++ b/packages/integrations/node/test/static-headers.test.ts
@@ -75,6 +75,59 @@ describe('Static headers', () => {
 	});
 });
 
+describe('Static headers listener cleanup', () => {
+	let fixture: Fixture;
+	let server: AdapterServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/static-headers/',
+			outDir: './dist/listener-cleanup',
+			output: 'server',
+			adapter: nodejs({ mode: 'standalone', staticHeaders: true }),
+		});
+		await fixture.build();
+		const { startServer } = await fixture.loadAdapterEntryModule();
+		process.env.PORT = '4324';
+		const res = startServer();
+		server = res.server;
+		await waitServerListen(server.server);
+	});
+
+	after(async () => {
+		await server.stop();
+	});
+
+	it('does not leak socket close listeners on keep-alive connections', async () => {
+		const http = await import('node:http');
+		const agent = new http.Agent({ keepAlive: true });
+
+		let warningEmitted = false;
+		const onWarning = (warning: Error) => {
+			if (warning.name === 'MaxListenersExceededWarning') {
+				warningEmitted = true;
+			}
+		};
+		process.on('warning', onWarning);
+
+		try {
+			for (let i = 0; i < 30; i++) {
+				const res = await fetch(`http://${server.host}:${server.port}/`, {
+					// @ts-expect-error Node fetch doesn't type `agent`
+					agent,
+					headers: { Connection: 'keep-alive' },
+				});
+				await res.text();
+			}
+		} finally {
+			process.off('warning', onWarning);
+			agent.destroy();
+		}
+
+		assert.equal(warningEmitted, false, 'MaxListenersExceededWarning should not be emitted');
+	});
+});
+
 describe('Static headers with non-root base', () => {
 	let fixture: Fixture;
 	let server: AdapterServer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7119,10 +7119,13 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
-  triage/gh-17624:
+  triage/gh-17657:
     dependencies:
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../../packages/integrations/node
       astro:
-        specifier: ^7.2.0
+        specifier: workspace:*
         version: link:../../packages/astro
 
 packages:


### PR DESCRIPTION
## Changes

- Fixes a `MaxListenersExceededWarning` that fires after ~11 keep-alive requests when `staticHeaders: true` and `security.csp` are both active on the Node adapter. `serve-static.ts` calls `createRequestFromNodeRequest()` solely for route matching via `app.match()`, but that function wires an `AbortController` `close` listener on the socket that was never cleaned up. On keep-alive connections the listener count grows by one per request. The fix adds `getAbortControllerCleanup(req)?.()` immediately after `app.match()`, using the same cleanup pattern already applied to `serve-app.ts` in #15735.

## Testing

- Added a `'Static headers listener cleanup'` test suite to `packages/integrations/node/test/static-headers.test.ts` that sends 30 keep-alive requests and asserts no `MaxListenersExceededWarning` is emitted.

## Docs

- No docs update needed; this is an internal resource-management fix with no user-facing API change.

Closes #17657