### PR TITLE
Fix incremental build cache invalidation caused by Shiki mutating the `langAlias` config object

### DIFF
--- a/.changeset/major-ads-follow.md
+++ b/.changeset/major-ads-follow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/internal-helpers': patch
+---
+
+Fixes incremental build cache invalidation caused by Shiki mutating the `langAlias` config object when loading languages

--- a/packages/internal-helpers/src/shiki.ts
+++ b/packages/internal-helpers/src/shiki.ts
@@ -173,7 +173,9 @@ async function createShikiHighlighterInternal({
 
 	const highlighter = await createHighlighter({
 		langs: ['plaintext', ...langs],
-		langAlias,
+		// Shallow-clone to prevent Shiki's Registry.loadLanguage() from mutating
+		// the caller's object when it registers built-in language aliases.
+		langAlias: { ...langAlias },
 		themes: Object.values(themes).length ? Object.values(themes) : [theme],
 		engine: shikiEngine,
 	});

--- a/packages/internal-helpers/test/shiki.test.ts
+++ b/packages/internal-helpers/test/shiki.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createShikiHighlighter } from '../dist/shiki.js';
+
+describe('createShikiHighlighter', () => {
+	it('does not mutate the provided langAlias object', async () => {
+		const langAlias = {};
+		const highlighter = await createShikiHighlighter({ langAlias });
+
+		// Highlight a JavaScript code block, which causes Shiki to register
+		// built-in aliases (js, cjs, mjs) for the "javascript" grammar.
+		await highlighter.codeToHtml('const x = 1;', 'javascript', {});
+
+		assert.deepStrictEqual(
+			langAlias,
+			{},
+			'langAlias should not be mutated by Shiki language loading',
+		);
+	});
+});


### PR DESCRIPTION
## Changes

- Shallow-clones `langAlias` before passing it to Shiki's `createHighlighter()` in `packages/internal-helpers/src/shiki.ts`. Shiki's `Registry.loadLanguage()` writes built-in language aliases (e.g. `js`, `cjs`, `mjs` for JavaScript) directly into the `langAlias` object it receives. Because Astro passed the same object reference from the resolved config, those aliases leaked back into `config.markdown.shikiConfig.langAlias`. Since `computeConfigHash()` runs after the Vite build, the hash then reflected which languages appeared in code blocks rather than the user's actual config, causing the incremental build cache to be invalidated on every content change.

Closes #17693

## Testing

- Adds `packages/internal-helpers/test/shiki.test.ts` with a test that highlights a JavaScript code block and asserts the original `langAlias` object passed to `createShikiHighlighter` is not mutated.

## Docs

- No docs update needed; this is an internal bug fix with no user-facing API change.
