### PR TITLE
Normalize request paths before route matching

### DIFF
--- a/.changeset/eight-actors-marry.md
+++ b/.changeset/eight-actors-marry.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes route selection for normalized request paths when adapters provide route data
+Fixes route selection for normalized request paths in adapter and development request handling

--- a/.changeset/eight-actors-marry.md
+++ b/.changeset/eight-actors-marry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes route selection for normalized request paths when adapters provide route data

--- a/packages/astro/src/core/app/base.ts
+++ b/packages/astro/src/core/app/base.ts
@@ -23,6 +23,7 @@ import { handleRequest } from '../routing/handler.js';
 import { getDefaultStatusCode } from '../routing/helpers.js';
 import { matchRequest } from '../routing/match-request.js';
 import { getRouteTable, matchRoute, updateRouteTable } from '../routing/route-table.js';
+import { validateAndDecodePathname } from '../util/pathname.js';
 import { setRenderOptions } from './render-options.js';
 import type { WaitUntilHook } from '../wait-until.js';
 import type { SSRManifest } from './types.js';
@@ -285,22 +286,22 @@ export abstract class BaseApp {
 	}
 
 	/**
-	 * Decodes a pathname with `decodeURI`, falling back to the raw pathname when it
-	 * contains an invalid percent-sequence (e.g. `%C0%AF`, an overlong-UTF-8 encoding of
-	 * `/` commonly sent by path-traversal scanners). A raw `decodeURI()` would throw
-	 * `URIError: URI malformed`, and because `match()` runs before `render()` that error
-	 * escapes the adapter's request handler as an uncaught exception (HTTP 500) that user
-	 * middleware can't catch.
+	 * Fully decodes a pathname, falling back to a single decode and then the raw pathname
+	 * when validation fails. Adapter matching runs before `render()`, so it must not throw
+	 * for request input that render-time validation handles.
 	 */
-	private safeDecodeURI(pathname: string): string {
+	private safeDecodePathname(pathname: string): string {
 		try {
-			return decodeURI(pathname);
+			return validateAndDecodePathname(pathname);
 		} catch (e: any) {
-			// Malformed request paths are expected client input (commonly from automated
-			// scanners) rather than a server fault, and this runs per-request on the hot
-			// path. Log at `debug` so it stays diagnosable without flooding error logs.
+			// Path decoding failures are request input rather than a server fault. Log at
+			// `debug` so they stay diagnosable without flooding error logs.
 			this.adapterLogger.debug(e.toString());
-			return pathname;
+			try {
+				return decodeURI(pathname);
+			} catch {
+				return pathname;
+			}
 		}
 	}
 
@@ -311,7 +312,7 @@ export abstract class BaseApp {
 	public getPathnameFromRequest(request: Request): string {
 		const url = new URL(request.url);
 		const pathname = prependForwardSlash(this.removeBase(url.pathname));
-		return this.safeDecodeURI(pathname);
+		return this.safeDecodePathname(pathname);
 	}
 
 	/**
@@ -398,7 +399,7 @@ export abstract class BaseApp {
 		if (!routeData) {
 			const domainPathname = this.computePathnameFromDomain(request);
 			if (domainPathname) {
-				routeData = matchRoute(this.manifest, this.safeDecodeURI(domainPathname));
+				routeData = matchRoute(this.manifest, this.safeDecodePathname(domainPathname));
 			}
 		}
 		const resolvedOptions: ResolvedRenderOptions = {

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -378,10 +378,6 @@ export class FetchState implements AstroFetchState {
 			setOriginPathname(this.request, this.pathname, manifest.trailingSlash, manifest.buildFormat);
 		}
 
-		// Eagerly resolve the route when it wasn't provided via render
-		// options. In dev the route is always passed through render options
-		// (handleRequest calls devMatch before render). In production
-		// app.match() is synchronous.
 		this.#resolveRouteData();
 	}
 
@@ -930,10 +926,11 @@ export class FetchState implements AstroFetchState {
 
 	/**
 	 * Resolves the route to use for this request and stores it on
-	 * `this.routeData`. If the adapter (or the dev server) provided a
-	 * `routeData` via render options it's already set and this is a
-	 * no-op. Otherwise we use the app's synchronous route matcher and
-	 * fall back to a `404.astro` route so middleware can still run.
+	 * `this.routeData`. Build-provided route data is authoritative because
+	 * prerendering may target a lower-priority route for a pathname. Route data
+	 * provided at runtime is retained when it agrees with the normalized request
+	 * pathname. Otherwise the app's synchronous route matcher selects the route.
+	 * A `404.astro` route is used as a fallback so middleware can still run.
 	 *
 	 * Called eagerly from the constructor so individual handlers
 	 * (actions, pages, middleware, etc.) always see a resolved route
@@ -972,17 +969,22 @@ export class FetchState implements AstroFetchState {
 	}
 
 	#resolveRouteData(): void {
-		// Fast path: routeData was provided via render options (build, dev
-		// with adapter).
-		if (this.routeData) {
-			this.#stripHtmlExtension();
-			return;
-		}
-
 		// this.pathname is already fully decoded by #computePathname
 		// (which iteratively decodes all encoding levels), so no
 		// additional decoding is needed here.
 		const matched = matchRoute(this.manifest, this.pathname);
+		if (
+			this.routeData &&
+			(getEnvironment(this.manifest).errorStrategy === 'build' ||
+				(matched &&
+					this.routeData.route === matched.route &&
+					this.routeData.component === matched.component))
+		) {
+			this.#stripHtmlExtension();
+			return;
+		}
+		this.routeData = undefined;
+
 		// In production SSR, prerendered routes are served as static files
 		// by the hosting layer and should not be rendered by the app.
 		// When the first match is a prerendered *dynamic* route, try to find

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -378,6 +378,10 @@ export class FetchState implements AstroFetchState {
 			setOriginPathname(this.request, this.pathname, manifest.trailingSlash, manifest.buildFormat);
 		}
 
+		// Eagerly resolve the route when it wasn't provided via render
+		// options. In dev the route is always passed through render options
+		// (handleRequest calls devMatch before render). In production
+		// app.match() is synchronous.
 		this.#resolveRouteData();
 	}
 
@@ -926,11 +930,10 @@ export class FetchState implements AstroFetchState {
 
 	/**
 	 * Resolves the route to use for this request and stores it on
-	 * `this.routeData`. Build-provided route data is authoritative because
-	 * prerendering may target a lower-priority route for a pathname. Route data
-	 * provided at runtime is retained when it agrees with the normalized request
-	 * pathname. Otherwise the app's synchronous route matcher selects the route.
-	 * A `404.astro` route is used as a fallback so middleware can still run.
+	 * `this.routeData`. If the adapter (or the dev server) provided a
+	 * `routeData` via render options it's already set and this is a
+	 * no-op. Otherwise we use the app's synchronous route matcher and
+	 * fall back to a `404.astro` route so middleware can still run.
 	 *
 	 * Called eagerly from the constructor so individual handlers
 	 * (actions, pages, middleware, etc.) always see a resolved route
@@ -969,22 +972,17 @@ export class FetchState implements AstroFetchState {
 	}
 
 	#resolveRouteData(): void {
+		// Fast path: routeData was provided via render options (build, dev
+		// with adapter).
+		if (this.routeData) {
+			this.#stripHtmlExtension();
+			return;
+		}
+
 		// this.pathname is already fully decoded by #computePathname
 		// (which iteratively decodes all encoding levels), so no
 		// additional decoding is needed here.
 		const matched = matchRoute(this.manifest, this.pathname);
-		if (
-			this.routeData &&
-			(getEnvironment(this.manifest).errorStrategy === 'build' ||
-				(matched &&
-					this.routeData.route === matched.route &&
-					this.routeData.component === matched.component))
-		) {
-			this.#stripHtmlExtension();
-			return;
-		}
-		this.routeData = undefined;
-
 		// In production SSR, prerendered routes are served as static files
 		// by the hosting layer and should not be rendered by the app.
 		// When the first match is a prerendered *dynamic* route, try to find

--- a/packages/astro/src/core/routing/match-request.ts
+++ b/packages/astro/src/core/routing/match-request.ts
@@ -4,29 +4,29 @@ import type { SSRManifest } from '../app/types.js';
 import { computePathnameFromDomain } from '../i18n/domain.js';
 import { AstroIntegrationLogger } from '../logger/core.js';
 import { getLogger } from '../logger/manifest-logger.js';
+import { validateAndDecodePathname } from '../util/pathname.js';
 import { matchAllRoutes, matchRoute } from './route-table.js';
 
 /**
- * Decodes a pathname with `decodeURI`, falling back to the raw pathname when it
- * contains an invalid percent-sequence (e.g. `%C0%AF`, an overlong-UTF-8 encoding of
- * `/` commonly sent by path-traversal scanners). A raw `decodeURI()` would throw
- * `URIError: URI malformed`, and because `match()` runs before `render()` that error
- * escapes the adapter's request handler as an uncaught exception (HTTP 500) that user
- * middleware can't catch.
+ * Fully decodes a pathname, falling back to a single decode and then the raw pathname
+ * when validation fails. Matching runs before `render()`, so it must not throw for
+ * request input that render-time validation handles.
  */
-function safeDecodeURI(manifest: SSRManifest, pathname: string): string {
+function safeDecodePathname(manifest: SSRManifest, pathname: string): string {
 	try {
-		return decodeURI(pathname);
+		return validateAndDecodePathname(pathname);
 	} catch (e: any) {
-		// Malformed request paths are expected client input (commonly from automated
-		// scanners) rather than a server fault, and this runs per-request on the hot
-		// path. Log at `debug` so it stays diagnosable without flooding error logs.
-		// Allocated lazily — only on the malformed branch — with the same options
-		// and label as the facade's `adapterLogger`.
+		// Path decoding failures are request input rather than a server fault. Log at
+		// `debug` so they stay diagnosable without flooding error logs. The logger is
+		// allocated lazily with the same options and label as the facade's `adapterLogger`.
 		new AstroIntegrationLogger(getLogger(manifest).options, manifest.adapterName).debug(
 			e.toString(),
 		);
-		return pathname;
+		try {
+			return decodeURI(pathname);
+		} catch {
+			return pathname;
+		}
 	}
 }
 
@@ -56,7 +56,8 @@ export function matchRequest(
 	if (!pathname) {
 		pathname = prependForwardSlash(stripRequestBase(url.pathname, manifest.base));
 	}
-	const routeData = matchRoute(manifest, safeDecodeURI(manifest, pathname));
+	pathname = safeDecodePathname(manifest, pathname);
+	const routeData = matchRoute(manifest, pathname);
 	if (!routeData) return undefined;
 	if (allowPrerenderedRoutes) {
 		return routeData;
@@ -68,7 +69,7 @@ export function matchRequest(
 	// the same pattern should handle all other URLs.
 	if (routeData.prerender) {
 		if (routeData.params.length > 0) {
-			const allMatches = matchAllRoutes(manifest, safeDecodeURI(manifest, pathname));
+			const allMatches = matchAllRoutes(manifest, pathname);
 			return allMatches.find((r) => !r.prerender);
 		}
 		return undefined;

--- a/packages/astro/src/vite-plugin-app/handle-request.ts
+++ b/packages/astro/src/vite-plugin-app/handle-request.ts
@@ -8,6 +8,7 @@ import { createSafeError } from '../core/errors/index.js';
 import { setLogger } from '../core/logger/manifest-logger.js';
 import type { ModuleLoader } from '../core/module-loader/index.js';
 import { createRequest } from '../core/request.js';
+import { validateAndDecodePathname } from '../core/util/pathname.js';
 import { SERIALIZED_MANIFEST_ID } from '../manifest/serialized.js';
 import type { AstroSettings } from '../types/astro.js';
 import type { SSRManifest } from '../types/public/index.js';
@@ -114,8 +115,12 @@ export async function handleDevRequest(
 		pathname = '';
 	} else {
 		// We already have a middleware that checks if there's an incoming URL that has invalid URI, so it's safe
-		// to not handle the error: packages/astro/src/vite-plugin-astro-server/base.ts
-		pathname = decodeURI(url.pathname);
+		// to only handle paths that exceed the supported decoding depth here.
+		try {
+			pathname = validateAndDecodePathname(url.pathname);
+		} catch {
+			pathname = decodeURI(url.pathname);
+		}
 	}
 
 	// Add config.base back to url before passing it to SSR

--- a/packages/astro/test/units/app/double-encoding-bypass.test.ts
+++ b/packages/astro/test/units/app/double-encoding-bypass.test.ts
@@ -132,12 +132,13 @@ function createApp(middleware: ReturnType<typeof createAuthMiddleware>) {
 }
 
 describe('URL normalization: double-encoding middleware bypass', () => {
-	it('resolves adapter-provided route data from the raw request URL', async () => {
+	it('normalizes the request pathname before adapter route matching', async () => {
 		const app = createApp(createPassthroughMiddleware());
 		const request = new Request('http://example.com/api/%2561dmin/users');
 		const routeData = app.match(request);
 
-		assert.equal(routeData?.route, '/api/[...path]');
+		assert.equal(app.getPathnameFromRequest(request), '/api/admin/users');
+		assert.equal(routeData?.route, '/api/admin/users');
 		const response = await app.render(request, { routeData });
 		assert.equal(response.status, 200);
 		assert.equal(await response.text(), 'admin');

--- a/packages/astro/test/units/app/double-encoding-bypass.test.ts
+++ b/packages/astro/test/units/app/double-encoding-bypass.test.ts
@@ -26,6 +26,11 @@ const apiCatchAllRouteData = parseRoute('api/[...path].ts', routeOptions, {
 	type: 'endpoint',
 });
 
+const adminRouteData = parseRoute('api/admin/users.ts', routeOptions, {
+	component: 'src/pages/api/admin/users.ts',
+	type: 'endpoint',
+});
+
 const publicRouteData = parseRoute('index.astro', routeOptions, {
 	component: 'src/pages/index.astro',
 });
@@ -47,6 +52,14 @@ const pageMap = new Map<string, any>([
 						}),
 						{ headers: { 'Content-Type': 'application/json' } },
 					),
+			}),
+		}),
+	],
+	[
+		adminRouteData.component,
+		async () => ({
+			page: async () => ({
+				GET: async () => new Response('admin'),
 			}),
 		}),
 	],
@@ -98,10 +111,20 @@ function createRewriteAuthMiddleware() {
 	})) as () => Promise<{ onRequest: MiddlewareHandler }>;
 }
 
+function createPassthroughMiddleware() {
+	return (async () => ({
+		onRequest: (async (_context, next) => next()) satisfies MiddlewareHandler,
+	})) as () => Promise<{ onRequest: MiddlewareHandler }>;
+}
+
 function createApp(middleware: ReturnType<typeof createAuthMiddleware>) {
 	return new App(
 		createManifest({
-			routes: [createRouteInfo(apiCatchAllRouteData), createRouteInfo(publicRouteData)],
+			routes: [
+				createRouteInfo(adminRouteData),
+				createRouteInfo(apiCatchAllRouteData),
+				createRouteInfo(publicRouteData),
+			],
 			pageMap: pageMap as any,
 			middleware: middleware as any,
 		}) as any,
@@ -109,6 +132,17 @@ function createApp(middleware: ReturnType<typeof createAuthMiddleware>) {
 }
 
 describe('URL normalization: double-encoding middleware bypass', () => {
+	it('resolves adapter-provided route data from the raw request URL', async () => {
+		const app = createApp(createPassthroughMiddleware());
+		const request = new Request('http://example.com/api/%2561dmin/users');
+		const routeData = app.match(request);
+
+		assert.equal(routeData?.route, '/api/[...path]');
+		const response = await app.render(request, { routeData });
+		assert.equal(response.status, 200);
+		assert.equal(await response.text(), 'admin');
+	});
+
 	it('middleware blocks /api/admin/users', async () => {
 		const app = createApp(createAuthMiddleware());
 		const request = new Request('http://example.com/api/admin/users');


### PR DESCRIPTION
## Changes

- Repeatedly encoded characters can make a request select a catch-all route instead of the exact page users expect. For example, `/docs/%2567uide` can be matched differently from its normalized `/docs/guide` path, including between development and deployed apps.
- Fully normalizes pathnames before adapter and development route matching, so route selection and rendering use the same pathname while preserving adapter-provided route data.

## Testing

- Adds app-level coverage confirming a multi-encoded request selects the exact route before adapter rendering.

## Docs

- No docs update needed because this corrects internal route selection without changing public APIs.