### PR TITLE
fix: rebuild module imports after content entry deletion

### DIFF
--- a/.changeset/fix-content-modules-stale-import.md
+++ b/.changeset/fix-content-modules-stale-import.md
@@ -3,3 +3,5 @@
 ---
 
 Fixes `content-modules.mjs` not removing entries for deleted or renamed content files, which could cause Vite to attempt to resolve non-existent modules
+
+As part of this fix, `#moduleImports` is now fully rebuilt from `deferredRender` entries before every write, so a module import added only through the public `addModuleImport()` API without a corresponding `deferredRender` entry in the store will no longer be preserved across writes.

--- a/.changeset/fix-content-modules-stale-import.md
+++ b/.changeset/fix-content-modules-stale-import.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `content-modules.mjs` not removing entries for deleted or renamed content files, which could cause Vite to attempt to resolve non-existent modules

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -59,6 +59,7 @@ export class MutableDataStore extends ImmutableDataStore {
 			collection.delete(String(key));
 			this.#saveToDiskDebounced();
 			this.#writeAssetsImportsDebounced();
+			this.#writeModulesImportsDebounced();
 		}
 	}
 
@@ -66,12 +67,14 @@ export class MutableDataStore extends ImmutableDataStore {
 		this._collections.delete(collectionName);
 		this.#saveToDiskDebounced();
 		this.#writeAssetsImportsDebounced();
+		this.#writeModulesImportsDebounced();
 	}
 
 	clearAll() {
 		this._collections.clear();
 		this.#saveToDiskDebounced();
 		this.#writeAssetsImportsDebounced();
+		this.#writeModulesImportsDebounced();
 	}
 
 	addAssetImport(assetImport: string, filePath?: string) {
@@ -123,6 +126,27 @@ export class MutableDataStore extends ImmutableDataStore {
 		}
 	}
 
+	/**
+	 * Rebuilds #moduleImports from the current entries in _collections.
+	 * This ensures stale module entries are removed when content files are
+	 * deleted or renamed, preventing Vite from attempting to resolve
+	 * non-existent files listed in content-modules.mjs.
+	 */
+	#rebuildModuleImports() {
+		this.#moduleImports.clear();
+		for (const collection of this._collections.values()) {
+			for (const entry of collection.values()) {
+				const typedEntry = entry as DataEntry;
+				if (typedEntry.deferredRender && typedEntry.filePath) {
+					const id = contentModuleToId(typedEntry.filePath);
+					if (id) {
+						this.#moduleImports.set(typedEntry.filePath, id);
+					}
+				}
+			}
+		}
+	}
+
 	async writeAssetImports(filePath: PathLike) {
 		this.#assetsFile = filePath;
 		this.#rebuildAssetImports();
@@ -164,6 +188,7 @@ export default new Map([${exports.join(', ')}]);
 
 	async writeModuleImports(filePath: PathLike) {
 		this.#modulesFile = filePath;
+		this.#rebuildModuleImports();
 
 		if (this.#moduleImports.size === 0) {
 			try {

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -196,6 +196,7 @@ export default new Map([${exports.join(', ')}]);
 			} catch (err) {
 				throw new AstroError(AstroErrorData.UnknownFilesystemError, { cause: err });
 			}
+			return;
 		}
 
 		if (!this.#modulesDirty && existsSync(filePath)) {

--- a/packages/astro/test/units/content-collections/mutable-data-store.test.ts
+++ b/packages/astro/test/units/content-collections/mutable-data-store.test.ts
@@ -128,7 +128,7 @@ describe('MutableDataStore', () => {
 		);
 	});
 
-	it('removes stale module imports when an entry is deleted', async () => {
+	it('removes stale module imports when an entry is deleted (via debounced write trigger)', async () => {
 		const modulesFilePath = path.join(tmpDir, 'content-modules-delete.mjs');
 		const store = new MutableDataStore();
 		const scoped = store.scopedStore('docs');
@@ -152,8 +152,12 @@ describe('MutableDataStore', () => {
 		assert.ok(contentBefore.includes('page-a.mdx'), 'should contain page-a before deletion');
 		assert.ok(contentBefore.includes('page-b.mdx'), 'should contain page-b before deletion');
 
+		// Do NOT call writeModuleImports() again here: that would rebuild and write
+		// synchronously regardless of whether delete() actually schedules a rewrite.
+		// Rely solely on the debounced trigger that delete() is supposed to schedule,
+		// flushed via waitUntilSaveComplete(), so this test exercises the real
+		// dev-server code path (a filesystem delete triggers a rewrite on its own).
 		scoped.delete('page-a');
-		await store.writeModuleImports(modulesFilePath);
 		await store.waitUntilSaveComplete();
 
 		const contentAfter = await fs.readFile(modulesFilePath, 'utf-8');
@@ -164,7 +168,7 @@ describe('MutableDataStore', () => {
 		assert.ok(contentAfter.includes('page-b.mdx'), 'should still contain page-b');
 	});
 
-	it('removes stale module imports when a collection is cleared', async () => {
+	it('removes stale module imports when a collection is cleared (via debounced write trigger)', async () => {
 		const modulesFilePath = path.join(tmpDir, 'content-modules-clear.mjs');
 		const store = new MutableDataStore();
 		const scoped = store.scopedStore('docs');
@@ -181,13 +185,88 @@ describe('MutableDataStore', () => {
 		assert.ok(contentBefore.includes('page-1.mdx'), 'should contain page-1 before clear');
 
 		scoped.clear();
-		await store.writeModuleImports(modulesFilePath);
 		await store.waitUntilSaveComplete();
 
 		const contentAfter = await fs.readFile(modulesFilePath, 'utf-8');
 		assert.ok(
 			!contentAfter.includes('page-1.mdx'),
 			'should NOT contain page-1 after the collection is cleared',
+		);
+	});
+
+	it('removes stale module imports when the entire store is cleared via clearAll (via debounced write trigger)', async () => {
+		const modulesFilePath = path.join(tmpDir, 'content-modules-clear-all.mjs');
+		const store = new MutableDataStore();
+		const docsScoped = store.scopedStore('docs');
+		const blogScoped = store.scopedStore('blog');
+
+		docsScoped.set({
+			id: 'page-1',
+			data: {},
+			filePath: 'src/content/docs/page-1.mdx',
+			deferredRender: true,
+		});
+		blogScoped.set({
+			id: 'post-1',
+			data: {},
+			filePath: 'src/content/blog/post-1.mdx',
+			deferredRender: true,
+		});
+
+		await store.writeModuleImports(modulesFilePath);
+		const contentBefore = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(contentBefore.includes('page-1.mdx'), 'should contain page-1 before clearAll');
+		assert.ok(contentBefore.includes('post-1.mdx'), 'should contain post-1 before clearAll');
+
+		store.clearAll();
+		await store.waitUntilSaveComplete();
+
+		const contentAfter = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(
+			!contentAfter.includes('page-1.mdx'),
+			'should NOT contain page-1 after clearAll',
+		);
+		assert.ok(
+			!contentAfter.includes('post-1.mdx'),
+			'should NOT contain post-1 after clearAll',
+		);
+	});
+
+	it('removes the old module import and adds the new one when an entry is renamed (issue #17707)', async () => {
+		// A rename is how glob.ts actually models it: delete the old id, then set the new one.
+		const modulesFilePath = path.join(tmpDir, 'content-modules-rename.mjs');
+		const store = new MutableDataStore();
+		const scoped = store.scopedStore('docs');
+
+		scoped.set({
+			id: 'otp',
+			data: {},
+			filePath: 'src/content/docs/otp.mdx',
+			deferredRender: true,
+		});
+
+		await store.writeModuleImports(modulesFilePath);
+		const contentBefore = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(contentBefore.includes('otp.mdx'), 'should contain the original file before rename');
+
+		// Rename: delete the old entry, then set the new one under a new id/filePath.
+		scoped.delete('otp');
+		scoped.set({
+			id: 'the-otp',
+			data: {},
+			filePath: 'src/content/docs/the-otp.mdx',
+			deferredRender: true,
+		});
+		await store.waitUntilSaveComplete();
+
+		const contentAfter = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(
+			!contentAfter.includes('"src/content/docs/otp.mdx"'),
+			'should NOT reference the old (renamed-away) file path',
+		);
+		assert.ok(
+			contentAfter.includes('the-otp.mdx'),
+			'should reference the new (renamed-to) file path',
 		);
 	});
 

--- a/packages/astro/test/units/content-collections/mutable-data-store.test.ts
+++ b/packages/astro/test/units/content-collections/mutable-data-store.test.ts
@@ -128,6 +128,69 @@ describe('MutableDataStore', () => {
 		);
 	});
 
+	it('removes stale module imports when an entry is deleted', async () => {
+		const modulesFilePath = path.join(tmpDir, 'content-modules-delete.mjs');
+		const store = new MutableDataStore();
+		const scoped = store.scopedStore('docs');
+
+		scoped.set({
+			id: 'page-a',
+			data: {},
+			filePath: 'src/content/docs/page-a.mdx',
+			deferredRender: true,
+		});
+
+		scoped.set({
+			id: 'page-b',
+			data: {},
+			filePath: 'src/content/docs/page-b.mdx',
+			deferredRender: true,
+		});
+
+		await store.writeModuleImports(modulesFilePath);
+		const contentBefore = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(contentBefore.includes('page-a.mdx'), 'should contain page-a before deletion');
+		assert.ok(contentBefore.includes('page-b.mdx'), 'should contain page-b before deletion');
+
+		scoped.delete('page-a');
+		await store.writeModuleImports(modulesFilePath);
+		await store.waitUntilSaveComplete();
+
+		const contentAfter = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(
+			!contentAfter.includes('page-a.mdx'),
+			'should NOT contain page-a after the entry is deleted',
+		);
+		assert.ok(contentAfter.includes('page-b.mdx'), 'should still contain page-b');
+	});
+
+	it('removes stale module imports when a collection is cleared', async () => {
+		const modulesFilePath = path.join(tmpDir, 'content-modules-clear.mjs');
+		const store = new MutableDataStore();
+		const scoped = store.scopedStore('docs');
+
+		scoped.set({
+			id: 'page-1',
+			data: {},
+			filePath: 'src/content/docs/page-1.mdx',
+			deferredRender: true,
+		});
+
+		await store.writeModuleImports(modulesFilePath);
+		const contentBefore = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(contentBefore.includes('page-1.mdx'), 'should contain page-1 before clear');
+
+		scoped.clear();
+		await store.writeModuleImports(modulesFilePath);
+		await store.waitUntilSaveComplete();
+
+		const contentAfter = await fs.readFile(modulesFilePath, 'utf-8');
+		assert.ok(
+			!contentAfter.includes('page-1.mdx'),
+			'should NOT contain page-1 after the collection is cleared',
+		);
+	});
+
 	it('reproduces race condition: concurrent writeToDisk() calls lose data', async () => {
 		const filePath = pathToFileURL(path.join(tmpDir, 'data-store.json'));
 		const store = await MutableDataStore.fromFile(filePath);


### PR DESCRIPTION
Fixes #17707

## Changes

- `content-modules.mjs` was only ever appended to via `#moduleImports`, so deleting or renaming a content file with `deferredRender` left a stale entry pointing at a non-existent file. This caused Vite to attempt to resolve the missing module (e.g. in dev, after removing an MDX/Markdown page).
- Added `#rebuildModuleImports()`, mirroring the existing `#rebuildAssetImports()` pattern used for the asset-imports stale-entry fix (#16097). It clears `#moduleImports` and rebuilds it from the current `_collections` state.
- `writeModuleImports()` now calls `#rebuildModuleImports()` before writing, and `delete()`, `clear()`, and `clearAll()` now also trigger a debounced module-imports rewrite (previously they only rewrote asset imports).

## Testing

Added two unit tests to `packages/astro/test/units/content-collections/mutable-data-store.test.ts`:

- `removes stale module imports when an entry is deleted`
- `removes stale module imports when a collection is cleared`

Ran the full `mutable-data-store.test.ts` suite locally (8 tests, all passing):

```
✔ removes stale image asset import after entry image path is updated (issue #16097)
✔ removes asset imports when an entry is deleted
✔ removes asset imports when a collection is cleared
✔ removes stale module imports when an entry is deleted
✔ removes stale module imports when a collection is cleared
✔ reproduces race condition: concurrent writeToDisk() calls lose data
✔ strips image prefixes and records their paths as out-of-band imageImports
✔ does not set imageImports when the entry has no images
```

## Docs

No user-facing API changes; no docs needed.