### PR TITLE
Fix incremental build serving cached HTML with stale CSS filenames after stylesheet-only edits

### DIFF
--- a/.changeset/wacky-teeth-wear.md
+++ b/.changeset/wacky-teeth-wear.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes incremental builds serving cached HTML that references stale CSS filenames after a stylesheet-only edit

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -1,11 +1,12 @@
 import crypto from 'node:crypto';
+import nodeFs from 'node:fs';
 import type { Plugin as VitePlugin } from 'vite';
 import { FONTS_SERVER_ADDRESS_PLACEHOLDER } from '../../../assets/fonts/constants.js';
 import { PROPAGATED_ASSET_FLAG } from '../../../content/consts.js';
 import { hasContentFlag } from '../../../content/utils.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../constants.js';
 import { removeQueryString } from '../../path.js';
-import { rootRelativePath } from '../../viteUtils.js';
+import { CSS_LANGS_RE, rootRelativePath } from '../../viteUtils.js';
 import { moduleIsTopLevelPage } from '../graph.js';
 import { isContentDataIncrementalModule } from '../incremental-metadata.js';
 import type { BuildInternals } from '../internal.js';
@@ -84,6 +85,10 @@ function resolveAssetPlaceholders(graph: ModuleGraph, code: string): string {
  * file on disk but still carry generated code. Emitted-asset placeholders in
  * that code are resolved to their file names first, since the handles
  * themselves are not stable between builds.
+ *
+ * CSS modules are a special case: Vite extracts their content during the
+ * prerender build, leaving `code` as an empty string. For those modules, the
+ * source file is read from disk so that CSS edits invalidate the hash.
  */
 function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
 	const hasher = crypto.createHash('sha256');
@@ -91,8 +96,18 @@ function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
 		hasher.update(id);
 		hasher.update('\n');
 		const code = graph.getModuleInfo(id)?.code;
-		if (code != null) {
+		if (code != null && code.length > 0) {
 			hasher.update(resolveAssetPlaceholders(graph, code));
+		} else if (CSS_LANGS_RE.test(id)) {
+			// Vite extracts CSS into separate assets, so the module's `code` in the
+			// prerender bundle is empty. Read the source file so that stylesheet
+			// changes are reflected in the dependency hash (#17704).
+			try {
+				hasher.update(nodeFs.readFileSync(removeQueryString(id), 'utf-8'));
+			} catch {
+				// Virtual CSS or unreadable file — skip. The worst case is a
+				// cache miss (re-render), never a stale hit.
+			}
 		}
 		hasher.update('\n');
 	}

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, describe, it } from 'node:test';
 import { pluginIncremental } from '../../../dist/core/build/plugins/plugin-incremental.js';
 import { VIRTUAL_PAGE_RESOLVED_MODULE_ID } from '../../../dist/vite-plugin-pages/const.js';
 
@@ -121,6 +124,32 @@ describe('pluginIncremental', () => {
 			const second = dependencyHash(code, {});
 			assert.equal(first, second);
 			assert.match(first, /^[0-9a-f]{64}$/);
+		});
+
+		describe('CSS modules (#17704)', () => {
+			const tmpDir = mkdtempSync(join(tmpdir(), 'astro-css-test-'));
+			after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+			it('changes when a CSS file on disk is modified', () => {
+				const cssPath = join(tmpDir, 'global.css');
+				writeFileSync(cssPath, 'body { color: red; }');
+				const first = dependencyHash({ [cssPath]: '' }, {});
+
+				writeFileSync(cssPath, 'body { color: blue; }');
+				const second = dependencyHash({ [cssPath]: '' }, {});
+
+				assert.notEqual(first, second);
+			});
+
+			it('is stable for an unchanged CSS file', () => {
+				const cssPath = join(tmpDir, 'styles.css');
+				writeFileSync(cssPath, 'body { color: green; }');
+
+				const first = dependencyHash({ [cssPath]: '' }, {});
+				const second = dependencyHash({ [cssPath]: '' }, {});
+
+				assert.equal(first, second);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- CSS modules in the prerender build have empty `code` — Vite extracts their content into separate assets, leaving the module's `code` as `""`. Because `hashModules()` was skipping modules with no code, CSS edits never changed the dependency hash and `canSkip()` incorrectly returned `true`, restoring cached HTML that referenced the old, now-missing `_astro/*.css` filename.
- When a module's code is empty and its ID matches `CSS_LANGS_RE`, `hashModules()` now reads the source file from disk and includes its contents in the hash. CSS edits now produce a different dependency hash, causing affected pages to re-render with the correct stylesheet reference.

Closes #17704

## Testing

- Added two unit tests in `plugin-incremental.test.ts` under `CSS modules (#17704)`: one that asserts the hash changes when the CSS file is modified on disk, and one that asserts the hash is stable when the file is unchanged.

## Docs

- No docs update needed — this fixes a bug in `experimental.incrementalBuild`, which is not yet documented beyond the config reference.