### PR TITLE
fix(cloudflare): resolve image format from the source when `f` is absent

### DIFF
--- a/.changeset/rotten-lions-scream.md
+++ b/.changeset/rotten-lions-scream.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes remote images without a file extension failing with `400 Unsupported format: null` when using the `cloudflare-binding` image service
+
+Astro only adds the `f` (format) parameter to `/_image` URLs when it can infer a format from the source, and otherwise leaves it off so the image service resolves the format from the source itself. Extensionless remote images, such as GitHub avatars like `https://avatars.githubusercontent.com/u/1234`, take that path. The image transform endpoint now falls back to the source's media type when `f` is absent, passing SVG sources through unchanged and encoding everything else as WebP. This also fixes SVG images, which are requested as `f=svg` and previously failed the same way.

--- a/packages/integrations/cloudflare/src/utils/image-binding-transform.ts
+++ b/packages/integrations/cloudflare/src/utils/image-binding-transform.ts
@@ -12,16 +12,26 @@ const qualityTable: Record<ImageQualityPreset, number> = {
 	max: 100,
 };
 
+const SVG_CONTENT_TYPE = 'image/svg+xml';
+
 /**
  * Transforms an already-resolved image stream. Split out from `transform` so the build
  * can hand over source bytes it read itself: during the build the original image lives
  * in Astro's intermediate output rather than behind the ASSETS binding, so the worker
  * has no way to fetch it.
+ *
+ * `sourceContentType` is the media type the source was served with. It resolves the output
+ * format for requests that carry no `f` parameter, which core omits whenever it cannot
+ * infer a source format from the URL — extensionless remote images such as
+ * `https://avatars.githubusercontent.com/u/1234` are the common case. Core leaves the
+ * format undefined there on purpose, expecting the image service to determine it from the
+ * source itself, as the Sharp service does. See withastro/astro.build#2610.
  */
 export async function transformStream(
 	body: ReadableStream,
 	params: URLSearchParams,
 	images: ImagesBinding,
+	sourceContentType?: string | null,
 ): Promise<Response> {
 	const supportedFormats: Record<string, ImageOutputOptions['format']> = {
 		jpeg: 'image/jpeg',
@@ -32,10 +42,23 @@ export async function transformStream(
 		avif: 'image/avif',
 	};
 
-	const outputFormat = supportedFormats[params.get('f') ?? ''];
+	const requestedFormat = params.get('f');
+	const sourceType = sourceContentType?.split(';')[0].trim().toLowerCase();
+
+	// Core asks for `svg` when the source is an SVG, meaning "leave it alone". The IMAGES
+	// binding cannot emit SVG and Astro does not rasterize SVG sources by default, so serve
+	// the original bytes.
+	if (requestedFormat === 'svg' || (!requestedFormat && sourceType === SVG_CONTENT_TYPE)) {
+		return new Response(body, {
+			headers: { 'Content-Type': sourceContentType || SVG_CONTENT_TYPE },
+		});
+	}
+
+	// Mirrors core's `resolveDefaultOutputFormat`, which webp-encodes every non-SVG source.
+	const outputFormat = requestedFormat ? supportedFormats[requestedFormat] : 'image/webp';
 
 	if (!outputFormat) {
-		return new Response(`Unsupported format: ${params.get('f')}`, { status: 400 });
+		return new Response(`Unsupported format: ${requestedFormat}`, { status: 400 });
 	}
 
 	return (
@@ -94,5 +117,10 @@ export async function transform(
 		return new Response(null, { status: 404 });
 	}
 
-	return transformStream(content.body, url.searchParams, images);
+	return transformStream(
+		content.body,
+		url.searchParams,
+		images,
+		content.headers.get('content-type'),
+	);
 }

--- a/packages/integrations/cloudflare/test/binding-image-service.test.ts
+++ b/packages/integrations/cloudflare/test/binding-image-service.test.ts
@@ -1,13 +1,45 @@
 import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
 import { after, before, describe, it } from 'node:test';
 import { type Fixture, loadFixture, type PreviewServer } from './test-utils.ts';
+
+const PLACEHOLDER_JPEG = readFileSync(
+	new URL('./fixtures/binding-image-service/public/placeholder.jpg', import.meta.url),
+);
+const LOGO_SVG = readFileSync(
+	new URL('./fixtures/binding-image-service/public/logo.svg', import.meta.url),
+);
+
+/** Serves images from extensionless paths, the way GitHub serves user avatars. */
+function startRemoteImageServer(): Promise<{ server: Server; port: number }> {
+	const server = createServer((req, res) => {
+		if (req.url?.startsWith('/svg')) {
+			res.writeHead(200, { 'Content-Type': 'image/svg+xml' });
+			res.end(LOGO_SVG);
+			return;
+		}
+		res.writeHead(200, { 'Content-Type': 'image/jpeg' });
+		res.end(PLACEHOLDER_JPEG);
+	});
+	return new Promise((resolve) => {
+		server.listen(0, () => {
+			const address = server.address();
+			if (typeof address === 'string' || !address) {
+				throw new TypeError('Unexpected address for testing');
+			}
+			resolve({ server, port: address.port });
+		});
+	});
+}
 
 describe('BindingImageService', () => {
 	let fixture: Fixture;
 	let previewServer: PreviewServer;
 	let redirectServer: Server;
 	let redirectServerPort: number;
+	let imageServer: Server;
+	let imageServerPort: number;
 
 	before(async () => {
 		// Start a local HTTP server that always responds with a 302 redirect.
@@ -27,6 +59,8 @@ describe('BindingImageService', () => {
 			});
 		});
 
+		({ server: imageServer, port: imageServerPort } = await startRemoteImageServer());
+
 		fixture = await loadFixture({
 			root: './fixtures/binding-image-service/',
 		});
@@ -37,6 +71,7 @@ describe('BindingImageService', () => {
 	after(async () => {
 		await previewServer.stop();
 		await new Promise((resolve) => redirectServer.close(resolve));
+		await new Promise((resolve) => imageServer.close(resolve));
 	});
 
 	it('returns 403 for missing href parameter', async () => {
@@ -78,5 +113,35 @@ describe('BindingImageService', () => {
 		const href = `http://localhost:${redirectServerPort}/image.jpg`;
 		const res = await fixture.fetch(`/_image?href=${encodeURIComponent(href)}&f=webp`);
 		assert.equal(res.status, 404);
+	});
+
+	// Core omits `f` when it cannot infer a source format from the URL, which is the case
+	// for every extensionless remote image (GitHub avatars, for one). See withastro/astro.build#2610.
+	it('defaults to webp for remote images with no format parameter', async () => {
+		const href = `http://localhost:${imageServerPort}/u/2738`;
+		const res = await fixture.fetch(`/_image?href=${encodeURIComponent(href)}&w=100`);
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('content-type'), 'image/webp');
+	});
+
+	it('passes through remote SVGs with no format parameter', async () => {
+		const href = `http://localhost:${imageServerPort}/svg`;
+		const res = await fixture.fetch(`/_image?href=${encodeURIComponent(href)}&w=100`);
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('content-type'), 'image/svg+xml');
+		assert.ok((await res.text()).includes('<svg'));
+	});
+
+	it('passes through local SVGs requested as f=svg', async () => {
+		const res = await fixture.fetch('/_image?href=/logo.svg&f=svg&w=100');
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('content-type'), 'image/svg+xml');
+		assert.ok((await res.text()).includes('<svg'));
+	});
+
+	it('defaults to webp for local images with no format parameter', async () => {
+		const res = await fixture.fetch('/_image?href=/placeholder.jpg&w=100');
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('content-type'), 'image/webp');
 	});
 });

--- a/packages/integrations/cloudflare/test/dev-image-endpoint.test.ts
+++ b/packages/integrations/cloudflare/test/dev-image-endpoint.test.ts
@@ -51,6 +51,13 @@ describe('Dev image endpoint', () => {
 		assert.equal(res.status, 200);
 		assert.equal(res.headers.get('content-type'), 'image/avif');
 	});
+
+	// Core omits `f` when it cannot infer a source format from the URL. See withastro/astro.build#2610.
+	it('defaults to webp when no format parameter is given', async () => {
+		const res = await fixture.fetch('/_image?href=/placeholder.jpg&w=100');
+		assert.equal(res.status, 200);
+		assert.equal(res.headers.get('content-type'), 'image/webp');
+	});
 });
 
 describe('Dev image endpoint with prerenderEnvironment: node', () => {

--- a/packages/integrations/cloudflare/test/fixtures/binding-image-service/public/logo.svg
+++ b/packages/integrations/cloudflare/test/fixtures/binding-image-service/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+	<rect width="64" height="64" fill="#ff5d01" />
+</svg>


### PR DESCRIPTION
## Changes

Remote images whose URL has no file extension fail with `400 Unsupported format: null` under the `cloudflare-binding` image service (the adapter default).

Astro's `baseService.validateOptions` only sets `options.format` when it can infer a source format from the URL, and since #16665 deliberately leaves it `undefined` otherwise so the image service resolves the format from the source bytes instead — which is what the Sharp service does at [`sharp.ts#L155-L156`](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/services/sharp.ts#L155-L156). With `format` undefined, no `f` parameter is emitted onto the `/_image` URL, and `transformStream` treated a missing `f` as a client error.

Extensionless remote images are the common case here — GitHub avatars like `https://avatars.githubusercontent.com/u/192622539?s=200&v=4` have no extension to infer from, which is why every theme author avatar on astro.build is currently broken:

```console
$ curl -sD - -o /dev/null 'https://astro.build/_image?href=https%3A%2F%2Favatars.githubusercontent.com%2Fu%2F192622539%3Fs%3D200%26v%3D4&w=300&h=300'
HTTP/1.1 400 Bad Request
Unsupported format: null

# ...the same URL with an explicit format works
$ curl -so /dev/null -w '%{http_code} %{content_type}\n' '...&w=300&h=300&f=webp'
200 image/webp
```

- `transformStream` now takes the source's media type and uses it when `f` is absent: SVG sources pass through unchanged, everything else is encoded as WebP. This mirrors core's `resolveDefaultOutputFormat`, which webp-encodes every non-SVG source.
- Requests that explicitly ask for a format the IMAGES binding cannot produce (e.g. `f=tiff`) still return `400`.
- This also fixes SVG images, which core requests as `f=svg` and which previously failed the same way — the IMAGES binding cannot emit SVG, so those bytes are served as-is.

Fixes withastro/astro.build#2610

## Testing

Added four cases to `test/binding-image-service.test.ts` (build + preview, exercising the IMAGES binding for real) covering remote/local sources with no `f`, and SVG passthrough. A local HTTP server serves images from extensionless paths to reproduce the GitHub avatar shape. Also added the no-`f` case to `test/dev-image-endpoint.test.ts`.

All four new binding tests fail on `main` with `400` and pass with this change; the seven pre-existing tests in that file are unaffected.

> [!NOTE]
> Two things worth flagging for maintainers, both pre-existing and left untouched here:
> - `caches.default` is persisted under `test/fixtures/binding-image-service/.wrangler/state/v3/cache`, so a previously-cached `200` can mask a genuine failure for any stable `/_image` URL. I had to clear that directory to see the new tests fail on `main`.
> - `createPreviewServer` returns the *requested* port rather than the bound one ([`preview.ts#L97`](https://github.com/withastro/astro/blob/main/packages/integrations/cloudflare/src/entrypoints/preview.ts#L97)), so the whole suite 404s if port 4321 is already taken.

## Docs

No docs changes needed. This restores the documented behavior of `image.remotePatterns`/`image.domains` for remote images; there's no API or configuration surface change.
