### PR TITLE
fix(assets): forward the SVG file path to the optimizer

### DIFF
--- a/.changeset/svgo-prefix-ids-path.md
+++ b/.changeset/svgo-prefix-ids-path.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `experimental.svgOptimizer` not passing the file path to SVGO, so path-dependent plugins like `prefixIds` fell back to the same generic prefix for every SVG and IDs collided once multiple optimized SVGs were inlined on the same page.

--- a/packages/astro/src/assets/svg/svgo.ts
+++ b/packages/astro/src/assets/svg/svgo.ts
@@ -5,6 +5,6 @@ import { optimize, type Config } from 'svgo';
 export function svgoOptimizer(config?: Config): SvgOptimizer {
 	return {
 		name: 'svgo',
-		optimize: (contents) => optimize(contents, config).data,
+		optimize: (contents, path) => optimize(contents, { ...config, path }).data,
 	};
 }

--- a/packages/astro/src/assets/svg/types.ts
+++ b/packages/astro/src/assets/svg/types.ts
@@ -1,4 +1,4 @@
 export interface SvgOptimizer {
 	name: string;
-	optimize: (contents: string) => string | Promise<string>;
+	optimize: (contents: string, path?: string) => string | Promise<string>;
 }

--- a/packages/astro/src/assets/svg/utils.ts
+++ b/packages/astro/src/assets/svg/utils.ts
@@ -17,7 +17,7 @@ async function parseSvg({
 	let processedContents = contents;
 	if (svgOptimizer) {
 		try {
-			processedContents = await svgOptimizer.optimize(contents);
+			processedContents = await svgOptimizer.optimize(contents, path);
 		} catch (cause) {
 			throw new AstroError(
 				{

--- a/packages/astro/test/core-image-svg.test.ts
+++ b/packages/astro/test/core-image-svg.test.ts
@@ -237,4 +237,44 @@ describe('astro:assets - SVG Components', () => {
 			});
 		});
 	});
+
+	describe('SVGO optimization with prefixIds', () => {
+		let prefixFixture: Fixture;
+		let prefixDevServer: DevServer;
+
+		before(async () => {
+			prefixFixture = await loadFixture({
+				root: './fixtures/core-image-svg/',
+				experimental: {
+					svgOptimizer: svgoOptimizer({
+						plugins: ['cleanupIds', 'prefixIds'],
+					}),
+				},
+				outDir: './dist/core-image-svg-svgo-prefix-ids/',
+			});
+
+			prefixDevServer = await prefixFixture.startDevServer();
+		});
+
+		after(async () => {
+			await prefixDevServer.stop();
+		});
+
+		it('gives two SVGs that share an id different prefixes', async () => {
+			const res = await prefixFixture.fetch('/prefix-ids');
+			const html = await res.text();
+			const $ = cheerio.load(html, { xml: true });
+
+			const idOne = $('#gradient-one linearGradient').attr('id');
+			const idTwo = $('#gradient-two linearGradient').attr('id');
+
+			assert.ok(idOne, 'first gradient should have an id');
+			assert.ok(idTwo, 'second gradient should have an id');
+			assert.notEqual(
+				idOne,
+				idTwo,
+				'ids from different source files should not collide once inlined on the same page',
+			);
+		});
+	});
 });

--- a/packages/astro/test/fixtures/core-image-svg/src/assets/gradient-one.svg
+++ b/packages/astro/test/fixtures/core-image-svg/src/assets/gradient-one.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="a">
+      <stop offset="0" stop-color="red" />
+    </linearGradient>
+  </defs>
+  <rect width="24" height="24" fill="url(#a)" />
+</svg>

--- a/packages/astro/test/fixtures/core-image-svg/src/assets/gradient-two.svg
+++ b/packages/astro/test/fixtures/core-image-svg/src/assets/gradient-two.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="a">
+      <stop offset="0" stop-color="blue" />
+    </linearGradient>
+  </defs>
+  <rect width="24" height="24" fill="url(#a)" />
+</svg>

--- a/packages/astro/test/fixtures/core-image-svg/src/pages/prefix-ids.astro
+++ b/packages/astro/test/fixtures/core-image-svg/src/pages/prefix-ids.astro
@@ -1,0 +1,18 @@
+---
+import GradientOne from '../assets/gradient-one.svg';
+import GradientTwo from '../assets/gradient-two.svg';
+---
+
+<html>
+  <head>
+    <title>SVGO prefixIds Test</title>
+  </head>
+  <body>
+    <div id="gradient-one">
+      <GradientOne />
+    </div>
+    <div id="gradient-two">
+      <GradientTwo />
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Changes

Fixes #17728. `experimental.svgOptimizer` never passed the file path to the optimizer, so SVGO plugins that derive a per-file value from `path` — `prefixIds` in particular — fell back to the same generic prefix for every SVG. Two optimized SVGs with the same element ID (e.g. both use SVGO's own `cleanupIds` output) collide once inlined on the same page.

`parseSvg()` in `packages/astro/src/assets/svg/utils.ts` already has the path in scope — it's used for the `CannotOptimizeSvg` error message — it just wasn't forwarded to `svgOptimizer.optimize()`.

Three one-line changes:
- `types.ts`: `optimize` gains an optional second `path` parameter
- `svgo.ts`: forwards it into SVGO's config as `{ ...config, path }`
- `utils.ts`: passes `path` at the call site

`path` is optional rather than required on the public `SvgOptimizer` interface, so a custom optimizer written as `(contents) => ...` keeps compiling without changes — this repo's own `svgoOptimizer()` is the only implementation that needs to read the new argument.

## Testing

Added a case to `packages/astro/test/core-image-svg.test.ts`: two SVGs with a colliding gradient ID (`gradient-one.svg`, `gradient-two.svg`), rendered together via a new `prefix-ids.astro` fixture page, with `prefixIds` enabled. Asserts the two resulting IDs differ after inlining.

Reverted the fix locally and reran — the new test fails with exactly the collision described in the issue (`ids from different source files should not collide once inlined on the same page`); restored, all 15 tests in the file pass. `pnpm turbo run build --filter=astro` is clean (0 type errors).

## Docs

No docs change — this restores documented per-file `prefixIds` behavior, it doesn't add anything new.
