### PR TITLE
Fix server islands endpoint missing in static Vercel builds

### DIFF
--- a/.changeset/curly-donkeys-say.md
+++ b/.changeset/curly-donkeys-say.md
@@ -2,4 +2,4 @@
 '@astrojs/vercel': patch
 ---
 
-Fixes server islands not working with `output: "static"`. The adapter now creates a serverless function for `/_server-islands/*` when `server:defer` components are used in static builds.
+Fixes server islands returning 404 responses in Vercel deployments using `output: "static"`

--- a/.changeset/curly-donkeys-say.md
+++ b/.changeset/curly-donkeys-say.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fixes server islands not working with `output: "static"`. The adapter now creates a serverless function for `/_server-islands/*` when `server:defer` components are used in static builds.

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -405,6 +405,13 @@ export default function vercelAdapter({
 			},
 			'astro:build:done': async ({ logger }: HookParameters<'astro:build:done'>) => {
 				const outDir = new URL('./.vercel/output/', _config.root);
+
+				// In static builds, server islands cause Astro core to produce an
+				// SSR bundle in outDir (not build.server). Detect this so we still
+				// create a serverless function for the /_server-islands/* endpoint.
+				const staticEntryFile = new URL(_serverEntry, _config.outDir);
+				const needsServerIslandFunction = _buildOutput === 'static' && existsSync(staticEntryFile);
+
 				if (staticDir) {
 					if (existsSync(staticDir)) {
 						await emptyDir(staticDir);
@@ -526,6 +533,35 @@ export default function vercelAdapter({
 							middlewareSecret,
 						);
 					}
+				} else if (needsServerIslandFunction) {
+					// Static build with server islands: the SSR entry lives in outDir
+					// (not build.server) because getServerOutputDirectory() returns
+					// outDir when buildOutput is 'static'. Build a serverless function
+					// so /_server-islands/* requests are handled at runtime.
+					const includeFiles = _includeFiles
+						.map((file) => new URL(file, _config.root))
+						.concat(extraFilesToInclude);
+					const excludeFiles = _excludeFiles.map((file) => new URL(file, _config.root));
+
+					const builder = new VercelBuilder(
+						_config,
+						excludeFiles,
+						includeFiles,
+						logger,
+						outDir,
+						maxDuration,
+					);
+
+					await builder.buildServerlessFolder(staticEntryFile, NODE_PATH, _config.root);
+
+					for (const route of routes) {
+						if (!route.isPrerendered) {
+							routeDefinitions.push({
+								src: route.patternRegex.source,
+								dest: NODE_PATH,
+							});
+						}
+					}
 				}
 				const fourOhFourRoute = routes.find((route) => route.pathname === '/404');
 				const vercelConfigJson = new URL('./.vercel/output/config.json', _config.root);
@@ -538,7 +574,7 @@ export default function vercelAdapter({
 						continue: true,
 					},
 				];
-				if (_buildOutput === 'server') {
+				if (_buildOutput === 'server' || needsServerIslandFunction) {
 					finalRoutes.push(...routeDefinitions);
 				}
 

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -127,6 +127,7 @@ function getAdapter({
 		adapterFeatures: {
 			buildOutput,
 			middlewareMode,
+			preserveBuildServerDir: true,
 			staticHeaders,
 		},
 		supportedAstroFeatures: {
@@ -266,6 +267,7 @@ export default function vercelAdapter({
 	let _buildTempFolder: URL;
 	let _serverEntry: string;
 	let _middlewareEntryPoint: URL | undefined;
+	let _hasServerBuild = false;
 	let _routeToHeaders: RouteToHeaders | undefined = undefined;
 	// Extra files to be merged with `includeFiles` during build
 	const extraFilesToInclude: URL[] = [];
@@ -295,6 +297,9 @@ export default function vercelAdapter({
 					build: {
 						format: 'directory',
 						redirects: false,
+						...(config.output === 'static'
+							? { server: new URL('./.vercel/output/server/', config.root) }
+							: {}),
 					},
 					integrations: [
 						{
@@ -393,10 +398,12 @@ export default function vercelAdapter({
 				_serverEntry = config.build.serverEntry;
 			},
 			'astro:build:start': async () => {
+				_hasServerBuild = false;
 				// Ensure to have `.vercel/output` empty.
 				await emptyDir(new URL('./.vercel/output/', _config.root));
 			},
 			'astro:build:ssr': async ({ middlewareEntryPoint }) => {
+				_hasServerBuild = true;
 				_middlewareEntryPoint = middlewareEntryPoint;
 			},
 
@@ -405,12 +412,6 @@ export default function vercelAdapter({
 			},
 			'astro:build:done': async ({ logger }: HookParameters<'astro:build:done'>) => {
 				const outDir = new URL('./.vercel/output/', _config.root);
-
-				// In static builds, server islands cause Astro core to produce an
-				// SSR bundle in outDir (not build.server). Detect this so we still
-				// create a serverless function for the /_server-islands/* endpoint.
-				const staticEntryFile = new URL(_serverEntry, _config.outDir);
-				const needsServerIslandFunction = _buildOutput === 'static' && existsSync(staticEntryFile);
 
 				if (staticDir) {
 					if (existsSync(staticDir)) {
@@ -435,9 +436,9 @@ export default function vercelAdapter({
 					middlewarePath?: string;
 				}> = [];
 
-				if (_buildOutput === 'server') {
+				if (_hasServerBuild) {
 					// Merge any includes from `vite.assetsInclude
-					if (_config.vite.assetsInclude) {
+					if (_buildOutput === 'server' && _config.vite.assetsInclude) {
 						const mergeGlobbedIncludes = (globPattern: unknown) => {
 							if (typeof globPattern === 'string') {
 								const entries = globSync(globPattern).map((p) => pathToFileURL(p));
@@ -467,7 +468,7 @@ export default function vercelAdapter({
 					);
 
 					const entryFile = new URL(_serverEntry, _buildTempFolder);
-					if (isr) {
+					if (_buildOutput === 'server' && isr) {
 						const isrConfig = typeof isr === 'object' ? isr : {};
 						await builder.buildServerlessFolder(entryFile, NODE_PATH, _config.root);
 						if (isrConfig.exclude?.length) {
@@ -533,35 +534,6 @@ export default function vercelAdapter({
 							middlewareSecret,
 						);
 					}
-				} else if (needsServerIslandFunction) {
-					// Static build with server islands: the SSR entry lives in outDir
-					// (not build.server) because getServerOutputDirectory() returns
-					// outDir when buildOutput is 'static'. Build a serverless function
-					// so /_server-islands/* requests are handled at runtime.
-					const includeFiles = _includeFiles
-						.map((file) => new URL(file, _config.root))
-						.concat(extraFilesToInclude);
-					const excludeFiles = _excludeFiles.map((file) => new URL(file, _config.root));
-
-					const builder = new VercelBuilder(
-						_config,
-						excludeFiles,
-						includeFiles,
-						logger,
-						outDir,
-						maxDuration,
-					);
-
-					await builder.buildServerlessFolder(staticEntryFile, NODE_PATH, _config.root);
-
-					for (const route of routes) {
-						if (!route.isPrerendered) {
-							routeDefinitions.push({
-								src: route.patternRegex.source,
-								dest: NODE_PATH,
-							});
-						}
-					}
 				}
 				const fourOhFourRoute = routes.find((route) => route.pathname === '/404');
 				const vercelConfigJson = new URL('./.vercel/output/config.json', _config.root);
@@ -574,7 +546,7 @@ export default function vercelAdapter({
 						continue: true,
 					},
 				];
-				if (_buildOutput === 'server' || needsServerIslandFunction) {
+				if (_hasServerBuild) {
 					finalRoutes.push(...routeDefinitions);
 				}
 
@@ -674,7 +646,7 @@ export default function vercelAdapter({
 				});
 
 				// Remove temporary folder
-				if (_buildOutput === 'server') {
+				if (_hasServerBuild) {
 					await removeDir(_buildTempFolder);
 				}
 			},

--- a/packages/integrations/vercel/test/fixtures/server-islands-static/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/server-islands-static/astro.config.mjs
@@ -1,0 +1,7 @@
+import vercel from '@astrojs/vercel';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	output: 'static',
+	adapter: vercel(),
+});

--- a/packages/integrations/vercel/test/fixtures/server-islands-static/package.json
+++ b/packages/integrations/vercel/test/fixtures/server-islands-static/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@test/vercel-server-islands-static",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"@astrojs/vercel": "workspace:*",
+		"astro": "workspace:*"
+	}
+}

--- a/packages/integrations/vercel/test/fixtures/server-islands-static/src/components/Island.astro
+++ b/packages/integrations/vercel/test/fixtures/server-islands-static/src/components/Island.astro
@@ -1,0 +1,1 @@
+<h1>I'm an island</h1>

--- a/packages/integrations/vercel/test/fixtures/server-islands-static/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/server-islands-static/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import Island from '../components/Island.astro';
+---
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+		<Island server:defer />
+	</body>
+</html>

--- a/packages/integrations/vercel/test/server-islands.test.ts
+++ b/packages/integrations/vercel/test/server-islands.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { before, describe, it } from 'node:test';
 import { type Fixture, loadFixture, getVercelConfig } from './test-utils.ts';
 
@@ -22,5 +23,38 @@ describe('Server Islands', () => {
 			}
 		}
 		assert.notEqual(found, null, 'Default server islands route included');
+	});
+});
+
+describe('Server Islands (static output)', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/server-islands-static/',
+		});
+		await fixture.build({});
+	});
+
+	it('creates _render.func for server islands in static builds', { timeout: 30000 }, async () => {
+		const renderFuncDir = new URL('.vercel/output/functions/_render.func/', fixture.config.root);
+		assert.ok(existsSync(renderFuncDir), '_render.func directory should exist');
+		assert.ok(
+			existsSync(new URL('.vc-config.json', renderFuncDir)),
+			'.vc-config.json should exist in _render.func',
+		);
+	});
+
+	it('includes server islands route in config', { timeout: 30000 }, async () => {
+		const config = await getVercelConfig(fixture);
+		let found = null;
+		for (const route of config.routes) {
+			if (route.src?.includes('_server-islands')) {
+				found = route;
+				break;
+			}
+		}
+		assert.notEqual(found, null, 'Server islands route should be in config');
+		assert.equal(found.dest, '_render', 'Server islands route should point to _render');
 	});
 });

--- a/packages/integrations/vercel/test/server-islands.test.ts
+++ b/packages/integrations/vercel/test/server-islands.test.ts
@@ -28,12 +28,22 @@ describe('Server Islands', () => {
 
 describe('Server Islands (static output)', () => {
 	let fixture: Fixture;
+	let renderFunction: { default: { fetch(request: Request): Promise<Response> } };
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/server-islands-static/',
 		});
 		await fixture.build({});
+
+		const functionConfig = JSON.parse(
+			await fixture.readFile('../.vercel/output/functions/_render.func/.vc-config.json'),
+		);
+		const functionEntry = new URL(
+			`../.vercel/output/functions/_render.func/${functionConfig.handler}`,
+			fixture.config.outDir,
+		);
+		renderFunction = await import(functionEntry.href);
 	});
 
 	it('creates _render.func for server islands in static builds', { timeout: 30000 }, async () => {
@@ -42,6 +52,25 @@ describe('Server Islands (static output)', () => {
 		assert.ok(
 			existsSync(new URL('.vc-config.json', renderFuncDir)),
 			'.vc-config.json should exist in _render.func',
+		);
+	});
+
+	it('renders the server island', { timeout: 30000 }, async () => {
+		const html = await fixture.readFile('../.vercel/output/static/index.html');
+		const islandUrl = /fetch\((["'])(\/_server-islands\/[^"']+)\1/.exec(html)?.[2];
+		assert.ok(islandUrl, 'prerendered HTML should include the server island URL');
+
+		const response = await renderFunction.default.fetch(
+			new Request(new URL(islandUrl, 'https://example.com')),
+		);
+		assert.equal(response.status, 200);
+		assert.match(await response.text(), /I'm an island/);
+	});
+
+	it('does not publish the server entry as a static file', () => {
+		assert.equal(
+			existsSync(new URL('.vercel/output/static/entry.mjs', fixture.config.root)),
+			false,
 		);
 	});
 
@@ -54,7 +83,7 @@ describe('Server Islands (static output)', () => {
 				break;
 			}
 		}
-		assert.notEqual(found, null, 'Server islands route should be in config');
+		assert.ok(found, 'Server islands route should be in config');
 		assert.equal(found.dest, '_render', 'Server islands route should point to _render');
 	});
 });

--- a/packages/integrations/vercel/test/static.test.ts
+++ b/packages/integrations/vercel/test/static.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { before, describe, it } from 'node:test';
 import { type Fixture, loadFixture } from './test-utils.ts';
 
@@ -20,5 +21,12 @@ describe('static routing', () => {
 			dest: '/404.html',
 			status: 404,
 		});
+	});
+
+	it('does not create a serverless function', () => {
+		assert.equal(
+			existsSync(new URL('.vercel/output/functions/_render.func/', fixture.config.root)),
+			false,
+		);
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7137,15 +7137,6 @@ importers:
         specifier: ^4.22.0
         version: 4.22.3
 
-  triage/gh-17678:
-    dependencies:
-      '@astrojs/vercel':
-        specifier: workspace:*
-        version: link:../../packages/integrations/vercel
-      astro:
-        specifier: workspace:*
-        version: link:../../packages/astro
-
 packages:
 
   '@anthropic-ai/sdk@0.91.1':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6435,6 +6435,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/server-islands-static:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/serverless-prerender:
     dependencies:
       '@astrojs/vercel':
@@ -7127,6 +7136,15 @@ importers:
       tsx:
         specifier: ^4.22.0
         version: 4.22.3
+
+  triage/gh-17678:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../packages/integrations/vercel
+      astro:
+        specifier: workspace:*
+        version: link:../../packages/astro
 
 packages:
 


### PR DESCRIPTION
## Changes

- Fixes `server:defer` components returning 404 responses on Vercel when using `output: "static"`.
- Preserves a dedicated server build directory and packages it through the existing Vercel serverless and middleware path only when Astro runs the SSR build for discovered server islands. Fully static sites continue to emit no serverless function, and server build files are not published as static assets.

Closes #17678

## Testing

- Adds a static server-islands fixture that verifies `_render.func`, its route configuration, and rendering through the packaged function.
- Verifies the server entry is excluded from static assets and a fully static fixture does not create a serverless function.

## Docs

- No docs update needed because this restores the documented `server:defer` behavior for static output.