### PR TITLE
Fix type error when using content collection images after apng support

### DIFF
--- a/.changeset/gold-bugs-glow.md
+++ b/.changeset/gold-bugs-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a type error when passing an image from a content collection `image()` schema to a component or `<Image />`. The schema returned by `image()` was missing the `apng` format, so it no longer matched the type of an imported image.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,17 +7,13 @@ on:
       - main
   merge_group:
   pull_request:
-    # `astro check` type-checks the examples against Astro's emitted types, which are assembled
-    # from across `src` (assets, content, and more) rather than a single public entry point.
-    # Trigger on all of `src` and the shipped ambient declarations so type regressions that only
-    # surface in the examples are caught here instead of on `main`.
     paths:
       - "examples/**"
       - ".github/workflows/check.yml"
       - "scripts/smoke/check.js"
-      - "packages/astro/src/**"
-      - "packages/astro/*.d.ts"
+      - "packages/astro/src/types/public/**"
       - "pnpm-lock.yaml"
+      - "packages/astro/types.d.ts"
 
 permissions: {}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,13 +7,17 @@ on:
       - main
   merge_group:
   pull_request:
+    # `astro check` type-checks the examples against Astro's emitted types, which are assembled
+    # from across `src` (assets, content, and more) rather than a single public entry point.
+    # Trigger on all of `src` and the shipped ambient declarations so type regressions that only
+    # surface in the examples are caught here instead of on `main`.
     paths:
       - "examples/**"
       - ".github/workflows/check.yml"
       - "scripts/smoke/check.js"
-      - "packages/astro/src/types/public/**"
+      - "packages/astro/src/**"
+      - "packages/astro/*.d.ts"
       - "pnpm-lock.yaml"
-      - "packages/astro/types.d.ts"
 
 permissions: {}
 

--- a/packages/astro/src/content/config.ts
+++ b/packages/astro/src/content/config.ts
@@ -39,6 +39,7 @@ type ImageFunction = () => z.ZodObject<{
 			zCore.$ZodLiteral<'gif'>,
 			zCore.$ZodLiteral<'svg'>,
 			zCore.$ZodLiteral<'avif'>,
+			zCore.$ZodLiteral<'apng'>,
 		]
 	>;
 }>;

--- a/packages/astro/test/types/schemas.ts
+++ b/packages/astro/test/types/schemas.ts
@@ -9,6 +9,8 @@ import type { SessionDriverConfigSchema } from '../../dist/core/session/config.j
 import type { SessionDriverConfig } from '../../dist/core/session/types.js';
 import type { SvgOptimizer } from '../../dist/assets/svg/types.js';
 import type { SvgOptimizerSchema } from '../../dist/assets/svg/config.js';
+import type { ImageInputFormat } from '../../dist/assets/types.js';
+import type { SchemaContext } from '../../dist/content/config.js';
 
 describe('fonts', () => {
 	it('FontFamily type matches FontFamilySchema', () => {
@@ -42,5 +44,12 @@ describe('session', () => {
 describe('svgOptimizer', () => {
 	it('SvgOptimizer type matches SvgOptimizerSchema', () => {
 		expectTypeOf<z.input<typeof SvgOptimizerSchema>>().toEqualTypeOf<SvgOptimizer>();
+	});
+});
+
+describe('content image()', () => {
+	it('image() schema format matches ImageInputFormat', () => {
+		type ImageSchema = ReturnType<SchemaContext['image']>;
+		expectTypeOf<z.output<ImageSchema>['format']>().toEqualTypeOf<ImageInputFormat>();
 	});
 });


### PR DESCRIPTION
## Changes

- Adds `apng` to the format union returned by `image()`. #17774 added `apng` to `VALID_INPUT_FORMATS` but not to the matching `ImageFunction` type, so images from a collection schema no longer type-check against `ImageMetadata` — this breaks `astro check` on `examples/blog`, and `main` has been red since it merged.

## Testing

- Adds a type test asserting the `image()` schema's `format` matches `ImageInputFormat`; it fails without the fix. This runs in `test:types`, which is why the drift is caught here rather than by widening the `astro check` path filter.

## Docs

- Not needed, this restores the intended type for an existing API.
