### PR TITLE
Restore `Kebab` and `KebabKeys` type utilities removed as dead code

### DIFF
--- a/.changeset/restore-kebab-keys-type.md
+++ b/.changeset/restore-kebab-keys-type.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Restores `Kebab` and `KebabKeys` type utilities that were incorrectly removed as dead code. These types are used by `astro-jsx.d.ts` to provide kebab-case CSS property autocomplete in `style={{ }}` objects. Their removal caused a TS2694 error for users who set `skipLibCheck: false`.

--- a/packages/astro/src/type-utils.ts
+++ b/packages/astro/src/type-utils.ts
@@ -21,6 +21,14 @@ export type OmitPreservingIndexSignature<T, K extends PropertyKey> = {
 	[P in keyof T as Exclude<P, K>]: T[P];
 };
 
+// Transform a string into its kebab case equivalent (camelCase -> kebab-case). Useful for CSS-in-JS to CSS.
+export type Kebab<T extends string, A extends string = ''> = T extends `${infer F}${infer R}`
+	? Kebab<R, `${A}${F extends Lowercase<F> ? '' : '-'}${Lowercase<F>}`>
+	: A;
+
+// Transform every key of an object to its kebab case equivalent using the above utility
+export type KebabKeys<T> = { [K in keyof T as K extends string ? Kebab<K> : K]: T[K] };
+
 // Similar to `keyof`, gets the type of all the values of an object
 export type ValueOf<T> = T[keyof T];
 


### PR DESCRIPTION
## Changes

- Restores `Kebab` and `KebabKeys` type utilities to `packages/astro/src/type-utils.ts`. These were removed in PR #13591 ("chore: clean dead code") but are still referenced by `astro-jsx.d.ts:509` to produce `KebabCSSDOMProperties`, which enables kebab-case CSS property autocomplete (e.g. `background-color`) in `style={{ }}` objects.
- Without them, `KebabCSSDOMProperties` silently resolves to `any`, and any user who sets `skipLibCheck: false` hits `TS2694: Namespace '.../dist/type-utils' has no exported member 'KebabKeys'`. The error was invisible to all shipped tsconfigs because `base.json` sets `skipLibCheck: true`.

Closes #17727

## Testing

- `pnpm test:types` passes after the fix; no new test was added because the existing type suite covers this, and the bug is in a hand-written `.d.ts` file rather than compiled source.

## Docs

- No docs update needed; this restores a previously-working internal type with no user-facing API change.