### PR TITLE
Fix content collection edits serving stale content in dev on Windows

### DIFF
--- a/.changeset/light-pandas-repeat.md
+++ b/.changeset/light-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where editing a content collection entry during `astro dev` on Windows kept serving stale content until the dev server was restarted. The data store now notifies the dev server directly after each write instead of relying only on the file watcher, which can miss the atomic rename that commits the write on some platforms.

--- a/packages/astro/src/content/data-store-writer.ts
+++ b/packages/astro/src/content/data-store-writer.ts
@@ -14,8 +14,17 @@ export type DataStoreManifest = Record<string, string[]>;
  * (build/dev) and are never imported at runtime.
  */
 export interface DataStoreWriter {
-	/** Serialize and persist the given collections. */
-	write(collections: Map<string, Map<string, any>>): Promise<void>;
+	/**
+	 * Serialize and persist the given collections.
+	 * Resolves to `true` if the data on disk changed, or `false` if the write
+	 * was skipped because the persisted data was already identical.
+	 */
+	write(collections: Map<string, Map<string, any>>): Promise<boolean>;
+	/**
+	 * The file whose write commits a store update: the store file itself, or
+	 * the manifest for chunked stores.
+	 */
+	readonly target: PathLike;
 }
 
 /**
@@ -102,17 +111,20 @@ export function chunkString(str: string, maxBytes: number): string[] {
  * partial reads. If the file already contains identical data, the write is
  * skipped. Callers are responsible for serializing concurrent writes to the
  * same file.
+ *
+ * Returns `true` if the file was written, or `false` if the write was skipped.
  */
-export async function writeFileAtomic(file: PathLike, data: string): Promise<void> {
+export async function writeFileAtomic(file: PathLike, data: string): Promise<boolean> {
 	const tempFile = file instanceof URL ? new URL(`${file.href}.tmp`) : `${file}.tmp`;
 	const oldData = await fs.readFile(file, 'utf-8').catch(() => '');
 	if (oldData === data) {
 		// If the data hasn't changed, we can skip the write.
-		return;
+		return false;
 	}
 	// Write to a temporary file first and then move it to prevent partial reads.
 	await fs.writeFile(tempFile, data);
 	await fs.rename(tempFile, file);
+	return true;
 }
 
 /**
@@ -125,8 +137,12 @@ export class FileWriter implements DataStoreWriter {
 		this.#file = file;
 	}
 
-	async write(collections: Map<string, Map<string, any>>): Promise<void> {
-		await writeFileAtomic(this.#file, serializeDataStore(collections));
+	get target(): PathLike {
+		return this.#file;
+	}
+
+	async write(collections: Map<string, Map<string, any>>): Promise<boolean> {
+		return await writeFileAtomic(this.#file, serializeDataStore(collections));
 	}
 }
 
@@ -155,7 +171,11 @@ export class ChunkedWriter implements DataStoreWriter {
 		this.#chunkSize = chunkSize;
 	}
 
-	async write(collections: Map<string, Map<string, any>>): Promise<void> {
+	get target(): PathLike {
+		return this.#manifestFile;
+	}
+
+	async write(collections: Map<string, Map<string, any>>): Promise<boolean> {
 		if (!this.#hasher) {
 			this.#hasher = await xxhash();
 		}
@@ -168,12 +188,14 @@ export class ChunkedWriter implements DataStoreWriter {
 		}
 
 		// The manifest is the commit point: every part it references already
-		// exists on disk, so a reader never sees a dangling reference.
-		await writeFileAtomic(this.#manifestFile, JSON.stringify(manifest));
+		// exists on disk, so a reader never sees a dangling reference. Parts are
+		// content-addressed, so an unchanged manifest means unchanged data.
+		const didWrite = await writeFileAtomic(this.#manifestFile, JSON.stringify(manifest));
 		this.#writtenFiles.add(DATA_STORE_MANIFEST_FILE);
 
 		// Prune files left behind by previous snapshots.
 		emptyDir(this.#dir, this.#writtenFiles);
+		return didWrite;
 	}
 
 	async #writeCollection(entries: Iterable<[string, unknown]>) {

--- a/packages/astro/src/content/index.ts
+++ b/packages/astro/src/content/index.ts
@@ -3,4 +3,7 @@ export { createContentTypesGenerator } from './types-generator.js';
 export { getContentPaths } from './utils.js';
 export { astroContentAssetPropagationPlugin } from './vite-plugin-content-assets.js';
 export { astroContentImportPlugin } from './vite-plugin-content-imports.js';
-export { astroContentVirtualModPlugin } from './vite-plugin-content-virtual-mod.js';
+export {
+	astroContentVirtualModPlugin,
+	attachDataStoreInvalidation,
+} from './vite-plugin-content-virtual-mod.js';

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -46,6 +46,35 @@ export class MutableDataStore extends ImmutableDataStore {
 	#writeInProgress = false;
 	#writeQueued = false;
 
+	#fileWrittenListeners = new Set<(path: string) => void>();
+
+	/**
+	 * Registers a listener called with the file path whenever this store writes a
+	 * file to disk (the data store itself, or the asset/module import files).
+	 * Writes that are skipped because the data on disk is already identical do
+	 * not notify. The dev server uses this to invalidate the content virtual
+	 * modules deterministically, instead of relying on the file watcher to
+	 * observe the write — on some platforms (notably Windows) the watcher can
+	 * miss the atomic rename that commits it.
+	 * Returns a function that removes the listener.
+	 */
+	onFileWritten(listener: (path: string) => void): () => void {
+		this.#fileWrittenListeners.add(listener);
+		return () => {
+			this.#fileWrittenListeners.delete(listener);
+		};
+	}
+
+	#notifyFileWritten(path: PathLike) {
+		if (this.#fileWrittenListeners.size === 0) {
+			return;
+		}
+		const normalized = path instanceof URL ? fileURLToPath(path) : path.toString();
+		for (const listener of this.#fileWrittenListeners) {
+			listener(normalized);
+		}
+	}
+
 	set(collectionName: string, key: string, value: unknown) {
 		const collection = this._collections.get(collectionName) ?? new Map();
 		collection.set(String(key), value);
@@ -318,6 +347,7 @@ export default new Map([\n${lines.join(',\n')}]);
 			// Write it to a temporary file first and then move it to prevent partial reads.
 			await fs.writeFile(tempFile, data);
 			await fs.rename(tempFile, filePath);
+			this.#notifyFileWritten(filePath);
 		} finally {
 			// We're done writing. Unflag the file and check if there are any pending writes for this file.
 			this.#writing.delete(fileKey);
@@ -461,7 +491,10 @@ export default new Map([\n${lines.join(',\n')}]);
 			// Mark as clean before writing to disk so that it catches any changes that happen during the write
 			this.#dirty = false;
 			this.#writeInProgress = true;
-			await this.#writer.write(this._collections);
+			const didWrite = await this.#writer.write(this._collections);
+			if (didWrite) {
+				this.#notifyFileWritten(this.#writer.target);
+			}
 		} catch (err) {
 			throw new AstroError(AstroErrorData.UnknownFilesystemError, { cause: err });
 		} finally {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -28,6 +28,7 @@ import {
 	RESOLVED_VIRTUAL_MODULE_ID,
 	VIRTUAL_MODULE_ID,
 } from './consts.js';
+import type { MutableDataStore } from './mutable-data-store.js';
 import { getDataStoreChunkSize, getDataStoreDir, getDataStoreFile } from './paths.js';
 import { getContentPaths, isDeferredModule } from './utils.js';
 
@@ -90,6 +91,57 @@ function invalidateDataStore(viteServer: ViteDevServer, { notifyClient = true } 
 			path: '*',
 		});
 	}
+}
+
+// Timestamps of direct (write-driven) invalidations, keyed by file path. The
+// file watcher usually observes the same write shortly afterwards; watcher
+// events inside this window are echoes of an invalidation that has already
+// happened and are skipped so clients don't get two full reloads for one change.
+const directInvalidations = new Map<string, number>();
+const DIRECT_INVALIDATION_ECHO_MS = 1000;
+
+function markDirectInvalidation(path: string) {
+	directInvalidations.set(path, Date.now());
+}
+
+function isDirectInvalidationEcho(path: string) {
+	const time = directInvalidations.get(path);
+	return time !== undefined && Date.now() - time < DIRECT_INVALIDATION_ECHO_MS;
+}
+
+/** The file whose write commits a data store update during dev. */
+function getDevDataStoreFile(settings: AstroSettings): URL {
+	if (getDataStoreChunkSize(settings) !== undefined) {
+		return new URL(DATA_STORE_MANIFEST_FILE, getDataStoreDir(settings, true));
+	}
+	return getDataStoreFile(settings, true);
+}
+
+/**
+ * Invalidates the content virtual modules directly whenever the given store
+ * writes to disk. The watcher listeners in `configureServer` cover writes from
+ * other processes, but the watcher can miss the atomic rename that commits a
+ * write on some platforms (notably Windows, see #17335), leaving dev serving
+ * stale content until a restart. Subscribing to the store's own write
+ * notifications makes invalidation of this process's writes deterministic.
+ */
+export function attachDataStoreInvalidation(
+	store: MutableDataStore,
+	server: ViteDevServer,
+	settings: AstroSettings,
+) {
+	const dataStorePath = fileURLToPath(getDevDataStoreFile(settings));
+	const assetImportsPath = fileURLToPath(new URL(ASSET_IMPORTS_FILE, settings.dotAstroDir));
+	store.onFileWritten((path) => {
+		if (path === dataStorePath) {
+			markDirectInvalidation(dataStorePath);
+			invalidateDataStore(server);
+			invalidateAssetImports(server, assetImportsPath);
+		} else if (path === assetImportsPath) {
+			markDirectInvalidation(assetImportsPath);
+			invalidateAssetImports(server, assetImportsPath);
+		}
+	});
 }
 
 export function astroContentVirtualModPlugin({
@@ -335,7 +387,7 @@ export function astroContentVirtualModPlugin({
 			const assetImportsPath = fileURLToPath(new URL(ASSET_IMPORTS_FILE, settings.dotAstroDir));
 
 			server.watcher.on('add', (addedPath) => {
-				if (addedPath === dataStorePath) {
+				if (addedPath === dataStorePath && !isDirectInvalidationEcho(dataStorePath)) {
 					invalidateDataStore(server);
 					invalidateAssetImports(server, assetImportsPath);
 				}
@@ -343,9 +395,15 @@ export function astroContentVirtualModPlugin({
 
 			server.watcher.on('change', (changedPath) => {
 				if (changedPath === dataStorePath) {
+					if (isDirectInvalidationEcho(dataStorePath)) {
+						return;
+					}
 					invalidateDataStore(server);
 					invalidateAssetImports(server, assetImportsPath);
-				} else if (changedPath === assetImportsPath) {
+				} else if (
+					changedPath === assetImportsPath &&
+					!isDirectInvalidationEcho(assetImportsPath)
+				) {
 					invalidateAssetImports(server, assetImportsPath);
 				}
 			});

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -7,7 +7,7 @@ import { gt, major, minor, patch } from 'semver';
 import type * as vite from 'vite';
 import { getDataStoreChunkSize, getDataStoreDir, getDataStoreFile } from '../../content/paths.js';
 import { globalContentLayer } from '../../content/instance.js';
-import { attachContentServerListeners } from '../../content/index.js';
+import { attachContentServerListeners, attachDataStoreInvalidation } from '../../content/index.js';
 import { MutableDataStore } from '../../content/mutable-data-store.js';
 import { globalContentConfigObserver } from '../../content/utils.js';
 import { telemetry } from '../../events/index.js';
@@ -105,6 +105,11 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 
 	if (!store) {
 		logger.error('content', 'Failed to create data store');
+	} else {
+		// Invalidate the content virtual modules directly when the store is
+		// written, rather than relying on the file watcher to observe the write.
+		// On Windows the watcher can miss it, leaving dev serving stale content.
+		attachDataStoreInvalidation(store, restart.container.viteServer, restart.container.settings);
 	}
 	await attachContentServerListeners(restart.container);
 

--- a/packages/astro/test/units/content-layer/content-virtual-mod.test.ts
+++ b/packages/astro/test/units/content-layer/content-virtual-mod.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import nodeFs from 'node:fs';
-import { describe, it } from 'node:test';
-import { astroContentVirtualModPlugin } from '../../../dist/content/vite-plugin-content-virtual-mod.js';
+import { describe, it, mock } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { MutableDataStore } from '../../../dist/content/mutable-data-store.js';
+import { getDataStoreFile } from '../../../dist/content/paths.js';
+import {
+	astroContentVirtualModPlugin,
+	attachDataStoreInvalidation,
+} from '../../../dist/content/vite-plugin-content-virtual-mod.js';
 import { createMinimalSettings, createTempDir } from './test-helpers.ts';
 
 /**
@@ -21,6 +27,7 @@ function createMockModuleGraph() {
  */
 function createMockViteDevServer() {
 	const sentMessages: Array<Record<string, unknown>> = [];
+	const watcherListeners = new Map<string, Array<(path: string) => void>>();
 	return {
 		sentMessages,
 		environments: {
@@ -43,9 +50,24 @@ function createMockViteDevServer() {
 		},
 		watcher: {
 			add: () => {},
-			on: () => {},
+			on: (event: string, listener: (path: string) => void) => {
+				if (!watcherListeners.has(event)) {
+					watcherListeners.set(event, []);
+				}
+				watcherListeners.get(event)!.push(listener);
+			},
+			emit: (event: string, path: string) => {
+				for (const listener of watcherListeners.get(event) ?? []) {
+					listener(path);
+				}
+			},
 		},
 	};
+}
+
+function countClientReloads(server: ReturnType<typeof createMockViteDevServer>) {
+	return server.sentMessages.filter((msg) => msg.channel === 'client' && msg.type === 'full-reload')
+		.length;
 }
 
 describe('astroContentVirtualModPlugin', () => {
@@ -164,5 +186,54 @@ describe('astroContentVirtualModPlugin', () => {
 			0,
 			'buildStart should not send full-reload to client during startup',
 		);
+	});
+});
+
+describe('attachDataStoreInvalidation', () => {
+	it('invalidates on store writes without a watcher event, and skips the watcher echo (#17335)', async (t) => {
+		const root = createTempDir('content-data-store-invalidation-test-');
+		const settings = createMinimalSettings(root, { config: { legacy: {} } });
+		const dataStoreFile = getDataStoreFile(settings, true);
+		const dataStorePath = fileURLToPath(dataStoreFile);
+		await nodeFs.promises.mkdir(settings.dotAstroDir, { recursive: true });
+
+		// Mock only Date so the direct-invalidation echo window can be advanced
+		// without waiting; the store's debounce timers stay real.
+		t.mock.timers.enable({ apis: ['Date'], now: 10_000 });
+		t.after(() => mock.timers.reset());
+
+		const mockServer = createMockViteDevServer();
+		const plugin = astroContentVirtualModPlugin({ settings, fs: nodeFs });
+		// @ts-expect-error - mock args are sufficient for this test
+		plugin.config?.({}, { command: 'serve' });
+		// @ts-expect-error - mock server has enough structure for this test
+		plugin.configureServer?.(mockServer);
+
+		const store = await MutableDataStore.fromFile(dataStoreFile);
+		// @ts-expect-error - mock server has enough structure for this test
+		attachDataStoreInvalidation(store, mockServer, settings);
+
+		// A content change is written to the data store. No watcher event is
+		// emitted, simulating platforms where the watcher misses the atomic
+		// rename (the Windows failure mode in #17335).
+		store.set('dogs', 'beagle', { id: 'beagle', data: { breed: 'Beagle' } });
+		await store.waitUntilSaveComplete();
+
+		assert.equal(countClientReloads(mockServer), 1, 'the store write should trigger a reload');
+		const contentChanged = mockServer.sentMessages.filter(
+			(msg) => msg.channel === 'ssr' && msg.type === 'astro:content-changed',
+		);
+		assert.equal(contentChanged.length, 1, 'the SSR runner should be told content changed');
+
+		// The watcher observes the same write shortly afterwards: that echo must
+		// not reload clients a second time.
+		mockServer.watcher.emit('change', dataStorePath);
+		assert.equal(countClientReloads(mockServer), 1, 'the watcher echo should be skipped');
+
+		// A watcher event well outside the echo window (e.g. another process
+		// wrote the store) still invalidates: the fallback path is preserved.
+		t.mock.timers.tick(5_000);
+		mockServer.watcher.emit('change', dataStorePath);
+		assert.equal(countClientReloads(mockServer), 2, 'a later external change should reload');
 	});
 });

--- a/packages/astro/test/units/content-layer/store-write-notifications.test.ts
+++ b/packages/astro/test/units/content-layer/store-write-notifications.test.ts
@@ -1,0 +1,101 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { DATA_STORE_MANIFEST_FILE } from '../../../dist/content/consts.js';
+import { MutableDataStore } from '../../../dist/content/mutable-data-store.js';
+import { createTempDir } from './test-helpers.ts';
+
+const CHUNK_SIZE = 1024 * 1024;
+
+// The dev server subscribes to these notifications to invalidate the content
+// virtual modules deterministically after each write, because the file watcher
+// can miss the atomic rename that commits a write on some platforms (notably
+// Windows, see #17335).
+describe('MutableDataStore - write notifications', () => {
+	it('notifies with the store file path after a write', async () => {
+		const tempDir = createTempDir();
+		const dataStoreFile = new URL('./data-store.json', tempDir);
+		const store = await MutableDataStore.fromFile(dataStoreFile);
+
+		const written: string[] = [];
+		store.onFileWritten((path) => written.push(path));
+
+		store.set('dogs', 'beagle', { id: 'beagle', data: { breed: 'Beagle' } });
+		await store.waitUntilSaveComplete();
+
+		assert.deepEqual(written, [fileURLToPath(dataStoreFile)]);
+	});
+
+	it('does not notify when the data on disk is already identical', async () => {
+		const tempDir = createTempDir();
+		const dataStoreFile = new URL('./data-store.json', tempDir);
+		const store = await MutableDataStore.fromFile(dataStoreFile);
+
+		store.set('dogs', 'beagle', { id: 'beagle', data: { breed: 'Beagle' } });
+		await store.waitUntilSaveComplete();
+
+		const written: string[] = [];
+		store.onFileWritten((path) => written.push(path));
+
+		// Force another save cycle without changing the serialized data. The
+		// writer skips the identical write, so no notification is emitted and
+		// the dev server does not reload the page for a no-op sync.
+		store.set('dogs', 'beagle', { id: 'beagle', data: { breed: 'Beagle' } });
+		await store.waitUntilSaveComplete();
+
+		assert.deepEqual(written, []);
+	});
+
+	it('notifies with the manifest path for chunked stores', async () => {
+		const tempDir = createTempDir();
+		const dataStoreDir = new URL('./data-store/', tempDir);
+		const store = await MutableDataStore.fromDir(dataStoreDir, CHUNK_SIZE);
+
+		const written: string[] = [];
+		store.onFileWritten((path) => written.push(path));
+
+		store.set('dogs', 'beagle', { id: 'beagle', data: { breed: 'Beagle' } });
+		await store.waitUntilSaveComplete();
+
+		assert.deepEqual(written, [
+			fileURLToPath(new URL(`./${DATA_STORE_MANIFEST_FILE}`, dataStoreDir)),
+		]);
+	});
+
+	it('notifies for asset import file writes', async () => {
+		const tempDir = createTempDir();
+		const assetsFile = new URL('./content-assets.mjs', tempDir);
+		const store = new MutableDataStore();
+
+		const written: string[] = [];
+		store.onFileWritten((path) => written.push(path));
+
+		store.scopedStore('categories').set({
+			id: 'example',
+			data: {},
+			filePath: 'src/content/categories/example.json',
+			assetImports: ['./images/seed.webp'],
+		});
+		await store.writeAssetImports(assetsFile);
+
+		assert.deepEqual(written, [fileURLToPath(assetsFile)]);
+	});
+
+	it('stops notifying after the listener is removed', async () => {
+		const tempDir = createTempDir();
+		const dataStoreFile = new URL('./data-store.json', tempDir);
+		const store = await MutableDataStore.fromFile(dataStoreFile);
+
+		const written: string[] = [];
+		const unsubscribe = store.onFileWritten((path) => written.push(path));
+
+		store.set('dogs', 'beagle', { id: 'beagle', data: { breed: 'Beagle' } });
+		await store.waitUntilSaveComplete();
+		assert.equal(written.length, 1);
+
+		unsubscribe();
+		store.set('dogs', 'poodle', { id: 'poodle', data: { breed: 'Poodle' } });
+		await store.waitUntilSaveComplete();
+		assert.equal(written.length, 1);
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes #17335. Astro updates the content store after a collection changes, but Windows sometimes misses the file-change event needed to clear Vite's cached content.
- The content store now tells Vite directly when Astro finishes writing the update, so invalidation no longer depends on that unreliable event.
- Vite clears its cached content and route data before reloading the page, allowing the updated content to appear.

## Testing

- `store-write-notifications.test.ts`: write notifications fire for the store file (single-file and chunked), asset imports file, not for identical data, and stop after unsubscribe.
- `content-virtual-mod.test.ts`: simulates the Windows failure mode. A store write with no watcher event still invalidates and reloads once, the watcher echo is skipped, and a later external watcher event still invalidates.

## Docs

- No docs update needed; this is a bug fix with no API or behavior change beyond dev HMR working as documented.