### PR TITLE
fix(core): stop dropping every other frame from printed error stacks

### DIFF
--- a/.changeset/tidy-mangos-repeat.md
+++ b/.changeset/tidy-mangos-repeat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes error stack traces dropping every other frame in the terminal

--- a/packages/astro/src/core/messages/runtime.ts
+++ b/packages/astro/src/core/messages/runtime.ts
@@ -247,8 +247,8 @@ export function formatConfigErrorMessage(err: $ZodError) {
 }
 
 // a regex to match the first line of a stack trace
-const STACK_LINE_REGEXP = /^\s+at /g;
-const IRRELEVANT_STACK_REGEXP = /node_modules|astro[/\\]dist/g;
+const STACK_LINE_REGEXP = /^\s+at /;
+const IRRELEVANT_STACK_REGEXP = /node_modules|astro[/\\]dist/;
 
 function formatErrorStackTrace(
 	err: Error | ErrorWithMetadata,

--- a/packages/astro/test/units/errors/format-error-message.test.js
+++ b/packages/astro/test/units/errors/format-error-message.test.js
@@ -1,0 +1,33 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { formatErrorMessage } from '../../../dist/core/messages/runtime.js';
+
+function errorWithStack(frames) {
+	const err = new Error('boom');
+	err.stack = ['Error: boom', ...frames].join('\n');
+	return err;
+}
+
+describe('formatErrorMessage()', () => {
+	it('keeps every stack frame', () => {
+		const frames = [
+			'    at first (/app/src/pages/index.astro:3:1)',
+			'    at second (/app/src/lib/a.ts:10:5)',
+			'    at third (/app/src/lib/b.ts:2:2)',
+			'    at fourth (/app/src/lib/c.ts:4:4)',
+		];
+		const output = formatErrorMessage(errorWithStack(frames), true);
+		for (const frame of frames) {
+			assert.ok(output.includes(frame.trim()), `missing stack frame: ${frame.trim()}`);
+		}
+	});
+
+	it('formats the same stack the same way every time', () => {
+		const err = errorWithStack([
+			'    at first (/app/src/pages/index.astro:3:1)',
+			'    at second (/app/src/lib/a.ts:10:5)',
+			'    at vite (/app/node_modules/vite/dist/node/index.js:1:1)',
+		]);
+		assert.equal(formatErrorMessage(err, true), formatErrorMessage(err, true));
+	});
+});

--- a/packages/astro/test/units/errors/format-error-message.test.ts
+++ b/packages/astro/test/units/errors/format-error-message.test.ts
@@ -1,9 +1,10 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { formatErrorMessage } from '../../../dist/core/messages/runtime.js';
+import type { ErrorWithMetadata } from '../../../dist/core/errors/errors.js';
 
-function errorWithStack(frames) {
-	const err = new Error('boom');
+function errorWithStack(frames: string[]): ErrorWithMetadata {
+	const err = new Error('boom') as ErrorWithMetadata;
 	err.stack = ['Error: boom', ...frames].join('\n');
 	return err;
 }


### PR DESCRIPTION
## Changes

Error stack traces printed to the terminal lose every other frame.

`formatErrorStackTrace` filters the stack with a module-level global regex:

```ts
const STACK_LINE_REGEXP = /^\s+at /g;
...
const stackLines = (err.stack || '').split('\n').filter((line) => STACK_LINE_REGEXP.test(line));
```

`RegExp.prototype.test` on a `/g` regex advances `lastIndex` on every match. The next call starts searching mid-string, where `^` cannot match, so it returns `false` — and then resets `lastIndex` to 0, which lets the frame after that match again. The result is that exactly half the frames are dropped:

```js
const STACK_LINE_REGEXP = /^\s+at /g;
const stack = [
  'Error: boom',
  '    at first (/app/src/pages/index.astro:3:1)',
  '    at second (/app/src/lib/a.ts:10:5)',
  '    at third (/app/src/lib/b.ts:2:2)',
  '    at fourth (/app/src/lib/c.ts:4:4)',
];
stack.filter((l) => STACK_LINE_REGEXP.test(l));
// → [ 'at first …', 'at third …' ]     // second and fourth are gone
stack.filter((l) => /^\s+at /.test(l));
// → [ 'at first …', 'at second …', 'at third …', 'at fourth …' ]
```

`IRRELEVANT_STACK_REGEXP` on the next line has the same shape — it is also only ever asked whether one line matches, and it feeds `findIndex`, which decides where the stack gets truncated.

Neither regex needs the `g` flag, so this drops it from both. Nothing else changes: both are still single-line predicates.

## Testing

Added `packages/astro/test/units/errors/format-error-message.test.js`:

- every frame of a four-frame stack survives `formatErrorMessage()`
- formatting the same error twice produces the same string (the leaked `lastIndex` is per-regex module state, so repeated calls were order-dependent)

The first test fails on `main` with `missing stack frame: at second (/app/src/lib/a.ts:10:5)` and passes with this change.

## Docs

Not applicable — no API or behaviour that is documented changes; printed stacks just stop losing lines.
