### PR TITLE
feat: add render component

### DIFF
--- a/.changeset/olive-queens-enjoy.md
+++ b/.changeset/olive-queens-enjoy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds `AstroContainer.renderComponent()` to render a component with its direct styles and scripts

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -10,7 +10,13 @@ import { removeLeadingForwardSlash } from '../core/path.js';
 import { getParts } from '../core/routing/parts.js';
 import { getPattern } from '../core/routing/pattern.js';
 import { validateSegment } from '../core/routing/segment.js';
-import type { AstroComponentFactory } from '../runtime/server/index.js';
+import {
+	createComponent,
+	renderComponent as renderAstroComponent,
+	renderScript,
+	renderTemplate,
+	type AstroComponentFactory,
+} from '../runtime/server/index.js';
 import { SlotString } from '../runtime/server/render/slot.js';
 import type { ComponentInstance } from '../types/astro.js';
 import type { AstroMiddlewareInstance, MiddlewareHandler, Props } from '../types/public/common.js';
@@ -542,6 +548,41 @@ export class experimental_AstroContainer {
 
 		const response = await this.renderToResponse(component, options);
 		return await response.text();
+	}
+
+	/**
+	 * Renders an Astro component with its direct styles prepended and direct scripts appended.
+	 */
+	public async renderComponent(
+		component: AstroComponentFactory,
+		options: Omit<ContainerRenderOptions, 'routeType'> = {},
+	): Promise<string> {
+		const assets = component.containerAssets ?? { styles: [], scripts: [] };
+		let scripts = '';
+		const Wrapper = createComponent(async (result, props, slots) => {
+			const renderedScripts = await Promise.all(
+				assets.scripts.map((id) => renderScript(result, id)),
+			);
+			scripts = renderedScripts.map((script) => script.content).join('');
+			for (const script of renderedScripts) {
+				result._metadata.renderedScripts.add(script.id);
+			}
+			const componentSlots = Object.fromEntries(
+				Object.entries(slots).map(([name, slot]) => [name, () => renderTemplate`${slot}`]),
+			);
+			return renderTemplate`${renderAstroComponent(
+				result,
+				component.name,
+				component,
+				props,
+				componentSlots,
+			)}`;
+		});
+		const html = await this.renderToString(Wrapper, options);
+		const styles = assets.styles
+			.map((style) => `<style>${style.replace(/<\/style/gi, '<\\/style')}</style>`)
+			.join('');
+		return styles + html + scripts;
 	}
 
 	/**

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -580,7 +580,7 @@ export class experimental_AstroContainer {
 		});
 		const html = await this.renderToString(Wrapper, options);
 		const styles = assets.styles
-			.map((style) => `<style>${style.replace(/<\/style/gi, '<\\/style')}</style>`)
+			.map((style) => `<style>${style.replace(/<\/style(?=[\t\n\f\r />])/gi, '<\\/style')}</style>`)
 			.join('');
 		return styles + html + scripts;
 	}

--- a/packages/astro/src/runtime/compiler/index.ts
+++ b/packages/astro/src/runtime/compiler/index.ts
@@ -16,6 +16,7 @@ export {
 	renderScript,
 	renderSlot,
 	renderTransition,
+	setComponentAssets,
 	templateEnter,
 	templateExit,
 	spreadAttributes,

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -40,6 +40,7 @@ export {
 	renderTemplate,
 	renderToString,
 	renderUniqueStylesheet,
+	setComponentAssets,
 	voidElementNames,
 } from './render/index.js';
 export type { ServerIslandComponent } from './render/server-islands.js';

--- a/packages/astro/src/runtime/server/render/astro/factory.ts
+++ b/packages/astro/src/runtime/server/render/astro/factory.ts
@@ -30,7 +30,7 @@ export function setComponentAssets(
 	factory: AstroComponentFactory,
 	assets: AstroContainerAssets,
 ): void {
-	Object.defineProperty(factory, 'assets', { value: assets });
+	Object.defineProperty(factory, 'containerAssets', { value: assets });
 }
 
 export function isAstroComponentFactory(obj: any): obj is AstroComponentFactory {

--- a/packages/astro/src/runtime/server/render/astro/factory.ts
+++ b/packages/astro/src/runtime/server/render/astro/factory.ts
@@ -29,8 +29,9 @@ export interface AstroComponentFactory {
 export function setComponentAssets(
 	factory: AstroComponentFactory,
 	assets: AstroContainerAssets,
-): void {
+): AstroComponentFactory {
 	Object.defineProperty(factory, 'containerAssets', { value: assets });
+	return factory;
 }
 
 export function isAstroComponentFactory(obj: any): obj is AstroComponentFactory {

--- a/packages/astro/src/runtime/server/render/astro/factory.ts
+++ b/packages/astro/src/runtime/server/render/astro/factory.ts
@@ -8,12 +8,29 @@ import type { RenderTemplateResult } from './render-template.js';
 
 export type AstroFactoryReturnValue = RenderTemplateResult | Response | HeadAndContent | ThinHead;
 
+export interface AstroContainerAssets {
+	styles: string[];
+	scripts: string[];
+}
+
 // The callback passed to $$createComponent
 export interface AstroComponentFactory {
 	(result: any, props: any, slots: any): AstroFactoryReturnValue | Promise<AstroFactoryReturnValue>;
 	isAstroComponentFactory?: boolean;
 	moduleId?: string | undefined;
 	propagation?: PropagationHint;
+	/**
+	 * Inline assets extracted by the compiler. They should be used only by the container,
+	 * as these assets aren't the ones computed via vite.
+	 */
+	containerAssets?: AstroContainerAssets;
+}
+
+export function setComponentAssets(
+	factory: AstroComponentFactory,
+	assets: AstroContainerAssets,
+): void {
+	Object.defineProperty(factory, 'assets', { value: assets });
 }
 
 export function isAstroComponentFactory(obj: any): obj is AstroComponentFactory {

--- a/packages/astro/src/runtime/server/render/astro/index.ts
+++ b/packages/astro/src/runtime/server/render/astro/index.ts
@@ -1,5 +1,5 @@
-export type { AstroComponentFactory } from './factory.js';
-export { isAstroComponentFactory } from './factory.js';
+export type { AstroContainerAssets, AstroComponentFactory } from './factory.js';
+export { isAstroComponentFactory, setComponentAssets } from './factory.js';
 export { createHeadAndContent, isHeadAndContent } from './head-and-content.js';
 export type { AstroComponentInstance } from './instance.js';
 export { createAstroComponentInstance, isAstroComponentInstance } from './instance.js';

--- a/packages/astro/src/runtime/server/render/index.ts
+++ b/packages/astro/src/runtime/server/render/index.ts
@@ -1,5 +1,14 @@
-export type { AstroComponentFactory, AstroComponentInstance } from './astro/index.js';
-export { createHeadAndContent, renderTemplate, renderToString } from './astro/index.js';
+export type {
+	AstroContainerAssets,
+	AstroComponentFactory,
+	AstroComponentInstance,
+} from './astro/index.js';
+export {
+	createHeadAndContent,
+	renderTemplate,
+	renderToString,
+	setComponentAssets,
+} from './astro/index.js';
 export { chunkToByteArray, chunkToString, Fragment, Renderer } from './common.js';
 export { renderComponent, renderComponentToString } from './component.js';
 export { renderHTMLElement } from './dom.js';

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -18,6 +18,7 @@ export async function compileAstro({
 	astroFileToCompileMetadata,
 }: CompileAstroOption): Promise<CompileAstroResult> {
 	const transformResult = await compile(compileProps);
+	let code = transformResult.code;
 
 	const { fileId: file, fileUrl: url } = getFileInfo(
 		compileProps.filename,
@@ -29,18 +30,41 @@ export async function compileAstro({
 		url,
 	)};export { $$file as file, $$url as url };\n`;
 	await init;
-	const [, exports] = parse(transformResult.code);
+	const [imports, exports] = parse(code);
 	const defaultExport = exports.find((entry) => entry.n === 'default');
 	const componentName =
 		defaultExport?.ln ??
-		(defaultExport
-			? /^\s*([$A-Z_a-z][$\w]*)/.exec(transformResult.code.slice(defaultExport.e))?.[1]
-			: undefined);
+		(defaultExport ? /^\s*([$A-Z_a-z][$\w]*)/.exec(code.slice(defaultExport.e))?.[1] : undefined);
 	if (componentName) {
-		const scripts = transformResult.scripts.map(
-			(_, index) => `${compileProps.filename}?astro&type=script&index=${index}&lang.ts`,
-		);
-		SUFFIX += `import { setComponentAssets as $$setComponentAssets } from "astro/compiler-runtime";\n$$setComponentAssets(${componentName}, ${JSON.stringify({ styles: transformResult.css.map((style) => style.code), scripts })});\n`;
+		const declaration = `const ${componentName} = `;
+		const declarationStart = code.indexOf(declaration);
+		const initializerStart = declarationStart + declaration.length;
+		const initializerEnd = code.lastIndexOf(';', defaultExport!.s);
+		const runtimeImport = imports.find((entry) => entry.n === 'astro/compiler-runtime');
+		const importEnd = runtimeImport ? code.indexOf('}', runtimeImport.ss) : -1;
+		if (
+			declarationStart !== -1 &&
+			initializerEnd !== -1 &&
+			runtimeImport &&
+			importEnd !== -1 &&
+			importEnd < runtimeImport.s
+		) {
+			const scripts = transformResult.scripts.map(
+				(_, index) => `${compileProps.filename}?astro&type=script&index=${index}&lang.ts`,
+			);
+			const assets = JSON.stringify({
+				styles: transformResult.css.map((style) => style.code),
+				scripts,
+			});
+			code =
+				code.slice(0, initializerStart) +
+				`/* @__PURE__ */ $$setComponentAssets(${code.slice(initializerStart, initializerEnd)}, ${assets})` +
+				code.slice(initializerEnd);
+			code =
+				code.slice(0, importEnd) +
+				', setComponentAssets as $$setComponentAssets' +
+				code.slice(importEnd);
+		}
 	}
 
 	// Add HMR handling in dev mode.
@@ -61,7 +85,7 @@ export async function compileAstro({
 
 	return {
 		...transformResult,
-		code: transformResult.code + SUFFIX,
+		code: code + SUFFIX,
 		map: transformResult.map || null,
 	};
 }

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -27,6 +27,13 @@ export async function compileAstro({
 	SUFFIX += `\nconst $$file = ${JSON.stringify(file)};\nconst $$url = ${JSON.stringify(
 		url,
 	)};export { $$file as file, $$url as url };\n`;
+	const componentName = /export default ([$\w]+);/.exec(transformResult.code)?.[1];
+	if (componentName) {
+		const scripts = transformResult.scripts.map(
+			(_, index) => `${compileProps.filename}?astro&type=script&index=${index}&lang.ts`,
+		);
+		SUFFIX += `import { setComponentAssets as $$setComponentAssets } from "astro/compiler-runtime";\n$$setComponentAssets(${componentName}, ${JSON.stringify({ styles: transformResult.css.map((style) => style.code), scripts })});\n`;
+	}
 
 	// Add HMR handling in dev mode.
 	if (!compileProps.viteConfig.isProduction) {

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -1,4 +1,5 @@
 import type { Rolldown } from 'vite';
+import { init, parse } from 'es-module-lexer';
 import { type CompileProps, type CompileResult, compile } from '../core/compile/index.js';
 import { getFileInfo } from '../vite-plugin-utils/index.js';
 import type { CompileMetadata } from './types.js';
@@ -27,7 +28,14 @@ export async function compileAstro({
 	SUFFIX += `\nconst $$file = ${JSON.stringify(file)};\nconst $$url = ${JSON.stringify(
 		url,
 	)};export { $$file as file, $$url as url };\n`;
-	const componentName = /export default ([$\w]+);/.exec(transformResult.code)?.[1];
+	await init;
+	const [, exports] = parse(transformResult.code);
+	const defaultExport = exports.find((entry) => entry.n === 'default');
+	const componentName =
+		defaultExport?.ln ??
+		(defaultExport
+			? /^\s*([$A-Z_a-z][$\w]*)/.exec(transformResult.code.slice(defaultExport.e))?.[1]
+			: undefined);
 	if (componentName) {
 		const scripts = transformResult.scripts.map(
 			(_, index) => `${compileProps.filename}?astro&type=script&index=${index}&lang.ts`,

--- a/packages/astro/test/container.test.ts
+++ b/packages/astro/test/container.test.ts
@@ -53,4 +53,15 @@ describe('Container with renderers', () => {
 		assert.match(html, /I am a react button/);
 		assert.doesNotMatch(html, /<!DOCTYPE html>/);
 	});
+
+	it('renders direct assets around compiled component HTML', async () => {
+		const request = new Request('https://example.com/assets');
+		const response = await app.render(request);
+		const html = await response.text();
+
+		assert.match(html, /^<style>[\s\S]*\.asset[\s\S]*<\/style>/);
+		assert.match(html, /<style>\s*\.inline \{\s*color: blue;\s*\}\s*<\/style>/);
+		assert.match(html, /<span>Child<\/span><script type="module" src="[^"]+"><\/script><\/div>/);
+		assert.match(html, /<script type="module" src="[^"]+"><\/script>$/);
+	});
 });

--- a/packages/astro/test/fixtures/container-custom-renderers/src/components/Assets.astro
+++ b/packages/astro/test/fixtures/container-custom-renderers/src/components/Assets.astro
@@ -1,0 +1,20 @@
+---
+import Child from './AssetsChild.astro';
+const { message } = Astro.props;
+---
+
+<style>
+  .asset {
+    color: red;
+  }
+</style>
+
+<style is:inline>
+  .inline {
+    color: blue;
+  }
+</style>
+
+<div class="asset">{message}<slot /><Child /></div>
+<script is:inline>console.log('inline')</script>
+<script>console.log('page')</script>

--- a/packages/astro/test/fixtures/container-custom-renderers/src/components/AssetsChild.astro
+++ b/packages/astro/test/fixtures/container-custom-renderers/src/components/AssetsChild.astro
@@ -1,0 +1,2 @@
+<span>Child</span>
+<script>console.log('child')</script>

--- a/packages/astro/test/fixtures/container-custom-renderers/src/pages/assets.ts
+++ b/packages/astro/test/fixtures/container-custom-renderers/src/pages/assets.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from 'astro';
+import { experimental_AstroContainer } from 'astro/container';
+import Component from '../components/Assets.astro';
+
+export const GET: APIRoute = async () => {
+	const container = await experimental_AstroContainer.create();
+	return new Response(
+		await container.renderComponent(Component, {
+			props: { message: 'Hello ' },
+			slots: { default: 'World' },
+		}),
+	);
+};

--- a/packages/astro/test/units/render/container.test.ts
+++ b/packages/astro/test/units/render/container.test.ts
@@ -10,8 +10,10 @@ import {
 	render,
 	renderComponent,
 	renderHead,
+	renderScript,
 	renderSlot,
 	renderTemplate,
+	setComponentAssets,
 } from '../../../dist/runtime/server/index.js';
 
 const BaseLayout = createComponent((result, _props, slots) => {
@@ -275,6 +277,37 @@ describe('Container', () => {
 		});
 
 		assert.match(result, /Is open/);
+	});
+
+	it('Renders direct assets around component HTML', async () => {
+		const Child = createComponent((result) => {
+			return render`<span>Child</span>${renderScript(result, 'child-script')}`;
+		});
+		const Page = createComponent((result, props, slots) => {
+			return render`<div>${props.message}${renderSlot(result, slots.default)}${renderComponent(
+				result,
+				'Child',
+				Child,
+				{},
+			)}</div>${renderScript(result, 'page-script')}`;
+		});
+		setComponentAssets(Page, {
+			styles: ['div { color: red; }'],
+			scripts: ['page-script'],
+		});
+
+		const container = await experimental_AstroContainer.create({
+			resolve: async (id) => `/assets/${id}.js`,
+		});
+		const result = await container.renderComponent(Page, {
+			props: { message: 'Hello ' },
+			slots: { default: 'World' },
+		});
+
+		assert.equal(
+			result,
+			'<style>div { color: red; }</style><div>Hello World<span>Child</span><script type="module" src="/assets/child-script.js"></script></div><script type="module" src="/assets/page-script.js"></script>',
+		);
 	});
 
 	it('Astro.site reflects astroConfig.site', async () => {

--- a/packages/astro/test/units/render/container.test.ts
+++ b/packages/astro/test/units/render/container.test.ts
@@ -310,6 +310,19 @@ describe('Container', () => {
 		);
 	});
 
+	it('Escapes style end tags in direct CSS', async () => {
+		const Page = createComponent(() => render`<div></div>`);
+		setComponentAssets(Page, {
+			styles: ['.test::before { content: "</style >"; }'],
+			scripts: [],
+		});
+
+		const container = await experimental_AstroContainer.create();
+		const result = await container.renderComponent(Page);
+
+		assert.equal(result, '<style>.test::before { content: "<\\/style >"; }</style><div></div>');
+	});
+
 	it('Astro.site reflects astroConfig.site', async () => {
 		const $Astro = createAstro('https://example.com');
 		const SitePage = createComponent((result, props, slots) => {

--- a/packages/astro/test/units/vite-plugin-astro/compile.test.ts
+++ b/packages/astro/test/units/vite-plugin-astro/compile.test.ts
@@ -92,6 +92,20 @@ const name = 'world
 		assert.equal(names.includes('file'), true);
 		assert.equal(names.includes('url'), true);
 	});
+
+	it('attaches direct styles and scripts to the component factory', async () => {
+		const result = await compile(
+			`<style>h1 { color: red; }</style><h1>Hello World</h1><script>console.log('hello')</script>`,
+			'/src/components/index.astro',
+		);
+
+		assert.match(result.code, /setComponentAssets/);
+		assert.match(result.code, /h1:where\(.astro-/);
+		assert.match(
+			result.code,
+			/\/src\/components\/index\.astro\?astro&type=script&index=0&lang\.ts/,
+		);
+	});
 });
 
 // #endregion

--- a/packages/astro/test/units/vite-plugin-astro/compile.test.ts
+++ b/packages/astro/test/units/vite-plugin-astro/compile.test.ts
@@ -100,6 +100,7 @@ const name = 'world
 		);
 
 		assert.match(result.code, /setComponentAssets/);
+		assert.equal((result.code.match(/from "astro\/compiler-runtime"/g) ?? []).length, 1);
 		assert.match(result.code, /h1:where\(.astro-/);
 		assert.match(
 			result.code,


### PR DESCRIPTION
## Changes

Adds `renderComponent()` to the Astro container APIs. The added feature to this function is that it renders the scripts and styles that are declared in the component. It uses the compiler the runtime to dynamically attach and swap them.

```ts

import Component from "./components/Footer.astro"

const container = await experimental_AstroContainer.create();

export const GET: APIRoute = async () => {

	return new Response(
		await container.renderComponent(Component, {
			props: { message: 'Hello ' },
			slots: { default: 'World' },
		}),
	);
};

``` 

What do you think? 

## Testing

Added new tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Will create one

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
