### PR TITLE
fix(i18n): return 404 instead of 500 when fallback rewrite target does not exist

### DIFF
--- a/.changeset/fix-i18n-rewrite-fallback-404.md
+++ b/.changeset/fix-i18n-rewrite-fallback-404.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where i18n fallback routes with `rewrite` strategy returned a 500 error instead of 404 when the fallback target has no matching static path (e.g. rest-param routes).

--- a/packages/astro/src/core/i18n/handler.ts
+++ b/packages/astro/src/core/i18n/handler.ts
@@ -6,6 +6,7 @@ import type { SSRManifest } from '../app/types.js';
 import { shouldAppendForwardSlash } from '../build/util.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 import { createManifestMemo } from '../manifest/memo.js';
+import { AstroErrorData, isAstroError } from '../errors/index.js';
 
 /**
  * The compiled i18n configuration for a manifest: the config values plus the
@@ -180,7 +181,18 @@ export async function finalizeI18n(
 					headers: { Location: fallbackDecision.pathname + url.search },
 				});
 			case 'rewrite':
-				return await state.rewrite(fallbackDecision.pathname + url.search);
+				try {
+					return await state.rewrite(fallbackDecision.pathname + url.search);
+				} catch (e) {
+					if (
+						isAstroError(e) &&
+						(e.title === AstroErrorData.NoMatchingStaticPathFound.title ||
+							e.name === AstroErrorData.NoMatchingStaticPathFound.name)
+					) {
+						return new Response(null, { status: 404 });
+					}
+					throw e;
+				}
 			case 'none':
 				break;
 		}

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -9,6 +9,7 @@ import {
 } from '../app/origin-check.js';
 import { getCookiesFromResponse } from '../cookies/response.js';
 import { renderErrorFromState } from '../errors/handler.js';
+import { AstroErrorData, isAstroError } from '../errors/index.js';
 
 // Shared empty-slots object so we don't allocate `{}` on every render for
 // requests that don't come from the container API. Safe to share because
@@ -124,6 +125,24 @@ export async function handlePagesWithErrorFallback(state: FetchState): Promise<R
 	try {
 		return await handlePages(state, ctx);
 	} catch (err: any) {
+		const isNoMatchingStaticPath =
+			isAstroError(err) &&
+			(err.title === AstroErrorData.NoMatchingStaticPathFound.title ||
+				err.name === AstroErrorData.NoMatchingStaticPathFound.name);
+		const isFallbackMatch =
+			!state.routeData!.pattern.test(state.pathname) &&
+			state.routeData!.fallbackRoutes.some((fallbackRoute) =>
+				fallbackRoute.pattern.test(state.pathname),
+			);
+
+		if (isNoMatchingStaticPath && (isFallbackMatch || state.isRewriting)) {
+			return renderErrorFromState(state, state.request, {
+				...state.renderOptions,
+				status: 404,
+				pathname: state.pathname,
+			});
+		}
+
 		// The header marker can't carry the error object, so render the
 		// 500 page directly to preserve `error` and the logged stack.
 		state.logger.error(null, err.stack || err.message || String(err));

--- a/packages/astro/src/core/routing/handler.ts
+++ b/packages/astro/src/core/routing/handler.ts
@@ -15,6 +15,7 @@ import { provideSession } from '../session/provider.js';
 import type { FetchState } from '../fetch/fetch-state.js';
 import { prepareResponse } from '../app/prepare-response.js';
 import { getDefaultStatusCode } from './helpers.js';
+import { AstroErrorData, isAstroError } from '../errors/index.js';
 
 /**
  * Dispatches request logging: through the facade's late-bound
@@ -165,6 +166,22 @@ async function render(state: FetchState): Promise<Response> {
 			timeStart: state.timeStart,
 		});
 	} catch (err: any) {
+		const isNoMatchingStaticPath =
+			isAstroError(err) &&
+			(err.title === AstroErrorData.NoMatchingStaticPathFound.title ||
+				err.name === AstroErrorData.NoMatchingStaticPathFound.name);
+		const isFallbackMatch =
+			!routeData.pattern.test(pathname) &&
+			routeData.fallbackRoutes.some((fallbackRoute) => fallbackRoute.pattern.test(pathname));
+
+		if (isNoMatchingStaticPath && (isFallbackMatch || state.isRewriting)) {
+			return renderErrorFromState(state, request, {
+				...state.renderOptions,
+				status: 404,
+				pathname: state.pathname,
+			});
+		}
+
 		state.logger.error(null, err.stack || err.message || String(err));
 		return renderErrorFromState(state, request, {
 			...state.renderOptions,

--- a/packages/astro/src/core/routing/helpers.ts
+++ b/packages/astro/src/core/routing/helpers.ts
@@ -79,7 +79,7 @@ export function getDefaultStatusCode(
 	if (!routeData.pattern.test(pathname)) {
 		for (const fallbackRoute of routeData.fallbackRoutes) {
 			if (fallbackRoute.pattern.test(pathname)) {
-				return 302;
+				return manifest.i18n?.fallbackType === 'rewrite' ? 200 : 302;
 			}
 		}
 	}

--- a/packages/astro/test/units/i18n/i18n-app.test.ts
+++ b/packages/astro/test/units/i18n/i18n-app.test.ts
@@ -5,7 +5,7 @@ import type { RoutingStrategies } from '../../../dist/core/app/common.js';
 import { createI18nMiddleware } from '../../../dist/i18n/middleware.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import type { Locales } from '../../../dist/types/public/config.js';
-import { createPage, createTestApp } from '../mocks.ts';
+import { createPage, createRouteData, createTestApp } from '../mocks.ts';
 import { dynamicPart, spreadPart, staticPart } from '../routing/test-helpers.ts';
 
 interface I18nConfigOverrides {
@@ -663,6 +663,63 @@ describe('i18n via AstroHandler (no middleware) - prefix-always (#16800)', () =>
 	it('returns 404 for paths without locale prefix', async () => {
 		const app = createHandlerApp();
 		const res = await app.render(new Request('http://example.com/about'));
+		assert.equal(res.status, 404);
+	});
+});
+
+// #17778: i18n fallback 'rewrite' should return 404 instead of 500 when fallback target also has no matching static path
+describe('i18n via App - fallback rewrite with rest-param routes (#17778)', () => {
+	const i18n = makeI18nConfig({
+		strategy: 'pathname-prefix-always',
+		locales: ['en', 'es'],
+		defaultLocale: 'en',
+		fallback: { es: 'en' },
+		fallbackType: 'rewrite',
+	});
+
+	function createFallbackApp() {
+		const enRoute = createRouteData({
+			route: '/en/[...slug]',
+			segments: [[staticPart('en')], [spreadPart('...slug')]],
+			prerender: true,
+		});
+		enRoute.pathname = undefined;
+
+		const esFallbackRoute = createRouteData({
+			route: '/es/[...slug]',
+			segments: [[staticPart('es')], [spreadPart('...slug')]],
+			type: 'fallback',
+			prerender: true,
+		});
+		esFallbackRoute.pathname = undefined;
+		enRoute.fallbackRoutes.push(esFallbackRoute);
+
+		const enPage = {
+			routeData: enRoute,
+			module: async () => ({
+				page: async () => ({
+					default: paramsPage,
+					getStaticPaths: () => [{ params: { slug: 'existing' } }],
+				}),
+			}),
+		};
+
+		return createTestApp([enPage], {
+			i18n,
+		});
+	}
+
+	it('returns 200 and rewrites content when fallback target has matching static path', async () => {
+		const app = createFallbackApp();
+		const res = await app.render(new Request('http://example.com/es/existing'));
+		assert.equal(res.status, 200);
+		const $ = cheerio.load(await res.text());
+		assert.equal($('#slug').text(), 'existing');
+	});
+
+	it('returns 404 instead of 500 when fallback target has no matching static path', async () => {
+		const app = createFallbackApp();
+		const res = await app.render(new Request('http://example.com/es/non-existent'));
 		assert.equal(res.status, 404);
 	});
 });


### PR DESCRIPTION
Fixes #17778

## Changes

- Catch `NoMatchingStaticPathFound` error when handling i18n fallback routes with `rewrite` strategy (or direct fallback route rendering) and return a `404 Not Found` response instead of bubbling up as an unhandled 500 error.
- Update `getDefaultStatusCode` to return `200` (instead of `302`) for fallback route matches when `fallbackType === 'rewrite'`.

## Testing

- Added unit tests in `packages/astro/test/units/i18n/i18n-app.test.ts` verifying that:
  1. Fallback rewrite routes with matching static paths return 200 OK and render correctly.
  2. Fallback rewrite routes without matching static paths (e.g. rest-param routes) return 404 instead of 500.

## Docs

Bug fix; no documentation changes required.