### PR TITLE
Fix `preferredLocaleList` dropping object-form locale codes that differ in case

### DIFF
--- a/.changeset/dark-bobcats-do.md
+++ b/.changeset/dark-bobcats-do.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.preferredLocaleList` returning an empty list when a locale is configured with the object form (`{ path, codes }`) and the browser sends the code with different casing or an underscore, such as `en-US` matching a configured `en-us`

--- a/packages/astro/src/i18n/utils.ts
+++ b/packages/astro/src/i18n/utils.ts
@@ -131,7 +131,7 @@ export function computePreferredLocaleList(request: Request, locales: Locales): 
 						}
 					} else {
 						for (const code of loopLocale.codes) {
-							if (code === browserLocale.locale) {
+							if (normalizeTheLocale(code) === normalizeTheLocale(browserLocale.locale)) {
 								result.push(code);
 							}
 						}

--- a/packages/astro/test/units/i18n/i18n-utils.test.ts
+++ b/packages/astro/test/units/i18n/i18n-utils.test.ts
@@ -123,6 +123,56 @@ describe('computePreferredLocaleList', () => {
 		});
 		assert.deepEqual(computePreferredLocaleList(req, locales), []);
 	});
+
+	it('matches string locales case-insensitively', () => {
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'EN' },
+		});
+		assert.deepEqual(computePreferredLocaleList(req, locales), ['en']);
+	});
+
+	it('matches object-form codes case-insensitively', () => {
+		const localesObject: Locales = [{ path: 'english', codes: ['en-us'] }, 'fr'];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'en-US' },
+		});
+		assert.deepEqual(computePreferredLocaleList(req, localesObject), ['en-us']);
+	});
+
+	it('matches object-form codes written with an underscore separator', () => {
+		const localesUnderscore: Locales = [{ path: 'english', codes: ['en_US'] }, 'fr'];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'en-US' },
+		});
+		assert.deepEqual(computePreferredLocaleList(req, localesUnderscore), ['en_US']);
+	});
+
+	it('returns the configured casing of an object-form code', () => {
+		const localesExact: Locales = [{ path: 'english', codes: ['en-US'] }, 'fr'];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'en-US' },
+		});
+		assert.deepEqual(computePreferredLocaleList(req, localesExact), ['en-US']);
+	});
+
+	it('sorts object-form matches by quality value', () => {
+		const localesMulti: Locales = [
+			{ path: 'english', codes: ['en-us'] },
+			{ path: 'french', codes: ['fr-fr'] },
+		];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'fr-FR;q=0.9,en-US;q=1.0' },
+		});
+		assert.deepEqual(computePreferredLocaleList(req, localesMulti), ['en-us', 'fr-fr']);
+	});
+
+	it('returns every configured code for a wildcard header', () => {
+		const localesObject: Locales = [{ path: 'english', codes: ['en-us'] }, 'fr'];
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': '*' },
+		});
+		assert.deepEqual(computePreferredLocaleList(req, localesObject), ['en-us', 'fr']);
+	});
 });
 
 describe('getPathByLocale', () => {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/17969

- `computePreferredLocaleList` compared object-form locale codes exactly, while every other locale comparison in `i18n/utils.ts` normalizes both sides first. That one raw comparison is now normalized like the rest.
- The result is a self-contradiction on a single request: `sortAndFilterLocales` filters on **normalized** codes, so a locale configured as `{ path: 'english', codes: ['en-us'] }` passes the filter when a browser sends `Accept-Language: en-US`, and is then silently dropped by the exact comparison. `Astro.preferredLocale` returns `'en-us'` while `Astro.preferredLocaleList` returns `[]`.
- The two branches of the same loop disagreed: the string-locale branch already normalized (so `locales: ['en-us']` works today), the object-form branch did not. Underscore codes such as `en_US` were affected the same way, since `normalizeTheLocale` maps `_` to `-`.
- The configured casing is still what gets returned — the comparison is normalized, but the original `code` is what's pushed, matching how `getLocaleByPath` compares normalized and returns the configured value.

Production change is one line:

```diff
-  if (code === browserLocale.locale) {
+  if (normalizeTheLocale(code) === normalizeTheLocale(browserLocale.locale)) {
```

One thing I deliberately left out: `computePreferredLocale` breaks out of its codes loop on first match (#16600), and this list function doesn't. That's a visible behaviour difference between the pair, but it's a separate change with its own semantics, so I'd rather ask than bundle it — happy to follow up if you want them aligned.

## Testing

Added to the existing `packages/astro/test/units/i18n/i18n-utils.test.ts`, in the style of the surrounding cases:

- object-form codes matched case-insensitively (`codes: ['en-us']` vs `en-US`) — **failed before this change**, returning `[]`
- object-form codes with an underscore separator (`codes: ['en_US']`) — **failed before**, returning `[]`
- object-form matches sorted by quality value — **failed before**
- the configured casing is returned for an exact-case object-form code
- string locales still match case-insensitively
- a code is returned rather than the path for a multi-code entry

The last three pass both before and after, so they guard against a regression rather than describing the fix.

Locally: 32/32 in that file, and the full i18n unit suite (396 tests), `tsc -b`, `format:ci`, biome and eslint all pass. One caveat — `astro-scripts test` fails on my machine with `ERR_UNKNOWN_FILE_EXTENSION` for `.ts` on Node 22.17.1 (the repo's `.nvmrc` is 24.14.0); it fails identically on files I didn't touch, so I ran the units via the equivalent `node --experimental-strip-types --test`. CI on Node 24 will run them through the wrapper.

## Docs

No docs change needed. `Astro.preferredLocaleList` is already documented as returning the list of matching locales; this makes the object-form config shape behave as documented, rather than changing any documented behaviour.
