### PR TITLE
Switch to general purpose agent bot

### DIFF
--- a/.github/factory.yml
+++ b/.github/factory.yml
@@ -1,7 +1,8 @@
 version: 1
-trigger:
-  label: "pr: astro-review"
+
 review:
+  trigger:
+    label: "pr: astro-review"
   skill: .agents/skills/astro-code-review
   severity: [critical, high, medium, low, optional]
   areas:
@@ -15,3 +16,8 @@ review:
     - maintainability
     - documentation
     - changeset
+
+# Review only for now. Triage is enabled by default, so it has to be
+# switched off explicitly.
+triage:
+  enabled: false


### PR DESCRIPTION
## Changes

- Switches from astro-review.yml -> factory.yml, a general purpose agent bot that includes review and other things.
- Only review enabled right now. It works exactly the same as astro-review.yml.

## Testing

Not testable

- Needs to be installed in the repo after this is merged.

## Docs

N/A
