### PR TITLE
docs: fix the code snippets in the JSDoc for the configuration options

### DIFF
--- a/.changeset/hungry-rockets-nail.md
+++ b/.changeset/hungry-rockets-nail.md
@@ -1,0 +1,9 @@
+---
+'astro': patch
+---
+
+Fixes several documentation issues related to the JSDoc for configuration options.
+
+- When hovering over the `server` and `fonts` options, the JSDoc for the nested options was displayed instead of the JSDoc for the top-level property.
+- Two i18n configuration options were being used incorrectly in the examples.
+- The indentation of some code blocks was broken on hover.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -112,6 +112,7 @@ export type ServerConfig = {
 	 * hostname is allowed.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -144,6 +145,7 @@ export type ServerConfig = {
 	 * Pass a full URL string (e.g. "http://example.com") or a pathname (e.g. "/about") to specify the URL to open.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -191,6 +193,7 @@ export interface AstroUserConfig<
 	 * Your final, deployed URL. Astro uses this full URL to generate your sitemap and canonical URLs in your final build. It is strongly recommended that you set this configuration to get the most out of Astro.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -210,6 +213,7 @@ export interface AstroUserConfig<
 	 * In the example below, `astro dev` will start your server at `/docs`.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -227,6 +231,7 @@ export interface AstroUserConfig<
 	 *
 	 * In the example below, the values of `import.meta.env.BASE_URL` and `config.base` when processed will both be `/docs`:
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -238,6 +243,7 @@ export interface AstroUserConfig<
 	 * In the example below, the values of `import.meta.env.BASE_URL` and `config.base` when processed will both be `/docs/`:
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -267,6 +273,7 @@ export interface AstroUserConfig<
 	 * See your hosting platform's documentation for more information. You cannot use Astro [redirects](https://docs.astro.build/en/reference/configuration-reference/#redirects) for this use case at this point.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -291,6 +298,7 @@ export interface AstroUserConfig<
 	 *
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * export default defineConfig({
 	 *   redirects: {
 	 *    '/old': '/new',
@@ -316,6 +324,7 @@ export interface AstroUserConfig<
 	 * You can customize the [redirection status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) using an object in the redirect config:
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * export default defineConfig({
 	 *   redirects: {
 	 *     '/other': {
@@ -342,6 +351,7 @@ export interface AstroUserConfig<
 	 * - `'server'` - Use server-side rendering (SSR) for all pages by default, always outputting a server-rendered site.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -363,6 +373,7 @@ export interface AstroUserConfig<
 	 * See our [on-demand rendering guide](https://docs.astro.build/en/guides/on-demand-rendering/) for more on Astro's server rendering options.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 * import netlify from '@astrojs/netlify';
 	 *
@@ -385,6 +396,7 @@ export interface AstroUserConfig<
 	 * Read our [Integrations Guide](https://docs.astro.build/en/guides/integrations/) for help getting started with Astro Integrations.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 * import react from '@astrojs/react';
 	 * import mdx from '@astrojs/mdx';
@@ -411,15 +423,16 @@ export interface AstroUserConfig<
 	 * If you provide a relative path (ex: `--root: './my-project'`) Astro will resolve it against your current working directory.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
 	 *   root: './my-project-directory'
 	 * });
 	 * ```
-	 * 
+	 *
 	 * The following example sets the root directory using the CLI:
-	 * 
+	 *
 	 * ```bash
 	 * astro build --root ./my-project-directory
 	 * ```
@@ -436,6 +449,7 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -456,6 +470,7 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -476,6 +491,7 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -495,6 +511,7 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -520,6 +537,7 @@ export interface AstroUserConfig<
 	 * Setting this option to `false` disables HTML compression and preserves all whitespace.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -563,6 +581,7 @@ export interface AstroUserConfig<
 	 * - `ignore`: silently build using the highest-priority route when conflicts occur
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -585,6 +604,7 @@ export interface AstroUserConfig<
 	 * #### Examples
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -598,6 +618,7 @@ export interface AstroUserConfig<
 	 * ```
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -677,6 +698,7 @@ export interface AstroUserConfig<
 		 * - `**.example.com` - matches any subdomain depth (e.g., both `sub.example.com` and `deep.sub.example.com`)
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -700,6 +722,7 @@ export interface AstroUserConfig<
 		 * In some specific contexts (e.g., applications behind trusted reverse proxies with dynamic domains), you may need to allow all domains. To do this, use an empty object:
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1275,6 +1298,7 @@ export interface AstroUserConfig<
 		 *   - `'preserve'`: Astro will generate HTML files exactly as they appear in your source folder. (e.g. `src/pages/about.astro` builds `/about.html` and `src/pages/about/index.astro` builds the file `/about/index.html`)
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1312,6 +1336,7 @@ export interface AstroUserConfig<
 		 * This value is relative to the `outDir`.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1334,6 +1359,7 @@ export interface AstroUserConfig<
 		 * This value is relative to the `outDir`.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1355,6 +1381,7 @@ export interface AstroUserConfig<
 		 * Specifies the directory in the build output where Astro-generated assets (bundled JS and CSS for example) should live.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1380,6 +1407,7 @@ export interface AstroUserConfig<
 		 * To fetch all assets uploaded to the same domain (e.g. `https://cdn.example.com/_astro/...`), set `assetsPrefix` to the root domain as a string (regardless of your `base` configuration):
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1395,6 +1423,7 @@ export interface AstroUserConfig<
 		 * In this case, a `fallback` property is required and will be used by default for any other files.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1425,6 +1454,7 @@ export interface AstroUserConfig<
 		 * detects that the file is a JavaScript module.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1450,6 +1480,7 @@ export interface AstroUserConfig<
 		 * configuration files for redirects and do not need/want HTML based redirects.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1473,6 +1504,7 @@ export interface AstroUserConfig<
 		 *  - `'never'` - project styles are sent in external stylesheets
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1498,6 +1530,7 @@ export interface AstroUserConfig<
 		 * If the number is set too high, page rendering may slow down due to insufficient memory resources and because JS is single-threaded.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -1523,6 +1556,7 @@ export interface AstroUserConfig<
 	 * Customize the Astro dev server, used by both `astro dev` and `astro preview`.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -1533,6 +1567,7 @@ export interface AstroUserConfig<
 	 * To set different configuration based on the command run ("dev", "preview") a function can also be passed to this configuration option.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -1566,6 +1601,7 @@ export interface AstroUserConfig<
 	 * If the given port is already in use, Astro will automatically try the next available port.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -1586,6 +1622,7 @@ export interface AstroUserConfig<
 	 * hostname is allowed.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -1608,6 +1645,7 @@ export interface AstroUserConfig<
 	 * Pass a full URL string (e.g. "http://example.com") or a pathname (e.g. "/about") to specify the URL to open.
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig } from 'astro/config';
 	 *
 	 * export default defineConfig({
@@ -1969,6 +2007,7 @@ export interface AstroUserConfig<
 				 * This value defaults to `true` when using the `<ClientRouter />` router. Otherwise, the default value is `false`.
 				 *
 				 * ```js
+				 * // astro.config.mjs
 				 * import { defineConfig } from 'astro/config';
 				 *
 				 * export default defineConfig({
@@ -2024,6 +2063,7 @@ export interface AstroUserConfig<
 		 * Set the endpoint to use for image optimization in dev and SSR. The `entrypoint` property can be set to `undefined` to use the default image endpoint.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -2056,6 +2096,7 @@ export interface AstroUserConfig<
 		 * The service entrypoint can be either one of the included services, or a third-party package.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -2222,6 +2263,7 @@ export interface AstroUserConfig<
 		 * 4. pathname
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -2389,6 +2431,7 @@ export interface AstroUserConfig<
 		 * - `false` - do not apply syntax highlighting.
 
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -2459,6 +2502,7 @@ export interface AstroUserConfig<
 		 * Pass [remark plugins](https://github.com/remarkjs/remark) to customize how your Markdown is built. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 * import remarkToc from 'remark-toc';
 		 *
@@ -2481,6 +2525,7 @@ export interface AstroUserConfig<
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 * import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
 		 *
@@ -2505,6 +2550,7 @@ export interface AstroUserConfig<
 		 * Astro uses [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) by default. To disable this, set the `gfm` flag to `false`:
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -2547,6 +2593,7 @@ export interface AstroUserConfig<
 		 * Pass options to [remark-rehype](https://github.com/remarkjs/remark-rehype#api).
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -2662,6 +2709,7 @@ export interface AstroUserConfig<
 		 * The following example configures your content fallback strategy to redirect unavailable pages in `/pt-br/` to their `es` version, and unavailable pages in `/fr/` to their `en` version. Unavailable `/es/` pages will return a 404.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * export default defineConfig({
 		 *   i18n: {
 		 *     defaultLocale: "en",
@@ -2694,6 +2742,7 @@ export interface AstroUserConfig<
 		 * Controls the routing strategy to determine your site URLs. Set this based on your folder/URL path configuration for your default language.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * export default defineConfig({
 		 *   i18n: {
 		 *     defaultLocale: "en",
@@ -2710,6 +2759,7 @@ export interface AstroUserConfig<
 		 * Since 4.6.0, this option can also be set to `manual`. When this routing strategy is enabled, Astro will **disable** its i18n middleware and no other `routing` options (e.g. `prefixDefaultLocale`) may be configured. You will be responsible for writing your own routing logic, or executing Astro's i18n middleware manually alongside your own.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * export default defineConfig({
 		 *   i18n: {
 		 *     defaultLocale: "en",
@@ -2740,6 +2790,7 @@ export interface AstroUserConfig<
 					 * Localized folders are used for every language, including the default.
 					 *
 					 * ```js
+					 * // astro.config.mjs
 					 * export default defineConfig({
 					 *   i18n: {
 					 *     defaultLocale: "en",
@@ -2961,6 +3012,7 @@ export interface AstroUserConfig<
 	 * The source of your font files. You can use a [built-in provider](https://docs.astro.build/en/reference/font-provider-reference/#built-in-providers) or write your own [custom provider](https://docs.astro.build/en/reference/font-provider-reference/#building-a-font-provider):
 	 *
 	 * ```js
+	 * // astro.config.mjs
 	 * import { defineConfig, fontProviders } from "astro/config";
 	 *
 	 * export default defineConfig({
@@ -3235,6 +3287,7 @@ export interface AstroUserConfig<
 		 * Use the provider's config function to get type-safe configuration:
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig, memoryCache } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -3362,6 +3415,7 @@ export interface AstroUserConfig<
 		 * When enabled, this feature will generate and add JSON schemas to the `.astro` directory in your project. These files can be used by the Astro language server to provide Intellisense inside content files (`.md`, `.mdx`, `.mdoc`).
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -3388,6 +3442,7 @@ export interface AstroUserConfig<
 		 * allowing you to edit files directly in the browser and have those changes reflected in your local file system.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -3413,6 +3468,7 @@ export interface AstroUserConfig<
 		 * and better performance while maintaining visual quality.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({
@@ -3446,6 +3502,7 @@ export interface AstroUserConfig<
 		 * is recommended for broad adapter compatibility.
 		 *
 		 * ```js
+		 * // astro.config.mjs
 		 * import { defineConfig } from 'astro/config';
 		 *
 		 * export default defineConfig({

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -410,8 +410,6 @@ export interface AstroUserConfig<
 	 *
 	 * If you provide a relative path (ex: `--root: './my-project'`) Astro will resolve it against your current working directory.
 	 *
-	 * #### Examples
-	 *
 	 * ```js
 	 * import { defineConfig } from 'astro/config';
 	 *
@@ -419,8 +417,11 @@ export interface AstroUserConfig<
 	 *   root: './my-project-directory'
 	 * });
 	 * ```
+	 * 
+	 * The following example sets the root directory using the CLI:
+	 * 
 	 * ```bash
-	 * $ astro build --root ./my-project-directory
+	 * astro build --root ./my-project-directory
 	 * ```
 	 */
 	root?: string;

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -114,7 +114,7 @@ export type ServerConfig = {
 	 * ```js
 	 * {
 	 *   server: {
-	 *   	allowedHosts: ['staging.example.com', 'qa.example.com']
+	 *     allowedHosts: ['staging.example.com', 'qa.example.com']
 	 *   }
 	 * }
 	 * ```
@@ -220,8 +220,8 @@ export interface AstroUserConfig<
 	 * In the example below, the values of `import.meta.env.BASE_URL` and `config.base` when processed will both be `/docs`:
 	 * ```js
 	 * {
-	 * 	 base: '/docs/',
-	 * 	 trailingSlash: "never"
+	 *   base: '/docs/',
+	 *   trailingSlash: "never"
 	 * }
 	 * ```
 	 *
@@ -229,8 +229,8 @@ export interface AstroUserConfig<
 	 *
 	 * ```js
 	 * {
-	 * 	 base: '/docs',
-	 * 	 trailingSlash: "always"
+	 *   base: '/docs',
+	 *   trailingSlash: "always"
 	 * }
 	 * ```
 	 */
@@ -287,7 +287,7 @@ export interface AstroUserConfig<
 	 *      destination: 'https://example.com/news'
 	 *    },
 	 *    // '/product1/', '/product1' // Note, this is not supported
-	 * 	}
+	 *   }
 	 * })
 	 * ```
 	 *
@@ -1419,9 +1419,9 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * {
-		 * 	build: {
-		 *		inlineStylesheets: `never`,
-		 * 	},
+		 *   build: {
+		 *     inlineStylesheets: `never`,
+		 *   },
 		 * }
 		 * ```
 		 */
@@ -1523,7 +1523,7 @@ export interface AstroUserConfig<
 	 * ```js
 	 * {
 	 *   server: {
-	 *   	allowedHosts: ['staging.example.com', 'qa.example.com']
+	 *     allowedHosts: ['staging.example.com', 'qa.example.com']
 	 *   }
 	 * }
 	 * ```
@@ -1894,7 +1894,7 @@ export interface AstroUserConfig<
 				 *
 				 * ```js
 				 * prefetch: {
-				 * 	prefetchAll: true
+				 *   prefetchAll: true
 				 * }
 				 * ```
 				 *
@@ -1948,9 +1948,9 @@ export interface AstroUserConfig<
 		 *   image: {
 		 *     // Example: Use a custom image endpoint at `/custom_endpoint`
 		 *     endpoint: {
-		 * 		 	route: '/custom_endpoint',
-		 * 		 	entrypoint: 'src/my_endpoint.ts',
-		 * 		},
+		 *       route: '/custom_endpoint',
+		 *       entrypoint: 'src/my_endpoint.ts',
+		 *     },
 		 *   },
 		 * }
 		 * ```
@@ -1978,18 +1978,18 @@ export interface AstroUserConfig<
 		 *   image: {
 		 *     // Example: Enable the Sharp-based image service with a custom config
 		 *     service: {
-		 * 			 entrypoint: 'astro/assets/services/sharp',
-		 * 			 config: {
-		 * 				 limitInputPixels: false,
-		 * 				 webp: {
-		 * 					 effort: 6,
-		 * 					 alphaQuality: 80,
-		 * 				 },
-		 * 				 jpeg: {
-		 * 					 mozjpeg: true,
-		 * 				 },
+		 *       entrypoint: 'astro/assets/services/sharp',
+		 *       config: {
+		 *         limitInputPixels: false,
+		 *         webp: {
+		 *           effort: 6,
+		 *           alphaQuality: 80,
+		 *         },
+		 *         jpeg: {
+		 *           mozjpeg: true,
+		 *         },
 		 *       },
-		 * 		 },
+		 *     },
 		 *   },
 		 * }
 		 * ```
@@ -2565,14 +2565,14 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * export default defineConfig({
-		 * 	i18n: {
-		 * 		defaultLocale: "en",
-		 * 		locales: ["en", "fr", "pt-br", "es"],
-		 * 		fallback: {
-		 * 		  "pt-br": "es",
-		 * 		  fr: "en"
-		 * 		}
-		 * 	}
+		 *   i18n: {
+		 *     defaultLocale: "en",
+		 *     locales: ["en", "fr", "pt-br", "es"],
+		 *     fallback: {
+		 *       "pt-br": "es",
+		 *       fr: "en"
+		 *     }
+		 *   }
 		 * })
 		 * ```
 		 */
@@ -2597,15 +2597,15 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * export default defineConfig({
-		 * 	i18n: {
-		 * 		defaultLocale: "en",
-		 * 		locales: ["en", "fr"],
-		 * 		routing: {
-		 * 			prefixDefaultLocale: false,
-		 * 			redirectToDefaultLocale: true,
-		 * 			fallbackType: "redirect",
-		 * 		}
-		 * 	}
+		 *   i18n: {
+		 *     defaultLocale: "en",
+		 *     locales: ["en", "fr"],
+		 *     routing: {
+		 *       prefixDefaultLocale: false,
+		 *       redirectToDefaultLocale: true,
+		 *       fallbackType: "redirect",
+		 *     }
+		 *   }
 		 * })
 		 * ```
 		 *
@@ -2613,11 +2613,11 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * export default defineConfig({
-		 * 	i18n: {
-		 * 		defaultLocale: "en",
-		 * 		locales: ["en", "fr"],
-		 * 		routing: "manual"
-		 * 	}
+		 *   i18n: {
+		 *     defaultLocale: "en",
+		 *     locales: ["en", "fr"],
+		 *     routing: "manual"
+		 *   }
 		 * })
 		 * ```
 		 *
@@ -2643,13 +2643,13 @@ export interface AstroUserConfig<
 					 *
 					 * ```js
 					 * export default defineConfig({
-					 * 	i18n: {
-					 * 		defaultLocale: "en",
-					 * 		locales: ["en", "fr", "pt-br", "es"],
-					 * 		routing: {
-					 * 			prefixDefaultLocale: true,
-					 * 		}
-					 * 	}
+					 *   i18n: {
+					 *     defaultLocale: "en",
+					 *     locales: ["en", "fr", "pt-br", "es"],
+					 *     routing: {
+					 *       prefixDefaultLocale: true,
+					 *     }
+					 *   }
 					 * })
 					 * ```
 					 */
@@ -2673,7 +2673,7 @@ export interface AstroUserConfig<
 					 * export default defineConfig({
 					 *   i18n:{
 					 *     defaultLocale: "en",
-					 * 		locales: ["en", "fr"],
+					 *     locales: ["en", "fr"],
 					 *     routing: {
 					 *       prefixDefaultLocale: true,
 					 *       redirectToDefaultLocale: true
@@ -2705,15 +2705,15 @@ export interface AstroUserConfig<
 					 * ```js
 					 * //astro.config.mjs
 					 * export default defineConfig({
-					 * 	 i18n: {
+					 *   i18n: {
 					 *     defaultLocale: "en",
 					 *     locales: ["en", "fr"],
 					 *     routing: {
-					 *     	prefixDefaultLocale: false,
-					 *     	fallbackType: "rewrite",
+					 *       prefixDefaultLocale: false,
+					 *       fallbackType: "rewrite",
 					 *     },
 					 *     fallback: {
-					 *     	fr: "en",
+					 *       fr: "en",
 					 *     }
 					 *   },
 					 * })
@@ -2741,12 +2741,12 @@ export interface AstroUserConfig<
 		 * ```js
 		 * //astro.config.mjs
 		 * export default defineConfig({
-		 * 	 site: "https://example.com",
-		 * 	 output: "server", // required, with no prerendered pages
-		 * 	 adapter: node({
-		 * 	   mode: 'standalone',
-		 * 	 }),
-		 * 	 i18n: {
+		 *   site: "https://example.com",
+		 *   output: "server", // required, with no prerendered pages
+		 *   adapter: node({
+		 *     mode: 'standalone',
+		 *   }),
+		 *   i18n: {
 		 *     defaultLocale: "en",
 		 *     locales: ["en", "fr", "pt-br", "es"],
 		 *     routing: {
@@ -3234,9 +3234,9 @@ export interface AstroUserConfig<
 		 *     prefetchAll: true,
 		 *     defaultStrategy: 'viewport',
 		 *   },
-		 * 	experimental: {
-		 * 		clientPrerender: true,
-		 * 	},
+		 *   experimental: {
+		 *     clientPrerender: true,
+		 *   },
 		 * }
 		 * ```
 		 *

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -300,6 +300,8 @@ export interface AstroUserConfig<
 	 *
 	 * ```js
 	 * // astro.config.mjs
+	 * import { defineConfig } from 'astro/config';
+	 *
 	 * export default defineConfig({
 	 *   redirects: {
 	 *    '/old': '/new',
@@ -326,6 +328,8 @@ export interface AstroUserConfig<
 	 *
 	 * ```js
 	 * // astro.config.mjs
+	 * import { defineConfig } from 'astro/config';
+	 *
 	 * export default defineConfig({
 	 *   redirects: {
 	 *     '/other': {
@@ -654,6 +658,8 @@ export interface AstroUserConfig<
 	 *
 	 * ```js
 	 * // astro.config.mjs
+	 * import { defineConfig } from 'astro/config';
+	 *
 	 * export default defineConfig({
 	 *   output: "server",
 	 *   security: {
@@ -758,6 +764,8 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
+		 * import { defineConfig } from 'astro/config';
+		 *
 		 * export default defineConfig({
 		 *   security: {
 		 *     actionBodySizeLimit: 10 * 1024 * 1024 // 10 MB
@@ -783,6 +791,8 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
+		 * import { defineConfig } from 'astro/config';
+		 *
 		 * export default defineConfig({
 		 *   security: {
 		 *     serverIslandBodySizeLimit: 10 * 1024 * 1024 // 10 MB
@@ -2714,6 +2724,8 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
+		 * import { defineConfig } from 'astro/config';
+		 *
 		 * export default defineConfig({
 		 *   i18n: {
 		 *     defaultLocale: "en",
@@ -2747,6 +2759,8 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
+		 * import { defineConfig } from 'astro/config';
+		 *
 		 * export default defineConfig({
 		 *   i18n: {
 		 *     defaultLocale: "en",
@@ -2764,6 +2778,8 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
+		 * import { defineConfig } from 'astro/config';
+		 *
 		 * export default defineConfig({
 		 *   i18n: {
 		 *     defaultLocale: "en",
@@ -2795,6 +2811,8 @@ export interface AstroUserConfig<
 					 *
 					 * ```js
 					 * // astro.config.mjs
+					 * import { defineConfig } from 'astro/config';
+					 *
 					 * export default defineConfig({
 					 *   i18n: {
 					 *     defaultLocale: "en",
@@ -2823,6 +2841,8 @@ export interface AstroUserConfig<
 					 * Set `redirectToDefaultLocale: true` to enable this automatic redirection at the root of your site:
 					 * ```js
 					 * // astro.config.mjs
+					 * import { defineConfig } from 'astro/config';
+					 *
 					 * export default defineConfig({
 					 *   i18n:{
 					 *     defaultLocale: "en",
@@ -2857,6 +2877,8 @@ export interface AstroUserConfig<
 					 *
 					 * ```js
 					 * //astro.config.mjs
+					 * import { defineConfig } from 'astro/config';
+					 *
 					 * export default defineConfig({
 					 *   i18n: {
 					 *     defaultLocale: "en",

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -290,7 +290,8 @@ export interface AstroUserConfig<
 	 * @type {Record<string, RedirectConfig>}
 	 * @default `{}`
 	 * @version 2.9.0
-	 * @description Specify a mapping of redirects where the key is the route to match
+	 * @description
+	 * Specify a mapping of redirects where the key is the route to match
 	 * and the value is the path to redirect to.
 	 *
 	 * You can redirect both static and dynamic routes, but only to the same kind of route.
@@ -418,7 +419,8 @@ export interface AstroUserConfig<
 	 * @type {string}
 	 * @default `"."` (current working directory)
 	 * @summary Set the project root. The project root is the directory where your Astro project (and all `src`, `public` and `package.json` files) live.
-	 * @description  You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the Astro config file, since Astro needs to know your project root before it can locate your config file.
+	 * @description
+	 * You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the Astro config file, since Astro needs to know your project root before it can locate your config file.
 	 *
 	 * If you provide a relative path (ex: `--root: './my-project'`) Astro will resolve it against your current working directory.
 	 *
@@ -444,7 +446,8 @@ export interface AstroUserConfig<
 	 * @name srcDir
 	 * @type {string}
 	 * @default `"./src"`
-	 * @description Set the directory that Astro will read your site from.
+	 * @description
+	 * Set the directory that Astro will read your site from.
 	 *
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
@@ -486,7 +489,8 @@ export interface AstroUserConfig<
 	 * @type {string}
 	 * @default `"./dist"`
 	 * @see build.server
-	 * @description Set the directory that `astro build` writes your final build to.
+	 * @description
+	 * Set the directory that `astro build` writes your final build to.
 	 *
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
@@ -506,7 +510,8 @@ export interface AstroUserConfig<
 	 * @name cacheDir
 	 * @type {string}
 	 * @default `"./node_modules/.astro"`
-	 * @description Set the directory for caching build artifacts. Files in this directory will be used in subsequent builds to speed up the build time.
+	 * @description
+	 * Set the directory for caching build artifacts. Files in this directory will be used in subsequent builds to speed up the build time.
 	 *
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1722,7 +1722,7 @@ export interface AstroUserConfig<
 	 * import vercel from '@astrojs/vercel'
 	 *
 	 * export default defineConfig({
-	 *   adapter: vercel()
+	 *   adapter: vercel(),
 	 *   session: {
 	 *     driver: sessionDrivers.redis({
 	 *       url: process.env.REDIS_URL
@@ -2569,7 +2569,7 @@ export interface AstroUserConfig<
 		 * 		defaultLocale: "en",
 		 * 		locales: ["en", "fr", "pt-br", "es"],
 		 * 		fallback: {
-		 * 			pt: "es",
+		 * 		  "pt-br": "es",
 		 * 		  fr: "en"
 		 * 		}
 		 * 	}
@@ -2749,7 +2749,9 @@ export interface AstroUserConfig<
 		 * 	 i18n: {
 		 *     defaultLocale: "en",
 		 *     locales: ["en", "fr", "pt-br", "es"],
-		 *     prefixDefaultLocale: false,
+		 *     routing: {
+		 *       prefixDefaultLocale: false,
+		 *     },
 		 *     domains: {
 		 *       fr: "https://fr.example.com",
 		 *       es: "https://example.es"

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -112,11 +112,13 @@ export type ServerConfig = {
 	 * hostname is allowed.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   server: {
 	 *     allowedHosts: ['staging.example.com', 'qa.example.com']
 	 *   }
-	 * }
+	 * });
 	 * ```
 	 */
 	allowedHosts?: string[] | true;
@@ -142,9 +144,11 @@ export type ServerConfig = {
 	 * Pass a full URL string (e.g. "http://example.com") or a pathname (e.g. "/about") to specify the URL to open.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   server: { open: "/about" }
-	 * }
+	 * });
 	 * ```
 	 */
 	open?: string | boolean;
@@ -187,9 +191,11 @@ export interface AstroUserConfig<
 	 * Your final, deployed URL. Astro uses this full URL to generate your sitemap and canonical URLs in your final build. It is strongly recommended that you set this configuration to get the most out of Astro.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   site: 'https://www.my-site.dev'
-	 * }
+	 * });
 	 * ```
 	 */
 	site?: string;
@@ -204,9 +210,11 @@ export interface AstroUserConfig<
 	 * In the example below, `astro dev` will start your server at `/docs`.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   base: '/docs'
-	 * }
+	 * });
 	 * ```
 	 *
 	 * When using this option, all of your static asset imports and URLs should add the base as a prefix. You can access this value via `import.meta.env.BASE_URL`.
@@ -219,19 +227,23 @@ export interface AstroUserConfig<
 	 *
 	 * In the example below, the values of `import.meta.env.BASE_URL` and `config.base` when processed will both be `/docs`:
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   base: '/docs/',
 	 *   trailingSlash: "never"
-	 * }
+	 * });
 	 * ```
 	 *
 	 * In the example below, the values of `import.meta.env.BASE_URL` and `config.base` when processed will both be `/docs/`:
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   base: '/docs',
 	 *   trailingSlash: "always"
-	 * }
+	 * });
 	 * ```
 	 */
 	base?: string;
@@ -255,10 +267,12 @@ export interface AstroUserConfig<
 	 * See your hosting platform's documentation for more information. You cannot use Astro [redirects](https://docs.astro.build/en/reference/configuration-reference/#redirects) for this use case at this point.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   // Example: Require a trailing slash during development
 	 *   trailingSlash: 'always'
-	 * }
+	 * });
 	 * ```
 	 */
 	trailingSlash?: 'always' | 'never' | 'ignore';
@@ -288,7 +302,7 @@ export interface AstroUserConfig<
 	 *    },
 	 *    // '/product1/', '/product1' // Note, this is not supported
 	 *   }
-	 * })
+	 * });
 	 * ```
 	 *
 	 *
@@ -309,9 +323,7 @@ export interface AstroUserConfig<
 	 *       destination: '/place',
 	 *     },
 	 *   }
-	 * })
-	 *
-	 *
+	 * });
 	 * ```
 	 */
 	redirects?: Record<string, RedirectConfig>;
@@ -334,7 +346,7 @@ export interface AstroUserConfig<
 	 *
 	 * export default defineConfig({
 	 *   output: 'static'
-	 * })
+	 * });
 	 * ```
 	 */
 	output?: 'static' | 'server';
@@ -351,11 +363,13 @@ export interface AstroUserConfig<
 	 * See our [on-demand rendering guide](https://docs.astro.build/en/guides/on-demand-rendering/) for more on Astro's server rendering options.
 	 *
 	 * ```js
+	 * import { defineConfig } from 'astro/config';
 	 * import netlify from '@astrojs/netlify';
-	 * {
+	 *
+	 * export default defineConfig({
 	 *   // Example: Build for Netlify serverless deployment
 	 *   adapter: netlify(),
-	 * }
+	 * });
 	 * ```
 	 */
 	adapter?: AstroIntegration;
@@ -371,12 +385,14 @@ export interface AstroUserConfig<
 	 * Read our [Integrations Guide](https://docs.astro.build/en/guides/integrations/) for help getting started with Astro Integrations.
 	 *
 	 * ```js
+	 * import { defineConfig } from 'astro/config';
 	 * import react from '@astrojs/react';
 	 * import mdx from '@astrojs/mdx';
-	 * {
+	 *
+	 * export default defineConfig({
 	 *   // Example: Add React + MDX support to Astro
 	 *   integrations: [react(), mdx()]
-	 * }
+	 * });
 	 * ```
 	 */
 	integrations?: Array<
@@ -397,9 +413,11 @@ export interface AstroUserConfig<
 	 * #### Examples
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   root: './my-project-directory'
-	 * }
+	 * });
 	 * ```
 	 * ```bash
 	 * $ astro build --root ./my-project-directory
@@ -417,9 +435,11 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   srcDir: './www'
-	 * }
+	 * });
 	 * ```
 	 */
 	srcDir?: string;
@@ -435,9 +455,11 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   publicDir: './my-custom-publicDir-directory'
-	 * }
+	 * });
 	 * ```
 	 */
 	publicDir?: string;
@@ -453,9 +475,11 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   outDir: './my-custom-build-directory'
-	 * }
+	 * });
 	 * ```
 	 */
 	outDir?: string;
@@ -470,9 +494,11 @@ export interface AstroUserConfig<
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   cacheDir: './my-custom-cache-directory'
-	 * }
+	 * });
 	 * ```
 	 */
 	cacheDir?: string;
@@ -493,11 +519,13 @@ export interface AstroUserConfig<
 	 * Setting this option to `false` disables HTML compression and preserves all whitespace.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   compressHTML: true
 	 *   // or:
 	 *   // compressHTML: false
-	 * }
+	 * });
 	 * ```
 	 */
 	compressHTML?: boolean | 'jsx';
@@ -534,9 +562,11 @@ export interface AstroUserConfig<
 	 * - `ignore`: silently build using the highest-priority route when conflicts occur
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   prerenderConflictBehavior: 'error'
-	 * }
+	 * });
 	 * ```
 	 */
 	prerenderConflictBehavior?: 'error' | 'warn' | 'ignore';
@@ -554,23 +584,27 @@ export interface AstroUserConfig<
 	 * #### Examples
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   vite: {
 	 *     ssr: {
 	 *       // Example: Force a broken package to skip SSR processing, if needed
 	 *       external: ['broken-npm-package'],
 	 *     }
 	 *   }
-	 * }
+	 * });
 	 * ```
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   vite: {
 	 *     // Example: Add custom vite plugins directly to your Astro project
 	 *     plugins: [myPlugin()],
 	 *   }
-	 * }
+	 * });
 	 * ```
 	 */
 	vite?: ViteUserConfig;
@@ -598,7 +632,7 @@ export interface AstroUserConfig<
 	 *   security: {
 	 *     checkOrigin: false
 	 *   }
-	 * })
+	 * });
 	 * ```
 	 */
 	security?: {
@@ -642,7 +676,9 @@ export interface AstroUserConfig<
 		 * - `**.example.com` - matches any subdomain depth (e.g., both `sub.example.com` and `deep.sub.example.com`)
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   security: {
 		 *     // Example: Allow any subdomain of example.com on https
 		 *     allowedDomains: [
@@ -657,18 +693,20 @@ export interface AstroUserConfig<
 		 *       }
 		 *     ]
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 		 * In some specific contexts (e.g., applications behind trusted reverse proxies with dynamic domains), you may need to allow all domains. To do this, use an empty object:
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   security: {
 		 *     // Allow any domain - use this only when necessary
 		 *     allowedDomains: [{}]
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 		 * When not configured, `X-Forwarded-Host` headers are not trusted and will be ignored.
@@ -695,7 +733,7 @@ export interface AstroUserConfig<
 		 *   security: {
 		 *     actionBodySizeLimit: 10 * 1024 * 1024 // 10 MB
 		 *   }
-		 * })
+		 * });
 		 * ```
 		 */
 		actionBodySizeLimit?: number;
@@ -720,7 +758,7 @@ export interface AstroUserConfig<
 		 *   security: {
 		 *     serverIslandBodySizeLimit: 10 * 1024 * 1024 // 10 MB
 		 *   }
-		 * })
+		 * });
 		 * ```
 		 */
 		serverIslandBodySizeLimit?: number;
@@ -1236,12 +1274,14 @@ export interface AstroUserConfig<
 		 *   - `'preserve'`: Astro will generate HTML files exactly as they appear in your source folder. (e.g. `src/pages/about.astro` builds `/about.html` and `src/pages/about/index.astro` builds the file `/about/index.html`)
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     // Example: Generate `page.html` instead of `page/index.html` during build.
 		 *     format: 'file'
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 		 *
@@ -1271,12 +1311,14 @@ export interface AstroUserConfig<
 		 * This value is relative to the `outDir`.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   output: 'server',
 		 *   build: {
 		 *     client: './client'
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		client?: string;
@@ -1291,11 +1333,13 @@ export interface AstroUserConfig<
 		 * This value is relative to the `outDir`.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     server: './server'
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		server?: string;
@@ -1310,11 +1354,13 @@ export interface AstroUserConfig<
 		 * Specifies the directory in the build output where Astro-generated assets (bundled JS and CSS for example) should live.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     assets: '_custom'
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		assets?: string;
@@ -1333,11 +1379,13 @@ export interface AstroUserConfig<
 		 * To fetch all assets uploaded to the same domain (e.g. `https://cdn.example.com/_astro/...`), set `assetsPrefix` to the root domain as a string (regardless of your `base` configuration):
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     assetsPrefix: 'https://cdn.example.com'
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 		 * **Added in:** `astro@4.5.0`
@@ -1346,7 +1394,9 @@ export interface AstroUserConfig<
 		 * In this case, a `fallback` property is required and will be used by default for any other files.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     assetsPrefix: {
 		 *       'js': 'https://js.cdn.example.com',
@@ -1355,7 +1405,7 @@ export interface AstroUserConfig<
 		 *       'fallback': 'https://cdn.example.com'
 		 *     }
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 		 */
@@ -1374,11 +1424,13 @@ export interface AstroUserConfig<
 		 * detects that the file is a JavaScript module.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     serverEntry: 'main.mjs'
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		serverEntry?: string;
@@ -1397,11 +1449,13 @@ export interface AstroUserConfig<
 		 * configuration files for redirects and do not need/want HTML based redirects.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     redirects: false
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		redirects?: boolean;
@@ -1418,11 +1472,13 @@ export interface AstroUserConfig<
 		 *  - `'never'` - project styles are sent in external stylesheets
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     inlineStylesheets: `never`,
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 */
 		inlineStylesheets?: 'always' | 'auto' | 'never';
@@ -1441,11 +1497,13 @@ export interface AstroUserConfig<
 		 * If the number is set too high, page rendering may slow down due to insufficient memory resources and because JS is single-threaded.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   build: {
 		 *     concurrency: 2
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 		 *  :::caution[Breaking changes possible]
@@ -1464,18 +1522,22 @@ export interface AstroUserConfig<
 	 * Customize the Astro dev server, used by both `astro dev` and `astro preview`.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   server: { port: 1234, host: true}
-	 * }
+	 * });
 	 * ```
 	 *
 	 * To set different configuration based on the command run ("dev", "preview") a function can also be passed to this configuration option.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   // Example: Use the function syntax to customize based on command
 	 *   server: ({ command }) => ({ port: command === 'dev' ? 4321 : 4000 })
-	 * }
+	 * });
 	 * ```
 	 */
 
@@ -1503,9 +1565,11 @@ export interface AstroUserConfig<
 	 * If the given port is already in use, Astro will automatically try the next available port.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   server: { port: 8080 }
-	 * }
+	 * });
 	 * ```
 	 */
 
@@ -1521,11 +1585,13 @@ export interface AstroUserConfig<
 	 * hostname is allowed.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   server: {
 	 *     allowedHosts: ['staging.example.com', 'qa.example.com']
 	 *   }
-	 * }
+	 * });
 	 * ```
 	 */
 
@@ -1541,9 +1607,11 @@ export interface AstroUserConfig<
 	 * Pass a full URL string (e.g. "http://example.com") or a pathname (e.g. "/about") to specify the URL to open.
 	 *
 	 * ```js
-	 * {
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
 	 *   server: { open: "/about" }
-	 * }
+	 * });
 	 * ```
 	 */
 
@@ -1728,7 +1796,7 @@ export interface AstroUserConfig<
 	 *       url: process.env.REDIS_URL
 	 *     }),
 	 *   }
-	 * })
+	 * });
 	 * ```
 	 *
 	 * :::note
@@ -1751,15 +1819,17 @@ export interface AstroUserConfig<
 	 * The driver-specific options to use for session storage. The options depend on the driver you are using. See the [Unstorage documentation](https://unstorage.unjs.io/drivers)
 	 * for more information on the options available for each driver.
 	 *
-	 * ```js title="astro.config.mjs" ins={4-6}
-	 * {
-	 *    session: {
-	 *      driver: "redis",
-	 *      options: {
-	 *        url: process.env.REDIS_URL
-	 *      },
-	 *    }
-	 * }
+	 * ```js title="astro.config.mjs" ins={6-8}
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
+	 *   session: {
+	 *     driver: "redis",
+	 *     options: {
+	 *       url: process.env.REDIS_URL
+	 *     },
+	 *   }
+	 * });
 	 * ```
 	 */
 
@@ -1774,27 +1844,30 @@ export interface AstroUserConfig<
 	 * The session cookie configuration. If set to a string, it will be used as the cookie name.
 	 * Alternatively, you can pass an object with additional options. These will be merged with the defaults.
 	 *
-	 * ```js title="astro.config.mjs" ins={3-4}
-	 * {
-	 *  session: {
-	 *    // If set to a string, it will be used as the cookie name.
-	 *    cookie: "my-session-cookie",
-	 *  }
-	 * }
+	 * ```js title="astro.config.mjs" ins={5-6}
+	 * import { defineConfig } from 'astro/config';
 	 *
+	 * export default defineConfig({
+	 *   session: {
+	 *     // If set to a string, it will be used as the cookie name.
+	 *     cookie: "my-session-cookie",
+	 *   }
+	 * });
 	 * ```
 	 *
-	 * ```js title="astro.config.mjs" ins={4-8}
-	 * {
-	 *  session: {
-	 *    // If set to an object, it will be used as the cookie options.
-	 *    cookie: {
-	 *      name: "my-session-cookie",
-	 *      sameSite: "lax",
-	 *      secure: true,
-	 *    }
-	 *  }
-	 * }
+	 * ```js title="astro.config.mjs" ins={5-10}
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
+	 *   session: {
+	 *     // If set to an object, it will be used as the cookie options.
+	 *     cookie: {
+	 *       name: "my-session-cookie",
+	 *       sameSite: "lax",
+	 *       secure: true,
+	 *     }
+	 *   }
+	 * });
 	 * ```
 	 */
 
@@ -1812,13 +1885,15 @@ export interface AstroUserConfig<
 	 * Set `session.ttl` to add a default expiration period for your session values. Passing a `ttl` option to [`session.set()`](https://docs.astro.build/en/reference/api-reference/#sessionset) will override the global default
 	 * for that individual entry.
 	 *
-	 * ```js title="astro.config.mjs" ins={3-4}
-	 * {
-	 *  session: {
-	 *    // Set a default expiration period of 1 hour (3600 seconds)
-	 *    ttl: 3600,
-	 *  }
-	 * }
+	 * ```js title="astro.config.mjs" ins={5-6}
+	 * import { defineConfig } from 'astro/config';
+	 *
+	 * export default defineConfig({
+	 *   session: {
+	 *     // Set a default expiration period of 1 hour (3600 seconds)
+	 *     ttl: 3600,
+	 *   }
+	 * });
 	 * ```
 	 * :::note
 	 * Setting a value for `ttl` does not automatically delete the value from storage after the time limit has passed.
@@ -1893,9 +1968,13 @@ export interface AstroUserConfig<
 				 * This value defaults to `true` when using the `<ClientRouter />` router. Otherwise, the default value is `false`.
 				 *
 				 * ```js
-				 * prefetch: {
-				 *   prefetchAll: true
-				 * }
+				 * import { defineConfig } from 'astro/config';
+				 *
+				 * export default defineConfig({
+				 *   prefetch: {
+				 *     prefetchAll: true,
+				 *   },
+				 * });
 				 * ```
 				 *
 				 * When set to `true`, you can disable prefetching individually by setting `data-astro-prefetch="false"` on any individual links.
@@ -1944,7 +2023,9 @@ export interface AstroUserConfig<
 		 * Set the endpoint to use for image optimization in dev and SSR. The `entrypoint` property can be set to `undefined` to use the default image endpoint.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   image: {
 		 *     // Example: Use a custom image endpoint at `/custom_endpoint`
 		 *     endpoint: {
@@ -1952,7 +2033,7 @@ export interface AstroUserConfig<
 		 *       entrypoint: 'src/my_endpoint.ts',
 		 *     },
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 */
 		endpoint?: {
@@ -1974,7 +2055,9 @@ export interface AstroUserConfig<
 		 * The service entrypoint can be either one of the included services, or a third-party package.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   image: {
 		 *     // Example: Enable the Sharp-based image service with a custom config
 		 *     service: {
@@ -1991,7 +2074,7 @@ export interface AstroUserConfig<
 		 *       },
 		 *     },
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 */
 		service?: ImageServiceConfig;
@@ -2110,12 +2193,14 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   image: {
 		 *     // Example: Allow remote image optimization from a single domain
 		 *     domains: ['astro.build'],
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 */
 		domains?: string[];
@@ -2136,7 +2221,9 @@ export interface AstroUserConfig<
 		 * 4. pathname
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   image: {
 		 *     // Example: allow processing all images from your aws s3 bucket
 		 *     remotePatterns: [{
@@ -2144,7 +2231,7 @@ export interface AstroUserConfig<
 		 *       hostname: '**.amazonaws.com',
 		 *     }],
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 *
 		 * You can use wildcards to define the permitted `hostname` and `pathname` values as described below. Otherwise, only the exact values provided will be configured.
@@ -2301,12 +2388,14 @@ export interface AstroUserConfig<
 		 * - `false` - do not apply syntax highlighting.
 
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   markdown: {
 		 *     // Example: Switch to use prism for syntax highlighting in Markdown
 		 *     syntaxHighlight: 'prism',
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 	 	 * For more control over syntax highlighting, you can instead specify a configuration object with the properties listed below.
@@ -2369,12 +2458,14 @@ export interface AstroUserConfig<
 		 * Pass [remark plugins](https://github.com/remarkjs/remark) to customize how your Markdown is built. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * ```js
+		 * import { defineConfig } from 'astro/config';
 		 * import remarkToc from 'remark-toc';
-		 * {
+		 *
+		 * export default defineConfig({
 		 *   markdown: {
 		 *     remarkPlugins: [ [remarkToc, { heading: "contents"} ] ]
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		remarkPlugins?: RemarkPlugins;
@@ -2389,12 +2480,14 @@ export interface AstroUserConfig<
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * ```js
+		 * import { defineConfig } from 'astro/config';
 		 * import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
-		 * {
+		 *
+		 * export default defineConfig({
 		 *   markdown: {
 		 *     rehypePlugins: [rehypeAccessibleEmojis]
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		rehypePlugins?: RehypePlugins;
@@ -2411,11 +2504,13 @@ export interface AstroUserConfig<
 		 * Astro uses [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) by default. To disable this, set the `gfm` flag to `false`:
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   markdown: {
 		 *     gfm: false,
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 */
 		gfm?: boolean;
@@ -2451,12 +2546,14 @@ export interface AstroUserConfig<
 		 * Pass options to [remark-rehype](https://github.com/remarkjs/remark-rehype#api).
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   markdown: {
 		 *     // Example: Translate the footnotes text to another language, here are the default English values
 		 *     remarkRehype: { footnoteLabel: "Footnotes", footnoteBackLabel: "Back to reference 1"},
 		 *   },
-		 * };
+		 * });
 		 * ```
 		 */
 		remarkRehype?: RemarkRehype;
@@ -2573,7 +2670,7 @@ export interface AstroUserConfig<
 		 *       fr: "en"
 		 *     }
 		 *   }
-		 * })
+		 * });
 		 * ```
 		 */
 		fallback?: [TLocales] extends [never]
@@ -2606,7 +2703,7 @@ export interface AstroUserConfig<
 		 *       fallbackType: "redirect",
 		 *     }
 		 *   }
-		 * })
+		 * });
 		 * ```
 		 *
 		 * Since 4.6.0, this option can also be set to `manual`. When this routing strategy is enabled, Astro will **disable** its i18n middleware and no other `routing` options (e.g. `prefixDefaultLocale`) may be configured. You will be responsible for writing your own routing logic, or executing Astro's i18n middleware manually alongside your own.
@@ -2618,7 +2715,7 @@ export interface AstroUserConfig<
 		 *     locales: ["en", "fr"],
 		 *     routing: "manual"
 		 *   }
-		 * })
+		 * });
 		 * ```
 		 *
 		 */
@@ -2650,7 +2747,7 @@ export interface AstroUserConfig<
 					 *       prefixDefaultLocale: true,
 					 *     }
 					 *   }
-					 * })
+					 * });
 					 * ```
 					 */
 					prefixDefaultLocale?: boolean;
@@ -2679,8 +2776,8 @@ export interface AstroUserConfig<
 					 *       redirectToDefaultLocale: true
 					 *     }
 					 *   }
-					 * })
-					 *```
+					 * });
+					 * ```
 					 * */
 					redirectToDefaultLocale?: boolean;
 
@@ -2716,7 +2813,7 @@ export interface AstroUserConfig<
 					 *       fr: "en",
 					 *     }
 					 *   },
-					 * })
+					 * });
 					 * ```
 					 */
 					fallbackType?: 'redirect' | 'rewrite';
@@ -2757,7 +2854,7 @@ export interface AstroUserConfig<
 		 *       es: "https://example.es"
 		 *     }
 		 *   },
-		 * })
+		 * });
 		 * ```
 		 *
 		 * Both page routes built and URLs returned by the `astro:i18n` helper functions [`getAbsoluteLocaleUrl()`](https://docs.astro.build/en/reference/modules/astro-i18n/#getabsolutelocaleurl) and [`getAbsoluteLocaleUrlList()`](https://docs.astro.build/en/reference/modules/astro-i18n/#getabsolutelocaleurllist) will use the options set in `i18n.domains`.
@@ -2807,7 +2904,7 @@ export interface AstroUserConfig<
 		 *       API_SECRET: envField.string({ context: "server", access: "secret" }),
 		 *     }
 		 *   }
-		 * })
+		 * });
 		 * ```
 		 */
 		schema?: EnvSchema;
@@ -2835,7 +2932,7 @@ export interface AstroUserConfig<
 		 *     },
 		 *     validateSecrets: true
 		 *   }
-		 * })
+		 * });
 		 * ```
 		 */
 		validateSecrets?: boolean;
@@ -3109,16 +3206,16 @@ export interface AstroUserConfig<
 	 *
 	 * ```js
 	 * // astro.config.mjs
-	 * import { memoryCache } from 'astro/config';
+	 * import { defineConfig, memoryCache } from 'astro/config';
 	 *
-	 * {
+	 * export default defineConfig({
 	 *   cache: {
 	 *     provider: memoryCache(),
 	 *   },
 	 *   routeRules: {
 	 *     '/blog/[...path]': { maxAge: 300, swr: 60 },
 	 *   },
-	 * }
+	 * });
 	 * ```
 	 *
 	 * Use `Astro.cache.set()` in routes and `context.cache.set()` in middleware
@@ -3162,15 +3259,15 @@ export interface AstroUserConfig<
 	 *
 	 * ```js
 	 * // astro.config.mjs
-	 * import { memoryCache } from 'astro/config';
+	 * import { defineConfig, memoryCache } from 'astro/config';
 	 *
-	 * {
+	 * export default defineConfig({
 	 *   cache: { provider: memoryCache() },
 	 *   routeRules: {
 	 *     '/api/[...path]': { swr: 600 },
 	 *     '/products/[...slug]': { maxAge: 3600, tags: ['products'] },
 	 *   },
-	 * }
+	 * });
 	 * ```
 	 */
 	routeRules?: RouteRules;
@@ -3229,7 +3326,9 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   prefetch: {
 		 *     prefetchAll: true,
 		 *     defaultStrategy: 'viewport',
@@ -3237,7 +3336,7 @@ export interface AstroUserConfig<
 		 *   experimental: {
 		 *     clientPrerender: true,
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 *
 		 * Continue to use the `data-astro-prefetch` attribute on any `<a />` link on your site to opt in to prefetching.
@@ -3262,11 +3361,13 @@ export interface AstroUserConfig<
 		 * When enabled, this feature will generate and add JSON schemas to the `.astro` directory in your project. These files can be used by the Astro language server to provide Intellisense inside content files (`.md`, `.mdx`, `.mdoc`).
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   experimental: {
 		 *     contentIntellisense: true,
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 *
 		 * To use this feature with the Astro VS Code extension, you must also enable the `astro.content-intellisense` option in your VS Code settings. For editors using the Astro language server directly, pass the `contentIntellisense: true` initialization parameter to enable this feature.
@@ -3311,12 +3412,14 @@ export interface AstroUserConfig<
 		 * and better performance while maintaining visual quality.
 		 *
 		 * ```js
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   experimental: {
 		 *     // Enable with defaults
 		 *     svgOptimizer: svgoOptimizer()
 		 *   }
-		 * }
+		 * });
 		 * ```
 		 *
 		 * See the [experimental SVG optimization docs](https://docs.astro.build/en/reference/experimental-flags/svg-optimization/) for more information.
@@ -3383,11 +3486,13 @@ export interface AstroUserConfig<
 		 *
 		 * ```js
 		 * // astro.config.mjs
-		 * {
+		 * import { defineConfig } from 'astro/config';
+		 *
+		 * export default defineConfig({
 		 *   experimental: {
 		 *     incrementalBuild: true,
 		 *   },
-		 * }
+		 * });
 		 * ```
 		 *
 		 * In your dynamic routes, return a `cacheKey` from `getStaticPaths()`:

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1581,6 +1581,7 @@ export interface AstroUserConfig<
 	 * });
 	 * ```
 	 */
+	server?: ServerConfig | ((options: { command: 'dev' | 'preview' }) => ServerConfig);
 
 	/**
 	 * @docs
@@ -1668,8 +1669,6 @@ export interface AstroUserConfig<
 	 * @description
 	 * Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
 	 */
-
-	server?: ServerConfig | ((options: { command: 'dev' | 'preview' }) => ServerConfig);
 
 	/**
 	 * @docs
@@ -3007,6 +3006,11 @@ export interface AstroUserConfig<
 	 *
 	 * See our guide for more information on [using custom fonts in Astro](https://docs.astro.build/en/guides/fonts/).
 	 */
+	fonts?: [TFontProviders] extends [never]
+		? Array<FontFamily>
+		: {
+				[K in keyof TFontProviders]: FontFamily<TFontProviders[K]>;
+			};
 
 	/**
 	 * @docs
@@ -3242,12 +3246,6 @@ export interface AstroUserConfig<
 	 * variationSettings: "'xhgt' 0.7"
 	 * ```
 	 */
-
-	fonts?: [TFontProviders] extends [never]
-		? Array<FontFamily>
-		: {
-				[K in keyof TFontProviders]: FontFamily<TFontProviders[K]>;
-			};
 
 	/**
 	 * @docs


### PR DESCRIPTION
This is part of my "Review Astro Docs code snippets" series. I know there a lot of changes... this is mostly because of indentation. I can split the PR if it's easier, but I mainly wanted to avoid having our translators update this file multiple times.

## Changes

Updates our [config reference](https://docs.astro.build/en/reference/configuration-reference/) to:
- Remove `$` from the CLI snippet in `root`. When someone copy/paste it from Astro Docs, `$` is included. If we want to highlight this is the CLI, we should add an introductory sentence instead.
- Fix some incorrect code snippets:
  - `session.driver`: missing comma
  - `i18n.fallback`: we got `Object literal may only specify known properties, and 'pt' does not exist in type`, we have to set `fallback` with the values available in `locales` (`pt-br` instead of `pt`)
  - `i18n.domains`: the option is `i18n.routing.prefixDefaultLocale` and not `i18n.prefixDefaultLocale`
- Normalize indentation: some code snippets mixed tabs and spaces. In Astro Docs, this is correctly rendered but not in the JSDoc on hover. I think this harms DX. For example in the following JSDoc, the whole `i18n` part is affected:
  <img width="524" height="366" alt="i18n.domains code snippet" src="https://github.com/user-attachments/assets/44b9ec35-35a2-46e4-b4d0-050c108105a2" />
- Add missing line breaks after `@description`: when the text starts on the same line as `@description`, the code snippets indentation is broken on hover:
  <img width="614" height="329" alt="redirects code snippet" src="https://github.com/user-attachments/assets/df1aa9b7-07c0-468a-b38b-856fae7e8925" />
- Update `server` and `fonts` JSDoc order: when hovering `server` (for example) in VSCode, the JSDoc for `server.headers` is displayed instead of the one for `server`. The nested properties should be defined after `server`, as we do for `logger`.
  <img width="798" height="284" alt="Hovering `server` in a project shows `server.headers`" src="https://github.com/user-attachments/assets/4ab87aa9-8168-47c9-8104-f93abd874ca6" />
- Wrap config objects in `export default defineConfig()`. The object alone might be fine for some properties (e.g. `site`) but others add imports on top and this becomes both invalid and confusing. For example: https://docs.astro.build/en/reference/configuration-reference/#routerules
  <img width="731" height="286" alt="routeRules code snippet in Astro Docs" src="https://github.com/user-attachments/assets/637dd2a4-10eb-4255-a11c-75d668d5cab0" />
- Add missing titles for consistency: Note that we use both `title="astro.config.mjs"` and `// astro.config.mjs` in this file. Both works for Astro Docs, but I think the comment format is better here as the filename is displayed in the JSDoc.


## Testing

N/A (well, manually by hovering the JSDoc 😅 )

## Docs

This is docs. However, I'm not quite sure about the changeset... I mean, we need one as this affects docs but, there is maybe a better way to summarize the changes affecting docs.

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
