### PR TITLE
Detect stale dev server lock files after PID reuse

### DIFF
--- a/.changeset/witty-ghosts-restart.md
+++ b/.changeset/witty-ghosts-restart.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes `astro dev` refusing to start with "Another astro dev server is already running" after a Docker container restart, where the persisted lock file's PID gets reused by an unrelated process. On Linux, the lock file now records the process start time alongside the PID and startup verifies both, so a stale lock file is detected and cleaned up instead of blocking startup — and since stale lock files are removed before `--force` would signal the recorded PID, the unrelated process that recycled it is no longer killed. Platforms without `/proc` keep the previous PID-existence check.
+Fixes `astro dev` refusing to start after a Docker container restart when an unrelated process reuses the PID from a persisted lock file. Astro now checks the process command across platforms, so stale lock files are cleaned up and `--force` does not signal the unrelated process.

--- a/.changeset/witty-ghosts-restart.md
+++ b/.changeset/witty-ghosts-restart.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro dev` refusing to start with "Another astro dev server is already running" after a Docker container restart, where the persisted lock file's PID gets reused by an unrelated process. On Linux, the lock file now records the process start time alongside the PID and startup verifies both, so a stale lock file is detected and cleaned up instead of blocking startup — and since stale lock files are removed before `--force` would signal the recorded PID, the unrelated process that recycled it is no longer killed. Platforms without `/proc` keep the previous PID-existence check.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -136,6 +136,7 @@
     "dset": "^3.1.4",
     "es-module-lexer": "^2.0.0",
     "esbuild": "^0.28.0",
+    "find-process": "^2.1.1",
     "flattie": "^1.1.1",
     "fontace": "~0.4.1",
     "get-tsconfig": "5.0.0-beta.4",

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -190,7 +190,7 @@ export async function dev({ flags }: DevOptions) {
 	// an existing server, and it won't be tracked by `astro dev stop`/`status`/`logs`.
 	// We still do a read-only check purely to give the user a heads-up.
 	if (ignoreLock) {
-		const existingServer = checkExistingServer(root);
+		const existingServer = await checkExistingServer(root);
 		if (existingServer) {
 			logger.info(
 				'SKIP_FORMAT',
@@ -204,7 +204,7 @@ export async function dev({ flags }: DevOptions) {
 		return await devServer(inlineConfig);
 	}
 
-	const existingServer = checkExistingServer(root);
+	const existingServer = await checkExistingServer(root);
 	if (existingServer) {
 		if (flags.force) {
 			// --force: kill the existing server and replace it

--- a/packages/astro/src/cli/preview/index.ts
+++ b/packages/astro/src/cli/preview/index.ts
@@ -80,7 +80,7 @@ export async function preview({ flags }: PreviewOptions) {
 	}
 
 	const root = pathToFileURL(resolveRoot(flags.root) + '/');
-	const existingServer = checkExistingServer(root, 'preview');
+	const existingServer = await checkExistingServer(root, 'preview');
 	if (existingServer) {
 		const message = [
 			'Another astro preview server is already running.',

--- a/packages/astro/src/cli/server.ts
+++ b/packages/astro/src/cli/server.ts
@@ -166,7 +166,7 @@ export async function background({
 }): Promise<void> {
 	const root = getRootURL(flags);
 
-	const existing = checkExistingServer(root, config.command);
+	const existing = await checkExistingServer(root, config.command);
 	if (existing && !flags.force) {
 		logger.info('SKIP_FORMAT', formatServerRunningMessage(existing, config, { existing: true }));
 		return;
@@ -251,7 +251,7 @@ export async function stop({
 	config: BackgroundCommandConfig;
 }): Promise<void> {
 	const root = getRootURL(flags);
-	const existing = checkExistingServer(root, config.command);
+	const existing = await checkExistingServer(root, config.command);
 
 	if (!existing) {
 		logger.info('SKIP_FORMAT', `No ${config.command} server is running.`);
@@ -272,7 +272,7 @@ export async function status({
 	config: BackgroundCommandConfig;
 }): Promise<void> {
 	const root = getRootURL(flags);
-	const existing = checkExistingServer(root, config.command);
+	const existing = await checkExistingServer(root, config.command);
 
 	if (!existing) {
 		logger.info('SKIP_FORMAT', `No ${config.command} server is running.`);
@@ -305,7 +305,7 @@ export async function logs({
 	config: BackgroundCommandConfig;
 }): Promise<void> {
 	const root = getRootURL(flags);
-	const existing = checkExistingServer(root, config.command);
+	const existing = await checkExistingServer(root, config.command);
 
 	if (!existing) {
 		logger.error('SKIP_FORMAT', `No ${config.command} server is running.`);

--- a/packages/astro/src/core/dev/lockfile.ts
+++ b/packages/astro/src/core/dev/lockfile.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { ResolvedServerUrls } from 'vite';
 
@@ -12,6 +12,12 @@ export interface LockFileData {
 	port: number;
 	url: string;
 	urls?: ResolvedServerUrls;
+	/**
+	 * Kernel start time of `pid`, captured when the lock file was written (Linux only).
+	 * Together with the PID it identifies the exact process instance, which survives PID
+	 * recycling — a reused PID always has a different start time.
+	 */
+	pidStartTime?: string;
 	background: boolean;
 	startedAt: string;
 }
@@ -67,6 +73,10 @@ export function parseLockFile(content: string): LockFileData | null {
 		if (data.urls !== undefined && !isResolvedServerUrls(data.urls)) {
 			return null;
 		}
+		// `pidStartTime` is optional, but if present it must be a string.
+		if (data.pidStartTime !== undefined && typeof data.pidStartTime !== 'string') {
+			return null;
+		}
 		return data as LockFileData;
 	} catch {
 		return null;
@@ -94,6 +104,67 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 /**
+ * Read the kernel start time of a process from `/proc/<pid>/stat` (Linux only).
+ * Together with the PID it uniquely identifies a process instance: a recycled PID
+ * always belongs to a process with a different start time. Returns undefined when the
+ * start time cannot be determined (unsupported platform, exited process, unreadable
+ * or malformed stat).
+ */
+export function getProcessStartTime(pid: number): string | undefined {
+	let stat: string;
+	try {
+		stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+	} catch {
+		return undefined;
+	}
+	// The comm field (2) is wrapped in parentheses and may itself contain spaces or
+	// parentheses, so the remaining fields are parsed after the final ')'.
+	const closeParen = stat.lastIndexOf(')');
+	if (closeParen === -1) {
+		return undefined;
+	}
+	const fields = stat.slice(closeParen + 2).split(' ');
+	// starttime is field 22 overall — index 19 of the fields after comm.
+	return fields.length > 19 ? fields[19] : undefined;
+}
+
+/**
+ * Clock ticks per second for the start time in `/proc/<pid>/stat` (USER_HZ).
+ * 100 on mainstream Linux (x86, arm64).
+ */
+const PROC_STAT_TICKS_PER_SECOND = 100;
+
+/**
+ * Margin (ms) for the legacy lock file check below: the recorded process must have
+ * started before the lock file was written, but the comparison inputs are soft —
+ * `btime` shifts when the system clock steps (NTP, suspend/resume) and the file
+ * mtime can come from a different clock (bind mounts, network filesystems). Only a
+ * start time clearly past the write marks the lock file as stale; anything within
+ * the margin is treated as alive, so a running server never loses its lock file.
+ */
+const LEGACY_LOCK_STALE_MARGIN_MS = 5000;
+
+/**
+ * Read the system boot time in seconds since the epoch from /proc/stat (Linux only).
+ * Returns undefined when the boot time cannot be determined.
+ */
+function getBootTime(): number | undefined {
+	let stat: string;
+	try {
+		stat = readFileSync('/proc/stat', 'utf-8');
+	} catch {
+		return undefined;
+	}
+	for (const line of stat.split('\n')) {
+		if (line.startsWith('btime ')) {
+			const seconds = Number(line.slice('btime '.length));
+			return Number.isFinite(seconds) ? seconds : undefined;
+		}
+	}
+	return undefined;
+}
+
+/**
  * Read the lock file from disk. Returns null if it doesn't exist or is invalid.
  */
 export function readLockFile(root: URL, command: ServerCommand = 'dev'): LockFileData | null {
@@ -107,16 +178,21 @@ export function readLockFile(root: URL, command: ServerCommand = 'dev'): LockFil
 }
 
 /**
- * Write the lock file to disk.
+ * Write the lock file to disk. The kernel start time of the recorded PID is stored
+ * alongside it when available, so later checks can tell the recorded process apart
+ * from an unrelated one that recycled the PID.
  */
 export function writeLockFile(root: URL, data: LockFileData, command: ServerCommand = 'dev'): void {
 	const lockFileURL = getLockFileURL(root, command);
 	const dirPath = fileURLToPath(new URL('.astro/', root));
+	// `pidStartTime` is output-only: any caller-supplied value is replaced. undefined
+	// (unsupported platform, exited process) is dropped by JSON serialization.
+	const stamped = { ...data, pidStartTime: getProcessStartTime(data.pid) };
 	try {
 		if (!existsSync(dirPath)) {
 			mkdirSync(dirPath, { recursive: true });
 		}
-		writeFileSync(lockFileURL, serializeLockFile(data), 'utf-8');
+		writeFileSync(lockFileURL, serializeLockFile(stamped), 'utf-8');
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to write lock file: ${message}`);
@@ -188,7 +264,49 @@ export async function killDevServer(root: URL, data: LockFileData): Promise<void
 }
 
 /**
- * Check for an existing server by reading the lock file and checking process liveness.
+ * Check whether the process recorded in the lock file is still the process that
+ * wrote it. PID existence alone is not enough: the kernel recycles PIDs, and inside
+ * a Docker container an unrelated process quickly reuses the recorded PID after a
+ * container restart while the lock file persists on a volume mount, making a stale
+ * lock file look alive. https://github.com/withastro/astro/issues/17656
+ *
+ * The recorded start time is compared exactly when present. Lock files written
+ * before process identity tracking carry none; there the process start time is
+ * compared against the lock file's write time, with {@link LEGACY_LOCK_STALE_MARGIN_MS}
+ * absorbing clock inaccuracies. When neither can be verified (a platform without
+ * /proc), falls back to PID existence only.
+ */
+function isLockFileProcessAlive(lockFile: URL, data: LockFileData): boolean {
+	if (!isProcessAlive(data.pid)) {
+		return false;
+	}
+	const startTime = getProcessStartTime(data.pid);
+	if (startTime === undefined) {
+		return true;
+	}
+	if (data.pidStartTime !== undefined) {
+		return startTime === data.pidStartTime;
+	}
+	let mtimeMs: number;
+	try {
+		mtimeMs = statSync(lockFile).mtimeMs;
+	} catch {
+		return true;
+	}
+	const bootTime = getBootTime();
+	if (bootTime === undefined) {
+		return true;
+	}
+	const processStartedAtMs = (bootTime + Number(startTime) / PROC_STAT_TICKS_PER_SECOND) * 1000;
+	if (!Number.isFinite(processStartedAtMs)) {
+		return true;
+	}
+	return processStartedAtMs <= mtimeMs + LEGACY_LOCK_STALE_MARGIN_MS;
+}
+
+/**
+ * Check for an existing server by reading the lock file and verifying that the
+ * recorded process is still the one that wrote it.
  * Automatically cleans up stale lock files.
  * Returns the server info if a live server is found, null otherwise.
  */
@@ -197,7 +315,10 @@ export function checkExistingServer(
 	command: ServerCommand = 'dev',
 ): LockFileData | null {
 	const data = readLockFile(root, command);
-	const result = evaluateExistingServer(data, data !== null && isProcessAlive(data.pid));
+	const result = evaluateExistingServer(
+		data,
+		data !== null && isLockFileProcessAlive(getLockFileURL(root, command), data),
+	);
 	if (result === null) {
 		return null;
 	}

--- a/packages/astro/src/core/dev/lockfile.ts
+++ b/packages/astro/src/core/dev/lockfile.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import findProcess from 'find-process';
 import type { ResolvedServerUrls } from 'vite';
 
 export type ServerCommand = 'dev' | 'preview';
@@ -12,12 +13,6 @@ export interface LockFileData {
 	port: number;
 	url: string;
 	urls?: ResolvedServerUrls;
-	/**
-	 * Kernel start time of `pid`, captured when the lock file was written (Linux only).
-	 * Together with the PID it identifies the exact process instance, which survives PID
-	 * recycling — a reused PID always has a different start time.
-	 */
-	pidStartTime?: string;
 	background: boolean;
 	startedAt: string;
 }
@@ -73,10 +68,6 @@ export function parseLockFile(content: string): LockFileData | null {
 		if (data.urls !== undefined && !isResolvedServerUrls(data.urls)) {
 			return null;
 		}
-		// `pidStartTime` is optional, but if present it must be a string.
-		if (data.pidStartTime !== undefined && typeof data.pidStartTime !== 'string') {
-			return null;
-		}
 		return data as LockFileData;
 	} catch {
 		return null;
@@ -103,65 +94,48 @@ export function isProcessAlive(pid: number): boolean {
 	}
 }
 
+// Match Astro's published CLI entry and package-manager shims, not arbitrary files named astro.
+const ASTRO_COMMAND_PATTERN =
+	/(?:^|[\\/\s"'])(?:astro[\\/]bin[\\/]astro\.mjs|\.bin[\\/]astro(?:\.cmd)?)(?=$|[\s"'])/i;
+
 /**
- * Read the kernel start time of a process from `/proc/<pid>/stat` (Linux only).
- * Together with the PID it uniquely identifies a process instance: a recycled PID
- * always belongs to a process with a different start time. Returns undefined when the
- * start time cannot be determined (unsupported platform, exited process, unreadable
- * or malformed stat).
+ * Check whether a process command points to the Astro CLI.
  */
-export function getProcessStartTime(pid: number): string | undefined {
-	let stat: string;
-	try {
-		stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
-	} catch {
-		return undefined;
-	}
-	// The comm field (2) is wrapped in parentheses and may itself contain spaces or
-	// parentheses, so the remaining fields are parsed after the final ')'.
-	const closeParen = stat.lastIndexOf(')');
-	if (closeParen === -1) {
-		return undefined;
-	}
-	const fields = stat.slice(closeParen + 2).split(' ');
-	// starttime is field 22 overall — index 19 of the fields after comm.
-	return fields.length > 19 ? fields[19] : undefined;
+export function isAstroCommand(command: string): boolean {
+	return ASTRO_COMMAND_PATTERN.test(command);
 }
 
-/**
- * Clock ticks per second for the start time in `/proc/<pid>/stat` (USER_HZ).
- * 100 on mainstream Linux (x86, arm64).
- */
-const PROC_STAT_TICKS_PER_SECOND = 100;
+interface ProcessInfo {
+	pid: number;
+	cmd?: string;
+}
+
+type ProcessLookup = (
+	by: 'pid',
+	value: number,
+	options: { logLevel: 'error' },
+) => Promise<ProcessInfo[]>;
 
 /**
- * Margin (ms) for the legacy lock file check below: the recorded process must have
- * started before the lock file was written, but the comparison inputs are soft —
- * `btime` shifts when the system clock steps (NTP, suspend/resume) and the file
- * mtime can come from a different clock (bind mounts, network filesystems). Only a
- * start time clearly past the write marks the lock file as stale; anything within
- * the margin is treated as alive, so a running server never loses its lock file.
+ * Check whether the live process recorded in a lock file is still Astro.
+ * If the command cannot be inspected, keep the existing PID-only behavior.
  */
-const LEGACY_LOCK_STALE_MARGIN_MS = 5000;
+export async function isLockFileProcessAlive(
+	data: LockFileData,
+	find: ProcessLookup = findProcess,
+): Promise<boolean> {
+	if (!isProcessAlive(data.pid)) {
+		return false;
+	}
 
-/**
- * Read the system boot time in seconds since the epoch from /proc/stat (Linux only).
- * Returns undefined when the boot time cannot be determined.
- */
-function getBootTime(): number | undefined {
-	let stat: string;
 	try {
-		stat = readFileSync('/proc/stat', 'utf-8');
+		const processInfo = (await find('pid', data.pid, { logLevel: 'error' })).find(
+			({ pid }) => pid === data.pid,
+		);
+		return processInfo?.cmd === undefined || isAstroCommand(processInfo.cmd);
 	} catch {
-		return undefined;
+		return true;
 	}
-	for (const line of stat.split('\n')) {
-		if (line.startsWith('btime ')) {
-			const seconds = Number(line.slice('btime '.length));
-			return Number.isFinite(seconds) ? seconds : undefined;
-		}
-	}
-	return undefined;
 }
 
 /**
@@ -178,21 +152,16 @@ export function readLockFile(root: URL, command: ServerCommand = 'dev'): LockFil
 }
 
 /**
- * Write the lock file to disk. The kernel start time of the recorded PID is stored
- * alongside it when available, so later checks can tell the recorded process apart
- * from an unrelated one that recycled the PID.
+ * Write the lock file to disk.
  */
 export function writeLockFile(root: URL, data: LockFileData, command: ServerCommand = 'dev'): void {
 	const lockFileURL = getLockFileURL(root, command);
 	const dirPath = fileURLToPath(new URL('.astro/', root));
-	// `pidStartTime` is output-only: any caller-supplied value is replaced. undefined
-	// (unsupported platform, exited process) is dropped by JSON serialization.
-	const stamped = { ...data, pidStartTime: getProcessStartTime(data.pid) };
 	try {
 		if (!existsSync(dirPath)) {
 			mkdirSync(dirPath, { recursive: true });
 		}
-		writeFileSync(lockFileURL, serializeLockFile(stamped), 'utf-8');
+		writeFileSync(lockFileURL, serializeLockFile(data), 'utf-8');
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to write lock file: ${message}`);
@@ -264,60 +233,18 @@ export async function killDevServer(root: URL, data: LockFileData): Promise<void
 }
 
 /**
- * Check whether the process recorded in the lock file is still the process that
- * wrote it. PID existence alone is not enough: the kernel recycles PIDs, and inside
- * a Docker container an unrelated process quickly reuses the recorded PID after a
- * container restart while the lock file persists on a volume mount, making a stale
- * lock file look alive. https://github.com/withastro/astro/issues/17656
- *
- * The recorded start time is compared exactly when present. Lock files written
- * before process identity tracking carry none; there the process start time is
- * compared against the lock file's write time, with {@link LEGACY_LOCK_STALE_MARGIN_MS}
- * absorbing clock inaccuracies. When neither can be verified (a platform without
- * /proc), falls back to PID existence only.
- */
-function isLockFileProcessAlive(lockFile: URL, data: LockFileData): boolean {
-	if (!isProcessAlive(data.pid)) {
-		return false;
-	}
-	const startTime = getProcessStartTime(data.pid);
-	if (startTime === undefined) {
-		return true;
-	}
-	if (data.pidStartTime !== undefined) {
-		return startTime === data.pidStartTime;
-	}
-	let mtimeMs: number;
-	try {
-		mtimeMs = statSync(lockFile).mtimeMs;
-	} catch {
-		return true;
-	}
-	const bootTime = getBootTime();
-	if (bootTime === undefined) {
-		return true;
-	}
-	const processStartedAtMs = (bootTime + Number(startTime) / PROC_STAT_TICKS_PER_SECOND) * 1000;
-	if (!Number.isFinite(processStartedAtMs)) {
-		return true;
-	}
-	return processStartedAtMs <= mtimeMs + LEGACY_LOCK_STALE_MARGIN_MS;
-}
-
-/**
- * Check for an existing server by reading the lock file and verifying that the
- * recorded process is still the one that wrote it.
+ * Check for an existing server by reading the lock file and checking process identity.
  * Automatically cleans up stale lock files.
  * Returns the server info if a live server is found, null otherwise.
  */
-export function checkExistingServer(
+export async function checkExistingServer(
 	root: URL,
 	command: ServerCommand = 'dev',
-): LockFileData | null {
+): Promise<LockFileData | null> {
 	const data = readLockFile(root, command);
 	const result = evaluateExistingServer(
 		data,
-		data !== null && isLockFileProcessAlive(getLockFileURL(root, command), data),
+		data !== null && (await isLockFileProcessAlive(data)),
 	);
 	if (result === null) {
 		return null;

--- a/packages/astro/test/units/dev/lockfile.test.ts
+++ b/packages/astro/test/units/dev/lockfile.test.ts
@@ -1,20 +1,21 @@
 import * as assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import { after, before, describe, it } from 'node:test';
 import {
 	parseLockFile,
 	serializeLockFile,
 	evaluateExistingServer,
-	checkExistingServer,
 	killDevServer,
 	writeLockFile,
 	readLockFile,
 	isProcessAlive,
-	getProcessStartTime,
+	isAstroCommand,
+	isLockFileProcessAlive,
+	checkExistingServer,
 	type LockFileData,
 } from '../../../dist/core/dev/lockfile.js';
 
@@ -25,18 +26,6 @@ const validData: LockFileData = {
 	background: false,
 	startedAt: '2026-05-05T10:00:00.000Z',
 };
-
-// Process identity via /proc is only available on Linux.
-const isLinux = process.platform === 'linux';
-
-// Write a lock file exactly as given, without the start-time stamping that
-// writeLockFile applies to live PIDs — simulates files written by another
-// container or astro version.
-function writeRawLockFile(root: URL, data: LockFileData): void {
-	const dir = join(fileURLToPath(root), '.astro');
-	mkdirSync(dir, { recursive: true });
-	writeFileSync(join(dir, 'dev.json'), serializeLockFile(data), 'utf-8');
-}
 
 // #region parseLockFile
 describe('parseLockFile', () => {
@@ -159,18 +148,6 @@ describe('parseLockFile', () => {
 		const data = { ...validData, urls: { local: [], network: [123] } };
 		assert.equal(parseLockFile(JSON.stringify(data)), null);
 	});
-
-	it('parses a valid pidStartTime field', () => {
-		const data = { ...validData, pidStartTime: '38462841' };
-		const result = parseLockFile(JSON.stringify(data));
-		assert.notEqual(result, null);
-		assert.equal(result!.pidStartTime, '38462841');
-	});
-
-	it('returns null when pidStartTime is not a string', () => {
-		const data = { ...validData, pidStartTime: 38462841 };
-		assert.equal(parseLockFile(JSON.stringify(data)), null);
-	});
 });
 // #endregion
 
@@ -215,57 +192,75 @@ describe('evaluateExistingServer', () => {
 });
 // #endregion
 
-// #region getProcessStartTime
-describe('getProcessStartTime', () => {
-	it('returns the kernel start time of a live process', { skip: !isLinux }, () => {
-		const startTime = getProcessStartTime(process.pid);
-		assert.match(startTime!, /^\d+$/);
+describe('isAstroCommand', () => {
+	it('recognizes Astro CLI commands on Unix', () => {
+		assert.equal(isAstroCommand('node /workspace/node_modules/astro/bin/astro.mjs dev'), true);
+		assert.equal(isAstroCommand('node ./node_modules/.bin/astro preview'), true);
 	});
 
-	it('returns undefined for a process that does not exist', () => {
-		assert.equal(getProcessStartTime(999_999), undefined);
-	});
-});
-// #endregion
-
-// #region writeLockFile
-describe('writeLockFile', () => {
-	let tempDir: string;
-	let root: URL;
-
-	before(() => {
-		tempDir = mkdtempSync(join(tmpdir(), 'astro-lockfile-'));
-		root = pathToFileURL(tempDir + '/');
+	it('recognizes Astro CLI commands on Windows', () => {
+		assert.equal(
+			isAstroCommand(
+				'"C:\\Program Files\\nodejs\\node.exe" "C:\\project\\node_modules\\astro\\bin\\astro.mjs" dev',
+			),
+			true,
+		);
+		assert.equal(
+			isAstroCommand('cmd.exe /d /s /c "C:\\project\\node_modules\\.bin\\astro.cmd dev"'),
+			true,
+		);
 	});
 
-	after(() => {
-		rmSync(tempDir, { recursive: true, force: true });
-	});
-
-	it('records the start time of the recorded PID when available', { skip: !isLinux }, () => {
-		const data: LockFileData = { ...validData, pid: process.pid };
-		writeLockFile(root, data);
-
-		const written = readLockFile(root);
-		assert.notEqual(written, null);
-		assert.equal(written!.pidStartTime, getProcessStartTime(process.pid));
-	});
-
-	it('omits the start time when it cannot be determined', async () => {
-		// A process that already exited has no readable start time.
-		const child = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' });
-		await new Promise((resolve) => child.on('exit', resolve));
-
-		writeLockFile(root, { ...validData, pid: child.pid! });
-
-		const written = readLockFile(root);
-		assert.notEqual(written, null);
-		assert.equal(written!.pidStartTime, undefined);
+	it('does not mistake an unrelated command for Astro', () => {
+		assert.equal(isAstroCommand('node /home/astro/server.mjs'), false);
+		assert.equal(isAstroCommand('node /workspace/astronomy.mjs'), false);
+		assert.equal(isAstroCommand('node ./astro.js'), false);
+		assert.equal(isAstroCommand('npm run dev'), false);
 	});
 });
-// #endregion
 
-// #region checkExistingServer
+describe('isLockFileProcessAlive', () => {
+	it('returns true when the recorded process command is Astro', async () => {
+		const data = { ...validData, pid: process.pid };
+		const findProcess = async () => [
+			{
+				pid: process.pid,
+				ppid: process.ppid,
+				name: 'node',
+				cmd: 'node /workspace/node_modules/astro/bin/astro.mjs dev',
+			},
+		];
+
+		assert.equal(await isLockFileProcessAlive(data, findProcess), true);
+	});
+
+	it('returns false when the PID belongs to another command', async () => {
+		const data = { ...validData, pid: process.pid };
+		const findProcess = async () => [
+			{
+				pid: process.pid,
+				ppid: process.ppid,
+				name: 'node',
+				cmd: 'node /app/server.mjs',
+			},
+		];
+
+		assert.equal(await isLockFileProcessAlive(data, findProcess), false);
+	});
+
+	it('keeps the PID-only result when the command cannot be inspected', async () => {
+		const data = { ...validData, pid: process.pid };
+
+		assert.equal(await isLockFileProcessAlive(data, async () => []), true);
+		assert.equal(
+			await isLockFileProcessAlive(data, async () => {
+				throw new Error('Process lookup failed');
+			}),
+			true,
+		);
+	});
+});
+
 describe('checkExistingServer', () => {
 	let tempDir: string;
 	let root: URL;
@@ -279,114 +274,14 @@ describe('checkExistingServer', () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it('treats the lock file as stale when the PID was reused by a different process', {
-		skip: !isLinux,
-	}, () => {
-		// Simulates the Docker container restart scenario from
-		// https://github.com/withastro/astro/issues/17656: the lock file persists on a
-		// volume mount, and the recorded PID is now used by an unrelated process.
-		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
-			stdio: 'ignore',
-		});
-		try {
-			const data: LockFileData = {
-				...validData,
-				pid: child.pid!,
-				// A start time that cannot match the reused process, as if the lock file
-				// was written by a previous container.
-				pidStartTime: '1',
-			};
-			writeRawLockFile(root, data);
+	it('cleans up a lock file when a live PID belongs to another command', async () => {
+		const data = { ...validData, pid: process.pid };
+		writeLockFile(root, data);
 
-			assert.equal(checkExistingServer(root), null);
-			// The stale lock file is cleaned up so a new server can start.
-			assert.equal(readLockFile(root), null);
-		} finally {
-			child.kill();
-		}
-	});
-
-	it('returns the lock data when the recorded process still matches', { skip: !isLinux }, () => {
-		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
-			stdio: 'ignore',
-		});
-		try {
-			const data: LockFileData = {
-				...validData,
-				pid: child.pid!,
-				pidStartTime: getProcessStartTime(child.pid!)!,
-			};
-			writeLockFile(root, data);
-
-			assert.deepEqual(checkExistingServer(root), data);
-		} finally {
-			child.kill();
-		}
-	});
-
-	it('treats a legacy lock file as stale when its process started after it was written', {
-		skip: !isLinux,
-	}, () => {
-		// Lock files written before process identity tracking carry no recorded start
-		// time. After a Docker container restart the reused PID belongs to a process
-		// that started after the lock file was written.
-		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
-			stdio: 'ignore',
-		});
-		try {
-			const data: LockFileData = {
-				...validData,
-				pid: child.pid!,
-			};
-			writeRawLockFile(root, data);
-			// Age the lock file so it predates the reused process.
-			const past = new Date(Date.now() - 3_600_000);
-			utimesSync(join(tempDir, '.astro', 'dev.json'), past, past);
-
-			assert.equal(checkExistingServer(root), null);
-			assert.equal(readLockFile(root), null);
-		} finally {
-			child.kill();
-		}
-	});
-
-	it('returns the lock data for a legacy lock file whose process predates it', () => {
-		// This test runner started well before the lock file is written.
-		const data: LockFileData = {
-			...validData,
-			pid: process.pid,
-		};
-		writeRawLockFile(root, data);
-
-		assert.deepEqual(checkExistingServer(root), data);
-	});
-
-	it('treats a legacy lock file as alive when its process started within the margin', {
-		skip: !isLinux,
-	}, () => {
-		// The process start time and file mtime come from soft clocks, so a legacy lock
-		// file is only stale when the recorded process clearly started after the write.
-		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
-			stdio: 'ignore',
-		});
-		try {
-			const data: LockFileData = {
-				...validData,
-				pid: child.pid!,
-			};
-			writeRawLockFile(root, data);
-			// Age the lock file by less than the stale margin, so its mtime is only
-			// slightly before the recorded process started.
-			const recent = new Date(Date.now() - 2_000);
-			utimesSync(join(tempDir, '.astro', 'dev.json'), recent, recent);
-
-			assert.deepEqual(checkExistingServer(root), data);
-		} finally {
-			child.kill();
-		}
+		assert.equal(await checkExistingServer(root), null);
+		assert.equal(readLockFile(root), null);
 	});
 });
-// #endregion
 
 // #region killDevServer
 describe('killDevServer', () => {

--- a/packages/astro/test/units/dev/lockfile.test.ts
+++ b/packages/astro/test/units/dev/lockfile.test.ts
@@ -1,18 +1,20 @@
 import * as assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { after, before, describe, it } from 'node:test';
 import {
 	parseLockFile,
 	serializeLockFile,
 	evaluateExistingServer,
+	checkExistingServer,
 	killDevServer,
 	writeLockFile,
 	readLockFile,
 	isProcessAlive,
+	getProcessStartTime,
 	type LockFileData,
 } from '../../../dist/core/dev/lockfile.js';
 
@@ -23,6 +25,18 @@ const validData: LockFileData = {
 	background: false,
 	startedAt: '2026-05-05T10:00:00.000Z',
 };
+
+// Process identity via /proc is only available on Linux.
+const isLinux = process.platform === 'linux';
+
+// Write a lock file exactly as given, without the start-time stamping that
+// writeLockFile applies to live PIDs — simulates files written by another
+// container or astro version.
+function writeRawLockFile(root: URL, data: LockFileData): void {
+	const dir = join(fileURLToPath(root), '.astro');
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, 'dev.json'), serializeLockFile(data), 'utf-8');
+}
 
 // #region parseLockFile
 describe('parseLockFile', () => {
@@ -145,6 +159,18 @@ describe('parseLockFile', () => {
 		const data = { ...validData, urls: { local: [], network: [123] } };
 		assert.equal(parseLockFile(JSON.stringify(data)), null);
 	});
+
+	it('parses a valid pidStartTime field', () => {
+		const data = { ...validData, pidStartTime: '38462841' };
+		const result = parseLockFile(JSON.stringify(data));
+		assert.notEqual(result, null);
+		assert.equal(result!.pidStartTime, '38462841');
+	});
+
+	it('returns null when pidStartTime is not a string', () => {
+		const data = { ...validData, pidStartTime: 38462841 };
+		assert.equal(parseLockFile(JSON.stringify(data)), null);
+	});
 });
 // #endregion
 
@@ -185,6 +211,179 @@ describe('evaluateExistingServer', () => {
 		assert.notEqual(result, null);
 		assert.equal(result!.stale, true);
 		assert.deepEqual(result!.data, validData);
+	});
+});
+// #endregion
+
+// #region getProcessStartTime
+describe('getProcessStartTime', () => {
+	it('returns the kernel start time of a live process', { skip: !isLinux }, () => {
+		const startTime = getProcessStartTime(process.pid);
+		assert.match(startTime!, /^\d+$/);
+	});
+
+	it('returns undefined for a process that does not exist', () => {
+		assert.equal(getProcessStartTime(999_999), undefined);
+	});
+});
+// #endregion
+
+// #region writeLockFile
+describe('writeLockFile', () => {
+	let tempDir: string;
+	let root: URL;
+
+	before(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'astro-lockfile-'));
+		root = pathToFileURL(tempDir + '/');
+	});
+
+	after(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('records the start time of the recorded PID when available', { skip: !isLinux }, () => {
+		const data: LockFileData = { ...validData, pid: process.pid };
+		writeLockFile(root, data);
+
+		const written = readLockFile(root);
+		assert.notEqual(written, null);
+		assert.equal(written!.pidStartTime, getProcessStartTime(process.pid));
+	});
+
+	it('omits the start time when it cannot be determined', async () => {
+		// A process that already exited has no readable start time.
+		const child = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' });
+		await new Promise((resolve) => child.on('exit', resolve));
+
+		writeLockFile(root, { ...validData, pid: child.pid! });
+
+		const written = readLockFile(root);
+		assert.notEqual(written, null);
+		assert.equal(written!.pidStartTime, undefined);
+	});
+});
+// #endregion
+
+// #region checkExistingServer
+describe('checkExistingServer', () => {
+	let tempDir: string;
+	let root: URL;
+
+	before(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'astro-lockfile-'));
+		root = pathToFileURL(tempDir + '/');
+	});
+
+	after(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('treats the lock file as stale when the PID was reused by a different process', {
+		skip: !isLinux,
+	}, () => {
+		// Simulates the Docker container restart scenario from
+		// https://github.com/withastro/astro/issues/17656: the lock file persists on a
+		// volume mount, and the recorded PID is now used by an unrelated process.
+		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+			stdio: 'ignore',
+		});
+		try {
+			const data: LockFileData = {
+				...validData,
+				pid: child.pid!,
+				// A start time that cannot match the reused process, as if the lock file
+				// was written by a previous container.
+				pidStartTime: '1',
+			};
+			writeRawLockFile(root, data);
+
+			assert.equal(checkExistingServer(root), null);
+			// The stale lock file is cleaned up so a new server can start.
+			assert.equal(readLockFile(root), null);
+		} finally {
+			child.kill();
+		}
+	});
+
+	it('returns the lock data when the recorded process still matches', { skip: !isLinux }, () => {
+		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+			stdio: 'ignore',
+		});
+		try {
+			const data: LockFileData = {
+				...validData,
+				pid: child.pid!,
+				pidStartTime: getProcessStartTime(child.pid!)!,
+			};
+			writeLockFile(root, data);
+
+			assert.deepEqual(checkExistingServer(root), data);
+		} finally {
+			child.kill();
+		}
+	});
+
+	it('treats a legacy lock file as stale when its process started after it was written', {
+		skip: !isLinux,
+	}, () => {
+		// Lock files written before process identity tracking carry no recorded start
+		// time. After a Docker container restart the reused PID belongs to a process
+		// that started after the lock file was written.
+		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+			stdio: 'ignore',
+		});
+		try {
+			const data: LockFileData = {
+				...validData,
+				pid: child.pid!,
+			};
+			writeRawLockFile(root, data);
+			// Age the lock file so it predates the reused process.
+			const past = new Date(Date.now() - 3_600_000);
+			utimesSync(join(tempDir, '.astro', 'dev.json'), past, past);
+
+			assert.equal(checkExistingServer(root), null);
+			assert.equal(readLockFile(root), null);
+		} finally {
+			child.kill();
+		}
+	});
+
+	it('returns the lock data for a legacy lock file whose process predates it', () => {
+		// This test runner started well before the lock file is written.
+		const data: LockFileData = {
+			...validData,
+			pid: process.pid,
+		};
+		writeRawLockFile(root, data);
+
+		assert.deepEqual(checkExistingServer(root), data);
+	});
+
+	it('treats a legacy lock file as alive when its process started within the margin', {
+		skip: !isLinux,
+	}, () => {
+		// The process start time and file mtime come from soft clocks, so a legacy lock
+		// file is only stale when the recorded process clearly started after the write.
+		const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+			stdio: 'ignore',
+		});
+		try {
+			const data: LockFileData = {
+				...validData,
+				pid: child.pid!,
+			};
+			writeRawLockFile(root, data);
+			// Age the lock file by less than the stale margin, so its mtime is only
+			// slightly before the recorded process started.
+			const recent = new Date(Date.now() - 2_000);
+			utimesSync(join(tempDir, '.astro', 'dev.json'), recent, recent);
+
+			assert.deepEqual(checkExistingServer(root), data);
+		} finally {
+			child.kill();
+		}
 	});
 });
 // #endregion

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,6 +778,9 @@ importers:
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      find-process:
+        specifier: ^2.1.1
+        version: 2.1.1
       flattie:
         specifier: ^1.1.1
         version: 1.1.1
@@ -11524,6 +11527,10 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -12349,6 +12356,10 @@ packages:
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
+
+  find-process@2.1.1:
+    resolution: {integrity: sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==}
+    hasBin: true
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
@@ -13354,6 +13365,10 @@ packages:
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -21245,6 +21260,8 @@ snapshots:
 
   commander@13.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@6.2.1: {}
@@ -22166,6 +22183,12 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 5.1.1
+
+  find-process@2.1.1:
+    dependencies:
+      chalk: 4.1.2
+      commander: 14.0.3
+      loglevel: 1.9.2
 
   find-up-simple@1.0.1: {}
 
@@ -23291,6 +23314,8 @@ snapshots:
       ms: 2.1.3
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
+
+  loglevel@1.9.2: {}
 
   long@5.3.2: {}
 


### PR DESCRIPTION
Closes #17656

## Changes

- Checks the command for the PID stored in the dev or preview lock file instead of assuming that any live process with the same PID is Astro.
- Uses an exact PID lookup on Linux, macOS, and Windows. This cleans up stale locks after container restarts and prevents `--force` from signalling an unrelated process when the command can be verified.

## Testing

- Added Unix and Windows command matching cases, including the Windows `.cmd` shim and unrelated commands.
- Added coverage for matching processes, reused PIDs, unavailable process lookups, and stale lock cleanup through the real process lookup.

## Docs

No docs update needed because the CLI workflow and user-facing messages stay the same.