### PR TITLE
Fix Fonts API making incremental build dependencyHash non-deterministic

### DIFF
--- a/packages/astro/src/assets/fonts/constants.ts
+++ b/packages/astro/src/assets/fonts/constants.ts
@@ -51,3 +51,12 @@ export const GENERIC_FALLBACK_NAMES = [
 ] as const;
 
 export const FONTS_TYPES_FILE = 'fonts.d.ts';
+
+/**
+ * Variable name used in the font-file-url-resolver virtual module to hold
+ * the ephemeral font HTTP server address. The incremental build plugin
+ * strips the variable declaration (which contains an OS-assigned port that
+ * changes every build) from the module source before hashing so that the
+ * dependency hash is deterministic across builds.
+ */
+export const FONTS_SERVER_ADDRESS_PLACEHOLDER = '__ASTRO_FONTS_SERVER_ADDRESS__';

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -17,6 +17,7 @@ import {
 	ASSETS_DIR,
 	CACHE_DIR,
 	DEFAULTS,
+	FONTS_SERVER_ADDRESS_PLACEHOLDER,
 	RESOLVED_RUNTIME_FONT_FILE_URL_RESOLVER_VIRTUAL_MODULE_ID,
 	RESOLVED_RUNTIME_VIRTUAL_MODULE_ID,
 	RESOLVED_VIRTUAL_MODULE_ID,
@@ -341,9 +342,10 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 					return {
 						code: `
 							import { RemoteRuntimeFontFileUrlResolver } from ${JSON.stringify(new URL('./infra/remote-runtime-font-file-url-resolver.js', import.meta.url))};
+							const ${FONTS_SERVER_ADDRESS_PLACEHOLDER} = ${JSON.stringify(serverAddress)};
 							export const runtimeFontFileUrlResolver = new RemoteRuntimeFontFileUrlResolver({
 								urls: new Set(${JSON.stringify(urls)}),
-								address: ${JSON.stringify(serverAddress)},
+								address: ${FONTS_SERVER_ADDRESS_PLACEHOLDER},
 							});
 						`,
 					};

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import type { Plugin as VitePlugin } from 'vite';
+import { FONTS_SERVER_ADDRESS_PLACEHOLDER } from '../../../assets/fonts/constants.js';
 import { PROPAGATED_ASSET_FLAG } from '../../../content/consts.js';
 import { hasContentFlag } from '../../../content/utils.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../constants.js';
@@ -54,6 +55,18 @@ const ASSET_PLACEHOLDERS = [
 ];
 
 /**
+ * Strip the fonts server address variable declaration from module code. The
+ * fonts plugin assigns the ephemeral HTTP server's AddressInfo to a variable
+ * named {@link FONTS_SERVER_ADDRESS_PLACEHOLDER}; the value includes an
+ * OS-assigned port that differs between builds. Removing the declaration
+ * (but keeping the stable variable reference) prevents the volatile port
+ * from poisoning the dependency hash.
+ */
+const FONTS_ADDRESS_DECLARATION = new RegExp(
+	`(?:const|let|var)\\s+${FONTS_SERVER_ADDRESS_PLACEHOLDER}\\s*=[^;]+;`,
+);
+
+/**
  * Replace the emit handles of imported assets with the file names they resolve
  * to. Handles are assigned by the bundler in the order modules finish
  * transforming, so two builds of the same sources can hand the same asset a
@@ -72,6 +85,9 @@ function resolveAssetPlaceholders(graph: ModuleGraph, code: string): string {
 				return placeholder;
 			}
 		});
+	}
+	if (resolved.includes(FONTS_SERVER_ADDRESS_PLACEHOLDER)) {
+		resolved = resolved.replace(FONTS_ADDRESS_DECLARATION, '');
 	}
 	return resolved;
 }

--- a/packages/astro/test/fixtures/incremental-build-fonts/astro.config.mjs
+++ b/packages/astro/test/fixtures/incremental-build-fonts/astro.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig, fontProviders } from 'astro/config';
+
+export default defineConfig({
+	experimental: {
+		incrementalBuild: true,
+	},
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: 'Roboto',
+			cssVariable: '--font-test',
+		},
+	],
+});

--- a/packages/astro/test/fixtures/incremental-build-fonts/package.json
+++ b/packages/astro/test/fixtures/incremental-build-fonts/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@test/incremental-build-fonts",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"astro": "workspace:*"
+	}
+}

--- a/packages/astro/test/fixtures/incremental-build-fonts/src/pages/[slug].astro
+++ b/packages/astro/test/fixtures/incremental-build-fonts/src/pages/[slug].astro
@@ -1,0 +1,20 @@
+---
+import { Font } from 'astro:assets';
+
+export async function getStaticPaths() {
+	return [
+		{ params: { slug: 'page-1' }, props: { title: 'Page 1' }, cacheKey: 'v1' },
+		{ params: { slug: 'page-2' }, props: { title: 'Page 2' }, cacheKey: 'v1' },
+	];
+}
+
+const { title } = Astro.props;
+---
+<html lang="en">
+	<head>
+		<Font cssVariable="--font-test" />
+	</head>
+	<body>
+		<h1>{title}</h1>
+	</body>
+</html>

--- a/packages/astro/test/incremental-build-fonts.test.ts
+++ b/packages/astro/test/incremental-build-fonts.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { after, before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+describe('incremental build + fonts API', () => {
+	const root = new URL('./fixtures/incremental-build-fonts/', import.meta.url);
+	const cacheFile = new URL('node_modules/.astro/incremental-build.json', root);
+	let fixture: Fixture;
+
+	before(async () => {
+		fs.rmSync(new URL('dist/', root), { recursive: true, force: true });
+		fs.rmSync(cacheFile, { force: true });
+		fixture = await loadFixture({ root });
+	});
+
+	after(async () => {
+		fs.rmSync(new URL('dist/', root), { recursive: true, force: true });
+		fs.rmSync(cacheFile, { force: true });
+	});
+
+	it('produces a stable dependencyHash across two builds when using the Fonts API', async () => {
+		// First build — populates the cache
+		await fixture.build();
+		assert.ok(fs.existsSync(cacheFile), 'Cache manifest should exist after first build');
+		const cache1 = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+		const route1 = cache1.routes['src/pages/[slug].astro'];
+		assert.ok(route1, 'Route should be tracked in cache');
+		const hash1 = route1.dependencyHash;
+		assert.ok(hash1, 'Should have a dependency hash after first build');
+
+		// Second build — no changes; dependencyHash should be identical
+		await fixture.build();
+		const cache2 = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+		const route2 = cache2.routes['src/pages/[slug].astro'];
+		const hash2 = route2.dependencyHash;
+
+		assert.equal(
+			hash2,
+			hash1,
+			`dependencyHash should be stable across builds, but got:\n  build 1: ${hash1}\n  build 2: ${hash2}`,
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3540,6 +3540,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/incremental-build-fonts:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/incremental-build-headers:
     dependencies:
       astro:
@@ -7118,12 +7124,6 @@ importers:
       tsx:
         specifier: ^4.22.0
         version: 4.22.3
-
-  triage/gh-17624:
-    dependencies:
-      astro:
-        specifier: ^7.2.0
-        version: link:../../packages/astro
 
 packages:
 


### PR DESCRIPTION
## Changes

- The `virtual:astro:assets/fonts/runtime/font-file-url-resolver` virtual module was embedding the font HTTP server's `AddressInfo` (including an OS-assigned ephemeral port) as a JSON literal directly in its compiled source text. Because the port changes on every build, any route that transitively imports `<Font />` got a different `dependencyHash` on every run, silently defeating `experimental.incrementalBuild` for any project using the Fonts API from a shared layout.
- Fixes this by assigning the server address to a named variable (`__ASTRO_FONTS_SERVER_ADDRESS__`) in the generated module, then stripping that variable declaration in `resolveAssetPlaceholders()` (in `plugin-incremental.ts`) before the module code is hashed. The stable variable reference remains in the hashed code; only the volatile declaration (with the changing port) is removed. This follows the same pattern already used to normalize asset emit handles before hashing.

Closes #17626

## Testing

- Added `packages/astro/test/incremental-build-fonts.test.ts`: runs two consecutive builds of a fixture that uses the Fonts API with `experimental.incrementalBuild: true` and asserts the route's `dependencyHash` is identical across both builds.
- Added the corresponding fixture (`packages/astro/test/fixtures/incremental-build-fonts/`) with a dynamic route using `<Font />` and a stable `cacheKey` from `getStaticPaths()`.

## Docs

No docs update needed — this is a bug fix for two experimental features; no user-facing API or behavior contract changed.
