### PR TITLE
fix(check): handle TypeScript 7 not exposing default export (#17268)

### DIFF
--- a/.changeset/hip-mangos-clap.md
+++ b/.changeset/hip-mangos-clap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a false "package not installed" error when a dependency (such as TypeScript 7+) no longer exposes a default entry in its `exports` map. Astro now falls back to checking `package.json` resolution before prompting to install the package.

--- a/.changeset/tame-planets-fly.md
+++ b/.changeset/tame-planets-fly.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/check': patch
+---
+
+Fixes `astro check` crashing with an opaque `ERR_PACKAGE_PATH_NOT_EXPORTED` error when TypeScript is installed but doesn't expose a default CJS export (as with TypeScript 7's native compiler). It now shows a clear, actionable message explaining that TypeScript 7's native compiler doesn't yet ship the programmatic Language Service API `astro check` relies on, instead of crashing or falling back to a misleading "please install typescript" prompt.
+
+Full `astro check` support for TypeScript 7 is tracked separately in [withastro/roadmap#1321](https://github.com/withastro/roadmap/discussions/1321) and requires TypeScript to ship that API first.

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -28,7 +28,22 @@ export async function getPackage<T>(
 		const resolved = require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
 		const packageImport = await import(pathToFileURL(resolved).href);
 		return packageImport as T;
-	} catch {
+	} catch (err) {
+		// Some packages (e.g. TypeScript 7+) no longer expose a default CJS export in their
+		// `exports` map, so `require.resolve()` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` even
+		// though the package is installed. Fall back to resolving `package.json` to confirm
+		// installation instead of treating this the same as "not installed".
+		if ((err as NodeJS.ErrnoException)?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+			try {
+				require.resolve(`${packageName}/package.json`, {
+					paths: [options.cwd ?? process.cwd()],
+				});
+				return {} as T;
+			} catch {
+				// Fall through to the "not installed" handling below
+			}
+		}
+
 		if (options.optional) return undefined;
 		let message = `To continue, Astro requires the following dependency to be installed: ${bold(
 			packageName,

--- a/packages/astro/test/units/cli/install-package.test.ts
+++ b/packages/astro/test/units/cli/install-package.test.ts
@@ -37,4 +37,42 @@ describe('getPackage', () => {
 			await rm(projectDir, { recursive: true, force: true });
 		}
 	});
+
+	it('treats a package with no default export map entry (e.g. TypeScript 7) as installed', async () => {
+		// Simulate a package whose `exports` map has no `.` entry, like TypeScript 7,
+		// which causes `require.resolve(packageName)` to throw `ERR_PACKAGE_PATH_NOT_EXPORTED`
+		// instead of `MODULE_NOT_FOUND`.
+		const projectDir = join(tmpdir(), `astro-test-getpackage-no-export-${Date.now()}`);
+		const pkgDir = join(projectDir, 'node_modules', 'fake-no-export-pkg');
+
+		try {
+			await mkdir(pkgDir, { recursive: true });
+			await writeFile(
+				join(pkgDir, 'package.json'),
+				JSON.stringify({
+					name: 'fake-no-export-pkg',
+					version: '1.0.0',
+					type: 'module',
+					exports: {
+						'./package.json': './package.json',
+						'./unstable/sync': './unstable/sync.js',
+					},
+				}),
+			);
+			await mkdir(join(pkgDir, 'unstable'), { recursive: true });
+			await writeFile(join(pkgDir, 'unstable', 'sync.js'), 'export const loaded = true;\n');
+
+			const result = await getPackage('fake-no-export-pkg', defaultLogger, {
+				cwd: projectDir,
+				optional: true,
+			});
+
+			assert.ok(
+				result,
+				'Expected getPackage to treat the package as installed despite ERR_PACKAGE_PATH_NOT_EXPORTED',
+			);
+		} finally {
+			await rm(projectDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/language-tools/astro-check/src/index.ts
+++ b/packages/language-tools/astro-check/src/index.ts
@@ -16,6 +16,33 @@ export function parseArgsAsCheckConfig(args: string[]) {
 
 export type Flags = Pick<ReturnType<typeof parseArgsAsCheckConfig>, keyof typeof options>;
 
+/**
+ * Message shown when TypeScript is installed but doesn't expose the programmatic
+ * Language Service API that `astro check` relies on (TypeScript 7's native compiler
+ * does not ship this API yet).
+ */
+export const UNSUPPORTED_TYPESCRIPT_MESSAGE =
+	`The installed version of TypeScript does not expose the programmatic Language Service API that ` +
+	`\`astro check\` relies on. TypeScript's native compiler (7.0 and later) does not ship this API yet. ` +
+	`Until it does, run \`astro check\` with a TypeScript version that still provides it (6.x). ` +
+	`See https://github.com/withastro/roadmap/discussions/1321 to track support.`;
+
+/**
+ * Resolves the path to the installed `typescript` package, or `undefined` if it's
+ * installed but has no default CJS export map entry (e.g. TypeScript 7+), which makes
+ * `resolve('typescript')` throw `ERR_PACKAGE_PATH_NOT_EXPORTED` instead of resolving.
+ */
+export function resolveTypeScriptPath(resolve: (id: string) => string): string | undefined {
+	try {
+		return resolve('typescript');
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException)?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+			return undefined;
+		}
+		throw err;
+	}
+}
+
 export async function check(flags: Partial<Flags> & { watch: true }): Promise<void>;
 export async function check(flags: Partial<Flags> & { watch: false }): Promise<boolean>;
 export async function check(flags: Partial<Flags>): Promise<boolean | void>;
@@ -25,7 +52,14 @@ export async function check(flags: Partial<Flags>): Promise<boolean | void>;
 export async function check(flags: Partial<Flags>): Promise<boolean | void> {
 	const workspaceRoot = path.resolve(flags.root ?? process.cwd());
 	const require = createRequire(import.meta.url);
-	const checker = new AstroCheck(workspaceRoot, require.resolve('typescript'), flags.tsconfig);
+
+	const typescriptPath = resolveTypeScriptPath((id) => require.resolve(id));
+	if (!typescriptPath) {
+		console.error(`${red(bold('✖'))} ${UNSUPPORTED_TYPESCRIPT_MESSAGE}`);
+		return true;
+	}
+
+	const checker = new AstroCheck(workspaceRoot, typescriptPath, flags.tsconfig);
 
 	let req = 0;
 

--- a/packages/language-tools/astro-check/test/resolveTypeScriptPath.test.ts
+++ b/packages/language-tools/astro-check/test/resolveTypeScriptPath.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { resolveTypeScriptPath } from '../dist/index.js';
+
+describe('resolveTypeScriptPath', () => {
+	it('returns the resolved path when resolution succeeds', () => {
+		const result = resolveTypeScriptPath(() => '/some/path/to/typescript/lib/typescript.js');
+		assert.strictEqual(result, '/some/path/to/typescript/lib/typescript.js');
+	});
+
+	it('returns undefined when typescript has no default export map entry (e.g. TypeScript 7)', () => {
+		const result = resolveTypeScriptPath(() => {
+			const err = new Error('ERR_PACKAGE_PATH_NOT_EXPORTED') as NodeJS.ErrnoException;
+			err.code = 'ERR_PACKAGE_PATH_NOT_EXPORTED';
+			throw err;
+		});
+		assert.strictEqual(result, undefined);
+	});
+
+	it('rethrows other resolution errors (e.g. package genuinely not installed)', () => {
+		assert.throws(
+			() =>
+				resolveTypeScriptPath(() => {
+					const err = new Error('Cannot find module') as NodeJS.ErrnoException;
+					err.code = 'MODULE_NOT_FOUND';
+					throw err;
+				}),
+			/Cannot find module/,
+		);
+	});
+});


### PR DESCRIPTION
Refs #17268

## Changes

`astro check` had **two** separate unguarded `require.resolve('typescript')` call sites that both break under TypeScript 7 (which removes the default `.` CJS export from its `exports` map, so resolution throws `ERR_PACKAGE_PATH_NOT_EXPORTED` instead of the expected `MODULE_NOT_FOUND`):

1. `packages/astro/src/cli/install-package.ts` (`getPackage()`), which gates the "please install typescript" prompt.
2. `packages/language-tools/astro-check/src/index.ts` (`@astrojs/check`'s own `check()` entrypoint), which is reached only *after* (1) is fixed.

**Both are now fixed:**

- `getPackage()` catches `ERR_PACKAGE_PATH_NOT_EXPORTED` specifically and falls back to resolving `${packageName}/package.json` to confirm the package is genuinely installed, instead of treating it the same as "not installed".
- `@astrojs/check`'s `check()` now catches the same error via a new `resolveTypeScriptPath()` helper. Previously, once (1) was fixed in isolation, this second call site would crash with an uncaught `ERR_PACKAGE_PATH_NOT_EXPORTED` a few lines later — arguably worse than the original misleading prompt. It now prints a clear, actionable message instead.

**Important scope note:** this does **not** make `astro check` run diagnostics under TypeScript 7. TypeScript 7's native compiler does not yet ship the programmatic Language Service API (`ts.createProgram`, `LanguageServiceHost`, etc.) that `@astrojs/check`'s Volar-based checker is built on — confirmed against the `typescript@7.x` `exports` map, which only exposes `./unstable/ast`, `./unstable/sync`, `./unstable/async`, not the classic compiler API. This is tracked upstream at [withastro/roadmap#1321](https://github.com/withastro/roadmap/discussions/1321) and requires TypeScript to ship that API first — it's out of scope for this PR. (There's already an `assertCompatibleTypeScript()` guard in `@astrojs/language-server`'s `AstroCheck` for the case where a *future* TS7 build partially exposes this API but still lacks pieces of it; this PR's fix is for the earlier crash that happens before that guard is ever reached.)

Because of this, `@astrojs/check`'s `peerDependencies` range for `typescript` intentionally still excludes `^7.0.0` — widening it would incorrectly advertise working type-checking support that doesn't exist yet.

**What this PR actually fixes** (matching the original report): `astro check` no longer falsely claims TypeScript "is not installed" when TypeScript 7 is present, at either call site, and no longer crashes with an opaque error. Instead, users now get an accurate, actionable message pointing at the tracking issue. Running diagnostics normally under TypeScript 7 remains blocked upstream by TypeScript itself.

## Testing

- `packages/astro/test/units/cli/install-package.test.ts`: existing regression test for `getPackage()`'s `ERR_PACKAGE_PATH_NOT_EXPORTED` handling.
- `packages/language-tools/astro-check/test/resolveTypeScriptPath.test.ts` (new): unit tests for `resolveTypeScriptPath()` covering success, `ERR_PACKAGE_PATH_NOT_EXPORTED` (returns `undefined`), and other resolution errors (rethrown).
- Ran `pnpm test` in `packages/language-tools/astro-check` — all 9 tests pass (3 new + 6 existing, unaffected).

## Changesets

- `astro` (existing): fixes the install-detection false negative.
- `@astrojs/check` (new): fixes the second crash site with a clear message, and documents that full TS7 support is tracked separately.
