### PR TITLE
Declare `satteri` as a runtime dependency of `@astrojs/mdx`

### DIFF
--- a/.changeset/fix-mdx-satteri-dependency.md
+++ b/.changeset/fix-mdx-satteri-dependency.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/mdx': patch
+---
+
+Adds `satteri` as a declared runtime dependency so pnpm's strict isolated `node_modules` can always resolve the bare `from 'satteri'` imports in the Sätteri MDX pipeline.
+
+Previously, `satteri` was only listed as a `devDependency`, which meant the package resolved accidentally through hoisting but failed with `ERR_MODULE_NOT_FOUND` in strict pnpm setups (e.g. Vercel monorepo deploys).

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -45,6 +45,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-smartypants": "^3.0.2",
+    "satteri": "^0.9.1",
     "source-map": "^0.7.6",
     "unist-util-visit": "^5.1.0",
     "vfile": "^6.0.3"
@@ -76,7 +77,6 @@
     "remark-math": "^6.0.0",
     "remark-rehype": "^11.1.2",
     "remark-toc": "^9.0.0",
-    "satteri": "^0.9.1",
     "shiki": "^4.0.2",
     "unified": "^11.0.5",
     "vite": "^8.0.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5198,6 +5198,9 @@ importers:
       remark-smartypants:
         specifier: ^3.0.2
         version: 3.0.2
+      satteri:
+        specifier: ^0.9.1
+        version: 0.9.1
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
@@ -5259,9 +5262,6 @@ importers:
       remark-toc:
         specifier: ^9.0.0
         version: 9.0.0
-      satteri:
-        specifier: ^0.9.1
-        version: 0.9.1
       shiki:
         specifier: ^4.0.2
         version: 4.0.2


### PR DESCRIPTION
## Changes

- Moves `satteri` from `devDependencies` to `dependencies` in `@astrojs/mdx`. The package has unconditional static `from 'satteri'` imports across four files under `src/satteri/`, making it a runtime requirement. Listing it only as a `devDependency` meant pnpm never linked it into `@astrojs/mdx`'s isolated `node_modules`, so `astro build` failed with `ERR_MODULE_NOT_FOUND` in strict pnpm setups (e.g. `hoist: false`, Vercel monorepo deploys). The import resolved accidentally in non-strict layouts only because pnpm hoisted `satteri` as a transitive dep of `astro → @astrojs/markdown-satteri`.

## Testing

- No new tests added. The bug is a packaging/manifest issue that cannot be covered by unit tests run inside the monorepo (which hoists all deps). The fix was confirmed in an isolated `hoist: false` pnpm project by @danielmlr, and by the `packageExtensions` counter-check in their report.

## Docs

- No docs update needed; this is an internal dependency declaration fix with no user-visible API change.

Closes #17371