### PR TITLE
fix: accept all sätteri plugin entry types

### DIFF
--- a/.changeset/grumpy-bats-return.md
+++ b/.changeset/grumpy-bats-return.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/mdx': patch
+'@astrojs/markdown-satteri': patch
+---
+
+Fixes Sätteri processor option types to accept all plugin entries supported by Sätteri v0.10.3.

--- a/packages/integrations/mdx/src/satteri/index.ts
+++ b/packages/integrations/mdx/src/satteri/index.ts
@@ -13,7 +13,9 @@ import {
 	mdxToJs,
 	type HastNode,
 	type HastPluginDefinition,
+	type HastPluginEntry,
 	type MdastPluginDefinition,
+	type MdastPluginEntry,
 	type MdxCompileOptions,
 } from 'satteri';
 import { ASTRO_IMAGE_IMPORT, USES_ASTRO_IMAGE_FLAG } from '../image-constants.js';
@@ -90,12 +92,9 @@ export function createMdxProcessor(
 				typeof syntaxHighlight === 'object' ? syntaxHighlight.excludeLangs : undefined;
 
 			// Collect last so image-URL rewrites by user plugins are captured.
-			const allMdastPlugins: MdastPluginDefinition[] = [
-				...satteriOptions.mdastPlugins,
-				collectImages,
-			];
+			const allMdastPlugins: MdastPluginEntry[] = [...satteriOptions.mdastPlugins, collectImages];
 
-			const hastPlugins: HastPluginDefinition[] = [];
+			const hastPlugins: HastPluginEntry[] = [];
 			if (highlightFn) {
 				hastPlugins.push(satteriHighlightPlugin(highlightFn, excludeLangs));
 			}

--- a/packages/markdown/satteri/src/processor.ts
+++ b/packages/markdown/satteri/src/processor.ts
@@ -1,10 +1,16 @@
 import type { MarkdownProcessor } from '@astrojs/internal-helpers/markdown';
-import type { Features, HastPluginDefinition, MdastPluginDefinition } from 'satteri';
+import type {
+	Features,
+	HastPluginEntry,
+	HastPluginList,
+	MdastPluginEntry,
+	MdastPluginList,
+} from 'satteri';
 import { createSatteriMarkdownProcessor } from './satteri-processor.js';
 
 export interface SatteriProcessorOptions {
-	mdastPlugins?: MdastPluginDefinition[];
-	hastPlugins?: HastPluginDefinition[];
+	mdastPlugins?: MdastPluginList;
+	hastPlugins?: HastPluginList;
 	features?: Features;
 }
 
@@ -13,8 +19,8 @@ export interface SatteriProcessorOptions {
  * (the factory normalises absent inputs into defaults).
  */
 export interface SatteriResolvedOptions {
-	mdastPlugins: MdastPluginDefinition[];
-	hastPlugins: HastPluginDefinition[];
+	mdastPlugins: MdastPluginEntry[];
+	hastPlugins: HastPluginEntry[];
 	features: Features;
 }
 

--- a/packages/markdown/satteri/src/satteri-processor.ts
+++ b/packages/markdown/satteri/src/satteri-processor.ts
@@ -5,7 +5,16 @@ import {
 	syntaxHighlightDefaults,
 } from '@astrojs/internal-helpers/markdown';
 import Slugger from 'github-slugger';
-import type { Features, HastNode, HastPluginDefinition, MdastPluginDefinition } from 'satteri';
+import type {
+	Features,
+	HastNode,
+	HastPluginDefinition,
+	HastPluginEntry,
+	HastPluginList,
+	MdastPluginDefinition,
+	MdastPluginEntry,
+	MdastPluginList,
+} from 'satteri';
 import { createShikiHighlighter } from '@astrojs/internal-helpers/shiki';
 import type {
 	AstroMarkdownOptions,
@@ -206,8 +215,8 @@ export function createHighlightPlugin(
 }
 
 export interface SatteriMarkdownProcessorOptions extends AstroMarkdownOptions {
-	mdastPlugins?: MdastPluginDefinition[];
-	hastPlugins?: HastPluginDefinition[];
+	mdastPlugins?: MdastPluginList;
+	hastPlugins?: HastPluginList;
 	features?: Features;
 }
 
@@ -291,12 +300,12 @@ export async function createSatteriMarkdownProcessor(
 			};
 
 			// Collect last so image-URL rewrites by user plugins are captured.
-			const allMdastPlugins: MdastPluginDefinition[] = [
+			const allMdastPlugins: MdastPluginEntry[] = [
 				...userMdastPlugins,
 				createCollectImagesPlugin(opts?.image),
 			];
 
-			const hastPlugins: HastPluginDefinition[] = [];
+			const hastPlugins: HastPluginEntry[] = [];
 			if (highlightFn) {
 				hastPlugins.push(createHighlightPlugin(highlightFn, syntaxHighlightExcludeLangs));
 			}

--- a/packages/markdown/satteri/test/markdown.test.ts
+++ b/packages/markdown/satteri/test/markdown.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { HastPluginDefinition, MdastPluginDefinition } from 'satteri';
-import { createSatteriMarkdownProcessor, satteriHeadingIdsPlugin } from '../dist/index.js';
+import { createSatteriMarkdownProcessor, satteri, satteriHeadingIdsPlugin } from '../dist/index.js';
 
 describe('satteri markdown', () => {
 	it('renders basic markdown', async () => {
@@ -135,5 +135,26 @@ describe('satteri markdown', () => {
 		});
 		assert.equal(metadata.frontmatter.title, 'hello');
 		assert.equal(metadata.frontmatter.injected, 'HELLO');
+	});
+
+	it('accepts conditional plugin factories', async () => {
+		const mdUppercasePlugin: MdastPluginDefinition = {
+			name: 'mdx-uppercase',
+			text(node, ctx) {
+				ctx.setProperty(node, 'value', node.value.toUpperCase());
+			},
+		};
+
+		const satteriProcessor = satteri({
+			mdastPlugins: [(ctx) => (ctx.sourceFormat === 'markdown' ? [mdUppercasePlugin] : null)],
+		});
+
+		const processor = await createSatteriMarkdownProcessor({
+			mdastPlugins: satteriProcessor.options.mdastPlugins,
+		});
+
+		const { code } = await processor.render('Hello');
+
+		assert.match(code, /<p>HELLO<\/p>/);
 	});
 });


### PR DESCRIPTION
## Changes

This PR fixes the Sätteri processor option types to accept all plugin entries supported by Sätteri v0.10.3 released yesterday.

## Testing

I added a test using a conditional plugin factory which is a new supported type of plugin entry.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This is a type-only change.