### PR TITLE
fix(collections): chunk writing of collections

### DIFF
--- a/.changeset/dark-owls-lead.md
+++ b/.changeset/dark-owls-lead.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where Astro could go into out of memory when the `experimental.collectionStorage` is set to `chunked`, and there are multiple, concurrent updates to the same collection.

--- a/.changeset/dark-owls-lead.md
+++ b/.changeset/dark-owls-lead.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue where Astro could go into out of memory when the `experimental.collectionStorage` is set to `chunked`, and there are multiple, concurrent updates to the same collection.
+Fixes an issue where Astro could run out of memory when `experimental.collectionStorage` is set to `chunked` and there are multiple concurrent updates to the same collection.

--- a/packages/astro/src/content/data-store-writer.ts
+++ b/packages/astro/src/content/data-store-writer.ts
@@ -163,7 +163,7 @@ export class ChunkedWriter implements DataStoreWriter {
 		this.#writtenFiles = new Set();
 		const manifest: DataStoreManifest = {};
 
-		for (const [collectionName, entries] of collections) {
+		for (const [collectionName, entries] of sortCollections(collections)) {
 			manifest[collectionName] = await this.#writeCollection(entries);
 		}
 

--- a/packages/astro/src/content/data-store-writer.ts
+++ b/packages/astro/src/content/data-store-writer.ts
@@ -4,10 +4,7 @@ import xxhash, { type XXHashAPI } from 'xxhash-wasm';
 import { emptyDir } from '../core/fs/index.js';
 import { DATA_STORE_MANIFEST_FILE } from './consts.js';
 
-/**
- * A chunked store manifest: each collection maps to the list of part file names
- * whose contents concatenate back into that collection's serialized string.
- */
+/** A chunked store manifest: each collection maps to its content-addressed part files. */
 export type DataStoreManifest = Record<string, string[]>;
 
 /**
@@ -52,6 +49,30 @@ export function serializeDataStore(collections: Map<string, Map<string, any>>): 
 const ENCODER = new TextEncoder();
 
 /**
+ * Finds the end of the largest UTF-8-safe slice beginning at `startIndex` that
+ * fits within `maxBytes`. A code point larger than `maxBytes` is returned on
+ * its own so callers always make progress.
+ */
+function getChunkEnd(str: string, startIndex: number, maxBytes: number) {
+	let index = startIndex;
+	let bytes = 0;
+	while (index < str.length) {
+		const codePoint = str.codePointAt(index)!;
+		const charLength = codePoint > 0xffff ? 2 : 1;
+		const charBytes = ENCODER.encode(str.slice(index, index + charLength)).length;
+		if (bytes + charBytes > maxBytes && index > startIndex) {
+			break;
+		}
+		index += charLength;
+		bytes += charBytes;
+		if (bytes >= maxBytes) {
+			break;
+		}
+	}
+	return { endIndex: index, bytes };
+}
+
+/**
  * Split a string into parts each at most `maxBytes` UTF-8 bytes, never splitting
  * a Unicode code point across parts.
  *
@@ -59,29 +80,17 @@ const ENCODER = new TextEncoder();
  * on UTF-16 code-unit boundaries (e.g. `String.prototype.slice`) can cut a
  * surrogate pair in half; encoding a lone surrogate to UTF-8 substitutes U+FFFD,
  * so concatenating the re-read parts would corrupt any astral-plane character
- * (emoji, some CJK, etc.). Iterating with `for...of` yields whole code points,
- * so `str.slice` is only ever called on code-point boundaries and the parts
- * always rejoin to the exact original string.
+ * (emoji, some CJK, etc.). `getChunkEnd()` advances by Unicode code point, so
+ * `str.slice` is only ever called on code-point boundaries and the parts always
+ * rejoin to the exact original string.
  */
 export function chunkString(str: string, maxBytes: number): string[] {
 	const chunks: string[] = [];
-	let startIndex = 0; // UTF-16 index where the current part starts
-	let index = 0; // current UTF-16 index (always on a code-point boundary)
-	let currentBytes = 0;
-	for (const char of str) {
-		const charBytes = ENCODER.encode(char).length;
-		// Close the current part before it would exceed the byte limit, but never
-		// emit an empty part (guards against a single code point over the limit).
-		if (currentBytes + charBytes > maxBytes && index > startIndex) {
-			chunks.push(str.slice(startIndex, index));
-			startIndex = index;
-			currentBytes = 0;
-		}
-		index += char.length; // 1 for BMP, 2 for a surrogate pair
-		currentBytes += charBytes;
-	}
-	if (startIndex < str.length) {
-		chunks.push(str.slice(startIndex));
+	let startIndex = 0;
+	while (startIndex < str.length) {
+		const { endIndex } = getChunkEnd(str, startIndex, maxBytes);
+		chunks.push(str.slice(startIndex, endIndex));
+		startIndex = endIndex;
 	}
 	return chunks;
 }
@@ -125,9 +134,9 @@ export class FileWriter implements DataStoreWriter {
  * A {@link DataStoreWriter} that splits the store across many content-addressed
  * files inside a directory, described by a manifest.
  *
- * Each collection is serialized to a string and split into parts no larger than
- * a fixed byte size, so no single file grows unbounded (platform file-size
- * limits). Each part file is named by the xxhash of its contents, so unchanged
+ * Entries are serialized independently into parts no larger than a fixed byte
+ * size, so writing a collection does not require a collection-wide serialized
+ * string. Each part file is named by the xxhash of its contents, so unchanged
  * parts keep the same name across builds and their writes are skipped, and two
  * identical parts are naturally deduplicated. The manifest is written last as
  * the commit point, and stale files are pruned afterwards. This is the inverse
@@ -138,6 +147,7 @@ export class ChunkedWriter implements DataStoreWriter {
 	#manifestFile: URL;
 	#chunkSize: number;
 	#hasher?: XXHashAPI;
+	#writtenFiles = new Set<string>();
 
 	constructor(dir: URL, chunkSize: number) {
 		this.#dir = dir;
@@ -149,32 +159,61 @@ export class ChunkedWriter implements DataStoreWriter {
 		if (!this.#hasher) {
 			this.#hasher = await xxhash();
 		}
-		const { h64ToString } = this.#hasher;
 
-		// Track every file this snapshot references so the rest can be pruned.
-		const writtenFiles = new Set<string>();
+		this.#writtenFiles = new Set();
 		const manifest: DataStoreManifest = {};
 
-		// Sorted iteration keeps file names deterministic across builds.
-		for (const [collectionName, entries] of sortCollections(collections)) {
-			const stringified = devalue.stringify(entries);
-			// Split the serialized collection so no single file grows unbounded.
-			const parts: string[] = [];
-			for (const part of chunkString(stringified, this.#chunkSize)) {
-				const fileName = `${h64ToString(part)}.txt`;
-				await writeFileAtomic(new URL(`./${fileName}`, this.#dir), part);
-				parts.push(fileName);
-				writtenFiles.add(fileName);
-			}
-			manifest[collectionName] = parts;
+		for (const [collectionName, entries] of collections) {
+			manifest[collectionName] = await this.#writeCollection(entries);
 		}
 
 		// The manifest is the commit point: every part it references already
 		// exists on disk, so a reader never sees a dangling reference.
 		await writeFileAtomic(this.#manifestFile, JSON.stringify(manifest));
-		writtenFiles.add(DATA_STORE_MANIFEST_FILE);
+		this.#writtenFiles.add(DATA_STORE_MANIFEST_FILE);
 
 		// Prune files left behind by previous snapshots.
-		emptyDir(this.#dir, writtenFiles);
+		emptyDir(this.#dir, this.#writtenFiles);
+	}
+
+	async #writeCollection(entries: Iterable<[string, unknown]>) {
+		const parts: string[] = [];
+		let chunk = '';
+		let chunkBytes = 0;
+
+		const writeChunk = async () => {
+			const fileName = `${this.#hasher!.h64ToString(chunk)}.txt`;
+			await writeFileAtomic(new URL(`./${fileName}`, this.#dir), chunk);
+			parts.push(fileName);
+			this.#writtenFiles.add(fileName);
+			chunk = '';
+			chunkBytes = 0;
+		};
+
+		for (const [id, entry] of entries) {
+			const serialized = `${devalue.stringify([id, entry])}\n`;
+			let startIndex = 0;
+
+			while (startIndex < serialized.length) {
+				const { endIndex, bytes } = getChunkEnd(
+					serialized,
+					startIndex,
+					this.#chunkSize - chunkBytes,
+				);
+				chunk += serialized.slice(startIndex, endIndex);
+				chunkBytes += bytes;
+				startIndex = endIndex;
+
+				if (chunkBytes >= this.#chunkSize) {
+					await writeChunk();
+				}
+			}
+		}
+
+		if (chunk) {
+			await writeChunk();
+		}
+
+		return parts;
 	}
 }

--- a/packages/astro/src/content/data-store.ts
+++ b/packages/astro/src/content/data-store.ts
@@ -37,6 +37,32 @@ export interface DataEntry<TData extends Record<string, unknown> = Record<string
 	assetImports?: Array<string>;
 }
 
+export class ChunkedCollectionParser {
+	#entries = new Map<string, any>();
+	#remainder = '';
+
+	add(part: string) {
+		const content = this.#remainder + part;
+		const records = content.split('\n');
+		this.#remainder = records.pop()!;
+
+		for (const record of records) {
+			const parsed = devalue.parse(record);
+			if (!Array.isArray(parsed) || parsed.length !== 2 || typeof parsed[0] !== 'string') {
+				throw new Error('Invalid chunked data store entry');
+			}
+			this.#entries.set(parsed[0], parsed[1]);
+		}
+	}
+
+	finish() {
+		if (this.#remainder) {
+			throw new Error('Invalid chunked data store entry');
+		}
+		return this.#entries;
+	}
+}
+
 /**
  * A read-only data store for content collections. This is used to retrieve data from the content layer at runtime.
  * To add or modify data, use {@link MutableDataStore} instead.
@@ -90,21 +116,19 @@ export class ImmutableDataStore {
 	 *
 	 * Each collection maps to a list of parts. A part is either a raw string
 	 * (when the store is loaded from disk) or an ESM namespace from a virtual
-	 * chunk import (`{ default: string }`, when emitted at runtime). A collection's
-	 * parts are concatenated back into the exact
-	 * serialized string, then parsed with devalue. This is the inverse of
+	 * chunk import (`{ default: string }`, when emitted at runtime). Each part
+	 * contains independently serialized entry records. This is the inverse of
 	 * {@link import('./data-store-writer.js').ChunkedWriter} and stays free of
 	 * Node built-ins so it can run at runtime.
 	 */
 	static manifestToMap(manifest: Record<string, Array<string | { default: string }>>) {
 		const collections = new Map<string, Map<string, any>>();
 		for (const [collectionName, parts] of Object.entries(manifest)) {
-			let stringified = '';
+			const parser = new ChunkedCollectionParser();
 			for (const part of parts) {
-				stringified += typeof part === 'string' ? part : part.default;
+				parser.add(typeof part === 'string' ? part : part.default);
 			}
-			const entries: Map<string, any> = devalue.parse(stringified);
-			collections.set(collectionName, entries);
+			collections.set(collectionName, parser.finish());
 		}
 		return collections;
 	}

--- a/packages/astro/src/content/data-store.ts
+++ b/packages/astro/src/content/data-store.ts
@@ -37,6 +37,10 @@ export interface DataEntry<TData extends Record<string, unknown> = Record<string
 	assetImports?: Array<string>;
 }
 
+/**
+ * Rebuilds a collection from ordered parts containing newline-delimited
+ * `devalue.stringify([id, entry])` records.
+ */
 export class ChunkedCollectionParser {
 	#entries = new Map<string, any>();
 	#remainder = '';

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -12,7 +12,7 @@ import {
 	FileWriter,
 	serializeDataStore,
 } from './data-store-writer.js';
-import { type DataEntry, ImmutableDataStore } from './data-store.js';
+import { ChunkedCollectionParser, type DataEntry, ImmutableDataStore } from './data-store.js';
 import { contentModuleToId } from './utils.js';
 
 const SAVE_DEBOUNCE_MS = 500;
@@ -519,17 +519,15 @@ export default new Map([\n${lines.join(',\n')}]);
 			try {
 				const manifestData = await fs.readFile(manifestFile, 'utf-8');
 				const manifest: DataStoreManifest = JSON.parse(manifestData);
-				// Swap each referenced part file name for its contents.
-				const expanded: Record<string, string[]> = {};
+				const collections = new Map<string, Map<string, any>>();
 				for (const collectionName in manifest) {
-					expanded[collectionName] = await Promise.all(
-						manifest[collectionName].map((fileName) =>
-							fs.readFile(new URL(`./${fileName}`, dirPath), 'utf-8'),
-						),
-					);
+					const parser = new ChunkedCollectionParser();
+					for (const fileName of manifest[collectionName]) {
+						parser.add(await fs.readFile(new URL(`./${fileName}`, dirPath), 'utf-8'));
+					}
+					collections.set(collectionName, parser.finish());
 				}
-				const map = ImmutableDataStore.manifestToMap(expanded);
-				const store = await MutableDataStore.fromMap(map);
+				const store = await MutableDataStore.fromMap(collections);
 				store.#writer = new ChunkedWriter(dirPath, chunkSize);
 				return store;
 			} catch (err) {

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -523,6 +523,8 @@ export default new Map([\n${lines.join(',\n')}]);
 				for (const collectionName in manifest) {
 					const parser = new ChunkedCollectionParser();
 					for (const fileName of manifest[collectionName]) {
+						// Parsing each part before reading the next prevents raw collection
+						// contents from accumulating in memory during cache restoration.
 						parser.add(await fs.readFile(new URL(`./${fileName}`, dirPath), 'utf-8'));
 					}
 					collections.set(collectionName, parser.finish());

--- a/packages/astro/test/units/content-layer/manifest-to-map.test.ts
+++ b/packages/astro/test/units/content-layer/manifest-to-map.test.ts
@@ -3,16 +3,16 @@ import { describe, it } from 'node:test';
 import * as devalue from 'devalue';
 import { ImmutableDataStore } from '../../../dist/content/data-store.js';
 
-function serialize(entries: Array<[string, any]>): string {
-	return devalue.stringify(new Map(entries));
+function serialize(id: string, entry: any): string {
+	return `${devalue.stringify([id, entry])}\n`;
 }
 
 describe('Content Layer - manifestToMap', () => {
 	it('parses a collection with a single part', () => {
-		const part = serialize([
-			['one', { id: 'one', data: { n: 1 } }],
-			['two', { id: 'two', data: { n: 2 } }],
-		]);
+		const part = `${serialize('one', { id: 'one', data: { n: 1 } })}${serialize('two', {
+			id: 'two',
+			data: { n: 2 },
+		})}`;
 		const map = ImmutableDataStore.manifestToMap({ blog: [part] });
 		assert.deepEqual([...map.keys()], ['blog']);
 		const blog: any = map.get('blog');
@@ -21,8 +21,8 @@ describe('Content Layer - manifestToMap', () => {
 		assert.deepEqual(blog.get('two'), { id: 'two', data: { n: 2 } });
 	});
 
-	it('concatenates multiple parts before parsing', () => {
-		const serialized = serialize([['a', { id: 'a', data: { n: 1 } }]]);
+	it('parses an entry split across multiple parts', () => {
+		const serialized = serialize('a', { id: 'a', data: { n: 1 } });
 		const mid = Math.floor(serialized.length / 2);
 		const parts = [serialized.slice(0, mid), serialized.slice(mid)];
 		const map = ImmutableDataStore.manifestToMap({ blog: parts });
@@ -31,8 +31,8 @@ describe('Content Layer - manifestToMap', () => {
 	});
 
 	it('rebuilds multiple collections', () => {
-		const blog = serialize([['post', { id: 'post', data: { title: 'Hi' } }]]);
-		const authors = serialize([['jane', { id: 'jane', data: { name: 'Jane' } }]]);
+		const blog = serialize('post', { id: 'post', data: { title: 'Hi' } });
+		const authors = serialize('jane', { id: 'jane', data: { name: 'Jane' } });
 		const map = ImmutableDataStore.manifestToMap({ blog: [blog], authors: [authors] });
 		assert.deepEqual([...map.keys()], ['blog', 'authors']);
 		const blogMap: any = map.get('blog');
@@ -42,7 +42,7 @@ describe('Content Layer - manifestToMap', () => {
 	});
 
 	it('accepts parts as raw-import namespaces ({ default: string })', () => {
-		const serialized = serialize([['a', { id: 'a', data: { n: 1 } }]]);
+		const serialized = serialize('a', { id: 'a', data: { n: 1 } });
 		const mid = Math.floor(serialized.length / 2);
 		const parts = [{ default: serialized.slice(0, mid) }, serialized.slice(mid)];
 		const map = ImmutableDataStore.manifestToMap({ blog: parts });

--- a/packages/astro/test/units/content-layer/store-persistence.test.ts
+++ b/packages/astro/test/units/content-layer/store-persistence.test.ts
@@ -492,4 +492,30 @@ describe('Content Layer - Store Persistence (chunked atomicity)', () => {
 		assert.equal(partsOnDisk.length, 1);
 		assert.equal(partsOnDisk[0], manifest.alpha[0]);
 	});
+
+	it('writes a deterministic manifest independent of entry insertion order', async () => {
+		const firstDir = new URL('./first/', createTempDir());
+		const firstStore = await MutableDataStore.fromDir(firstDir, CHUNK_SIZE);
+		firstStore.set('zoo', 'second', { id: 'second', data: { value: 2 } });
+		firstStore.set('zoo', 'first', { id: 'first', data: { value: 1 } });
+		firstStore.set('alpha', 'only', { id: 'only', data: { value: 3 } });
+		await firstStore.waitUntilSaveComplete();
+
+		const secondDir = new URL('./second/', createTempDir());
+		const secondStore = await MutableDataStore.fromDir(secondDir, CHUNK_SIZE);
+		secondStore.set('alpha', 'only', { id: 'only', data: { value: 3 } });
+		secondStore.set('zoo', 'first', { id: 'first', data: { value: 1 } });
+		secondStore.set('zoo', 'second', { id: 'second', data: { value: 2 } });
+		await secondStore.waitUntilSaveComplete();
+
+		const firstManifest = await fs.readFile(
+			new URL(`./${DATA_STORE_MANIFEST_FILE}`, firstDir),
+			'utf-8',
+		);
+		const secondManifest = await fs.readFile(
+			new URL(`./${DATA_STORE_MANIFEST_FILE}`, secondDir),
+			'utf-8',
+		);
+		assert.equal(firstManifest, secondManifest);
+	});
 });

--- a/packages/astro/test/units/content-layer/store-persistence.test.ts
+++ b/packages/astro/test/units/content-layer/store-persistence.test.ts
@@ -216,6 +216,25 @@ describe('Content Layer - Store Persistence', () => {
 });
 
 describe('Content Layer - Store Persistence (chunked)', () => {
+	it('streams entry records across part boundaries', async () => {
+		const tempDir = createTempDir();
+		const dataStoreDir = new URL('./data-store/', tempDir);
+		const store = await MutableDataStore.fromDir(dataStoreDir, 16);
+		store.set('notes', 'first', { id: 'first', data: { text: 'first\nentry' } });
+		store.set('notes', 'second', { id: 'second', data: { text: 'second entry' } });
+		await store.waitUntilSaveComplete();
+
+		const reloaded = await MutableDataStore.fromDir(dataStoreDir, 16);
+		assert.deepEqual(reloaded.get('notes', 'first'), {
+			id: 'first',
+			data: { text: 'first\nentry' },
+		});
+		assert.deepEqual(reloaded.get('notes', 'second'), {
+			id: 'second',
+			data: { text: 'second entry' },
+		});
+	});
+
 	it('persists and accumulates entries across builds', async () => {
 		const tempDir = createTempDir();
 		const dataStoreDir = new URL('./data-store/', tempDir);


### PR DESCRIPTION
## Changes

Fixes a bug I found while using the chunked collection storage. This fix splits the writing, so it should avoid the OOM I experienced

## Testing

Added new tests.

I will create a preview release and test it

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
