### PR TITLE
fix(i18n): respect implicit and zero Accept-Language quality values in preferredLocale

### DIFF
--- a/.changeset/fix-preferred-locale-quality-sort.md
+++ b/.changeset/fix-preferred-locale-quality-sort.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.preferredLocale` and `Astro.preferredLocaleList` ignoring `Accept-Language` quality values when they are absent or `0`. An entry without an explicit `q=` now correctly counts as quality `1.0` (per RFC 7231) and an entry with `q=0` is treated as not acceptable, so the highest-quality locale is selected regardless of header order.

--- a/packages/astro/src/i18n/utils.ts
+++ b/packages/astro/src/i18n/utils.ts
@@ -71,10 +71,11 @@ function sortAndFilterLocales(browserLocaleList: BrowserLocale[], locales: Local
 			return true;
 		})
 		.sort((a, b) => {
-			if (a.qualityValue && b.qualityValue) {
-				return Math.sign(b.qualityValue - a.qualityValue);
-			}
-			return 0;
+			// An absent `q=` means quality 1.0 (RFC 7231), while a bare `*` defaults
+			// to 0 so it is never ranked above a real locale.
+			const qa = a.locale === '*' ? (a.qualityValue ?? 0) : (a.qualityValue ?? 1);
+			const qb = b.locale === '*' ? (b.qualityValue ?? 0) : (b.qualityValue ?? 1);
+			return qb - qa;
 		});
 }
 

--- a/packages/astro/test/units/i18n/i18n-utils.test.ts
+++ b/packages/astro/test/units/i18n/i18n-utils.test.ts
@@ -67,6 +67,20 @@ describe('computePreferredLocale', () => {
 		assert.equal(computePreferredLocale(req, locales), 'fr');
 	});
 
+	it('prefers an implicit q=1 entry over a lower explicit-q entry regardless of header order', () => {
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'en;q=0.7, de' },
+		});
+		assert.equal(computePreferredLocale(req, ['en', 'fr', 'de']), 'de');
+	});
+
+	it('excludes a q=0 entry from winning', () => {
+		const req = new Request('http://example.com/', {
+			headers: { 'Accept-Language': 'de;q=0, en;q=0.5' },
+		});
+		assert.equal(computePreferredLocale(req, ['en', 'fr', 'de']), 'en');
+	});
+
 	it('returns undefined when no match', () => {
 		const req = new Request('http://example.com/', {
 			headers: { 'Accept-Language': 'de,ja' },


### PR DESCRIPTION
Closes #17780

## Summary

`Astro.preferredLocale` / `Astro.preferredLocaleList` can return the wrong locale because `sortAndFilterLocales` ignores `Accept-Language` quality values that are absent or `0`.

`parseLocale` stores `qualityValue = undefined` when an entry has no explicit `q=`, and `0` for `q=0`. The comparator only ran when **both** values were truthy:

```js
if (a.qualityValue && b.qualityValue) {
  return Math.sign(b.qualityValue - a.qualityValue);
}
return 0;
```

Per RFC 7231 §5.3.1 an absent `q=` means quality **1.0** (the highest), and `q=0` means "not acceptable". Because both are falsy, the guard failed, `sort` returned `0`, and the entries were left in raw header order — so a lower-quality locale earlier in the header could win.

For `Accept-Language: en;q=0.7, de` (locales `['en','fr','de']`), `de` has implicit quality `1.0` and should win, but the old code returned `en`.

## Fix

Default a missing `q` to `1.0`, and keep a bare `*` at `0` so it is never ranked above a real locale (the existing `firstResult.locale !== '*'` guard relies on that):

```js
const qa = a.locale === '*' ? (a.qualityValue ?? 0) : (a.qualityValue ?? 1);
const qb = b.locale === '*' ? (b.qualityValue ?? 0) : (b.qualityValue ?? 1);
return qb - qa;
```

## Test

Two cases added to the existing `computePreferredLocale` unit block: an implicit-`q=1` entry beating a lower explicit `q`, and a `q=0` entry being excluded. Both fail on `main` and pass with this change. A changeset is included.
