### PR TITLE
fix(routing): keep the trailing slash when stripping an injected .html

### DIFF
--- a/.changeset/preserve-trailing-slash-html.md
+++ b/.changeset/preserve-trailing-slash-html.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro build` throwing `TypeError: Missing parameter` for dynamic routes when `build.format: 'preserve'` and `trailingSlash: 'always'` are used together. Stripping the framework-injected `.html` suffix dropped the trailing slash that the compiled route pattern requires, so the route no longer matched itself and its params resolved as empty.

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -959,6 +959,16 @@ export class FetchState implements AstroFetchState {
 			!routeHasHtmlExtension(this.routeData)
 		) {
 			this.pathname = this.pathname.replace(/\/index\.html$/, '/').replace(/\.html$/, '');
+			// Route patterns are compiled with the configured trailing slash, so a
+			// pathname left without one after stripping `.html` no longer matches its
+			// own route and yields no params.
+			if (
+				this.manifest.trailingSlash === 'always' &&
+				this.pathname !== '' &&
+				!this.pathname.endsWith('/')
+			) {
+				this.pathname += '/';
+			}
 		}
 	}
 

--- a/packages/astro/test/units/fetch/index.test.ts
+++ b/packages/astro/test/units/fetch/index.test.ts
@@ -125,6 +125,31 @@ describe('FetchState (astro/fetch)', () => {
 		assert.equal(state.routeData!.type, 'endpoint');
 		assert.equal(state.pathname, '/file.html', '.html should be preserved for endpoint routes');
 	});
+
+	it('restores the trailing slash after stripping .html when trailingSlash is always', () => {
+		// Regression test for #17726: with `build.format: 'preserve'` the build
+		// requests `/welcome.html`, and route patterns are compiled with the
+		// configured trailing slash. Stripping `.html` without restoring the `/`
+		// leaves a pathname that no longer matches its own route, so the params
+		// come back empty and `stringifyParams()` throws `Missing parameter`.
+		const app = createTestApp([createPage(simplePage, { route: '/welcome' })], {
+			trailingSlash: 'always',
+		});
+		const request = stampApp(new Request('http://example.com/welcome.html'), app);
+		const state = new FetchState(request);
+
+		assert.equal(state.pathname, '/welcome/', 'trailing slash should survive .html stripping');
+	});
+
+	it('does not add a trailing slash when trailingSlash is not always', () => {
+		const app = createTestApp([createPage(simplePage, { route: '/welcome' })], {
+			trailingSlash: 'ignore',
+		});
+		const request = stampApp(new Request('http://example.com/welcome.html'), app);
+		const state = new FetchState(request);
+
+		assert.equal(state.pathname, '/welcome', 'pathname should be left without a trailing slash');
+	});
 });
 
 // #endregion


### PR DESCRIPTION
## Changes

Fixes #17726.

With `build.format: 'preserve'` the build asks for pages as `/welcome.html`, and `#stripHtmlExtension()` removes that framework-injected suffix so the pipeline sees the canonical path:

```ts
this.pathname = this.pathname.replace(/\/index\.html$/, '/').replace(/\.html$/, '');
```

The first replacement keeps the trailing slash; the second one drops it. Route patterns are compiled with the configured trailing slash, so under `trailingSlash: 'always'` the route no longer matches its own path. `getParams()` returns nothing and `stringifyParams()` then throws `TypeError: Missing parameter` for any dynamic route — the build fails with no way out other than changing config.

The trailing slash is now restored after stripping when `trailingSlash` is `'always'`, so the pathname matches the pattern it came from. Nothing changes for `'ignore'` or `'never'`, and `/index.html` was already handled by the first replacement.

This needs both settings together, which is why it looked unreproducible at first — `build.format: 'preserve'` alone is fine, and `trailingSlash: 'always'` alone is fine.

## Testing

Two cases in `packages/astro/test/units/fetch/index.test.ts`, next to the existing `.html` stripping test:

- `trailingSlash: 'always'` — `/welcome.html` resolves to `/welcome/`
- `trailingSlash: 'ignore'` — `/welcome.html` resolves to `/welcome`, unchanged

Reverting the source change fails the first with `trailing slash should survive .html stripping`. Worth noting these tests import from `dist/`, so the package has to be rebuilt for that check to mean anything — reverting only `src` leaves them passing.

`test/units/fetch` (80) and `test/units/routing` (56) both pass.

## Docs

No docs change — this restores the documented behaviour of a supported config combination.
