### PR TITLE
feat(appwrite): add Appwrite CDN cache provider for route caching

### DIFF
--- a/.changeset/wild-pandas-cache.md
+++ b/.changeset/wild-pandas-cache.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/appwrite': minor
+---
+
+Adds `@astrojs/appwrite`, the Appwrite CDN cache provider for route caching. `cacheAppwrite()` maps `Astro.cache.set()` and `routeRules` onto the `Appwrite-CDN-Cache-Control` and `Appwrite-CDN-Cache-Key` headers, and implements `cache.invalidate()` as a cache key or path purge through the Appwrite API. Appwrite Sites runs Astro through `@astrojs/node`, which stays the adapter.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,6 +60,12 @@
 
     //#region Adapters
     {
+      "groupName": "@astrojs/appwrite",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["packages/integrations/appwrite/**"]
+    },
+    {
       "groupName": "@astrojs/cloudflare",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],

--- a/packages/integrations/appwrite/README.md
+++ b/packages/integrations/appwrite/README.md
@@ -1,0 +1,75 @@
+# @astrojs/appwrite
+
+This package brings [route caching](https://docs.astro.build/en/guides/caching/) to Astro sites hosted on [Appwrite](https://appwrite.io/). Cache hits are served by the Appwrite CDN, so the site's function is never invoked for them.
+
+Appwrite Sites runs Astro through [`@astrojs/node`](https://docs.astro.build/en/guides/integrations-guide/node/), which stays the adapter. This package supplies the cache provider next to it:
+
+```js
+// astro.config.mjs
+import node from '@astrojs/node';
+import { defineConfig } from 'astro/config';
+import { cacheAppwrite } from '@astrojs/appwrite/cache';
+
+export default defineConfig({
+  adapter: node({ mode: 'standalone' }),
+  cache: {
+    provider: cacheAppwrite(),
+  },
+  routeRules: {
+    '/blog/[...path]': { maxAge: 300, swr: 60 },
+  },
+});
+```
+
+`Astro.cache.set()`, `routeRules` and `cache.invalidate()` then behave as documented. Cache directives are sent as `Appwrite-CDN-Cache-Control` and cache tags as `Appwrite-CDN-Cache-Key`; the Appwrite edge rewrites both into whatever the CDN in front of the domain speaks, and `cache.invalidate()` purges by cache key or by path through the Appwrite API.
+
+For `cache.invalidate()` to be allowed to purge, the site's dynamic API key needs the `proxy.invalidations.write` scope (Appwrite console → your site → **Settings** → **Scopes**). Caching itself works without it.
+
+## Options
+
+Every option is optional; the defaults suit a site deployed on Appwrite Sites.
+
+| Option      | Default                                                                                  | Description                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `domain`    | the domain of the request being served                                                   | Domain(s) purged by `cache.invalidate()`. A purge only clears the domain it names, so a site on several domains has to list them.  |
+| `endpoint`  | `APPWRITE_FUNCTION_API_ENDPOINT`, then `APPWRITE_SITE_API_ENDPOINT`, then Appwrite Cloud | Appwrite API endpoint.                                                                                                             |
+| `projectId` | `APPWRITE_FUNCTION_PROJECT_ID`, then `APPWRITE_SITE_PROJECT_ID`                          | Appwrite project ID.                                                                                                               |
+| `apiKey`    | the `x-appwrite-key` request header, then `APPWRITE_API_KEY`                             | Key used to invalidate. Prefer the default: a value set here is baked into the build output.                                       |
+| `noStore`   | `true`                                                                                   | Send `no-store` for responses that declare no cache intent, so the CDN's default TTL cannot cache a route that never asked for it. |
+
+## Good to know
+
+- **Cache keys are normalized.** The edge splits `Appwrite-CDN-Cache-Key` on whitespace and re-joins the keys with commas for the CDN's `Cache-Tag`, so a tag containing whitespace, a comma or a non-ASCII character is percent-encoded — identically on the response and on the purge. A tag longer than 128 characters once encoded cannot be named by a purge, so it is dropped with a warning; the response is still cached.
+- **A purge is one API call per reference per domain**, and invalidations are rate limited to 60 per minute.
+- **A path purge clears the exact path**, not copies cached under the same path with a query string. Tag those and purge by tag instead.
+- **To purge a whole domain**, call `createInvalidation({ domain, type: 'all' })` directly — Astro's `invalidate()` has no equivalent.
+
+## Support
+
+- Get help in the [Astro Discord][discord]. Post questions in our `#support` forum, or visit our dedicated `#dev` channel to discuss current development and more!
+
+- Check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+- Submit bug reports and feature requests as [GitHub issues][issues].
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR! These links will help you get started:
+
+- [Contributor Manual][contributing]
+- [Code of Conduct][coc]
+- [Community Guide][community]
+
+## License
+
+MIT
+
+Copyright (c) 2023–present [Astro][astro]
+
+[astro]: https://astro.build/
+[contributing]: https://github.com/withastro/astro/blob/main/CONTRIBUTING.md
+[coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
+[community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md
+[discord]: https://astro.build/chat/
+[issues]: https://github.com/withastro/astro/issues
+[astro-integration]: https://docs.astro.build/en/guides/integrations/

--- a/packages/integrations/appwrite/README.md
+++ b/packages/integrations/appwrite/README.md
@@ -29,13 +29,13 @@ For `cache.invalidate()` to be allowed to purge, the site's dynamic API key need
 
 Every option is optional; the defaults suit a site deployed on Appwrite Sites.
 
-| Option      | Default                                                                                  | Description                                                                                                                        |
-| ----------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `domain`    | the domain of the request being served                                                   | Domain(s) purged by `cache.invalidate()`. A purge only clears the domain it names, so a site on several domains has to list them.  |
-| `endpoint`  | `APPWRITE_FUNCTION_API_ENDPOINT`, then `APPWRITE_SITE_API_ENDPOINT`, then Appwrite Cloud | Appwrite API endpoint.                                                                                                             |
-| `projectId` | `APPWRITE_FUNCTION_PROJECT_ID`, then `APPWRITE_SITE_PROJECT_ID`                          | Appwrite project ID.                                                                                                               |
-| `apiKey`    | the `x-appwrite-key` request header, then `APPWRITE_API_KEY`                             | Key used to invalidate. Prefer the default: a value set here is baked into the build output.                                       |
-| `noStore`   | `true`                                                                                   | Send `no-store` for responses that declare no cache intent, so the CDN's default TTL cannot cache a route that never asked for it. |
+| Option      | Default                                                             | Description                                                                                                                        |
+| ----------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `domain`    | the domain of the request being served                              | Domain(s) purged by `cache.invalidate()`. A purge only clears the domain it names, so a site on several domains has to list them.  |
+| `endpoint`  | `APPWRITE_FUNCTION_API_ENDPOINT`, then `APPWRITE_SITE_API_ENDPOINT` | Appwrite API endpoint. Required, so pass it when neither variable is set.                                                          |
+| `projectId` | `APPWRITE_FUNCTION_PROJECT_ID`, then `APPWRITE_SITE_PROJECT_ID`     | Appwrite project ID.                                                                                                               |
+| `apiKey`    | the `x-appwrite-key` request header, then `APPWRITE_API_KEY`        | Key used to invalidate. Prefer the default: a value set here is baked into the build output.                                       |
+| `noStore`   | `true`                                                              | Send `no-store` for responses that declare no cache intent, so the CDN's default TTL cannot cache a route that never asked for it. |
 
 ## Good to know
 

--- a/packages/integrations/appwrite/package.json
+++ b/packages/integrations/appwrite/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@astrojs/appwrite",
+  "description": "Route caching for Astro sites hosted on Appwrite",
+  "version": "0.0.0",
+  "type": "module",
+  "author": "withastro",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/withastro/astro.git",
+    "directory": "packages/integrations/appwrite"
+  },
+  "keywords": [
+    "withastro",
+    "astro-adapter",
+    "appwrite"
+  ],
+  "bugs": "https://github.com/withastro/astro/issues",
+  "exports": {
+    ".": "./dist/index.js",
+    "./cache": "./dist/cache/index.js",
+    "./cache/provider": "./dist/cache/provider.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -b",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
+    "test": "astro-scripts test \"test/*.test.js\""
+  },
+  "dependencies": {
+    "node-appwrite": "https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09"
+  },
+  "peerDependencies": {
+    "astro": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.6",
+    "astro": "workspace:*",
+    "astro-scripts": "workspace:*"
+  },
+  "publishConfig": {
+    "provenance": true
+  }
+}

--- a/packages/integrations/appwrite/package.json
+++ b/packages/integrations/appwrite/package.json
@@ -32,7 +32,7 @@
     "test": "astro-scripts test \"test/*.test.js\""
   },
   "dependencies": {
-    "node-appwrite": "https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09"
+    "node-appwrite": "^28.0.0"
   },
   "peerDependencies": {
     "astro": "^7.0.0"

--- a/packages/integrations/appwrite/src/cache/index.ts
+++ b/packages/integrations/appwrite/src/cache/index.ts
@@ -3,64 +3,41 @@ import type { CacheProviderConfig } from 'astro';
 /**
  * Options for {@link cacheAppwrite}.
  *
- * Every value is optional: on Appwrite Sites the endpoint, project and API key
- * come from the runtime, and the domain to purge comes from the request being
- * served. The options cover the cases where that is not enough — a site
- * reachable on several domains, an invalidation triggered outside of a request,
- * or a self-hosted Appwrite instance.
- *
- * The object is serialized into the build manifest, so it must stay JSON-safe.
+ * Every value is optional becasue Appwrite Sites runtime provides
+ * endpoint, project ID and API key automatically.
+ * Domain to purge comes from the request itself.
  */
 export interface AppwriteCacheConfig {
 	/**
-	 * Domain(s) whose CDN cache is purged by `cache.invalidate()`.
-	 *
-	 * Defaults to the domain of the request being served. Set this when the site
-	 * answers on more than one domain (for example both its `*.appwrite.network`
-	 * subdomain and a custom domain), because a purge only clears the domain it
-	 * names.
+	 * Domain(s) whose CDN cache is purged by `cache.invalidate()`, e.g. `my-app.appwrite.network`.
 	 */
 	domain?: string | string[];
+
 	/**
 	 * Appwrite API endpoint, e.g. `https://<REGION>.cloud.appwrite.io/v1`.
-	 *
-	 * Defaults to `APPWRITE_FUNCTION_API_ENDPOINT`, then
-	 * `APPWRITE_SITE_API_ENDPOINT`, then Appwrite Cloud.
 	 */
 	endpoint?: string;
+
 	/**
-	 * Appwrite project ID.
-	 *
-	 * Defaults to `APPWRITE_FUNCTION_PROJECT_ID`, then
-	 * `APPWRITE_SITE_PROJECT_ID`.
+	 * Appwrite project ID, e.g. `6a78727a0196a3606522`
 	 */
 	projectId?: string;
+
 	/**
-	 * API key used to create invalidations. It needs the
-	 * `proxy.invalidations.write` scope.
-	 *
-	 * Defaults to the dynamic key Appwrite sends on the `x-appwrite-key` request
-	 * header, then `APPWRITE_API_KEY`. Prefer those over hardcoding a key here:
-	 * this value is baked into the build output.
+	 * API key used to create invalidations.
+	 * Key requires `proxy.invalidations.write` scope.
 	 */
 	apiKey?: string;
+
 	/**
-	 * Send `Appwrite-CDN-Cache-Control: no-store` for responses that declare no
-	 * cache intent, so that opting in to route caching never lets the CDN's
-	 * default TTL cache a route that never asked to be cached. Defaults to
-	 * `true`.
-	 *
-	 * Responses that set their own `Cache-Control` are left alone either way.
+	 * Prevent Appwrite CDN from caching the response
+	 * Defaults to `true`.
 	 */
 	noStore?: boolean;
 }
 
 /**
  * Configure the Appwrite CDN cache provider for Astro route caching.
- *
- * Uses `Appwrite-CDN-Cache-Control` and `Appwrite-CDN-Cache-Key` headers for the
- * CDN in front of the site's domain, and `createInvalidation()` from
- * `node-appwrite` for cache key and path invalidation.
  *
  * Appwrite Sites runs Astro through `@astrojs/node`, so this provider is
  * configured next to that adapter:

--- a/packages/integrations/appwrite/src/cache/index.ts
+++ b/packages/integrations/appwrite/src/cache/index.ts
@@ -1,0 +1,88 @@
+import type { CacheProviderConfig } from 'astro';
+
+/**
+ * Options for {@link cacheAppwrite}.
+ *
+ * Every value is optional: on Appwrite Sites the endpoint, project and API key
+ * come from the runtime, and the domain to purge comes from the request being
+ * served. The options cover the cases where that is not enough — a site
+ * reachable on several domains, an invalidation triggered outside of a request,
+ * or a self-hosted Appwrite instance.
+ *
+ * The object is serialized into the build manifest, so it must stay JSON-safe.
+ */
+export interface AppwriteCacheConfig {
+	/**
+	 * Domain(s) whose CDN cache is purged by `cache.invalidate()`.
+	 *
+	 * Defaults to the domain of the request being served. Set this when the site
+	 * answers on more than one domain (for example both its `*.appwrite.network`
+	 * subdomain and a custom domain), because a purge only clears the domain it
+	 * names.
+	 */
+	domain?: string | string[];
+	/**
+	 * Appwrite API endpoint, e.g. `https://<REGION>.cloud.appwrite.io/v1`.
+	 *
+	 * Defaults to `APPWRITE_FUNCTION_API_ENDPOINT`, then
+	 * `APPWRITE_SITE_API_ENDPOINT`, then Appwrite Cloud.
+	 */
+	endpoint?: string;
+	/**
+	 * Appwrite project ID.
+	 *
+	 * Defaults to `APPWRITE_FUNCTION_PROJECT_ID`, then
+	 * `APPWRITE_SITE_PROJECT_ID`.
+	 */
+	projectId?: string;
+	/**
+	 * API key used to create invalidations. It needs the
+	 * `proxy.invalidations.write` scope.
+	 *
+	 * Defaults to the dynamic key Appwrite sends on the `x-appwrite-key` request
+	 * header, then `APPWRITE_API_KEY`. Prefer those over hardcoding a key here:
+	 * this value is baked into the build output.
+	 */
+	apiKey?: string;
+	/**
+	 * Send `Appwrite-CDN-Cache-Control: no-store` for responses that declare no
+	 * cache intent, so that opting in to route caching never lets the CDN's
+	 * default TTL cache a route that never asked to be cached. Defaults to
+	 * `true`.
+	 *
+	 * Responses that set their own `Cache-Control` are left alone either way.
+	 */
+	noStore?: boolean;
+}
+
+/**
+ * Configure the Appwrite CDN cache provider for Astro route caching.
+ *
+ * Uses `Appwrite-CDN-Cache-Control` and `Appwrite-CDN-Cache-Key` headers for the
+ * CDN in front of the site's domain, and `createInvalidation()` from
+ * `node-appwrite` for cache key and path invalidation.
+ *
+ * Appwrite Sites runs Astro through `@astrojs/node`, so this provider is
+ * configured next to that adapter:
+ *
+ * ```js
+ * // astro.config.mjs
+ * import { defineConfig } from 'astro/config';
+ * import node from '@astrojs/node';
+ * import { cacheAppwrite } from '@astrojs/appwrite/cache';
+ *
+ * export default defineConfig({
+ *   adapter: node({ mode: 'standalone' }),
+ *   cache: { provider: cacheAppwrite() },
+ * });
+ * ```
+ */
+export function cacheAppwrite(
+	config: AppwriteCacheConfig = {},
+): CacheProviderConfig<AppwriteCacheConfig> {
+	return {
+		name: 'appwrite',
+		entrypoint: '@astrojs/appwrite/cache/provider',
+		config,
+	};
+}

--- a/packages/integrations/appwrite/src/cache/provider.ts
+++ b/packages/integrations/appwrite/src/cache/provider.ts
@@ -10,36 +10,11 @@ import {
 	toCacheKeys,
 } from './utils.js';
 
-/**
- * Cache directives for the Appwrite CDN. The edge rewrites this into the header
- * the CDN in front of the domain honors and strips it from the response, so it
- * never reaches the browser.
- */
 const CACHE_CONTROL_HEADER = 'Appwrite-CDN-Cache-Control';
+const CACHE_KEY_HEADER = 'Appwrite-CDN-Cache-Key'; // Whitespace-separated
+const API_KEY_HEADER = 'x-appwrite-key'; // Auto-provided by Appwrite Sites runtime
+const CACHE_CONTROL_HEADERS = [CACHE_CONTROL_HEADER, 'Cache-Control']; // Includes browser cache for no-cache support
 
-/** Whitespace-separated cache keys, Appwrite's unit of invalidation. */
-const CACHE_KEY_HEADER = 'Appwrite-CDN-Cache-Key';
-
-/** Deployment-scoped dynamic API key Appwrite sends with every request. */
-const API_KEY_HEADER = 'x-appwrite-key';
-
-/**
- * Headers that already express a cache intent for the response, and that the
- * `no-store` default therefore leaves alone.
- *
- * `CDN-Cache-Control` is deliberately not one of them: Astro strips it from the
- * response once a provider with `onRequest` has run, so a route setting it by
- * hand would otherwise end up announcing nothing at all.
- */
-const CACHE_CONTROL_HEADERS = [CACHE_CONTROL_HEADER, 'Cache-Control'];
-
-/**
- * `invalidate()` receives only what the caller passed to `cache.invalidate()`,
- * but the invalidation API also needs a domain and an API key. Both belong to the
- * request being served, so `onRequest` stashes them here for the invalidations
- * that happen while rendering it. Appwrite Sites runs on Node, so
- * `AsyncLocalStorage` is available.
- */
 const requestScope = new AsyncLocalStorage<RequestScope>();
 
 const factory: CacheProviderFactory<AppwriteCacheConfig> = (config = {}) => {
@@ -51,13 +26,12 @@ const factory: CacheProviderFactory<AppwriteCacheConfig> = (config = {}) => {
 		setHeaders(options) {
 			const headers = new Headers();
 
-			// Appwrite-CDN-Cache-Control (Appwrite-specific, highest priority)
 			const directives = buildCacheControlDirectives(options, ['public']);
 			if (directives) {
 				headers.set(CACHE_CONTROL_HEADER, directives);
 			}
 
-			// Unlike Netlify and Vercel, Appwrite purges a path natively, so there is
+			// Unlike Netlify and Vercel, Appwrite purges a path natively
 			// no auto-generated path tag to spend a cache key on.
 			const keys = toCacheKeys(options.tags);
 			if (keys.length > 0) {
@@ -73,23 +47,17 @@ const factory: CacheProviderFactory<AppwriteCacheConfig> = (config = {}) => {
 			return requestScope.run(
 				{
 					apiKey: context.request.headers.get(API_KEY_HEADER) ?? undefined,
-					// The rule to purge is registered on a bare domain, so the port (a
-					// local `astro preview`, say) is not part of it.
 					domain: context.url.hostname,
 				},
 				async () => {
 					const response = await next();
 
-					// A route that declared no cache intent gets `no-store`, so that
-					// configuring this provider cannot hand the CDN's default TTL a
-					// response nobody asked to have cached.
 					if (noStore && !CACHE_CONTROL_HEADERS.some((header) => response.headers.has(header))) {
 						try {
 							response.headers.set(CACHE_CONTROL_HEADER, 'no-store');
 						} catch {
-							// Some responses (one replayed from another cache layer, say)
-							// have immutable headers. The response is served as-is rather
-							// than rebuilt: no cache intent was declared for it either way.
+							// Ignore relayed response immutable headers exception
+							// Original response already has correct header
 						}
 					}
 
@@ -108,8 +76,7 @@ const factory: CacheProviderFactory<AppwriteCacheConfig> = (config = {}) => {
 
 			const { endpoint, projectId, apiKey } = resolveCredentials(config, scope);
 
-			// Imported lazily so the SDK stays out of the render path of every request
-			// that does not invalidate anything.
+			// Imported lazily so the SDK load doesnt occur on every request
 			const { Client, InvalidationType, Proxy } = await import('node-appwrite');
 
 			const proxy = new Proxy(

--- a/packages/integrations/appwrite/src/cache/provider.ts
+++ b/packages/integrations/appwrite/src/cache/provider.ts
@@ -1,0 +1,132 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { CacheProviderFactory } from 'astro';
+import { buildCacheControlDirectives, setConditionalHeaders } from 'astro/cache/provider-utils';
+import type { AppwriteCacheConfig } from './index.js';
+import {
+	planInvalidations,
+	type RequestScope,
+	resolveCredentials,
+	resolveDomains,
+	toCacheKeys,
+} from './utils.js';
+
+/**
+ * Cache directives for the Appwrite CDN. The edge rewrites this into the header
+ * the CDN in front of the domain honors and strips it from the response, so it
+ * never reaches the browser.
+ */
+const CACHE_CONTROL_HEADER = 'Appwrite-CDN-Cache-Control';
+
+/** Whitespace-separated cache keys, Appwrite's unit of invalidation. */
+const CACHE_KEY_HEADER = 'Appwrite-CDN-Cache-Key';
+
+/** Deployment-scoped dynamic API key Appwrite sends with every request. */
+const API_KEY_HEADER = 'x-appwrite-key';
+
+/**
+ * Headers that already express a cache intent for the response, and that the
+ * `no-store` default therefore leaves alone.
+ *
+ * `CDN-Cache-Control` is deliberately not one of them: Astro strips it from the
+ * response once a provider with `onRequest` has run, so a route setting it by
+ * hand would otherwise end up announcing nothing at all.
+ */
+const CACHE_CONTROL_HEADERS = [CACHE_CONTROL_HEADER, 'Cache-Control'];
+
+/**
+ * `invalidate()` receives only what the caller passed to `cache.invalidate()`,
+ * but the invalidation API also needs a domain and an API key. Both belong to the
+ * request being served, so `onRequest` stashes them here for the invalidations
+ * that happen while rendering it. Appwrite Sites runs on Node, so
+ * `AsyncLocalStorage` is available.
+ */
+const requestScope = new AsyncLocalStorage<RequestScope>();
+
+const factory: CacheProviderFactory<AppwriteCacheConfig> = (config = {}) => {
+	const noStore = config.noStore ?? true;
+
+	return {
+		name: 'appwrite',
+
+		setHeaders(options) {
+			const headers = new Headers();
+
+			// Appwrite-CDN-Cache-Control (Appwrite-specific, highest priority)
+			const directives = buildCacheControlDirectives(options, ['public']);
+			if (directives) {
+				headers.set(CACHE_CONTROL_HEADER, directives);
+			}
+
+			// Unlike Netlify and Vercel, Appwrite purges a path natively, so there is
+			// no auto-generated path tag to spend a cache key on.
+			const keys = toCacheKeys(options.tags);
+			if (keys.length > 0) {
+				headers.set(CACHE_KEY_HEADER, keys.join(' '));
+			}
+
+			setConditionalHeaders(headers, options);
+
+			return headers;
+		},
+
+		onRequest(context, next) {
+			return requestScope.run(
+				{
+					apiKey: context.request.headers.get(API_KEY_HEADER) ?? undefined,
+					// The rule to purge is registered on a bare domain, so the port (a
+					// local `astro preview`, say) is not part of it.
+					domain: context.url.hostname,
+				},
+				async () => {
+					const response = await next();
+
+					// A route that declared no cache intent gets `no-store`, so that
+					// configuring this provider cannot hand the CDN's default TTL a
+					// response nobody asked to have cached.
+					if (noStore && !CACHE_CONTROL_HEADERS.some((header) => response.headers.has(header))) {
+						try {
+							response.headers.set(CACHE_CONTROL_HEADER, 'no-store');
+						} catch {
+							// Some responses (one replayed from another cache layer, say)
+							// have immutable headers. The response is served as-is rather
+							// than rebuilt: no cache intent was declared for it either way.
+						}
+					}
+
+					return response;
+				},
+			);
+		},
+
+		async invalidate(options) {
+			const scope = requestScope.getStore();
+			const invalidations = planInvalidations(options, resolveDomains(config, scope));
+
+			if (invalidations.length === 0) {
+				return;
+			}
+
+			const { endpoint, projectId, apiKey } = resolveCredentials(config, scope);
+
+			// Imported lazily so the SDK stays out of the render path of every request
+			// that does not invalidate anything.
+			const { Client, InvalidationType, Proxy } = await import('node-appwrite');
+
+			const proxy = new Proxy(
+				new Client().setEndpoint(endpoint).setProject(projectId).setKey(apiKey),
+			);
+
+			await Promise.all(
+				invalidations.map(({ domain, type, reference }) =>
+					proxy.createInvalidation({
+						domain,
+						type: type === 'path' ? InvalidationType.Path : InvalidationType.Tag,
+						reference,
+					}),
+				),
+			);
+		},
+	};
+};
+
+export default factory;

--- a/packages/integrations/appwrite/src/cache/utils.ts
+++ b/packages/integrations/appwrite/src/cache/utils.ts
@@ -1,0 +1,214 @@
+import type { InvalidateOptions } from 'astro';
+import { normalizeTags } from 'astro/cache/provider-utils';
+import type { AppwriteCacheConfig } from './index.js';
+
+/** Appwrite Cloud, used when neither the config nor the runtime names an endpoint. */
+const DEFAULT_ENDPOINT = 'https://cloud.appwrite.io/v1';
+
+/**
+ * Longest cache key the invalidation API accepts as a `tag` reference. A longer
+ * key can be attached to a response but never purged, so it is dropped on both
+ * the response path and the purge path instead.
+ */
+export const CACHE_KEY_MAX_LENGTH = 128;
+
+/**
+ * Characters that reach the CDN unchanged. Everything else is percent-encoded,
+ * including `%` itself so the encoding stays reversible and a tag always
+ * normalizes to the same key on both paths.
+ *
+ * The edge splits `Appwrite-CDN-Cache-Key` on whitespace and re-joins the keys
+ * with commas for the CDN's `Cache-Tag`, so a key containing whitespace would
+ * become several keys and a key containing a comma would corrupt the header —
+ * in both cases the response ends up tagged with something no purge can name.
+ */
+const UNSAFE_KEY_CHARS = /[^A-Za-z0-9\-_.:~!$&'()*+;=@/]+/gu;
+
+const warned = new Set<string>();
+
+export class AppwriteCacheError extends Error {
+	override name = 'AppwriteCacheError';
+}
+
+/**
+ * Request-scoped values the invalidation API needs but `invalidate(options)`
+ * does not carry: the dynamic API key Appwrite sends with every request, and
+ * the domain the response was served on.
+ */
+export interface RequestScope {
+	apiKey?: string;
+	domain?: string;
+}
+
+export interface AppwriteCredentials {
+	endpoint: string;
+	projectId: string;
+	apiKey: string;
+}
+
+/** A single `POST /proxy/invalidations` call. */
+export interface Invalidation {
+	domain: string;
+	type: 'tag' | 'path';
+	reference: string;
+}
+
+/**
+ * Convert an Astro cache tag into an Appwrite cache key. Returns `null` when the
+ * tag cannot be represented as one.
+ */
+export function normalizeCacheKey(tag: string): string | null {
+	const key = tag.trim().replace(UNSAFE_KEY_CHARS, percentEncode);
+
+	if (!key) {
+		return null;
+	}
+
+	if (key.length > CACHE_KEY_MAX_LENGTH) {
+		warnOnce(
+			`[appwrite] Cache tag ${JSON.stringify(tag)} is longer than ${CACHE_KEY_MAX_LENGTH} characters once encoded and was skipped. Responses are still cached, but this tag cannot be invalidated.`,
+		);
+		return null;
+	}
+
+	return key;
+}
+
+/**
+ * Normalize Astro cache tags into deduplicated Appwrite cache keys, in the order
+ * they were declared.
+ */
+export function toCacheKeys(tags: readonly string[] | undefined): string[] {
+	if (!tags?.length) {
+		return [];
+	}
+
+	const keys = new Set<string>();
+	for (const tag of tags) {
+		const key = normalizeCacheKey(tag);
+		if (key) {
+			keys.add(key);
+		}
+	}
+
+	return [...keys];
+}
+
+/**
+ * Expand `cache.invalidate()` options into the invalidations to create.
+ *
+ * Appwrite purges one cache key or one URL path per call, for one domain, so `n`
+ * references across `m` domains is `n * m` calls. Returns an empty list when
+ * there is nothing to purge.
+ */
+export function planInvalidations(
+	options: InvalidateOptions,
+	domains: readonly string[],
+): Invalidation[] {
+	const references: Array<Omit<Invalidation, 'domain'>> = [];
+
+	for (const key of toCacheKeys(normalizeTags(options.tags))) {
+		references.push({ type: 'tag', reference: key });
+	}
+
+	if (options.path) {
+		references.push({ type: 'path', reference: normalizePathReference(options.path) });
+	}
+
+	return domains.flatMap((domain) => references.map((reference) => ({ domain, ...reference })));
+}
+
+/**
+ * Reduce a path to what the invalidation API accepts as a `path` reference: an
+ * absolute path with no relative segments, no query and no fragment. A full URL
+ * is accepted and reduced to its path.
+ *
+ * A path purge clears the exact URL, so responses cached under the same path
+ * with a query string are not covered by it.
+ */
+export function normalizePathReference(path: string): string {
+	// Resolving against a base normalizes `.`/`..` segments, percent-encodes what
+	// the API would reject, and drops the query and fragment for free.
+	return new URL(path, 'https://astrojs-appwrite.invalid').pathname;
+}
+
+/**
+ * Resolve the client credentials for an invalidation, preferring explicit config
+ * over the request over the runtime environment.
+ */
+export function resolveCredentials(
+	config: AppwriteCacheConfig,
+	scope: RequestScope | undefined,
+	env: Record<string, string | undefined> = process.env,
+): AppwriteCredentials {
+	const endpoint =
+		config.endpoint ||
+		env.APPWRITE_FUNCTION_API_ENDPOINT ||
+		env.APPWRITE_SITE_API_ENDPOINT ||
+		DEFAULT_ENDPOINT;
+
+	const projectId =
+		config.projectId || env.APPWRITE_FUNCTION_PROJECT_ID || env.APPWRITE_SITE_PROJECT_ID;
+
+	// The dynamic key on the request is scoped to this deployment and expires with
+	// it, which makes it a better default than a long-lived key in the environment.
+	const apiKey = config.apiKey || scope?.apiKey || env.APPWRITE_API_KEY;
+
+	if (!projectId) {
+		throw new AppwriteCacheError(
+			'Could not determine the Appwrite project to invalidate. Set `APPWRITE_FUNCTION_PROJECT_ID` or pass `projectId` to `cacheAppwrite()`.',
+		);
+	}
+
+	if (!apiKey) {
+		throw new AppwriteCacheError(
+			'Could not determine an Appwrite API key to invalidate with. Invalidate from a request so the `x-appwrite-key` header is available, or set `APPWRITE_API_KEY`, or pass `apiKey` to `cacheAppwrite()`. The key needs the `proxy.invalidations.write` scope.',
+		);
+	}
+
+	return { endpoint, projectId, apiKey };
+}
+
+/**
+ * Resolve which domains to purge. A purge only clears the domain it names, so a
+ * site on several domains has to name each of them.
+ */
+export function resolveDomains(
+	config: AppwriteCacheConfig,
+	scope: RequestScope | undefined,
+): string[] {
+	const configured = config.domain
+		? Array.isArray(config.domain)
+			? config.domain
+			: [config.domain]
+		: [];
+
+	const domains = (configured.length > 0 ? configured : [scope?.domain])
+		.map((domain) => domain?.trim().toLowerCase())
+		.filter((domain): domain is string => Boolean(domain));
+
+	if (domains.length === 0) {
+		throw new AppwriteCacheError(
+			'Could not determine which Appwrite domain to invalidate. Invalidate from a request, or pass `domain` to `cacheAppwrite()`.',
+		);
+	}
+
+	return [...new Set(domains)];
+}
+
+/** Percent-encode a run of characters as its UTF-8 bytes. */
+function percentEncode(run: string): string {
+	let encoded = '';
+	for (const byte of new TextEncoder().encode(run)) {
+		encoded += `%${byte.toString(16).padStart(2, '0').toUpperCase()}`;
+	}
+	return encoded;
+}
+
+function warnOnce(message: string): void {
+	if (warned.has(message)) {
+		return;
+	}
+	warned.add(message);
+	console.warn(message);
+}

--- a/packages/integrations/appwrite/src/cache/utils.ts
+++ b/packages/integrations/appwrite/src/cache/utils.ts
@@ -89,22 +89,15 @@ export function planInvalidations(
 }
 
 /**
- * Reduce a path to what the invalidation API accepts as a `path` reference: an
- * absolute path with no relative segments, no query and no fragment. A full URL
- * is accepted and reduced to its path.
- *
- * A path purge clears the exact URL, so responses cached under the same path
- * with a query string are not covered by it.
+ * Ensure path is valid for Appwrite
  */
 export function normalizePathReference(path: string): string {
-	// Resolving against a base normalizes `.`/`..` segments, percent-encodes what
-	// the API would reject, and drops the query and fragment for free.
+	// Ghost URL object for parsing purpose
 	return new URL(path, 'https://astrojs-appwrite.invalid').pathname;
 }
 
 /**
- * Resolve the client credentials for an invalidation, preferring explicit config
- * over the request over the runtime environment.
+ * Resolve the client credentials for use when doing invalidations.
  */
 export function resolveCredentials(
 	config: AppwriteCacheConfig,
@@ -117,8 +110,6 @@ export function resolveCredentials(
 	const projectId =
 		config.projectId || env.APPWRITE_FUNCTION_PROJECT_ID || env.APPWRITE_SITE_PROJECT_ID;
 
-	// The dynamic key on the request is scoped to this deployment and expires with
-	// it, which makes it a better default than a long-lived key in the environment.
 	const apiKey = config.apiKey || scope?.apiKey || env.APPWRITE_API_KEY;
 
 	if (!endpoint) {
@@ -143,8 +134,7 @@ export function resolveCredentials(
 }
 
 /**
- * Resolve which domains to purge. A purge only clears the domain it names, so a
- * site on several domains has to name each of them.
+ * Resolve which domains to purge
  */
 export function resolveDomains(
 	config: AppwriteCacheConfig,

--- a/packages/integrations/appwrite/src/cache/utils.ts
+++ b/packages/integrations/appwrite/src/cache/utils.ts
@@ -2,26 +2,7 @@ import type { InvalidateOptions } from 'astro';
 import { normalizeTags } from 'astro/cache/provider-utils';
 import type { AppwriteCacheConfig } from './index.js';
 
-/** Appwrite Cloud, used when neither the config nor the runtime names an endpoint. */
-const DEFAULT_ENDPOINT = 'https://cloud.appwrite.io/v1';
-
-/**
- * Longest cache key the invalidation API accepts as a `tag` reference. A longer
- * key can be attached to a response but never purged, so it is dropped on both
- * the response path and the purge path instead.
- */
 export const CACHE_KEY_MAX_LENGTH = 128;
-
-/**
- * Characters that reach the CDN unchanged. Everything else is percent-encoded,
- * including `%` itself so the encoding stays reversible and a tag always
- * normalizes to the same key on both paths.
- *
- * The edge splits `Appwrite-CDN-Cache-Key` on whitespace and re-joins the keys
- * with commas for the CDN's `Cache-Tag`, so a key containing whitespace would
- * become several keys and a key containing a comma would corrupt the header —
- * in both cases the response ends up tagged with something no purge can name.
- */
 const UNSAFE_KEY_CHARS = /[^A-Za-z0-9\-_.:~!$&'()*+;=@/]+/gu;
 
 const warned = new Set<string>();
@@ -30,11 +11,6 @@ export class AppwriteCacheError extends Error {
 	override name = 'AppwriteCacheError';
 }
 
-/**
- * Request-scoped values the invalidation API needs but `invalidate(options)`
- * does not carry: the dynamic API key Appwrite sends with every request, and
- * the domain the response was served on.
- */
 export interface RequestScope {
 	apiKey?: string;
 	domain?: string;
@@ -46,7 +22,6 @@ export interface AppwriteCredentials {
 	apiKey: string;
 }
 
-/** A single `POST /proxy/invalidations` call. */
 export interface Invalidation {
 	domain: string;
 	type: 'tag' | 'path';
@@ -54,8 +29,8 @@ export interface Invalidation {
 }
 
 /**
- * Convert an Astro cache tag into an Appwrite cache key. Returns `null` when the
- * tag cannot be represented as one.
+ * Convert an Astro cache tag into an Appwrite cache key.
+ * Returns `null` when the tag cannot be represented as one.
  */
 export function normalizeCacheKey(tag: string): string | null {
 	const key = tag.trim().replace(UNSAFE_KEY_CHARS, percentEncode);
@@ -75,8 +50,7 @@ export function normalizeCacheKey(tag: string): string | null {
 }
 
 /**
- * Normalize Astro cache tags into deduplicated Appwrite cache keys, in the order
- * they were declared.
+ * Normalize Astro cache tags into deduplicated Appwrite cache keys
  */
 export function toCacheKeys(tags: readonly string[] | undefined): string[] {
 	if (!tags?.length) {
@@ -95,11 +69,7 @@ export function toCacheKeys(tags: readonly string[] | undefined): string[] {
 }
 
 /**
- * Expand `cache.invalidate()` options into the invalidations to create.
- *
- * Appwrite purges one cache key or one URL path per call, for one domain, so `n`
- * references across `m` domains is `n * m` calls. Returns an empty list when
- * there is nothing to purge.
+ * Expand `cache.invalidate()` options into Appwrite invalidation
  */
 export function planInvalidations(
 	options: InvalidateOptions,
@@ -142,10 +112,7 @@ export function resolveCredentials(
 	env: Record<string, string | undefined> = process.env,
 ): AppwriteCredentials {
 	const endpoint =
-		config.endpoint ||
-		env.APPWRITE_FUNCTION_API_ENDPOINT ||
-		env.APPWRITE_SITE_API_ENDPOINT ||
-		DEFAULT_ENDPOINT;
+		config.endpoint || env.APPWRITE_FUNCTION_API_ENDPOINT || env.APPWRITE_SITE_API_ENDPOINT;
 
 	const projectId =
 		config.projectId || env.APPWRITE_FUNCTION_PROJECT_ID || env.APPWRITE_SITE_PROJECT_ID;
@@ -153,6 +120,12 @@ export function resolveCredentials(
 	// The dynamic key on the request is scoped to this deployment and expires with
 	// it, which makes it a better default than a long-lived key in the environment.
 	const apiKey = config.apiKey || scope?.apiKey || env.APPWRITE_API_KEY;
+
+	if (!endpoint) {
+		throw new AppwriteCacheError(
+			'Could not determine the Appwrite API endpoint to invalidate against. Set `APPWRITE_FUNCTION_API_ENDPOINT` or pass `endpoint` to `cacheAppwrite()`.',
+		);
+	}
 
 	if (!projectId) {
 		throw new AppwriteCacheError(

--- a/packages/integrations/appwrite/src/cache/utils.ts
+++ b/packages/integrations/appwrite/src/cache/utils.ts
@@ -3,7 +3,7 @@ import { normalizeTags } from 'astro/cache/provider-utils';
 import type { AppwriteCacheConfig } from './index.js';
 
 export const CACHE_KEY_MAX_LENGTH = 128;
-const UNSAFE_KEY_CHARS = /[^A-Za-z0-9\-_.:~!$&'()*+;=@/]+/gu;
+const UNSAFE_KEY_CHARS = /[^\w\-.:~!$&'()*+;=@/]+/gu;
 
 const warned = new Set<string>();
 

--- a/packages/integrations/appwrite/src/index.ts
+++ b/packages/integrations/appwrite/src/index.ts
@@ -1,0 +1,1 @@
+export { type AppwriteCacheConfig, cacheAppwrite } from './cache/index.js';

--- a/packages/integrations/appwrite/test/cache-invalidate.test.js
+++ b/packages/integrations/appwrite/test/cache-invalidate.test.js
@@ -1,0 +1,153 @@
+import * as assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { after, beforeEach, describe, it } from 'node:test';
+import factory from '../dist/cache/provider.js';
+
+/**
+ * The invalidation path is exercised against a stub of the Appwrite API rather
+ * than a mocked SDK, so the test covers the request the SDK actually sends:
+ * the endpoint it hits, the project and key headers it authenticates with, and
+ * the payload the invalidation endpoint validates.
+ */
+let received = [];
+
+// Started before the suite is declared, so that a provider built at declaration
+// time can never fall back to the real Appwrite endpoint.
+const { server, endpoint } = await (async () => {
+	const server = createServer((request, response) => {
+		const chunks = [];
+		request.on('data', (chunk) => chunks.push(chunk));
+		request.on('end', () => {
+			const body = Buffer.concat(chunks).toString();
+			const payload = body ? JSON.parse(body) : undefined;
+			received.push({
+				method: request.method,
+				url: request.url,
+				headers: request.headers,
+				body: payload,
+			});
+
+			if (payload?.reference === 'boom') {
+				response.writeHead(400, { 'content-type': 'application/json' });
+				response.end(JSON.stringify({ message: 'Tag reference is invalid', code: 400 }));
+				return;
+			}
+
+			response.writeHead(201, { 'content-type': 'application/json' });
+			response.end(
+				JSON.stringify({
+					domain: payload?.domain ?? '',
+					type: payload?.type ?? '',
+					reference: payload?.reference ?? '',
+					status: 'pending',
+				}),
+			);
+		});
+	});
+
+	await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+	return { server, endpoint: `http://127.0.0.1:${server.address().port}/v1` };
+})();
+
+after(() => server.close());
+
+beforeEach(() => {
+	received = [];
+});
+
+/**
+ * Invalidate from inside a request, the way a page or an API route does, so the
+ * provider sees the request the invalidation belongs to.
+ */
+function invalidateWhileServing(provider, options, { apiKey = 'dynamic-key' } = {}) {
+	const request = new Request('https://example.appwrite.network/api/revalidate', {
+		method: 'POST',
+		headers: { 'x-appwrite-key': apiKey },
+	});
+
+	return provider.onRequest({ request, url: new URL(request.url) }, async () => {
+		await provider.invalidate(options);
+		return new Response('ok');
+	});
+}
+
+describe('invalidate', () => {
+	const provider = factory({ endpoint, projectId: 'my-project' });
+
+	it('purges a tag on the domain the request was served on', async () => {
+		await invalidateWhileServing(provider, { tags: ['products'] });
+
+		assert.equal(received.length, 1);
+		const [call] = received;
+		assert.equal(call.method, 'POST');
+		assert.equal(call.url, '/v1/proxy/invalidations');
+		assert.deepEqual(call.body, {
+			domain: 'example.appwrite.network',
+			type: 'tag',
+			reference: 'products',
+		});
+	});
+
+	it('authenticates with the project and the dynamic key from the request', async () => {
+		await invalidateWhileServing(provider, { tags: ['products'] }, { apiKey: 'a-dynamic-key' });
+
+		const [{ headers }] = received;
+		assert.equal(headers['x-appwrite-project'], 'my-project');
+		assert.equal(headers['x-appwrite-key'], 'a-dynamic-key');
+	});
+
+	it('purges a path', async () => {
+		await invalidateWhileServing(provider, { path: '/products/123' });
+
+		assert.deepEqual(received[0].body, {
+			domain: 'example.appwrite.network',
+			type: 'path',
+			reference: '/products/123',
+		});
+	});
+
+	it('purges every tag and the path in one call each', async () => {
+		await invalidateWhileServing(provider, { tags: ['products', 'featured'], path: '/products' });
+
+		assert.deepEqual(received.map(({ body }) => `${body.type}:${body.reference}`).sort(), [
+			'path:/products',
+			'tag:featured',
+			'tag:products',
+		]);
+	});
+
+	it('purges each configured domain', async () => {
+		const multiDomain = factory({
+			endpoint,
+			projectId: 'my-project',
+			domain: ['example.com', 'www.example.com'],
+		});
+
+		await invalidateWhileServing(multiDomain, { tags: ['products'] });
+
+		assert.deepEqual(received.map(({ body }) => body.domain).sort(), [
+			'example.com',
+			'www.example.com',
+		]);
+	});
+
+	it('does not call the API when there is nothing to purge', async () => {
+		await invalidateWhileServing(provider, {});
+
+		assert.deepEqual(received, []);
+	});
+
+	it('does not call the API when no domain can be resolved', async () => {
+		await assert.rejects(provider.invalidate({ tags: ['products'] }), {
+			name: 'AppwriteCacheError',
+		});
+		assert.deepEqual(received, []);
+	});
+
+	it('surfaces an API error to the caller', async () => {
+		await assert.rejects(invalidateWhileServing(provider, { tags: ['boom'] }), {
+			message: 'Tag reference is invalid',
+		});
+	});
+});

--- a/packages/integrations/appwrite/test/cache-invalidate.test.js
+++ b/packages/integrations/appwrite/test/cache-invalidate.test.js
@@ -14,7 +14,7 @@ let received = [];
 // Started before the suite is declared, so that a provider built at declaration
 // time can never fall back to the real Appwrite endpoint.
 const { server, endpoint } = await (async () => {
-	const server = createServer((request, response) => {
+	const stub = createServer((request, response) => {
 		const chunks = [];
 		request.on('data', (chunk) => chunks.push(chunk));
 		request.on('end', () => {
@@ -45,9 +45,9 @@ const { server, endpoint } = await (async () => {
 		});
 	});
 
-	await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+	await new Promise((resolve) => stub.listen(0, '127.0.0.1', resolve));
 
-	return { server, endpoint: `http://127.0.0.1:${server.address().port}/v1` };
+	return { server: stub, endpoint: `http://127.0.0.1:${stub.address().port}/v1` };
 })();
 
 after(() => server.close());

--- a/packages/integrations/appwrite/test/cache-provider.test.js
+++ b/packages/integrations/appwrite/test/cache-provider.test.js
@@ -1,0 +1,139 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import factory from '../dist/cache/provider.js';
+
+const provider = factory(undefined);
+const dummyRequest = new Request('https://example.appwrite.network/products/123');
+
+/** Run a request through `onRequest`, rendering `response`. */
+function render(response, { provider: instance = provider } = {}) {
+	const request = dummyRequest;
+	return instance.onRequest({ request, url: new URL(request.url) }, async () => response);
+}
+
+describe('Appwrite cache provider', () => {
+	it('has the correct provider name', () => {
+		assert.equal(provider.name, 'appwrite');
+	});
+
+	describe('setHeaders', () => {
+		it('sets Appwrite-CDN-Cache-Control with public and max-age', () => {
+			const headers = provider.setHeaders({ maxAge: 300 }, dummyRequest);
+			assert.equal(headers.get('Appwrite-CDN-Cache-Control'), 'public, max-age=300');
+		});
+
+		it('includes stale-while-revalidate', () => {
+			const headers = provider.setHeaders({ maxAge: 300, swr: 60 }, dummyRequest);
+			assert.equal(
+				headers.get('Appwrite-CDN-Cache-Control'),
+				'public, max-age=300, stale-while-revalidate=60',
+			);
+		});
+
+		it('sets public even without maxAge or swr', () => {
+			const headers = provider.setHeaders({ tags: ['foo'] }, dummyRequest);
+			assert.equal(headers.get('Appwrite-CDN-Cache-Control'), 'public');
+		});
+
+		it('does not set CDN-Cache-Control (only Appwrite-specific)', () => {
+			const headers = provider.setHeaders({ maxAge: 300 }, dummyRequest);
+			assert.equal(headers.get('CDN-Cache-Control'), null);
+		});
+
+		it('sets Appwrite-CDN-Cache-Key with the tags, space-separated', () => {
+			const headers = provider.setHeaders(
+				{ maxAge: 60, tags: ['products', 'featured'] },
+				dummyRequest,
+			);
+			assert.equal(headers.get('Appwrite-CDN-Cache-Key'), 'products featured');
+		});
+
+		it('normalizes tags into keys the CDN can purge', () => {
+			const headers = provider.setHeaders({ maxAge: 60, tags: ['two words'] }, dummyRequest);
+			assert.equal(headers.get('Appwrite-CDN-Cache-Key'), 'two%20words');
+		});
+
+		it('does not add a path key: Appwrite purges a path natively', () => {
+			const headers = provider.setHeaders({ maxAge: 60 }, dummyRequest);
+			assert.equal(headers.get('Appwrite-CDN-Cache-Key'), null);
+		});
+
+		it('does not set generic Cache-Tag (only Appwrite-specific)', () => {
+			const headers = provider.setHeaders({ maxAge: 60, tags: ['foo'] }, dummyRequest);
+			assert.equal(headers.get('Cache-Tag'), null);
+		});
+
+		it('sets Last-Modified header', () => {
+			const date = new Date('2026-04-15T12:00:00Z');
+			const headers = provider.setHeaders({ maxAge: 60, lastModified: date }, dummyRequest);
+			assert.equal(headers.get('Last-Modified'), 'Wed, 15 Apr 2026 12:00:00 GMT');
+		});
+
+		it('sets ETag header', () => {
+			const headers = provider.setHeaders({ maxAge: 60, etag: '"v1"' }, dummyRequest);
+			assert.equal(headers.get('ETag'), '"v1"');
+		});
+	});
+
+	describe('onRequest', () => {
+		it('returns the rendered response', async () => {
+			const rendered = new Response('hello');
+			assert.equal(await render(rendered), rendered);
+		});
+
+		it('marks a response with no cache intent as no-store', async () => {
+			const response = await render(new Response('hello'));
+			assert.equal(response.headers.get('Appwrite-CDN-Cache-Control'), 'no-store');
+		});
+
+		it('leaves a cached response alone', async () => {
+			const cached = new Response('hello', {
+				headers: { 'Appwrite-CDN-Cache-Control': 'public, max-age=60' },
+			});
+			const response = await render(cached);
+			assert.equal(response.headers.get('Appwrite-CDN-Cache-Control'), 'public, max-age=60');
+		});
+
+		it('leaves a response that sets its own Cache-Control alone', async () => {
+			const response = await render(
+				new Response('hello', { headers: { 'Cache-Control': 'public, max-age=60' } }),
+			);
+			assert.equal(response.headers.get('Appwrite-CDN-Cache-Control'), null);
+		});
+
+		it('still marks a response that only sets CDN-Cache-Control, which Astro strips', async () => {
+			const response = await render(
+				new Response('hello', { headers: { 'CDN-Cache-Control': 'public, max-age=60' } }),
+			);
+			assert.equal(response.headers.get('Appwrite-CDN-Cache-Control'), 'no-store');
+		});
+
+		it('skips the no-store default when it is turned off', async () => {
+			const response = await render(new Response('hello'), {
+				provider: factory({ noStore: false }),
+			});
+			assert.equal(response.headers.get('Appwrite-CDN-Cache-Control'), null);
+		});
+
+		it('serves a response with immutable headers as-is', async () => {
+			const immutable = new Response('hello');
+			Object.defineProperty(immutable, 'headers', {
+				value: new Proxy(immutable.headers, {
+					get(target, property) {
+						if (property === 'set') {
+							return () => {
+								throw new TypeError('immutable');
+							};
+						}
+						const value = Reflect.get(target, property);
+						return typeof value === 'function' ? value.bind(target) : value;
+					},
+				}),
+			});
+
+			const response = await render(immutable);
+			assert.equal(response, immutable);
+			assert.equal(response.headers.get('Appwrite-CDN-Cache-Control'), null);
+		});
+	});
+});

--- a/packages/integrations/appwrite/test/cache-utils.test.js
+++ b/packages/integrations/appwrite/test/cache-utils.test.js
@@ -198,17 +198,6 @@ describe('resolveCredentials', () => {
 		assert.equal(credentials.projectId, 'site-project');
 	});
 
-	it('falls back to Appwrite Cloud when no endpoint is known', () => {
-		const credentials = resolveCredentials(
-			{},
-			{ apiKey: 'dynamic-key' },
-			{
-				APPWRITE_FUNCTION_PROJECT_ID: 'my-project',
-			},
-		);
-		assert.equal(credentials.endpoint, 'https://cloud.appwrite.io/v1');
-	});
-
 	it('falls back to APPWRITE_API_KEY outside of a request', () => {
 		const credentials = resolveCredentials({}, undefined, {
 			...SITE_ENV,
@@ -230,11 +219,26 @@ describe('resolveCredentials', () => {
 		});
 	});
 
-	it('explains how to supply a missing project', () => {
+	it('explains how to supply a missing endpoint', () => {
 		assert.throws(() => resolveCredentials({}, { apiKey: 'dynamic-key' }, {}), {
 			name: 'AppwriteCacheError',
-			message: /APPWRITE_FUNCTION_PROJECT_ID/,
+			message: /APPWRITE_FUNCTION_API_ENDPOINT/,
 		});
+	});
+
+	it('explains how to supply a missing project', () => {
+		assert.throws(
+			() =>
+				resolveCredentials(
+					{},
+					{ apiKey: 'dynamic-key' },
+					{ APPWRITE_FUNCTION_API_ENDPOINT: SITE_ENV.APPWRITE_FUNCTION_API_ENDPOINT },
+				),
+			{
+				name: 'AppwriteCacheError',
+				message: /APPWRITE_FUNCTION_PROJECT_ID/,
+			},
+		);
 	});
 
 	it('explains how to supply a missing API key', () => {

--- a/packages/integrations/appwrite/test/cache-utils.test.js
+++ b/packages/integrations/appwrite/test/cache-utils.test.js
@@ -1,0 +1,281 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	AppwriteCacheError,
+	CACHE_KEY_MAX_LENGTH,
+	normalizeCacheKey,
+	normalizePathReference,
+	planInvalidations,
+	resolveCredentials,
+	resolveDomains,
+	toCacheKeys,
+} from '../dist/cache/utils.js';
+
+describe('cache keys', () => {
+	describe('normalizeCacheKey', () => {
+		it('keeps a plain tag as-is', () => {
+			assert.equal(normalizeCacheKey('products'), 'products');
+		});
+
+		it('keeps the characters Astro tags conventionally use', () => {
+			assert.equal(normalizeCacheKey('products:123'), 'products:123');
+			assert.equal(normalizeCacheKey('astro-path:/products/123'), 'astro-path:/products/123');
+		});
+
+		it('trims surrounding whitespace', () => {
+			assert.equal(normalizeCacheKey('  products  '), 'products');
+		});
+
+		it('encodes inner whitespace, which the edge would split the key on', () => {
+			assert.equal(normalizeCacheKey('two words'), 'two%20words');
+			assert.equal(normalizeCacheKey('tab\tseparated'), 'tab%09separated');
+		});
+
+		it('encodes commas, which would corrupt the CDN cache-tag header', () => {
+			assert.equal(normalizeCacheKey('a,b'), 'a%2Cb');
+		});
+
+		it('encodes percent signs so the encoding stays reversible', () => {
+			assert.equal(normalizeCacheKey('50%off'), '50%25off');
+			// A tag that already looks encoded must not collide with the tag it
+			// would decode to.
+			assert.notEqual(normalizeCacheKey('two%20words'), normalizeCacheKey('two words'));
+		});
+
+		it('encodes non-ASCII as UTF-8 bytes', () => {
+			assert.equal(normalizeCacheKey('café'), 'caf%C3%A9');
+			assert.equal(normalizeCacheKey('🚀'), '%F0%9F%9A%80');
+		});
+
+		it('returns null for a tag with no content', () => {
+			assert.equal(normalizeCacheKey(''), null);
+			assert.equal(normalizeCacheKey('   '), null);
+		});
+
+		it('returns null for a tag too long to be invalidated', () => {
+			const longest = 'a'.repeat(CACHE_KEY_MAX_LENGTH);
+			assert.equal(normalizeCacheKey(longest), longest);
+			assert.equal(normalizeCacheKey(`${longest}a`), null);
+		});
+
+		it('measures the length after encoding', () => {
+			// 43 × 3 encoded bytes = 129 characters.
+			assert.equal(normalizeCacheKey('é'.repeat(43)), null);
+		});
+	});
+
+	describe('toCacheKeys', () => {
+		it('returns an empty list when there are no tags', () => {
+			assert.deepEqual(toCacheKeys(undefined), []);
+			assert.deepEqual(toCacheKeys([]), []);
+		});
+
+		it('preserves declaration order', () => {
+			assert.deepEqual(toCacheKeys(['b', 'a', 'c']), ['b', 'a', 'c']);
+		});
+
+		it('deduplicates tags that normalize to the same key', () => {
+			assert.deepEqual(toCacheKeys(['products', ' products ', 'products']), ['products']);
+		});
+
+		it('drops the tags it cannot represent, keeping the rest', () => {
+			assert.deepEqual(toCacheKeys(['products', '', 'a'.repeat(200), 'featured']), [
+				'products',
+				'featured',
+			]);
+		});
+	});
+});
+
+const DOMAINS = ['example.appwrite.network'];
+
+describe('planInvalidations', () => {
+	it('plans nothing when there is nothing to purge', () => {
+		assert.deepEqual(planInvalidations({}, DOMAINS), []);
+		assert.deepEqual(planInvalidations({ tags: [] }, DOMAINS), []);
+	});
+
+	it('plans one tag purge per tag', () => {
+		assert.deepEqual(planInvalidations({ tags: ['products', 'featured'] }, DOMAINS), [
+			{ domain: 'example.appwrite.network', type: 'tag', reference: 'products' },
+			{ domain: 'example.appwrite.network', type: 'tag', reference: 'featured' },
+		]);
+	});
+
+	it('accepts a single tag as a string', () => {
+		assert.deepEqual(planInvalidations({ tags: 'products' }, DOMAINS), [
+			{ domain: 'example.appwrite.network', type: 'tag', reference: 'products' },
+		]);
+	});
+
+	it('normalizes a tag the same way the response header does', () => {
+		assert.deepEqual(planInvalidations({ tags: ['two words'] }, DOMAINS), [
+			{ domain: 'example.appwrite.network', type: 'tag', reference: 'two%20words' },
+		]);
+	});
+
+	it('plans a path purge, which Appwrite supports natively', () => {
+		assert.deepEqual(planInvalidations({ path: '/products/123' }, DOMAINS), [
+			{ domain: 'example.appwrite.network', type: 'path', reference: '/products/123' },
+		]);
+	});
+
+	it('plans tags and a path together', () => {
+		assert.deepEqual(planInvalidations({ tags: ['products'], path: '/products' }, DOMAINS), [
+			{ domain: 'example.appwrite.network', type: 'tag', reference: 'products' },
+			{ domain: 'example.appwrite.network', type: 'path', reference: '/products' },
+		]);
+	});
+
+	it('repeats every purge for every domain', () => {
+		const plan = planInvalidations({ tags: ['products'], path: '/products' }, [
+			'example.appwrite.network',
+			'example.com',
+		]);
+		assert.deepEqual(
+			plan.map(({ domain, reference }) => `${domain}${reference}`),
+			[
+				'example.appwrite.networkproducts',
+				'example.appwrite.network/products',
+				'example.comproducts',
+				'example.com/products',
+			],
+		);
+	});
+});
+
+describe('normalizePathReference', () => {
+	it('keeps an absolute path', () => {
+		assert.equal(normalizePathReference('/products/123'), '/products/123');
+	});
+
+	it('makes a relative path absolute', () => {
+		assert.equal(normalizePathReference('products/123'), '/products/123');
+	});
+
+	it('resolves relative segments the API would reject', () => {
+		assert.equal(normalizePathReference('/products/../admin'), '/admin');
+		assert.equal(normalizePathReference('/products/./123'), '/products/123');
+	});
+
+	it('drops the query and fragment', () => {
+		assert.equal(normalizePathReference('/products?page=2#top'), '/products');
+	});
+
+	it('reduces a full URL to its path', () => {
+		assert.equal(normalizePathReference('https://example.com/products/123'), '/products/123');
+	});
+
+	it('encodes characters the API would reject', () => {
+		assert.equal(normalizePathReference('/products/two words'), '/products/two%20words');
+	});
+});
+
+const SITE_ENV = {
+	APPWRITE_FUNCTION_API_ENDPOINT: 'https://fra.cloud.appwrite.io/v1',
+	APPWRITE_FUNCTION_PROJECT_ID: 'my-project',
+};
+
+describe('resolveCredentials', () => {
+	it('reads the endpoint and project from the runtime, and the key from the request', () => {
+		assert.deepEqual(resolveCredentials({}, { apiKey: 'dynamic-key' }, SITE_ENV), {
+			endpoint: 'https://fra.cloud.appwrite.io/v1',
+			projectId: 'my-project',
+			apiKey: 'dynamic-key',
+		});
+	});
+
+	it('falls back to the site-flavoured environment variables', () => {
+		const credentials = resolveCredentials(
+			{},
+			{ apiKey: 'dynamic-key' },
+			{
+				APPWRITE_SITE_API_ENDPOINT: 'https://nyc.cloud.appwrite.io/v1',
+				APPWRITE_SITE_PROJECT_ID: 'site-project',
+			},
+		);
+		assert.equal(credentials.endpoint, 'https://nyc.cloud.appwrite.io/v1');
+		assert.equal(credentials.projectId, 'site-project');
+	});
+
+	it('falls back to Appwrite Cloud when no endpoint is known', () => {
+		const credentials = resolveCredentials(
+			{},
+			{ apiKey: 'dynamic-key' },
+			{
+				APPWRITE_FUNCTION_PROJECT_ID: 'my-project',
+			},
+		);
+		assert.equal(credentials.endpoint, 'https://cloud.appwrite.io/v1');
+	});
+
+	it('falls back to APPWRITE_API_KEY outside of a request', () => {
+		const credentials = resolveCredentials({}, undefined, {
+			...SITE_ENV,
+			APPWRITE_API_KEY: 'static-key',
+		});
+		assert.equal(credentials.apiKey, 'static-key');
+	});
+
+	it('prefers explicit config over everything else', () => {
+		const credentials = resolveCredentials(
+			{ endpoint: 'https://appwrite.example.com/v1', projectId: 'other', apiKey: 'configured' },
+			{ apiKey: 'dynamic-key' },
+			{ ...SITE_ENV, APPWRITE_API_KEY: 'static-key' },
+		);
+		assert.deepEqual(credentials, {
+			endpoint: 'https://appwrite.example.com/v1',
+			projectId: 'other',
+			apiKey: 'configured',
+		});
+	});
+
+	it('explains how to supply a missing project', () => {
+		assert.throws(() => resolveCredentials({}, { apiKey: 'dynamic-key' }, {}), {
+			name: 'AppwriteCacheError',
+			message: /APPWRITE_FUNCTION_PROJECT_ID/,
+		});
+	});
+
+	it('explains how to supply a missing API key', () => {
+		assert.throws(() => resolveCredentials({}, undefined, SITE_ENV), {
+			name: 'AppwriteCacheError',
+			message: /proxy\.invalidations\.write/,
+		});
+	});
+});
+
+describe('resolveDomains', () => {
+	it('purges the domain the request was served on', () => {
+		assert.deepEqual(resolveDomains({}, { domain: 'example.appwrite.network' }), [
+			'example.appwrite.network',
+		]);
+	});
+
+	it('prefers the configured domain', () => {
+		assert.deepEqual(resolveDomains({ domain: 'example.com' }, { domain: 'ignored.example' }), [
+			'example.com',
+		]);
+	});
+
+	it('accepts several domains', () => {
+		assert.deepEqual(resolveDomains({ domain: ['example.com', 'www.example.com'] }, undefined), [
+			'example.com',
+			'www.example.com',
+		]);
+	});
+
+	it('normalizes and deduplicates domains', () => {
+		assert.deepEqual(resolveDomains({ domain: [' Example.com ', 'example.com'] }, undefined), [
+			'example.com',
+		]);
+	});
+
+	it('explains how to supply a missing domain', () => {
+		assert.throws(() => resolveDomains({}, undefined), {
+			name: 'AppwriteCacheError',
+			message: /pass `domain` to `cacheAppwrite\(\)`/,
+		});
+		assert.throws(() => resolveDomains({ domain: '  ' }, undefined), AppwriteCacheError);
+	});
+});

--- a/packages/integrations/appwrite/tsconfig.build.json
+++ b/packages/integrations/appwrite/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../configs/tsconfig.build.json",
+  "include": ["./src"],
+  "references": [{ "path": "../../astro/tsconfig.json" }]
+}

--- a/packages/integrations/appwrite/tsconfig.build.json
+++ b/packages/integrations/appwrite/tsconfig.build.json
@@ -1,5 +1,4 @@
 {
   "extends": "../../../configs/tsconfig.build.json",
-  "include": ["./src"],
   "references": [{ "path": "../../astro/tsconfig.json" }]
 }

--- a/packages/integrations/appwrite/tsconfig.json
+++ b/packages/integrations/appwrite/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../configs/tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
+}

--- a/packages/integrations/appwrite/tsconfig.test.json
+++ b/packages/integrations/appwrite/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../configs/tsconfig.test.json",
+  "references": [{ "path": "./tsconfig.build.json" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4557,8 +4557,8 @@ importers:
   packages/integrations/appwrite:
     dependencies:
       node-appwrite:
-        specifier: https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09
-        version: https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09
+        specifier: ^28.0.0
+        version: 28.0.0
     devDependencies:
       '@types/node':
         specifier: ^22.19.0
@@ -13729,9 +13729,8 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-appwrite@https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09:
-    resolution: {integrity: sha512-tjXlc70/tstvyZTQZHIekUldV/dQPPFNttvC5syBaCzkEC457Jg6C73NdVqioUl11ZNLSdfUdd/7oQAB61olZw==, tarball: https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09}
-    version: 27.1.0
+  node-appwrite@28.0.0:
+    resolution: {integrity: sha512-3pLMannNwZf1WUJYdZ998B/ckgAkUGI+Wis31GEwy2NJlx0PooghXe6U3ZJvH86oFaLGl+evnjFWcaQJXu+PZg==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -23713,7 +23712,7 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
-  node-appwrite@https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09:
+  node-appwrite@28.0.0:
     dependencies:
       json-bigint: 1.0.0
       undici: 6.28.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4554,6 +4554,22 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/appwrite:
+    dependencies:
+      node-appwrite:
+        specifier: https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09
+        version: https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.0
+        version: 22.19.19
+      astro:
+        specifier: workspace:*
+        version: link:../../astro
+      astro-scripts:
+        specifier: workspace:*
+        version: link:../../../scripts
+
   packages/integrations/cloudflare:
     dependencies:
       '@astrojs/internal-helpers':
@@ -13713,6 +13729,10 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-appwrite@https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09:
+    resolution: {integrity: sha512-tjXlc70/tstvyZTQZHIekUldV/dQPPFNttvC5syBaCzkEC457Jg6C73NdVqioUl11ZNLSdfUdd/7oQAB61olZw==, tarball: https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09}
+    version: 27.1.0
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -15413,6 +15433,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
 
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
@@ -23689,6 +23713,11 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-appwrite@https://pkg.vc/-/@appwrite/node-appwrite@7c1fc09:
+    dependencies:
+      json-bigint: 1.0.0
+      undici: 6.28.0
+
   node-domexception@1.0.0: {}
 
   node-fetch-native@1.6.7: {}
@@ -25714,6 +25743,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@6.28.0: {}
 
   undici@7.24.8: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "./packages/astro/tsconfig.json" },
     { "path": "./packages/underscore-redirects/tsconfig.json" },
     { "path": "./packages/integrations/alpinejs/tsconfig.json" },
+    { "path": "./packages/integrations/appwrite/tsconfig.json" },
     { "path": "./packages/integrations/cloudflare/tsconfig.json" },
     { "path": "./packages/integrations/markdoc/tsconfig.json" },
     { "path": "./packages/integrations/mdx/tsconfig.json" },


### PR DESCRIPTION
ℹ️ Disclaimer: PR was made mostly with AI agent. I personally reviewed, and iterated until I was happy with final result. I also did manual QA. Going forward, there is no agentic automation for this PR.

Preview package for QA purposes: `npm install @meldiron/astro-appwrite-qa`
Demo app: `https://github.com/Meldiron/qa-appwrite-astro-isr-demo`
Live demo: `https://6a7ee6850015532ce4c1.appwrite.network/isr`

Screenshot:

<img width="1432" height="1298" alt="CleanShot 2026-08-15 at 02 18 41@2x" src="https://github.com/user-attachments/assets/dd41d355-ba96-4d5c-a106-2b08db46bf05" />

Keeping in draft until I can get tests green (blocked on 3 days delay from release of our node SDK)

_What follows is AI description._

---

## Changes

Adds `packages/integrations/appwrite` — `@astrojs/appwrite`, an Appwrite CDN cache provider for [route caching](https://docs.astro.build/en/guides/caching/), alongside the Netlify, Vercel and Cloudflare ones. Cache hits are served by the Appwrite CDN, so the site's function is never invoked for them.

```js
// astro.config.mjs
import node from '@astrojs/node';
import { defineConfig } from 'astro/config';
import { cacheAppwrite } from '@astrojs/appwrite/cache';

export default defineConfig({
  adapter: node({ mode: 'standalone' }),
  cache: { provider: cacheAppwrite() },
  routeRules: { '/blog/[...path]': { maxAge: 300, swr: 60 } },
});
```

**Draft, and deliberately so** — see [Open questions](#open-questions) before spending review time on it. Opening it early to check whether the shape is something core would want at all.

- `setHeaders()` maps `maxAge`/`swr` onto `Appwrite-CDN-Cache-Control` and `tags` onto `Appwrite-CDN-Cache-Key`, built from the existing `astro/cache/provider-utils` helpers.
- `invalidate()` purges by cache key (`type: 'tag'`) or by path (`type: 'path'`) through `node-appwrite`.
- Changeset, renovate group entry, and root `tsconfig.json` reference included.

### Where it differs from the three existing providers

| | Netlify | Vercel | Cloudflare | Appwrite |
| --- | --- | --- | --- | --- |
| directives | `Netlify-CDN-Cache-Control` | `Vercel-CDN-Cache-Control` | `Cloudflare-CDN-Cache-Control` | `Appwrite-CDN-Cache-Control` |
| tags | `Netlify-Cache-Tag`, comma-separated | `Vercel-Cache-Tag`, comma-separated | `Cache-Tag`, comma-separated | `Appwrite-CDN-Cache-Key`, **whitespace**-separated |
| purge by tag | `purgeCache({ tags })` | `invalidateByTag(tag)` | `cache.purge({ tags })` | `createInvalidation({ type: 'tag' })` |
| purge by path | via an `astro-path:` tag | via an `astro-path:` tag | via an `astro-path:` tag | **native** `type: 'path'` purge |

Three consequences worth flagging to a reviewer:

1. **Tags are normalised into cache keys.** The Appwrite edge splits `Appwrite-CDN-Cache-Key` on whitespace, scopes each key to the domain, and re-emits them for the CDN in front of it (space-delimited for one, comma-delimited for the other). A tag containing whitespace would become two keys and one containing a comma would corrupt the comma-delimited header — either way the response ends up tagged with something no purge can name. So tags are percent-encoded by one function used on both the response and the purge path, and a tag over the API's 128-character reference limit is dropped with a warning rather than attached un-purgeably.
2. **No `astro-path:` tag.** Path purging is native, so `invalidate({ path })` does not have to spend a cache key on finding the response again.
3. **The provider implements `onRequest`.** `invalidate(options)` carries no request, but the invalidation API needs a domain and an API key, and both belong to the request being served — so `onRequest` stashes the request's `x-appwrite-key` (a deployment-scoped dynamic key Appwrite sends on every request) and hostname in an `AsyncLocalStorage`. That keeps a long-lived key out of the build output. It also marks responses that declared *no* cache intent as `no-store`, the way `cloudflare/src/utils/handler.ts` does, so enabling the provider can't hand the CDN's default TTL a route that never asked to be cached (`cacheAppwrite({ noStore: false })` opts out). Everything is overridable via `cacheAppwrite({ domain, endpoint, projectId, apiKey })`.

### No adapter

Appwrite Sites runs Astro through `@astrojs/node`, so this package ships only `.`, `./cache` and `./cache/provider` — no server entrypoint, no `setAdapter()`. It's a cache provider in an adapter-shaped package. If core would rather it be a real adapter wrapping `@astrojs/node`, I'm happy to rework it.

## Testing

`packages/integrations/appwrite/test/` — 65 tests, all passing:

- `cache-provider.test.js` — header generation and the `no-store` default, in the style of the existing `cache-provider.test.js` files
- `cache-utils.test.js` — cache key normalisation, the invalidation plan, credential and domain resolution
- `cache-invalidate.test.js` — the invalidation path against a stub Appwrite API rather than a mocked SDK, so it asserts the request the SDK really sends (URL, project and key headers, payload)

Also verified end to end against a real `astro build` + `@astrojs/node` server:

```
GET /              →  appwrite-cdn-cache-control: public, max-age=120, stale-while-revalidate=60
                      appwrite-cdn-cache-key: products products:42
GET /blog/hello    →  appwrite-cdn-cache-control: public, max-age=300, stale-while-revalidate=60   (routeRules)
GET /uncached      →  appwrite-cdn-cache-control: no-store
POST /api/revalidate
  → POST /v1/proxy/invalidations  {"domain":"…","type":"tag","reference":"products"}
  → POST /v1/proxy/invalidations  {"domain":"…","type":"path","reference":"/products/1"}
     x-appwrite-project: my-project   x-appwrite-key: <the request's dynamic key>
```

`pnpm --filter @astrojs/appwrite build` is clean; biome and prettier are clean; the `pnpm-lock.yaml` diff is additive only. One caveat on my machine: `tsc -b` surfaces a pre-existing error in `packages/astro/src/core/config/schemas/base.ts` about the uninstalled optional peer `@astrojs/markdown-satteri`. Nothing in the new package errors.

## Docs

A new package needs a docs page (`docs/src/content/docs/en/guides/integrations-guide/appwrite.mdx`) before release; the package README currently carries the usage and options. Happy to open the docs PR once the shape here is settled — flagging rather than assuming.

/cc @withastro/maintainers-docs for feedback!

## Open questions

Reasons this is a draft, in order of how blocking they are:

1. ~~**`node-appwrite` points at a preview build.**~~ **Resolved.** `Proxy.createInvalidation()` shipped in [`node-appwrite@28.0.0`](https://github.com/appwrite/sdk-for-node/releases/tag/28.0.0) (published 2026-08-14), so `dependencies` now names `^28.0.0` instead of a tarball URL. One timing caveat: this repo's `minimumReleaseAge` is 3 days, so CI's `pnpm install` will reject `28.0.0` until 2026-08-17 — a re-run after that date goes green with no further changes.
2. **The `Appwrite-CDN-*` header contract is not publicly documented yet.** A reviewer can't verify the header semantics against public docs today. I'd expect this PR to wait on Appwrite publishing both.
3. **Does core want a first-party Appwrite package at all?** Happy to maintain it out-of-tree under the Appwrite org instead, if that's the preference — a provider only needs a module with a default `CacheProviderFactory`, so nothing about route caching requires it to live here. Say the word and I'll close this.

Disclosure: I work at Appwrite, and the header and invalidation behaviour above comes from the Appwrite side of the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

