### PR TITLE
fix: deprecation warnings and inline comments from Astro 7.0 to 8.0.

### DIFF
--- a/.changeset/cyan-pigs-take.md
+++ b/.changeset/cyan-pigs-take.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Updates deprecation warnings and inline comments for the all removal target from Astro 7.0 to 8.0.
+Updates deprecation messages target from Astro 7 to 8

--- a/.changeset/cyan-pigs-take.md
+++ b/.changeset/cyan-pigs-take.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates deprecation warnings and inline comments for the all removal target from Astro 7.0 to 8.0.

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -7,7 +7,7 @@
 /// <reference path="./types/transitions.d.ts" />
 
 interface ImportMetaEnv {
-	// TODO: remove in Astro 7
+	// TODO: remove in Astro 8
 	/**
 	 * The prefix for Astro-generated asset links if the build.assetsPrefix config option is set. This can be used to create asset links not handled by Astro.
 	 * @deprecated This will be removed in a future major version of Astro. Use `build.assetsPrefix` from `astro:config/server` instead.
@@ -149,11 +149,11 @@ declare module 'astro:components' {
 	export * from 'astro/components';
 }
 
-// TODO: remove in Astro 7
+// TODO: remove in Astro 8
 /**
  * @deprecated
  * `import { z } from 'astro:schema'` is deprecated and will be removed
- * in Astro 7. Use `import { z } from 'astro/zod'` instead.
+ * in Astro 8. Use `import { z } from 'astro/zod'` instead.
  */
 declare module 'astro:schema' {
 	export * from 'astro/zod';
@@ -162,7 +162,7 @@ declare module 'astro:schema' {
 	/**
 	 * @deprecated
 	 * `import { z } from 'astro:schema'` is deprecated and will be removed
-	 * in Astro 7. Use `import { z } from 'astro/zod'` instead.
+	 * in Astro 8. Use `import { z } from 'astro/zod'` instead.
 	 */
 	export const z = zod.z;
 }

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -214,13 +214,13 @@ export function createGetEntry({ liveCollections }: { liveCollections: LiveColle
 				data,
 				collection,
 			} as DataEntryResult | ContentEntryResult;
-			// TODO: remove in Astro 7
+			// TODO: remove in Astro 8
 			warnForPropertyAccess(
 				result.data,
 				'slug',
 				`[content] Attempted to access deprecated property on "${collection}" entry.\nThe "slug" property is no longer automatically added to entries. Please use the "id" property instead.`,
 			);
-			// TODO: remove in Astro 7
+			// TODO: remove in Astro 8
 			warnForPropertyAccess(
 				result,
 				'render',

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -50,7 +50,7 @@ export async function compile({
 			normalizedFilename: normalizeFilename(filename, astroConfig.root),
 			sourcemap: 'both',
 			internalURL: 'astro/compiler-runtime',
-			// TODO: remove in Astro v7
+			// TODO: remove in Astro v8
 			astroGlobalArgs: JSON.stringify(astroConfig.site),
 			scopedStyleStrategy: astroConfig.scopedStyleStrategy,
 			resultScopedSlot: true,

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -276,7 +276,7 @@ export async function createVite(
 					find: 'astro:middleware',
 					replacement: 'astro/virtual-modules/middleware.js',
 				},
-				// TODO: remove in Astro 7
+				// TODO: remove in Astro 8
 				{
 					find: 'astro:schema',
 					replacement: 'astro/zod',

--- a/packages/astro/src/core/session/types.ts
+++ b/packages/astro/src/core/session/types.ts
@@ -44,7 +44,7 @@ export interface BaseSessionConfig {
 interface DriverConfig<TDriver extends SessionDriverConfig> extends BaseSessionConfig {
 	/** Config object for a session driver */
 	driver: TDriver;
-	/** @deprecated Pass options to the driver function directly. This will be removed in Astro 7 */
+	/** @deprecated Pass options to the driver function directly. This will be removed in Astro 8 */
 	options?: never;
 }
 
@@ -56,12 +56,12 @@ interface UnstorageConfig<
 > extends BaseSessionConfig {
 	/**
 	 * Entrypoint for an unstorage session driver
-	 * @deprecated Use `import { sessionDrivers } from 'astro/config'` instead. This will be removed in Astro 7
+	 * @deprecated Use `import { sessionDrivers } from 'astro/config'` instead. This will be removed in Astro 8
 	 */
 	driver?: TDriver;
 	/**
 	 * Options for the unstorage driver
-	 * @deprecated Use `import { sessionDrivers } from 'astro/config'` instead. This will be removed in Astro 7
+	 * @deprecated Use `import { sessionDrivers } from 'astro/config'` instead. This will be removed in Astro 8
 	 */
 	options?: TOptions;
 }
@@ -69,12 +69,12 @@ interface UnstorageConfig<
 interface CustomConfig extends BaseSessionConfig {
 	/**
 	 * Entrypoint for a custom session driver
-	 * @deprecated Use the object shape (type `SessionDriverConfig`). This will be removed in Astro 7
+	 * @deprecated Use the object shape (type `SessionDriverConfig`). This will be removed in Astro 8
 	 */
 	driver?: string;
 	/**
 	 * Options for the custom session driver
-	 * @deprecated Use the object shape (type `SessionDriverConfig`). This will be removed in Astro 7
+	 * @deprecated Use the object shape (type `SessionDriverConfig`). This will be removed in Astro 8
 	 */
 	options?: Record<string, unknown>;
 }

--- a/packages/astro/src/runtime/server/astro-global.ts
+++ b/packages/astro/src/runtime/server/astro-global.ts
@@ -13,7 +13,7 @@ function createError(name: string) {
 // inside of getStaticPaths. See the `astroGlobalArgs` option for parameter type.
 export function createAstro(site: string | undefined): AstroGlobal {
 	return {
-		// TODO: throw in Astro 7
+		// TODO: throw in Astro 8
 		get site() {
 			// This is created inside of the runtime so we don't have access to the Astro logger.
 			console.warn(
@@ -21,7 +21,7 @@ export function createAstro(site: string | undefined): AstroGlobal {
 			);
 			return site ? new URL(site) : undefined;
 		},
-		// TODO: throw in Astro 7
+		// TODO: throw in Astro 8
 		get generator() {
 			// This is created inside of the runtime so we don't have access to the Astro logger.
 			console.warn(

--- a/packages/astro/templates/content/module.mjs
+++ b/packages/astro/templates/content/module.mjs
@@ -13,7 +13,7 @@ export {
 	defineLiveCollection,
 	renderEntry as render,
 } from 'astro/content/runtime';
-// TODO: remove in Astro 7
+// TODO: remove in Astro 8
 export { z } from 'astro/zod';
 
 /* @@LIVE_CONTENT_CONFIG@@ */
@@ -38,8 +38,8 @@ export const getLiveEntry = createGetLiveEntry({
 	liveCollections,
 });
 
-// TODO: remove in Astro 7
+// TODO: remove in Astro 8
 export const getEntryBySlug = createDeprecatedFunction('getEntryBySlug');
 
-// TODO: remove in Astro 7
+// TODO: remove in Astro 8
 export const getDataEntryById = createDeprecatedFunction('getDataEntryById');

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -10,11 +10,11 @@ declare module 'astro:content' {
 	} from 'astro/content/config';
 	export { defineLiveCollection, defineCollection } from 'astro/content/config';
 
-	// TODO: remove in Astro 7
+	// TODO: remove in Astro 8
 	/**
 	 * @deprecated
 	 * `import { z } from 'astro:content'` is deprecated and will be removed
-	 * in Astro 7. Use `import { z } from 'astro/zod'` instead.
+	 * in Astro 8. Use `import { z } from 'astro/zod'` instead.
 	 */
 	export const z = zod.z;
 


### PR DESCRIPTION
## Changes
Please refar this comment from @florian-lefebvre san.

> IIRC all comments/deprecations that talk about Astro 7 are wrong because v7 was a small focused major. Instead they should mention v8

In this PR, deprecation warnings and inline comments from Astro 7.0 to 8.0.