### PR TITLE
fix(assets): harden vendored image-size box and entry checks

### DIFF
--- a/.changeset/heavy-moons-repeat.md
+++ b/.changeset/heavy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes builds hanging when an image file is malformed

--- a/packages/astro/src/assets/utils/vendor/image-size/LICENSE
+++ b/packages/astro/src/assets/utils/vendor/image-size/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright © 2013-Present Aditya Yadav, http://netroy.in
+Copyright © 2026 lcf2212dev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/astro/src/assets/utils/vendor/image-size/README.md
+++ b/packages/astro/src/assets/utils/vendor/image-size/README.md
@@ -2,9 +2,27 @@
 
 Vendored from [image-size](https://github.com/image-size/image-size) v2.0.2.
 
+Upstream is archived and v2.0.2 is its final release, so there is nothing left to sync from. Hardening
+fixes below are ported from the maintained MIT community fork
+[image-size-next](https://github.com/lcf2212dev/image-size-next) v2.1.1, which keeps the same public API.
+
 ## Changes
 
 - Files removed: `fromFile.ts`, `index.ts`
+- `imageSize()` renamed to `lookup()`, dropping the `disabledTypes` option and the "pick the largest
+  image by area" behaviour (`./lookup.ts`)
+- Import specifiers rewritten to explicit `.js`/`.ts` extensions for `NodeNext` resolution
+- `node:fs` import dropped from `./types/tiff.ts` (unused, and it broke browser bundling)
 - Added `avis` brand for AVIF sequences (`./types/heif.ts`)
 - Added `detectType()` to handle files with out-of-order ftyp brands (`./types/heif.ts`)
 - Updates `BitReader` properties assignment to work with `erasableSyntaxOnly`
+- Assorted `as T` casts replaced with non-null assertions, and `String#match` with `RegExp#exec`,
+  to satisfy the repo's lint rules
+- Ported box and entry size guards from image-size-next so malformed input cannot stall the parser
+  (`./types/utils.ts`, `./types/icns.ts`, `./types/jxl.ts`, `./types/heif.ts`, `./types/jp2.ts`)
+
+## Not ported from image-size-next
+
+- Optional chaining on `typeHandlers.get()` in `./detector.ts` and `./lookup.ts`
+- The JPG segment length guard in `./types/jpg.ts`; that loop already advances by at least two bytes
+  per iteration, so it terminates regardless

--- a/packages/astro/src/assets/utils/vendor/image-size/README.md
+++ b/packages/astro/src/assets/utils/vendor/image-size/README.md
@@ -2,27 +2,9 @@
 
 Vendored from [image-size](https://github.com/image-size/image-size) v2.0.2.
 
-Upstream is archived and v2.0.2 is its final release, so there is nothing left to sync from. Hardening
-fixes below are ported from the maintained MIT community fork
-[image-size-next](https://github.com/lcf2212dev/image-size-next) v2.1.1, which keeps the same public API.
-
 ## Changes
 
 - Files removed: `fromFile.ts`, `index.ts`
-- `imageSize()` renamed to `lookup()`, dropping the `disabledTypes` option and the "pick the largest
-  image by area" behaviour (`./lookup.ts`)
-- Import specifiers rewritten to explicit `.js`/`.ts` extensions for `NodeNext` resolution
-- `node:fs` import dropped from `./types/tiff.ts` (unused, and it broke browser bundling)
 - Added `avis` brand for AVIF sequences (`./types/heif.ts`)
 - Added `detectType()` to handle files with out-of-order ftyp brands (`./types/heif.ts`)
 - Updates `BitReader` properties assignment to work with `erasableSyntaxOnly`
-- Assorted `as T` casts replaced with non-null assertions, and `String#match` with `RegExp#exec`,
-  to satisfy the repo's lint rules
-- Ported box and entry size guards from image-size-next so malformed input cannot stall the parser
-  (`./types/utils.ts`, `./types/icns.ts`, `./types/jxl.ts`, `./types/heif.ts`, `./types/jp2.ts`)
-
-## Not ported from image-size-next
-
-- Optional chaining on `typeHandlers.get()` in `./detector.ts` and `./lookup.ts`
-- The JPG segment length guard in `./types/jpg.ts`; that loop already advances by at least two bytes
-  per iteration, so it terminates regardless

--- a/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/heif.ts
@@ -56,11 +56,14 @@ export const HEIF: IImage = {
 
     const images: ISize[] = []
     let currentOffset = ipcoBox.offset + 8
+    const ipcoEnd = ipcoBox.offset + ipcoBox.size
 
     // Find all ispe and clap boxes
-    while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+    while (currentOffset < ipcoEnd) {
       const ispeBox = findBox(input, 'ispe', currentOffset)
       if (!ispeBox) break
+      if (ispeBox.size < 8) break
+      if (ispeBox.offset + ispeBox.size > ipcoEnd) break
 
       const rawWidth = readUInt32BE(input, ispeBox.offset + 12)
       const rawHeight = readUInt32BE(input, ispeBox.offset + 16)
@@ -69,14 +72,16 @@ export const HEIF: IImage = {
       const clapBox = findBox(input, 'clap', currentOffset)
       let width = rawWidth
       let height = rawHeight
-      if (clapBox && clapBox.offset < ipcoBox.offset + ipcoBox.size) {
+      if (clapBox && clapBox.offset < ipcoEnd && clapBox.size >= 8) {
         const cropRight = readUInt32BE(input, clapBox.offset + 12)
         width = rawWidth - cropRight
       }
 
       images.push({ height, width })
 
-      currentOffset = ispeBox.offset + ispeBox.size
+      const nextOffset = ispeBox.offset + ispeBox.size
+      if (nextOffset <= currentOffset) break
+      currentOffset = nextOffset
     }
 
     if (images.length === 0) {

--- a/packages/astro/src/assets/utils/vendor/image-size/types/icns.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/icns.ts
@@ -11,6 +11,7 @@ import { readUInt32BE, toUTF8String } from './utils.js'
  */
 const SIZE_HEADER = 4 + 4 // 8
 const FILE_LENGTH_OFFSET = 4 // MSB => BIG ENDIAN
+const MIN_ENTRY_LENGTH = 8
 
 /**
  * Image Entry
@@ -92,10 +93,20 @@ export const ICNS: IImage = {
     const images: ISize[] = []
 
     while (imageOffset < fileLength && imageOffset < inputLength) {
+      if (inputLength - imageOffset < MIN_ENTRY_LENGTH) break
+
       const imageHeader = readImageHeader(input, imageOffset)
+      const entryLength = imageHeader[1]
+      if (entryLength < MIN_ENTRY_LENGTH) break
+
       const imageSize = getImageSize(imageHeader[0])
-      images.push(imageSize)
-      imageOffset += imageHeader[1]
+      if (imageSize.width && imageSize.height) {
+        images.push(imageSize)
+      }
+
+      const nextOffset = imageOffset + entryLength
+      if (nextOffset <= imageOffset) break
+      imageOffset = nextOffset
     }
 
     if (images.length === 0) {

--- a/packages/astro/src/assets/utils/vendor/image-size/types/jp2.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/jp2.ts
@@ -15,8 +15,9 @@ export const JP2: IImage = {
 
   calculate(input) {
     const jp2hBox = findBox(input, 'jp2h', 0)
-    const ihdrBox = jp2hBox && findBox(input, 'ihdr', jp2hBox.offset + 8)
-    if (ihdrBox) {
+    const ihdrBox =
+      jp2hBox && jp2hBox.size >= 8 && findBox(input, 'ihdr', jp2hBox.offset + 8)
+    if (ihdrBox && ihdrBox.size >= 8) {
       return {
         height: readUInt32BE(input, ihdrBox.offset + 8),
         width: readUInt32BE(input, ihdrBox.offset + 12),

--- a/packages/astro/src/assets/utils/vendor/image-size/types/jxl.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/jxl.ts
@@ -5,7 +5,7 @@ import { findBox, toUTF8String } from './utils.js'
 /** Extracts the codestream from a containerized JPEG XL image */
 function extractCodestream(input: Uint8Array): Uint8Array | undefined {
   const jxlcBox = findBox(input, 'jxlc', 0)
-  if (jxlcBox) {
+  if (jxlcBox && jxlcBox.size >= 8) {
     return input.slice(jxlcBox.offset + 8, jxlcBox.offset + jxlcBox.size)
   }
 
@@ -24,10 +24,13 @@ function extractPartialStreams(input: Uint8Array): Uint8Array[] {
   while (offset < input.length) {
     const jxlpBox = findBox(input, 'jxlp', offset)
     if (!jxlpBox) break
+    if (jxlpBox.size < 12) break
     partialStreams.push(
       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size),
     )
-    offset = jxlpBox.offset + jxlpBox.size
+    const nextOffset = jxlpBox.offset + jxlpBox.size
+    if (nextOffset <= offset) break
+    offset = nextOffset
   }
   return partialStreams
 }

--- a/packages/astro/src/assets/utils/vendor/image-size/types/utils.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/utils.ts
@@ -63,28 +63,42 @@ export function readUInt(
   return methods[methodName](input, offset)
 }
 
+const MIN_BOX_HEADER = 8
+
 function readBox(input: Uint8Array, offset: number) {
-  if (input.length - offset < 4) return
+  if (input.length - offset < MIN_BOX_HEADER) return
   const boxSize = readUInt32BE(input, offset)
+
+  // ISO BMFF: size 0 means the box extends to the end of the file
+  if (boxSize === 0) {
+    return {
+      name: toUTF8String(input, offset + 4, offset + 8),
+      offset,
+      size: input.length - offset,
+    }
+  }
+
+  // ISO BMFF: size 1 signals a 64-bit largesize box, which is not supported
+  if (boxSize === 1) return
+  if (boxSize < MIN_BOX_HEADER) return
   if (input.length - offset < boxSize) return
+
   return {
-    name: toUTF8String(input, 4 + offset, 8 + offset),
+    name: toUTF8String(input, offset + 4, offset + 8),
     offset,
     size: boxSize,
   }
 }
 
-export function findBox(
-  input: Uint8Array,
-  boxName: string,
-  currentOffset: number,
-) {
-  while (currentOffset < input.length) {
-    const box = readBox(input, currentOffset)
+export function findBox(input: Uint8Array, boxName: string, startOffset: number) {
+  let offset = startOffset
+  while (offset < input.length) {
+    const box = readBox(input, offset)
     if (!box) break
     if (box.name === boxName) return box
-    // Fix the infinite loop by ensuring offset always increases
-    // If box.size is 0, advance by at least 8 bytes (the size of the box header)
-    currentOffset += box.size > 0 ? box.size : 8
+    if (box.size < MIN_BOX_HEADER) break
+    const nextOffset = offset + box.size
+    if (nextOffset <= offset) break
+    offset = nextOffset
   }
 }

--- a/packages/astro/test/units/assets/image-size-malformed.test.ts
+++ b/packages/astro/test/units/assets/image-size-malformed.test.ts
@@ -1,0 +1,96 @@
+import * as assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const lookupPath = fileURLToPath(
+	new URL('../../../dist/assets/utils/vendor/image-size/lookup.js', import.meta.url),
+);
+
+const PROBE_TIMEOUT = 10_000;
+
+function writeAscii(buffer: Uint8Array, offset: number, text: string) {
+	for (let i = 0; i < text.length; i++) {
+		buffer[offset + i] = text.charCodeAt(i);
+	}
+}
+
+// A missing guard shows up as a hang, so probe in a child process we can actually kill.
+function probe(payload: Uint8Array) {
+	const source = `
+		const { lookup } = await import(${JSON.stringify(lookupPath)});
+		const input = new Uint8Array(Buffer.from(process.argv[1], 'base64'));
+		try { lookup(input); } catch {}
+	`;
+	return spawnSync(
+		process.execPath,
+		['--input-type=module', '-e', source, Buffer.from(payload).toString('base64')],
+		{ timeout: PROBE_TIMEOUT, encoding: 'utf8' },
+	);
+}
+
+function assertTerminates(payload: Uint8Array) {
+	const result = probe(payload);
+	assert.equal(result.signal, null, `probe was killed after ${PROBE_TIMEOUT}ms instead of returning`);
+	assert.equal(result.status, 0, `probe exited unexpectedly: ${result.stderr}`);
+}
+
+describe('image-size malformed input', () => {
+	it('terminates on an ICNS entry declaring zero length', () => {
+		const payload = new Uint8Array(24);
+		const view = new DataView(payload.buffer);
+		writeAscii(payload, 0, 'icns');
+		view.setUint32(4, payload.length, false);
+		writeAscii(payload, 8, 'ic09');
+		view.setUint32(12, 0, false);
+
+		assertTerminates(payload);
+	});
+
+	it('terminates on a JXL container with a zero-size jxlp box', () => {
+		const payload = new Uint8Array(44);
+		const view = new DataView(payload.buffer);
+
+		view.setUint32(0, 12, false);
+		writeAscii(payload, 4, 'JXL ');
+		payload.set([0x0d, 0x0a, 0x87, 0x0a], 8);
+
+		view.setUint32(12, 20, false);
+		writeAscii(payload, 16, 'ftyp');
+		writeAscii(payload, 20, 'jxl ');
+		view.setUint32(24, 0, false);
+		writeAscii(payload, 28, 'jxl ');
+
+		view.setUint32(32, 0, false);
+		writeAscii(payload, 36, 'jxlp');
+
+		assertTerminates(payload);
+	});
+
+	it('terminates on a HEIF ipco containing a zero-size ispe box', () => {
+		// Oversized so the ispe dimension reads stay in bounds; a short buffer throws before the loop spins.
+		const payload = new Uint8Array(100);
+		const view = new DataView(payload.buffer);
+
+		view.setUint32(0, 20, false);
+		writeAscii(payload, 4, 'ftyp');
+		writeAscii(payload, 8, 'avif');
+		view.setUint32(12, 0, false);
+		writeAscii(payload, 16, 'avif');
+
+		view.setUint32(20, 80, false);
+		writeAscii(payload, 24, 'meta');
+		view.setUint32(28, 0, false);
+
+		view.setUint32(32, 68, false);
+		writeAscii(payload, 36, 'iprp');
+
+		view.setUint32(40, 60, false);
+		writeAscii(payload, 44, 'ipco');
+
+		view.setUint32(48, 0, false);
+		writeAscii(payload, 52, 'ispe');
+
+		assertTerminates(payload);
+	});
+});

--- a/packages/astro/test/units/assets/image-size-malformed.test.ts
+++ b/packages/astro/test/units/assets/image-size-malformed.test.ts
@@ -1,11 +1,10 @@
 import * as assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { describe, it } from 'node:test';
-import { fileURLToPath } from 'node:url';
 
-const lookupPath = fileURLToPath(
-	new URL('../../../dist/assets/utils/vendor/image-size/lookup.js', import.meta.url),
-);
+// Must stay a file:// URL: a bare Windows path is rejected by dynamic import as an unknown scheme.
+const lookupUrl = new URL('../../../dist/assets/utils/vendor/image-size/lookup.js', import.meta.url)
+	.href;
 
 const PROBE_TIMEOUT = 10_000;
 
@@ -18,7 +17,7 @@ function writeAscii(buffer: Uint8Array, offset: number, text: string) {
 // A missing guard shows up as a hang, so probe in a child process we can actually kill.
 function probe(payload: Uint8Array) {
 	const source = `
-		const { lookup } = await import(${JSON.stringify(lookupPath)});
+		const { lookup } = await import(${JSON.stringify(lookupUrl)});
 		const input = new Uint8Array(Buffer.from(process.argv[1], 'base64'));
 		try { lookup(input); } catch {}
 	`;


### PR DESCRIPTION
## Changes

Make sure `image-size` doesn't hang infinitely on some malformed images. This code has been ported from a community fork called `image-size-next`

## Testing

Added new tests

## Docs

N/A
