### PR TITLE
fix(cloudflare): preserve referenced original images in dist when using compile imageService

### DIFF
--- a/.changeset/modern-needles-watch.md
+++ b/.changeset/modern-needles-watch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Preserves original image files referenced directly in pages in `dist/client/_astro/` when using the Cloudflare adapter's `imageService: 'compile'` or `'cloudflare-binding'` with `output: 'static'`

--- a/packages/integrations/cloudflare/src/prerender-types.ts
+++ b/packages/integrations/cloudflare/src/prerender-types.ts
@@ -54,4 +54,9 @@ export interface SerializedStaticImageEntry {
 	}>;
 }
 
-export type StaticImagesResponse = SerializedStaticImageEntry[];
+export interface StaticImagesPayload {
+	entries: SerializedStaticImageEntry[];
+	referencedImages?: string[];
+}
+
+export type StaticImagesResponse = SerializedStaticImageEntry[] | StaticImagesPayload;

--- a/packages/integrations/cloudflare/src/prerenderer.ts
+++ b/packages/integrations/cloudflare/src/prerenderer.ts
@@ -311,7 +311,22 @@ export function createCloudflarePrerenderer({
 							);
 						}
 
-						const entries: StaticImagesResponse = await response.json();
+						const rawData: StaticImagesResponse = await response.json();
+						const entries: SerializedStaticImageEntry[] = Array.isArray(rawData)
+							? rawData
+							: rawData.entries;
+						const referencedImages: string[] = Array.isArray(rawData)
+							? []
+							: (rawData.referencedImages ?? []);
+
+						// Rehydrate referencedImages into Node global scope so generate.ts preserves original files
+						if (referencedImages.length > 0) {
+							globalThis.astroAsset ??= {};
+							globalThis.astroAsset.referencedImages ??= new Set();
+							for (const img of referencedImages) {
+								globalThis.astroAsset.referencedImages.add(img);
+							}
+						}
 
 						// Transforms left in this map fall through to the Node-side image
 						// service (the user-configured service, or Sharp).

--- a/packages/integrations/cloudflare/src/utils/prerender.ts
+++ b/packages/integrations/cloudflare/src/utils/prerender.ts
@@ -190,29 +190,34 @@ export function isImageTransformRequest(request: Request): boolean {
 	return pathname === IMAGE_TRANSFORM_ENDPOINT && request.method === 'POST';
 }
 
-/** Serializes the global staticImages map collected in workerd back to the Node-side build. */
+/** Serializes the global staticImages map and referencedImages collected in workerd back to the Node-side build. */
 export function handleStaticImagesRequest(): Response {
 	const staticImages = globalThis.astroAsset?.staticImages;
-	if (!staticImages || staticImages.size === 0) {
-		return new Response('[]', {
-			headers: { 'Content-Type': 'application/json' },
-		});
-	}
+	const referencedImages = globalThis.astroAsset?.referencedImages
+		? Array.from(globalThis.astroAsset.referencedImages)
+		: [];
 
-	const entries: StaticImagesResponse = [];
-	for (const [originalPath, { originalSrcPath, transforms }] of staticImages) {
-		const serializedTransforms: SerializedStaticImageEntry['transforms'] = [];
-		for (const [hash, { finalPath, transform }] of transforms) {
-			serializedTransforms.push({
-				hash,
-				finalPath,
-				transform: transform as Record<string, any>,
-			});
+	const entries: SerializedStaticImageEntry[] = [];
+	if (staticImages && staticImages.size > 0) {
+		for (const [originalPath, { originalSrcPath, transforms }] of staticImages) {
+			const serializedTransforms: SerializedStaticImageEntry['transforms'] = [];
+			for (const [hash, { finalPath, transform }] of transforms) {
+				serializedTransforms.push({
+					hash,
+					finalPath,
+					transform: transform as Record<string, any>,
+				});
+			}
+			entries.push({ originalPath, originalSrcPath, transforms: serializedTransforms });
 		}
-		entries.push({ originalPath, originalSrcPath, transforms: serializedTransforms });
 	}
 
-	return new Response(JSON.stringify(entries), {
+	const payload: StaticImagesResponse = {
+		entries,
+		referencedImages,
+	};
+
+	return new Response(JSON.stringify(payload), {
 		headers: { 'Content-Type': 'application/json' },
 	});
 }


### PR DESCRIPTION
## Summary

Fixes #17748

When building an Astro site with `output: "static"` and the Cloudflare adapter configured with `imageService: "compile"` (or `"cloudflare-binding"`), original image files referenced directly in pages (e.g. `<a href={image.src}>`, `og:image`, etc.) were missing from `dist/client/_astro/` while resized variants were emitted.

## Cause
1. During prerendering in the Cloudflare preview/workerd worker, raw `src` accesses add image paths to `globalThis.astroAsset.referencedImages` inside the workerd isolate.
2. The `/__astro_static_images` endpoint returned only `staticImages` transforms and did not serialize `globalThis.astroAsset.referencedImages`.
3. Consequently, the Node-side build (`generate.ts`) had an empty `referencedImages` set and deleted the original unoptimized images because it assumed they were only used as intermediate transform sources.

## Fix
- Extended `handleStaticImagesRequest` in `packages/integrations/cloudflare/src/utils/prerender.ts` to serialize `referencedImages` alongside `entries`.
- Updated `collectStaticImages` in `packages/integrations/cloudflare/src/prerenderer.ts` to deserialize and merge `referencedImages` into Node's `globalThis.astroAsset.referencedImages`.
- `generate.ts` now sees the referenced source paths and leaves the original image assets in `dist/client/_astro/`.
