### PR TITLE
Fix SSR full reload failing to re-import astro:server-app with third-party Vite plugins

### DIFF
--- a/.changeset/shaky-queens-know.md
+++ b/.changeset/shaky-queens-know.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a dev server error where an SSR full reload triggered by a third-party Vite plugin (such as `@tailwindcss/vite`) could fail with `Failed to load url astro:server-app.js`

--- a/packages/astro/src/vite-plugin-app/index.ts
+++ b/packages/astro/src/vite-plugin-app/index.ts
@@ -2,7 +2,7 @@ import type * as vite from 'vite';
 
 const ASTRO_APP_ID = 'virtual:astro:app';
 const RESOLVED_ASTRO_APP_ID = '\0' + ASTRO_APP_ID;
-export const ASTRO_DEV_SERVER_APP_ID = 'astro:server-app';
+export const ASTRO_DEV_SERVER_APP_ID = 'virtual:astro:server-app';
 
 export function vitePluginApp(): vite.Plugin[] {
 	let command: vite.ResolvedConfig['command'];


### PR DESCRIPTION
Closes #17684

## Changes

- Prefixes `ASTRO_DEV_SERVER_APP_ID` with `virtual:` (changing it from `astro:server-app` to `virtual:astro:server-app`), matching the convention already used by the sibling `virtual:astro:app` module in the same file. Vite's `ModuleGraph._resolveUrl()` skips URL normalization for IDs that start with `virtual:` — without this prefix, Vite appended `.js` to the stored URL, so full-reload attempts via `runner.import("astro:server-app.js")` failed to match Astro's `resolveId` filter.
- Fixes the error `Failed to load url astro:server-app.js` that appeared when a third-party Vite plugin (e.g. `@tailwindcss/vite`) triggered an SSR full reload on a non-page file.

## Testing

- No automated test added — reproducing this requires a live dev server with `@tailwindcss/vite` triggering an SSR full reload, which is outside the current unit/integration test infrastructure.
- Fix was manually verified against the minimal reproduction from the issue; editing `src/content/test.md` now produces `[vite] program reload` without the `astro:server-app.js` error, and the server continues serving successfully. Confirmed by the issue reporter (@mavam).

## Docs

No docs update needed — this is an internal virtual module ID fix with no user-facing API change.