### PR TITLE
Keep a Cloudflare deploy from serving HTML that its own build invalidated

### DIFF
--- a/.changeset/rare-pandas-repeat.md
+++ b/.changeset/rare-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Adds the Worker version to the cache metadata of cached responses when the `CF_VERSION_METADATA` binding is configured. Responses carry an `astro-version:<id>` cache tag for version-specific purging, and responses that already send `Last-Modified` get a weak `ETag` that folds the version in. Conditional revalidation then returns fresh content after a deploy that changes rendered output but not content — most commonly the hashed asset URLs in server-rendered HTML. Without the binding, nothing changes.

--- a/packages/integrations/cloudflare/src/cache/index.ts
+++ b/packages/integrations/cloudflare/src/cache/index.ts
@@ -6,7 +6,9 @@ import type { CacheProviderConfig } from 'astro';
  * Uses `Cloudflare-CDN-Cache-Control` and `Cache-Tag` headers for
  * Cloudflare's built-in Worker caching layer. Responses are auto-tagged
  * with the request path so that both tag-based and path-based invalidation
- * are implemented via tag purging through the Worker cache API.
+ * are implemented via tag purging through the Worker cache API. With the
+ * `CF_VERSION_METADATA` binding configured, they also carry the Worker
+ * version as an `astro-version:` tag.
  */
 export function cacheCloudflare(): CacheProviderConfig {
 	return {

--- a/packages/integrations/cloudflare/src/cache/provider.ts
+++ b/packages/integrations/cloudflare/src/cache/provider.ts
@@ -6,6 +6,34 @@ import {
 	setConditionalHeaders,
 } from 'astro/cache/provider-utils';
 
+const VERSION_TAG_PREFIX = 'astro-version:';
+
+/**
+ * Read the Worker version id from the `CF_VERSION_METADATA` binding.
+ *
+ * A top-level `cloudflare:workers` import breaks the `prerenderEnvironment:
+ * 'node'` build, so the module is imported dynamically. Full explanation:
+ * https://github.com/withastro/astro/pull/16335. Resolving once at module
+ * load keeps `setHeaders()` synchronous.
+ */
+async function readVersionId(): Promise<string | undefined> {
+	try {
+		const { env } = await import('cloudflare:workers');
+		const metadata = (env as Record<string, unknown>).CF_VERSION_METADATA;
+		if (metadata && typeof metadata === 'object' && 'id' in metadata) {
+			const id = (metadata as { id: unknown }).id;
+			if (typeof id === 'string' && id.length > 0) {
+				return id;
+			}
+		}
+	} catch {
+		// No Workers runtime, or no binding configured.
+	}
+	return undefined;
+}
+
+const versionId = await readVersionId();
+
 const factory: CacheProviderFactory = () => {
 	return {
 		name: 'cloudflare',
@@ -27,9 +55,21 @@ const factory: CacheProviderFactory = () => {
 			const { pathname } = new URL(request.url);
 			tags.push(pathTag(pathname));
 
+			if (versionId) {
+				tags.push(`${VERSION_TAG_PREFIX}${versionId}`);
+			}
+
 			headers.set('Cache-Tag', tags.join(','));
 
 			setConditionalHeaders(headers, options);
+
+			// The validator stays weak: two responses from one version are
+			// semantically equivalent, not byte-identical. Dropping the `lastModified`
+			// condition would mint a validator where none existed, which lets a cache
+			// answer `304` for a page whose content changes between deploys.
+			if (versionId && options.lastModified && !options.etag) {
+				headers.set('ETag', `W/"${versionId}:${options.lastModified.getTime()}"`);
+			}
 
 			return headers;
 		},

--- a/packages/integrations/cloudflare/test/cache-provider.test.ts
+++ b/packages/integrations/cloudflare/test/cache-provider.test.ts
@@ -78,4 +78,55 @@ describe('Cloudflare cache provider', () => {
 		assert.equal(res.headers.get('Cloudflare-CDN-Cache-Control'), 'no-store');
 		assert.equal(res.headers.get('Cache-Tag'), null);
 	});
+
+	it('tags cacheable responses with the Worker version', async () => {
+		const res = await fixture.fetch('/api');
+		const cacheTag = res.headers.get('Cache-Tag');
+		assert.ok(cacheTag, 'Cache-Tag header should be present');
+
+		const versionTag = cacheTag.split(',').find((tag) => tag.startsWith('astro-version:'));
+		assert.ok(versionTag, `expected an 'astro-version:' tag, got: ${cacheTag}`);
+		assert.ok(
+			versionTag.length > 'astro-version:'.length,
+			`expected a non-empty version id, got: ${versionTag}`,
+		);
+	});
+
+	it('folds the Worker version into the ETag of a response with lastModified', async () => {
+		const res = await fixture.fetch('/lastmod');
+		assert.equal(res.status, 200);
+
+		const lastModified = res.headers.get('Last-Modified');
+		assert.equal(lastModified, new Date('2026-01-15T10:00:00.000Z').toUTCString());
+
+		const etag = res.headers.get('ETag');
+		assert.ok(etag, 'ETag header should be present');
+
+		const match = /^W\/"(.+):(\d+)"$/.exec(etag);
+		assert.ok(match, `expected a weak versioned ETag, got: ${etag}`);
+		assert.equal(Number(match[2]), Date.parse('2026-01-15T10:00:00.000Z'));
+
+		const versionTag = res.headers
+			.get('Cache-Tag')
+			?.split(',')
+			.find((tag) => tag.startsWith('astro-version:'));
+		assert.equal(
+			versionTag,
+			`astro-version:${match[1]}`,
+			'ETag and Cache-Tag should carry the same version id',
+		);
+	});
+
+	it('leaves an explicitly provided ETag untouched', async () => {
+		const res = await fixture.fetch('/explicit-etag');
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('ETag'), '"user-supplied"');
+	});
+
+	it('does not mint an ETag for a cacheable response without a validator', async () => {
+		const res = await fixture.fetch('/api');
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('Last-Modified'), null);
+		assert.equal(res.headers.get('ETag'), null);
+	});
 });

--- a/packages/integrations/cloudflare/test/fixtures/cache-provider/src/pages/explicit-etag.ts
+++ b/packages/integrations/cloudflare/test/fixtures/cache-provider/src/pages/explicit-etag.ts
@@ -1,0 +1,10 @@
+export const prerender = false;
+
+export const GET = async (context: any) => {
+	context.cache.set({
+		maxAge: 300,
+		lastModified: new Date('2026-01-15T10:00:00.000Z'),
+		etag: '"user-supplied"',
+	});
+	return Response.json({ ok: true });
+};

--- a/packages/integrations/cloudflare/test/fixtures/cache-provider/src/pages/lastmod.ts
+++ b/packages/integrations/cloudflare/test/fixtures/cache-provider/src/pages/lastmod.ts
@@ -1,0 +1,8 @@
+export const prerender = false;
+
+const LAST_MODIFIED = new Date('2026-01-15T10:00:00.000Z');
+
+export const GET = async (context: any) => {
+	context.cache.set({ maxAge: 300, lastModified: LAST_MODIFIED });
+	return Response.json({ ok: true });
+};

--- a/packages/integrations/cloudflare/test/fixtures/cache-provider/wrangler.jsonc
+++ b/packages/integrations/cloudflare/test/fixtures/cache-provider/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "name": "test-cache-provider",
   "main": "@astrojs/cloudflare/entrypoints/server",
-  "compatibility_date": "2026-01-28"
+  "compatibility_date": "2026-01-28",
+  "version_metadata": { "binding": "CF_VERSION_METADATA" }
 }


### PR DESCRIPTION
## Changes

- A deploy that changes rendered output without changing content leaves a cached page's validator untouched. Revalidation answers `304`, so clients keep HTML that points at `/_astro/<hash>.css` from the previous build. Every validator the Cloudflare provider can send today comes from the caller and describes the content, never the build.
- With the [`CF_VERSION_METADATA`](https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/) binding configured, the provider reads the Worker version id, adds an `astro-version:<id>` cache tag for [version-specific purging](https://developers.cloudflare.com/workers/cache/purge/#version-specific-purging), and folds the id into a weak `ETag` (`W/"<id>:<lastModified-ms>"`) on responses that already send `Last-Modified` and no `etag` of their own. Without the binding, every header is exactly what it was before.
- Picks up #17038, which targeted `feat/cdn-cache-providers` and was closed when that branch was deleted. The version tag it built on never reached `main`, so this adds it.

## Testing

- `test/cache-provider.test.ts` gains four cases against the preview server: the version tag on a cacheable response, the weak `ETag` carrying the same id and the `lastModified` timestamp, an explicit `etag` surviving untouched, and a cacheable response without a validator still getting none. Two fixture pages (`/lastmod`, `/explicit-etag`) and the `version_metadata` binding support them.
- No automated case for the `prerenderEnvironment: 'node'` build path, since it would need a second fixture build per run. Checked by hand against a fixture build with a prerendered route and the provider enabled.

## Docs

- The adapter README does not cover route caching, so there is nothing to update there. The behavior is worth a paragraph in the Cloudflare adapter guide on docs.astro.build, and I will open that PR once this lands.
