### PR TITLE
Make create-astro tests local

### DIFF
--- a/packages/create-astro/test/units/proxy.test.ts
+++ b/packages/create-astro/test/units/proxy.test.ts
@@ -1,8 +1,13 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 const createAstroPath = path.resolve(fileURLToPath(import.meta.url), '../../../create-astro.mjs');
 
@@ -32,33 +37,49 @@ describe('proxy support', () => {
 			// This proves the proxy env var was respected.
 			const output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
 			assert.ok(
-				output.includes('ECONNREFUSED') || output.includes('127.0.0.1:19999'),
+				output.includes('ECONNREFUSED') ||
+					output.includes('127.0.0.1:19999') ||
+					output.includes('Unable to connect to the internet'),
 				`Expected proxy connection error, got: ${output.substring(0, 500)}`,
 			);
 		}
 	});
 
-	it('works normally without proxy env vars', () => {
-		// Without proxy vars, create-astro should not re-exec and should work normally
-		const result = execFileSync(
-			process.execPath,
-			[createAstroPath, '--template', 'minimal', '--yes', '--dry-run'],
-			{
-				env: {
-					...process.env,
-					HTTP_PROXY: '',
-					HTTPS_PROXY: '',
-					http_proxy: '',
-					https_proxy: '',
+	it('works normally without proxy env vars', async () => {
+		// Without proxy vars, create-astro should not re-exec and should work normally.
+		// Point --template at a local server (via create-astro's third-party template
+		// support) instead of a real GitHub template, so this test doesn't depend on
+		// GitHub being reachable. `execFile` (not `execFileSync`) is required here since
+		// a synchronous child process would block this process's event loop and prevent
+		// the local server below from accepting the connection.
+		const server = http.createServer((_req, res) => {
+			res.writeHead(200);
+			res.end();
+		});
+		await new Promise<void>((resolve) => server.listen(0, resolve));
+		const { port } = server.address() as AddressInfo;
+
+		try {
+			const { stdout } = await execFileAsync(
+				process.execPath,
+				[createAstroPath, '--template', `http://127.0.0.1:${port}/template`, '--yes', '--dry-run'],
+				{
+					env: {
+						...process.env,
+						HTTP_PROXY: '',
+						HTTPS_PROXY: '',
+						http_proxy: '',
+						https_proxy: '',
+					},
+					timeout: 15000,
 				},
-				timeout: 15000,
-				stdio: 'pipe',
-			},
-		);
-		const output = result.toString();
-		assert.ok(
-			output.includes('Skipping template copying') || output.includes('Project initialized'),
-			`Expected normal dry-run output, got: ${output.substring(0, 500)}`,
-		);
+			);
+			assert.ok(
+				stdout.includes('Skipping template copying') || stdout.includes('Project initialized'),
+				`Expected normal dry-run output, got: ${stdout.substring(0, 500)}`,
+			);
+		} finally {
+			server.close();
+		}
 	});
 });

--- a/packages/create-astro/test/verify.test.ts
+++ b/packages/create-astro/test/verify.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it, mock } from 'node:test';
 import { verify } from '../dist/index.js';
 import { mockExit, setup, type VerifyContext } from './test-utils.ts';
 
@@ -11,13 +11,34 @@ describe('verify', async () => {
 		exit: mockExit,
 	} satisfies Partial<VerifyContext>;
 
+	const originalFetch = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	// `verify()` checks whether a template exists by making a real request to GitHub.
+	// Mock `fetch` so these tests exercise `verify()`'s own logic without depending on
+	// GitHub being reachable, which has caused flaky CI failures (`SocketError: other
+	// side closed`) when hitting `github.com` directly.
+	function mockFetch(found: boolean) {
+		globalThis.fetch = mock.fn(async (input: string | URL) => {
+			// Resolves the default branch for templates that don't pin a ref (e.g. Starlight examples).
+			if (String(input).startsWith('https://api.github.com/')) {
+				return new Response(JSON.stringify({ default_branch: 'main' }), { status: 200 });
+			}
+			return new Response(null, { status: found ? 200 : 404 });
+		}) as unknown as typeof fetch;
+	}
+
 	it('basics', async () => {
+		mockFetch(true);
 		const context: VerifyContext = { ...baseContext, template: 'basics' };
 		await verify(context);
 		assert.equal(fixture.messages().length, 0, 'Did not expect `verify` to log any messages');
 	});
 
 	it('missing', async () => {
+		mockFetch(false);
 		const context: VerifyContext = { ...baseContext, template: 'missing' };
 		let err = null;
 		try {
@@ -30,12 +51,14 @@ describe('verify', async () => {
 	});
 
 	it('starlight', async () => {
+		mockFetch(true);
 		const context: VerifyContext = { ...baseContext, template: 'starlight' };
 		await verify(context);
 		assert.equal(fixture.messages().length, 0, 'Did not expect `verify` to log any messages');
 	});
 
 	it('starlight/tailwind', async () => {
+		mockFetch(true);
 		const context: VerifyContext = { ...baseContext, template: 'starlight/tailwind' };
 		await verify(context);
 		assert.equal(fixture.messages().length, 0, 'Did not expect `verify` to log any messages');


### PR DESCRIPTION
## Changes

- No code changes, just tests

## Testing

- Uses a local mock rather than going to GitHub, to prevent flakiness caused by GitHub not responding in time.

## Docs

N/A, test fix