### PR TITLE
Fix generated Netlify image config URLs

### DIFF
--- a/.changeset/moody-geckos-train.md
+++ b/.changeset/moody-geckos-train.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes generated Netlify Image CDN allowlists to reject remote URLs that contain an allowed image origin only within their path or query string

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -49,7 +49,7 @@ export function remotePatternToRegex(
 ): string | undefined {
 	let { protocol, hostname, port, pathname } = pattern;
 
-	let regexStr = '';
+	let regexStr = '^';
 
 	if (protocol) {
 		regexStr += `${protocol}://`;
@@ -125,7 +125,7 @@ function remoteImagesFromAstroConfig(
 	const remoteImages: string[] = [];
 	// Domains get a simple regex match
 	remoteImages.push(
-		...config.image.domains.map((domain) => `https?:\/\/${escapeRegex(domain)}\/.*`),
+		...config.image.domains.map((domain) => `^https?:\/\/${escapeRegex(domain)}\/.*$`),
 	);
 	// Remote patterns need to be converted to regexes
 	remoteImages.push(

--- a/packages/integrations/netlify/test/functions/image-cdn.test.ts
+++ b/packages/integrations/netlify/test/functions/image-cdn.test.ts
@@ -116,6 +116,19 @@ describe('Image CDN', { timeout: 120000 }, () => {
 			);
 		});
 
+		it('rejects allowed patterns embedded in another URL', async () => {
+			assert.equal(
+				regexes[0]!.test(
+					'http://169.254.169.254/latest/meta-data/?url=https://example.net/image.jpg',
+				),
+				false,
+			);
+			assert.equal(
+				regexes[2]!.test('http://127.0.0.1:6379/?url=https://www.example.org/images/a.jpg'),
+				false,
+			);
+		});
+
 		it('treats metacharacters in a literal pathname as literals', async () => {
 			const spyLogger = new SpyLogger();
 			const logger = spyLogger.forkIntegrationLogger('test-spy');


### PR DESCRIPTION
## Changes

- For `config.domains` we should be using `^` so that the URL matches at the front of the URL.
- This prevents query params from matching.

## Testing

- Tests explain what this fixes best.

## Docs

N/A, bug fix
