### PR TITLE
Fix build errors reporting wrong file location for MDX and plugin transform errors

### DIFF
--- a/packages/astro/src/core/errors/dev/utils.ts
+++ b/packages/astro/src/core/errors/dev/utils.ts
@@ -23,8 +23,8 @@ export function collectErrorMetadata(e: any, rootFolder?: URL): ErrorWithMetadat
 		AggregateError.is(e) || Array.isArray(e.errors) ? (e.errors as SSRError[]) : [e as SSRError];
 
 	err.forEach((error) => {
-		if (e.stack) {
-			const stackInfo = collectInfoFromStacktrace(e);
+		if (error.stack) {
+			const stackInfo = collectInfoFromStacktrace(error as SSRError & { stack: string });
 			try {
 				error.stack = stripVTControlCharacters(stackInfo.stack);
 			} catch {}
@@ -68,7 +68,7 @@ export function collectErrorMetadata(e: any, rootFolder?: URL): ErrorWithMetadat
 		}
 
 		// Generic error (probably from Vite, and already formatted)
-		error.hint = generateHint(e);
+		error.hint = generateHint(error);
 
 		// Strip ANSI for `message` property. Note that ESBuild errors may not have the property,
 		// but it will be handled and added below, which is already ANSI-free


### PR DESCRIPTION
## Changes

- Fixes `collectErrorMetadata()` using the outer parameter `e` instead of the loop variable `error` inside `err.forEach()`. When Vite wraps a plugin error (e.g. from `@astrojs/mdx`) in a parent error with its own stack trace, `collectInfoFromStacktrace(e)` was extracting location info from the *parent's* stack and overwriting the sub-error's correct file/line. This made build errors point to internal Vite frames (e.g. `node.js:33011`) instead of the actual source file (e.g. `index.mdx:42`).
- Also fixes `generateHint(e)` → `generateHint(error)`, which was generating spurious "Browser APIs are not available" hints by evaluating the parent error's message instead of the sub-error's.
- Single (non-aggregate) errors are unaffected — `e` and `error` are the same object in that path.

## Testing

- Verified against existing error unit tests, the MDX invalid component test, and the error-build-location integration test, all of which pass.

## Docs

- No docs update needed; this is a bug fix with no user-facing API or config changes.

Closes #17735