### PR TITLE
fix(cache): skip caching responses that set Astro.cookies or Astro.session

### DIFF
--- a/.changeset/fix-memory-cache-pending-cookies.md
+++ b/.changeset/fix-memory-cache-pending-cookies.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the in-memory response cache storing responses that set a cookie through `Astro.cookies` or `Astro.session`. Such a response is personalized for the current request, so caching and replaying it could leak one user's response to another and drop the intended `Set-Cookie` header. These responses are now skipped, matching the existing behavior for responses with a raw `Set-Cookie` header.

--- a/packages/astro/src/core/cache/memory-provider.ts
+++ b/packages/astro/src/core/cache/memory-provider.ts
@@ -1,4 +1,5 @@
 import picomatch from 'picomatch';
+import { getCookiesFromResponse } from '../cookies/response.js';
 import { AstroError } from '../errors/errors.js';
 import { CacheQueryConfigConflict } from '../errors/errors-data.js';
 import type { CacheProvider, CacheProviderFactory, InvalidateOptions } from './types.js';
@@ -255,8 +256,26 @@ function matchesVary(request: Request, entry: CachedEntry): boolean {
 	return true;
 }
 
+/**
+ * Check whether a response carries cookies that should prevent caching:
+ * either a raw Set-Cookie header, or an AstroCookies instance with pending
+ * writes (from `Astro.cookies.set()` / `Astro.session`) that has not been
+ * flushed to a Set-Cookie header yet.
+ *
+ * The cache provider's onRequest runs before prepareResponse() flushes
+ * AstroCookies onto the response, so at store time a pending cookie write
+ * would otherwise be invisible to a plain header check, and the response
+ * (personalized for the current user) would be cached and served to
+ * everyone else without their own Set-Cookie header.
+ */
 function hasSetCookieHeader(response: Response): boolean {
-	return response.headers.has('set-cookie');
+	if (response.headers.has('set-cookie')) return true;
+	const cookies = getCookiesFromResponse(response);
+	if (!cookies) return false;
+	for (const _pending of cookies.headers()) {
+		return true;
+	}
+	return false;
 }
 
 function warnSkippedSetCookie(url: URL): void {

--- a/packages/astro/test/units/cache/memory-provider.test.ts
+++ b/packages/astro/test/units/cache/memory-provider.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from 'node:test';
 import type { CacheProvider } from '../../../dist/core/cache/types.js';
 import type { MemoryCacheProviderOptions } from '../../../dist/core/cache/memory-provider.js';
 import memoryProvider from '../../../dist/core/cache/memory-provider.js';
+import { AstroCookies } from '../../../dist/core/cookies/cookies.js';
+import { attachCookiesToResponse } from '../../../dist/core/cookies/response.js';
 
 /**
  * Helper: create a CacheProvider instance with optional config.
@@ -123,6 +125,69 @@ describe('memory-provider onRequest', () => {
 			return new Response('fresh', { headers: h });
 		});
 		assert.equal(nextCalled, true);
+	});
+
+	it('does not cache responses with cookies pending via Astro.cookies (no Set-Cookie header yet)', async () => {
+		// Astro.cookies.set() / Astro.session writes land on an AstroCookies
+		// instance attached to the response by Symbol. The real Set-Cookie
+		// header is only synthesized later by prepareResponse(), which runs
+		// after the cache provider has already stored the response. So at
+		// store time, response.headers.has('set-cookie') is false even though
+		// the response carries a user-specific cookie write.
+		const provider = createProvider();
+		const url = 'http://localhost/page';
+
+		const req1 = makeRequest(url);
+		const cookies = new AstroCookies(req1);
+		cookies.set('session', 'user-1-secret');
+		await provider.onRequest!({ request: req1, url: new URL(req1.url) }, async () => {
+			const response = new Response('user-1 personalized page', {
+				headers: { 'CDN-Cache-Control': 'max-age=60' },
+			});
+			// Simulates handleMiddleware() attaching the request's AstroCookies
+			// to the response before prepareResponse() has flushed it.
+			attachCookiesToResponse(response, cookies);
+			return response;
+		});
+
+		// A second, unrelated request should never see the first user's
+		// cookie-personalized response served back from cache.
+		const req2 = makeRequest(url);
+		let nextCalled = false;
+		const res2 = await provider.onRequest!({ request: req2, url: new URL(req2.url) }, async () => {
+			nextCalled = true;
+			return new Response('fresh anonymous page', {
+				headers: { 'CDN-Cache-Control': 'max-age=60' },
+			});
+		});
+		assert.equal(nextCalled, true, "cache incorrectly served the first user's cached response");
+		assert.equal(await res2.text(), 'fresh anonymous page');
+	});
+
+	it('still caches responses that carry an AstroCookies instance with no pending writes', async () => {
+		const provider = createProvider();
+		const url = 'http://localhost/page';
+
+		const req1 = makeRequest(url);
+		await provider.onRequest!({ request: req1, url: new URL(req1.url) }, async () => {
+			const response = new Response('cacheable page', {
+				headers: { 'CDN-Cache-Control': 'max-age=60' },
+			});
+			// handleMiddleware() attaches an AstroCookies instance to every
+			// response. With no set()/delete() call the outgoing map stays empty,
+			// so this response must still be cached: the cookie check must not
+			// over-skip when nothing is actually pending.
+			attachCookiesToResponse(response, new AstroCookies(req1));
+			return response;
+		});
+
+		const req2 = makeRequest(url);
+		const res2 = await provider.onRequest!(
+			{ request: req2, url: new URL(req2.url) },
+			makeNext({ maxAge: 60, body: 'should not run' }),
+		);
+		assert.equal(res2.headers.get('X-Astro-Cache'), 'HIT');
+		assert.equal(await res2.text(), 'cacheable page');
 	});
 });
 


### PR DESCRIPTION
## Changes

Closes #17775.

The in-memory response cache stored responses that write a cookie through `Astro.cookies` or `Astro.session`, then replayed that personalized response to other visitors without their own `Set-Cookie`.

The cache only checked for a raw `Set-Cookie` header before storing. `Astro.cookies.set()` / `Astro.session` writes land on an `AstroCookies` instance attached to the response by Symbol, and that's only flushed into a real `Set-Cookie` header by `prepareResponse()`, which runs after the cache has already stored the response. So the header check saw nothing at store time.

`hasSetCookieHeader()` now also treats a response as carrying a cookie when its attached `AstroCookies` has pending writes, checked with the non-destructive `headers()` peek so the later flush in `prepareResponse()` still happens normally. A response with an attached but empty `AstroCookies` (nothing ever set) still caches as before.

## Testing

Added two unit tests in `memory-provider.test.ts`: one confirms a response with a pending `Astro.cookies` write is not cached and a second request re-renders instead of getting the first user's response, the other confirms a response with an empty `AstroCookies` still caches. Both the initial store path and the stale-while-revalidate path go through the same check.

## Docs

None needed. This is a bug fix with no public API changes.
