### PR TITLE
Update e18e dependency diffing action

### DIFF
--- a/.github/workflows/diff-dependencies.yml
+++ b/.github/workflows/diff-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0 # allows the diff action to access git history
 
       - name: Create Diff
-        uses: e18e/action-dependency-diff@5d3c6ac2ad2de2eaca1dc120c5accfd9590764b6 # v1.5.1
+        uses: e18e/action-dependency-diff@9a7f09f5f2993256322e0db17ee4c8d9339dab77 # v1.7.1
         with:
           # We’re using this package primarily to track size changes, not as worried about duplicates
           duplicate-threshold: 100


### PR DESCRIPTION
## Changes

- Updates the dependency diffing action to [1.7.1](https://github.com/e18e/action-dependency-diff/releases/tag/v1.7.1). Primarily to fix a bug for PRs from branches that were behind `main` where they would report changes that were inaccurate as you can see in https://github.com/withastro/astro/pull/17688#issuecomment-5282371369 for example. The issue should be fixed by https://github.com/e18e/action-dependency-diff/pull/177 which is included in the 1.7.1 release.
- Versions 1.6 and 1.7 updated internal dependencies, improved trusted publishing checks, and fixed duplicate scanning (a feature we don’t use) so otherwise should be a safe update.

## Testing

Tested upstream, 🤞 

## Docs
n/a
