### PR TITLE
Fix page directory boundary detection

### DIFF
--- a/.changeset/soft-pages-boundary.md
+++ b/.changeset/soft-pages-boundary.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevents files in directories whose names start with `pages` from being treated as page routes

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -77,8 +77,8 @@ export function resolvePages(config: AstroConfig) {
 }
 
 function isInPagesDir(file: URL, config: AstroConfig): boolean {
-	const pagesDir = resolvePages(config);
-	return file.toString().startsWith(pagesDir.toString());
+	const pagesDir = `${resolvePages(config).toString()}/`;
+	return file.toString().startsWith(pagesDir);
 }
 
 function isInjectedRoute(file: URL, settings: AstroSettings) {

--- a/packages/astro/test/units/util/core-util.test.ts
+++ b/packages/astro/test/units/util/core-util.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isEndpoint, isPage } from '../../../dist/core/util.js';
+import type { AstroSettings } from '../../../dist/types/astro.js';
+
+const root = new URL('file:///project/');
+const settings = {
+	config: {
+		root,
+		srcDir: new URL('./src/', root),
+	},
+	pageExtensions: ['.astro'],
+	resolvedInjectedRoutes: [],
+} as unknown as AstroSettings;
+
+describe('page directory detection', () => {
+	it('detects pages and endpoints inside the pages directory', () => {
+		assert.equal(isPage(new URL('pages/index.astro', settings.config.srcDir), settings), true);
+		assert.equal(isPage(new URL('pages/blog/post.astro', settings.config.srcDir), settings), true);
+		assert.equal(isEndpoint(new URL('pages/api.ts', settings.config.srcDir), settings), true);
+		assert.equal(isEndpoint(new URL('pages/index.astro', settings.config.srcDir), settings), false);
+	});
+
+	it('rejects files in sibling directories with the same prefix', () => {
+		assert.equal(isPage(new URL('pages-old/card.astro', settings.config.srcDir), settings), false);
+		assert.equal(isPage(new URL('pages2/card.astro', settings.config.srcDir), settings), false);
+		assert.equal(isEndpoint(new URL('pages-old/api.ts', settings.config.srcDir), settings), false);
+		assert.equal(isEndpoint(new URL('pages2/api.ts', settings.config.srcDir), settings), false);
+	});
+});


### PR DESCRIPTION
## Changes

- Require a directory boundary when checking whether a file is inside `src/pages`.
- Prevent sibling directories such as `src/pages-old` and `src/pages2` from receiving page-only handling.
- Add regression coverage for pages, nested pages, endpoints, and sibling-directory false positives.

## Testing

- `pnpm --filter astro exec astro-scripts test "test/units/util/*.test.ts" --strip-types` (41 passed)
- `pnpm --filter astro build`
- `pnpm lint:ai`

## Docs

No docs changes. This fixes internal path classification without changing the public API.