### PR TITLE
Modify issue template for chat and support options

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ contact_links:
   - name: 💁 Support
     url: https://astro.build/chat
     about: This issue tracker is not for support questions. Join us on Discord for assistance!
-  - name: ❔ Support (GitHub)
+  - name: 💁 Support (GitHub)
     url: https://github.com/withastro/community-support/discussions
     about: No Discord account? Open a discussion on GitHub for assistance.
   - name: 📘 Documentation

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,9 @@ contact_links:
   - name: 💡 Ideas for New Features, Improvements and RFCs
     url: https://github.com/withastro/roadmap/discussions
     about: Propose and discuss future improvements to Astro
-  - name: 👾 Chat
+  - name: 👾 Chat & support
     url: https://astro.build/chat
     about: Our Discord server is active, come join us!
+  - name: ❔ Support (GitHub)
+    url: https://github.com/withastro/community-support/discussions
+    about: Another support channel than our Discord server

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,16 +2,16 @@ blank_issues_enabled: false
 contact_links:
   - name: 💁 Support
     url: https://astro.build/chat
-    about: 'This issue tracker is not for support questions. Join us on Discord for assistance!'
+    about: This issue tracker is not for support questions. Join us on Discord for assistance!
+  - name: ❔ Support (GitHub)
+    url: https://github.com/withastro/community-support/discussions
+    about: No Discord account? Open a discussion on GitHub for assistance.
   - name: 📘 Documentation
     url: https://github.com/withastro/docs
     about: File an issue or make an improvement to the docs website.
   - name: 💡 Ideas for New Features, Improvements and RFCs
     url: https://github.com/withastro/roadmap/discussions
     about: Propose and discuss future improvements to Astro
-  - name: 👾 Chat & support
+  - name: 👾 Chat
     url: https://astro.build/chat
     about: Our Discord server is active, come join us!
-  - name: ❔ Support (GitHub)
-    url: https://github.com/withastro/community-support/discussions
-    about: Another support channel than our Discord server


### PR DESCRIPTION
## Changes

Updated the issue template configuration to rename 'Chat' to 'Chat & support' and added a new support option for GitHub discussions.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
