### PR TITLE
Restore Vue auto-import completions with the Astro extension

### DIFF
--- a/.changeset/legal-pets-leave.md
+++ b/.changeset/legal-pets-leave.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fixes missing Vue template auto-import completions when the Astro extension loads first

--- a/packages/language-tools/ts-plugin/test/units/proxy-language-service.test.mts
+++ b/packages/language-tools/ts-plugin/test/units/proxy-language-service.test.mts
@@ -1,0 +1,27 @@
+import 'mocha';
+import assert from 'node:assert';
+import type { Language } from '@volar/language-core';
+import { createProxyLanguageService } from '@volar/typescript/lib/node/proxyLanguageService.js';
+import type ts from 'typescript';
+
+suite('Proxy language service', () => {
+	test('uses language service methods assigned by a later plugin', () => {
+		let called = 'original';
+		const languageService = {
+			getCompletionsAtPosition() {
+				called = 'original';
+			},
+		} as unknown as ts.LanguageService;
+		const { initialize, proxy } = createProxyLanguageService(languageService);
+
+		initialize({ scripts: { get: () => undefined } } as unknown as Language<string>);
+		void proxy.getCompletionsAtPosition;
+		proxy.getCompletionsAtPosition = () => {
+			called = 'decorated';
+			return undefined;
+		};
+		proxy.getCompletionsAtPosition('component.vue', 0, undefined);
+
+		assert.strictEqual(called, 'decorated');
+	});
+});

--- a/patches/@volar__typescript@2.4.28.patch
+++ b/patches/@volar__typescript@2.4.28.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/node/proxyLanguageService.js b/lib/node/proxyLanguageService.js
+index 95f2cc3ef6336b7762bcd0a5036af27b114367a5..9b0c9e0a68bed912737dd8d2179afe21997277f7 100644
+--- a/lib/node/proxyLanguageService.js
++++ b/lib/node/proxyLanguageService.js
+@@ -112,6 +112,7 @@ function createProxyLanguageService(languageService) {
+                 return Reflect.get(target, p, receiver);
+             },
+             set(target, p, value, receiver) {
++                proxyCache.delete(p);
+                 return Reflect.set(target, p, value, receiver);
+             },
+         }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ overrides:
   '@types/node@22': ^22.19.0
   modern-tar: '>=0.7.7'
 
+patchedDependencies:
+  '@volar/typescript@2.4.28': 08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad
+
 importers:
 
   .:
@@ -6811,7 +6814,7 @@ importers:
         version: 2.4.28
       '@volar/typescript':
         specifier: ~2.4.28
-        version: 2.4.28
+        version: 2.4.28(patch_hash=08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad)
       astro-scripts:
         specifier: workspace:*
         version: link:../../../scripts
@@ -6869,7 +6872,7 @@ importers:
         version: 2.4.28
       '@volar/typescript':
         specifier: ~2.4.28
-        version: 2.4.28
+        version: 2.4.28(patch_hash=08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad)
       semver:
         specifier: ^7.7.4
         version: 7.8.5
@@ -20083,7 +20086,7 @@ snapshots:
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-service': 2.4.28
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(patch_hash=08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad)
       typesafe-path: 0.2.2
       typescript: 6.0.3
       vscode-languageserver-textdocument: 1.0.12
@@ -20097,7 +20100,7 @@ snapshots:
     dependencies:
       '@volar/language-core': 2.4.28
       '@volar/language-service': 2.4.28
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(patch_hash=08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad)
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
@@ -20121,7 +20124,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(patch_hash=08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,3 +101,6 @@ allowBuilds:
   protobufjs: false
   sharp: false
   workerd: false
+
+patchedDependencies:
+  '@volar/typescript@2.4.28': patches/@volar__typescript@2.4.28.patch


### PR DESCRIPTION
## Changes

- Astro's Volar proxy caches `getCompletionsAtPosition` the first time it is accessed. Vue later replaces that method, but the stale wrapper prevents Vue's auto-import logic from running.
- Invalidates the cached method on assignment so the next request rebuilds the wrapper around Vue's decorated method, restoring auto-imports when Astro loads first. Fixes #15962.

<img width="1728" height="1117" alt="vue-auto-import-fixed" src="https://github.com/user-attachments/assets/e1dc71e0-2485-4e31-8dcc-b0d2bedf95f7" />

## Testing

- Adds a regression test proving methods assigned by a later TypeScript plugin replace cached wrappers.

## Docs

- No docs update needed; this restores existing editor behavior.