### PR TITLE
Pin transitive nanoid to a patched version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,7 @@ settings:
 overrides:
   '@types/node@22': ^22.19.0
   modern-tar: '>=0.7.7'
+  nanoid@<3.3.17: ^3.3.17
 
 importers:
 
@@ -13698,8 +13699,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -23670,7 +23671,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   nanostores@1.1.1: {}
 
@@ -24383,7 +24384,7 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,11 @@ overrides:
   '@types/node@22': '^22.19.0'
   # Force modern-tar to 0.7.7 which fixes Unicode NFC/NFD path normalization on Linux (issue #17381)
   'modern-tar': '>=0.7.7'
+  # Force nanoid to ^3.3.17, which fixes an infinite loop in customAlphabet/customRandom
+  # when size is 0 (GHSA-6v77-jg2r-5qmr). Reaches us transitively via vite -> postcss.
+  # Pinned to the 3.x line because postcss depends on nanoid@^3; a `>=` range would
+  # pull the breaking, ESM-only nanoid@6 into postcss's v3 API slot.
+  'nanoid@<3.3.17': '^3.3.17'
 
 # Wait until three days after release to install new versions of packages
 minimumReleaseAge: 4320


### PR DESCRIPTION
## Changes

- Adds a `pnpm.overrides` entry pinning `nanoid@<3.3.17` to `^3.3.17`, fixing an infinite loop in `customAlphabet`/`customRandom` when `size` is 0 (GHSA-6v77-jg2r-5qmr). It reaches us transitively via `astro` → `vite` → `postcss` → `nanoid`.
- Pins to the 3.x line (not `>=`) because `postcss` expects `nanoid@^3`; a `>=` range pulls the breaking, ESM-only `nanoid@6` into that slot. Lockfile now resolves `nanoid@3.3.18` as the only version in the tree.

## Testing

- No tests. Root-config-only change; verified `pnpm install` succeeds and `nanoid@3.3.18` is the sole resolution.

## Docs

- No docs update needed; no public API or published `package.json` changes. Users already resolve the patched `nanoid` via Vite's `postcss@^8.5.25` range on a clean install.