### PR TITLE
fix(cli): only background astro preview when asked to

### DIFF
--- a/.changeset/preview-no-auto-background.md
+++ b/.changeset/preview-no-auto-background.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro preview` starting a background daemon when an AI coding agent is detected. The foreground process exited immediately, breaking anything supervising it such as Playwright's `webServer`. Backgrounding is now only enabled by `--background`, as documented. `astro dev` is unchanged.

--- a/packages/astro/src/cli/preview/index.ts
+++ b/packages/astro/src/cli/preview/index.ts
@@ -43,8 +43,11 @@ export async function preview({ flags }: PreviewOptions) {
 		return;
 	}
 
-	const agentDetected = !process.env.ASTRO_PREVIEW_BACKGROUND && isRunByAgent();
-	if (agentDetected) {
+	// When an AI coding agent is detected, log as JSON so the output is machine
+	// readable. Unlike `astro dev`, this does not imply background mode — a preview
+	// server is usually started by something that waits on the process, so
+	// backgrounding it has to stay opt-in via `--background`.
+	if (!process.env.ASTRO_PREVIEW_BACKGROUND && isRunByAgent()) {
 		flags.json = true;
 	}
 
@@ -66,7 +69,7 @@ export async function preview({ flags }: PreviewOptions) {
 		return;
 	}
 
-	if (flags.background || agentDetected) {
+	if (flags.background) {
 		await background({ flags, logger, config: previewServerCommand });
 		return;
 	}


### PR DESCRIPTION
## Changes

Fixes #17721.

`astro preview` starts a detached daemon and exits immediately whenever an AI coding agent is detected, even though `--background` is documented as the opt-in way to ask for that. Anything supervising the process — Playwright's `webServer`, CI wrappers, `astro build && astro preview` — sees it exit 0 straight away and gives up.

Background mode was added to `preview` by copying the pattern from `astro dev`, including its agent detection:

```ts
const agentDetected = !process.env.ASTRO_PREVIEW_BACKGROUND && isRunByAgent();
// ...
if (flags.background || agentDetected) {
```

That makes sense for `dev`, which a person runs and leaves running. A preview server is usually started by something that waits on it, so the same default breaks the common case.

`--background` is now the only thing that daemonises `preview`. JSON logging still switches on for agents, since that only changes the output format. `astro dev` is untouched.

## Testing

No automated test. The decision sits inside `preview()`, which starts a real server and writes a lock file, so covering it would mean spawning a process rather than asserting on a function — and there is currently no test around this path to extend.

What I did check:

- Both existing preview suites still pass — `astro-preview-headers` (2) and `astro-preview-allowed-hosts` (5).
- The built output carries the change: `packages/astro/dist/cli/preview/index.js` now reads `if (flags.background)`.
- `isRunByAgent()` is still consulted for the JSON logging, so agent environments keep machine-readable output.

To reproduce the original behaviour, run `astro preview` with an agent environment variable set (`CLAUDECODE=1` is enough — this repro is easy to hit from inside Claude Code or Cursor). Before this change the command prints a pid and returns immediately; after it, it blocks and prints the usual banner. `astro preview --background` still daemonises.

Happy to add an integration test that spawns the CLI and asserts it stays in the foreground if you would like one — it seemed heavier than the fix warranted, but I am glad to.

## Docs

No docs change. `--background` is already documented as opt-in; this makes the behaviour match.
