### PR TITLE
Trim build.format docs on Astro.url

### DIFF
--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1327,16 +1327,7 @@ export interface AstroUserConfig<
 		 *
 		 *
 		 * #### Effect on Astro.url
-		 * Setting `build.format` controls what `Astro.url` is set to during the build. When it is:
-		 * - `directory` - The `Astro.url.pathname` will include a trailing slash to mimic folder behavior. (e.g. `/foo/`)
-		 * - `file` - The `Astro.url.pathname` will include `.html`. (e.g. `/foo.html`)
-		 * - `preserve` - The `Astro.url.pathname` matches the generated file for each page: index pages include a trailing slash (e.g. `/foo/`), while non-index pages include `.html` (e.g. `/foo.html`).
-		 *
-		 * This means that when you create relative URLs using `new URL('./relative', Astro.url)`, you will get consistent behavior between dev and build.
-		 *
-		 * To prevent inconsistencies with trailing slash behaviour in dev, you can restrict the [`trailingSlash` option](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) to `'always'` or `'never'` depending on your build format:
-		 * - `directory` - Set `trailingSlash: 'always'`
-		 * - `file` - Set `trailingSlash: 'never'`
+		 * During the build, `Astro.url.pathname` reflects the path of the file generated for each page.
 		 */
 		format?: 'file' | 'directory' | 'preserve';
 		/**


### PR DESCRIPTION
## Changes

- Trims the `build.format` "Effect on Astro.url" section down to a single statement that these pathnames apply to the build output. The removed text claimed `new URL('./relative', Astro.url)` gives "consistent behavior between dev and build" and then immediately warned about dev inconsistencies two lines later, and its `trailingSlash` remediation list never covered `preserve`.

## Docs

- This is the docs change; the generated config reference updates on the next nightly docgen run.
