### PR TITLE
perf(cli): enable the Node.js compile cache

### DIFF
--- a/.changeset/tidy-pears-shake.md
+++ b/.changeset/tidy-pears-shake.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Speeds up the Astro CLI by caching compiled code between runs
+Improves the performance of the Astro CLI in local by enabling Node's module compilation cache.

--- a/.changeset/tidy-pears-shake.md
+++ b/.changeset/tidy-pears-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Speeds up the Astro CLI by caching compiled code between runs

--- a/packages/astro/bin/astro.mjs
+++ b/packages/astro/bin/astro.mjs
@@ -1,6 +1,21 @@
 #!/usr/bin/env node
 'use strict';
 
+import module from 'node:module';
+
+// Writing the cache only pays off once it is reused, and CI starts cold every run.
+if (!process.env.CI) {
+	try {
+		module.enableCompileCache?.();
+		// Long-running commands like `astro dev` never reach the flush that happens on process exit.
+		setTimeout(() => {
+			try {
+				module.flushCompileCache?.();
+			} catch {}
+		}, 10_000).unref();
+	} catch {}
+}
+
 const CI_INSTRUCTIONS = {
 	NETLIFY: 'https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript',
 	GITHUB_ACTIONS:

--- a/packages/astro/bin/astro.mjs
+++ b/packages/astro/bin/astro.mjs
@@ -3,7 +3,7 @@
 
 import module from 'node:module';
 
-// Writing the cache only pays off once it is reused, and CI starts cold every run.
+// In CI writing the cache is (most of the time) harmful, as it'll never get re-used and just slows down the CLI.
 if (!process.env.CI) {
 	try {
 		module.enableCompileCache?.();


### PR DESCRIPTION
## Changes

Enables the Node module compile cache. Vite and some other projects started doing this a few years back to great result. I tried it in local and it's a pretty good boost in local for little cost (a few mb, at worse). 

I got gains ranging from 50 to 200ms on the various commands of the CLI trying it in local, with most notably some of our examples `astro build` being 100-200ms faster, pretty neat.

## Testing

Tested manually

## Docs

N/A
