### PR TITLE
Support importing .apng files

### DIFF
--- a/.changeset/twelve-apes-smile.md
+++ b/.changeset/twelve-apes-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds support for importing `.apng` files as images, matching how `.png` and `.gif` already work

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -110,6 +110,10 @@ declare module '*.avif' {
 	const metadata: ImageMetadata;
 	export default metadata;
 }
+declare module '*.apng' {
+	const metadata: ImageMetadata;
+	export default metadata;
+}
 declare module '*.svg' {
 	const Component: import('./types').SvgComponent & ImageMetadata;
 	export default Component;

--- a/packages/astro/src/assets/consts.ts
+++ b/packages/astro/src/assets/consts.ts
@@ -32,7 +32,6 @@ export const VALID_SUPPORTED_FORMATS = [
 	'gif',
 	'svg',
 	'avif',
-	'apng',
 ] as const;
 export const DEFAULT_OUTPUT_FORMAT = 'webp' as const;
 export const VALID_OUTPUT_FORMATS = ['avif', 'png', 'webp', 'jpeg', 'jpg', 'svg'] as const;

--- a/packages/astro/src/assets/consts.ts
+++ b/packages/astro/src/assets/consts.ts
@@ -17,6 +17,7 @@ export const VALID_INPUT_FORMATS = [
 	'gif',
 	'svg',
 	'avif',
+	'apng',
 ] as const;
 /**
  * Valid formats that our base services support.
@@ -31,6 +32,7 @@ export const VALID_SUPPORTED_FORMATS = [
 	'gif',
 	'svg',
 	'avif',
+	'apng',
 ] as const;
 export const DEFAULT_OUTPUT_FORMAT = 'webp' as const;
 export const VALID_OUTPUT_FORMATS = ['avif', 'png', 'webp', 'jpeg', 'jpg', 'svg'] as const;

--- a/packages/astro/test/units/content-collections/image-references.test.ts
+++ b/packages/astro/test/units/content-collections/image-references.test.ts
@@ -19,6 +19,13 @@ const heroMeta: ImageMetadata = {
 	format: 'png',
 };
 
+describe('imageSrcToImportId', () => {
+	it('resolves an .apng import id', () => {
+		const id = imageSrcToImportId('./hero.apng', FILE_NAME);
+		assert.ok(id, 'imageSrcToImportId returned undefined for .apng');
+	});
+});
+
 describe('updateImageReferencesInData', () => {
 	it('replaces a top-level image src with resolved ImageMetadata', () => {
 		const data = { image: './hero.png' };

--- a/packages/astro/test/units/content-collections/image-references.test.ts
+++ b/packages/astro/test/units/content-collections/image-references.test.ts
@@ -19,13 +19,6 @@ const heroMeta: ImageMetadata = {
 	format: 'png',
 };
 
-describe('imageSrcToImportId', () => {
-	it('resolves an .apng import id', () => {
-		const id = imageSrcToImportId('./hero.apng', FILE_NAME);
-		assert.ok(id, 'imageSrcToImportId returned undefined for .apng');
-	});
-});
-
 describe('updateImageReferencesInData', () => {
 	it('replaces a top-level image src with resolved ImageMetadata', () => {
 		const data = { image: './hero.png' };
@@ -149,5 +142,12 @@ describe('resolveEntryData', () => {
 
 		assert.deepEqual(result.image, heroMeta);
 		assert.equal(data.image, './hero.png');
+	});
+});
+
+describe('imageSrcToImportId', () => {
+	it('resolves an .apng import id', () => {
+		const id = imageSrcToImportId('./hero.apng', FILE_NAME);
+		assert.ok(id);
 	});
 });


### PR DESCRIPTION
## Changes

- Adds `'apng'` to `VALID_INPUT_FORMATS` and `VALID_SUPPORTED_FORMATS` in `packages/astro/src/assets/consts.ts`, and a matching `declare module '*.apng'` block in `packages/astro/client.d.ts`, mirroring the existing `.png` entries. Without these, Vite's asset plugin never intercepts `.apng` imports, so they fall through as generic static assets (a data URI) instead of going through the image pipeline as `ImageMetadata`, and TypeScript reports `Cannot find module ... ts(2307)` on the import itself.
- APNG is binary-compatible with PNG, so the existing image-size probe and sharp already handle it correctly; this is purely a registration gap, not a missing codec.

Closes #17709

## Testing

- Added a test in `test/units/content-collections/image-references.test.ts` asserting `imageSrcToImportId` resolves an `.apng` path, which exercises the `VALID_INPUT_FORMATS` check directly.
- Ran the full unit suite (`pnpm run test:unit`) locally: all pre-existing tests still pass.

## Docs

No docs changes needed. `.apng` now behaves exactly like the other already-documented raster formats (`.png`, `.gif`, etc.).