### PR TITLE
Apply `prerenderConflictBehavior` to content collection duplicate ID warnings

### DIFF
--- a/.changeset/petite-dogs-unite.md
+++ b/.changeset/petite-dogs-unite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `prerenderConflictBehavior` not applying to content collection duplicate ID warnings in the `glob()` and `file()` loaders. Setting it to `'error'` now throws during content sync, and `'ignore'` suppresses the warning.

--- a/packages/astro/src/content/loaders/file.ts
+++ b/packages/astro/src/content/loaders/file.ts
@@ -2,7 +2,11 @@ import { existsSync, promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import * as yaml from 'js-yaml';
 import * as toml from 'smol-toml';
-import { FileGlobNotSupported, FileParserNotFound } from '../../core/errors/errors-data.js';
+import {
+	DuplicateContentEntrySlugError,
+	FileGlobNotSupported,
+	FileParserNotFound,
+} from '../../core/errors/errors-data.js';
 import { AstroError } from '../../core/errors/index.js';
 import { posixRelative } from '../utils.js';
 import type { Loader, LoaderContext } from './types.js';
@@ -49,7 +53,10 @@ export function file(fileName: string, options?: FileOptions): Loader {
 		});
 	}
 
-	async function syncData(filePath: string, { logger, parseData, store, config }: LoaderContext) {
+	async function syncData(
+		filePath: string,
+		{ logger, parseData, store, config, collection }: LoaderContext,
+	) {
 		let data: Array<Record<string, unknown>> | Record<string, Record<string, unknown>>;
 
 		try {
@@ -77,9 +84,20 @@ export function file(fileName: string, options?: FileOptions): Loader {
 					continue;
 				}
 				if (idList.has(id)) {
-					logger.warn(
-						`Duplicate id "${id}" found in ${fileName}. Later items with the same id will overwrite earlier ones.`,
+					const message = DuplicateContentEntrySlugError.message(
+						collection,
+						id,
+						fileName,
+						fileName,
 					);
+					if (config.prerenderConflictBehavior === 'error') {
+						throw new AstroError({
+							...DuplicateContentEntrySlugError,
+							message,
+						});
+					} else if (config.prerenderConflictBehavior !== 'ignore') {
+						logger.warn(message);
+					}
 				}
 				idList.add(id);
 				const parsedData = await parseData({ id, data: rawItem, filePath });

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -6,6 +6,8 @@ import colors from 'piccolore';
 import picomatch from 'picomatch';
 import { glob as tinyglobby } from 'tinyglobby';
 import type { ContentEntryRenderFunction, ContentEntryType } from '../../types/public/content.js';
+import * as AstroErrorData from '../../core/errors/errors-data.js';
+import { AstroError } from '../../core/errors/index.js';
 import type { RenderedContent } from '../data-store.js';
 import { getContentEntryIdAndSlug, posixRelative } from '../utils.js';
 import type { Loader } from './types.js';
@@ -186,9 +188,20 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 					// the unlink event just hasn't been processed yet
 					const oldFilePath = new URL(existingEntry.filePath, config.root);
 					if (existsSync(oldFilePath)) {
-						logger.warn(
-							`Duplicate id "${id}" found in ${filePath}. Later items with the same id will overwrite earlier ones.`,
+						const message = AstroErrorData.DuplicateContentEntrySlugError.message(
+							collection,
+							id,
+							existingEntry.filePath,
+							relativePath,
 						);
+						if (config.prerenderConflictBehavior === 'error') {
+							throw new AstroError({
+								...AstroErrorData.DuplicateContentEntrySlugError,
+								message,
+							});
+						} else if (config.prerenderConflictBehavior !== 'ignore') {
+							logger.warn(message);
+						}
 					}
 				}
 

--- a/packages/astro/test/units/content-layer/file-loader.test.ts
+++ b/packages/astro/test/units/content-layer/file-loader.test.ts
@@ -283,11 +283,88 @@ describe('File Loader', () => {
 		await contentLayer.sync();
 
 		// Check that a warning was logged
-		assert.ok(warnings.some((w) => w.includes('Duplicate id "beagle"')));
+		assert.ok(warnings.some((w) => w.includes('beagle')));
 
 		// Check that the last entry won
 		const entries = store.values('dogsWithDupes');
 		assert.equal(entries.length, 1);
 		assert.equal(entries[0].data.breed, 'Beagle 2');
+	});
+
+	it('throws on duplicate IDs when prerenderConflictBehavior is error', async () => {
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root, {
+			config: { prerenderConflictBehavior: 'error' },
+		});
+
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'info',
+		});
+
+		const collections = {
+			dogsWithDupes: defineCollection({
+				loader: file('src/data/dogs.json', {
+					parser: () => [
+						{ id: 'beagle', breed: 'Beagle 1' },
+						{ id: 'beagle', breed: 'Beagle 2' },
+					],
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await assert.rejects(() => contentLayer.sync(), {
+			name: 'DuplicateContentEntrySlugError',
+		});
+	});
+
+	it('suppresses duplicate ID warning when prerenderConflictBehavior is ignore', async () => {
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(root, {
+			config: { prerenderConflictBehavior: 'ignore' },
+		});
+
+		const warnings: string[] = [];
+		const logger = new AstroLogger({
+			destination: {
+				write: (msg: any) => {
+					if (msg.level === 'warn') {
+						warnings.push(msg.message);
+					}
+					return true;
+				},
+			},
+			level: 'info',
+		});
+
+		const collections = {
+			dogsWithDupes: defineCollection({
+				loader: file('src/data/dogs.json', {
+					parser: () => [
+						{ id: 'beagle', breed: 'Beagle 1' },
+						{ id: 'beagle', breed: 'Beagle 2' },
+					],
+				}),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		// No duplicate warnings should be logged
+		assert.ok(!warnings.some((w) => w.includes('beagle')));
 	});
 });

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -1,11 +1,15 @@
 import { strict as assert } from 'node:assert';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { glob } from '../../../dist/content/loaders/glob.js';
 import { defineCollection } from '../../../dist/content/config.js';
 import { ContentLayer } from '../../../dist/content/content-layer.js';
 import { MutableDataStore } from '../../../dist/content/mutable-data-store.js';
 import { AstroLogger } from '../../../dist/core/logger/core.js';
 import {
+	createTempDir,
 	createTestConfigObserver,
 	createMinimalSettings,
 	createMarkdownEntryType,
@@ -507,5 +511,94 @@ describe('Glob Loader', () => {
 		await contentLayer.sync();
 
 		assert.ok(warnings.some((w) => w.includes('No files found matching')));
+	});
+
+	it('throws on duplicate IDs when prerenderConflictBehavior is error', async () => {
+		const tempDir = createTempDir();
+		const contentDir = join(fileURLToPath(tempDir), 'src', 'content', 'posts');
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(contentDir, { recursive: true });
+		writeFileSync(join(contentDir, 'post.md'), '---\ntitle: Post MD\n---\nContent MD');
+		writeFileSync(join(contentDir, 'post.mdx'), '---\ntitle: Post MDX\n---\nContent MDX');
+
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(tempDir, {
+			contentEntryTypes: [
+				createMarkdownEntryType(),
+				{ extensions: ['.mdx'], getEntryInfo: createMarkdownEntryType().getEntryInfo },
+			],
+			config: { prerenderConflictBehavior: 'error' },
+		});
+
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'info',
+		});
+
+		const collections = {
+			posts: defineCollection({
+				loader: glob({ pattern: '*.{md,mdx}', base: 'src/content/posts' }),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await assert.rejects(() => contentLayer.sync(), {
+			name: 'DuplicateContentEntrySlugError',
+		});
+	});
+
+	it('suppresses duplicate ID warning when prerenderConflictBehavior is ignore', async () => {
+		const tempDir = createTempDir();
+		const contentDir = join(fileURLToPath(tempDir), 'src', 'content', 'posts');
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(contentDir, { recursive: true });
+		writeFileSync(join(contentDir, 'post.md'), '---\ntitle: Post MD\n---\nContent MD');
+		writeFileSync(join(contentDir, 'post.mdx'), '---\ntitle: Post MDX\n---\nContent MDX');
+
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(tempDir, {
+			contentEntryTypes: [
+				createMarkdownEntryType(),
+				{ extensions: ['.mdx'], getEntryInfo: createMarkdownEntryType().getEntryInfo },
+			],
+			config: { prerenderConflictBehavior: 'ignore' },
+		});
+
+		const warnings: string[] = [];
+		const logger = new AstroLogger({
+			destination: {
+				write: (msg: any) => {
+					if (msg.level === 'warn') {
+						warnings.push(msg.message);
+					}
+					return true;
+				},
+			},
+			level: 'info',
+		});
+
+		const collections = {
+			posts: defineCollection({
+				loader: glob({ pattern: '*.{md,mdx}', base: 'src/content/posts' }),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+
+		// No duplicate warnings should be logged
+		assert.ok(!warnings.some((w) => w.includes('post')));
 	});
 });


### PR DESCRIPTION
Closes #17679

## Changes

- The `glob()` and `file()` content loaders now respect `prerenderConflictBehavior` when a duplicate entry ID is detected. Previously, both loaders always emitted a hardcoded `logger.warn()` regardless of the config setting.
- `"error"` throws `DuplicateContentEntrySlugError` during content sync; `"ignore"` suppresses the warning entirely; `"warn"` (the default) preserves the existing behavior.

## Testing

- Added tests to `file-loader.test.ts` covering `"error"` (throws), `"warn"` (logs), and `"ignore"` (silent) modes for duplicate IDs in the `file()` loader.
- Added tests to `glob-loader.test.ts` covering the same three modes for duplicate IDs in the `glob()` loader.

## Docs

No docs update needed — `prerenderConflictBehavior` is already documented; this extends its existing behavior to a new context without changing its API or semantics.