### PR TITLE
Respect multiline lang attributes in syntax highlighting

### DIFF
--- a/.changeset/small-worms-double.md
+++ b/.changeset/small-worms-double.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fixes syntax highlighting for multiline `<script>` and `<style>` tags with a `lang` or `type` attribute

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
@@ -766,6 +766,21 @@
         }
       ]
     },
+    "tags-lang-start-attributes-prescan": {
+      "begin": "\\G",
+      "end": "(?=/>)|>|(?=\\s*(?:type|lang)\\s*=\\s*(?:\"(?:text/|application/)?[\\w\\/+]+\"|'(?:text/|application/)?[\\w\\/+]+'|(?:text/|application/)?[\\w\\/+]+)(?=\\s|/?>|$))",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.astro"
+        }
+      },
+      "name": "meta.tag.start.astro",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
     "tags-start-node": {
       "match": "(<)([^/\\s>/]*)",
       "captures": {
@@ -857,7 +872,7 @@
       "name": "meta.scope.tag.$1.astro meta.$1.astro",
       "patterns": [
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
+          "begin": "\\G(?=\\s*(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2(?=\\s|/?>|$))",
           "end": "(?=</|/>)",
           "name": "meta.lang.json.astro",
           "patterns": [
@@ -867,7 +882,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
+          "begin": "\\G(?=\\s*(type|lang)\\s*=\\s*(['\"]|)(module)\\2(?=\\s|/?>|$))",
           "end": "(?=</|/>)",
           "name": "meta.lang.javascript.astro",
           "patterns": [
@@ -877,7 +892,7 @@
           ]
         },
         {
-          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
+          "begin": "\\G(?=\\s*(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2(?=\\s|/?>|$))",
           "end": "(?=</|/>)",
           "name": "meta.lang.$3.astro",
           "patterns": [
@@ -887,7 +902,47 @@
           ]
         },
         {
-          "include": "#tags-lang-start-attributes"
+          "begin": "\\G",
+          "end": "(?=</|/>)",
+          "patterns": [
+            {
+              "include": "#tags-lang-start-attributes-prescan"
+            },
+            {
+              "begin": "(?=\\s*(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2(?=\\s|/?>|$))",
+              "end": "(?=</|/>)",
+              "name": "meta.lang.json.astro",
+              "patterns": [
+                {
+                  "include": "#tags-lang-start-attributes"
+                }
+              ]
+            },
+            {
+              "begin": "(?=\\s*(type|lang)\\s*=\\s*(['\"]|)(module)\\2(?=\\s|/?>|$))",
+              "end": "(?=</|/>)",
+              "name": "meta.lang.javascript.astro",
+              "patterns": [
+                {
+                  "include": "#tags-lang-start-attributes"
+                }
+              ]
+            },
+            {
+              "begin": "(?=\\s*(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2(?=\\s|/?>|$))",
+              "end": "(?=</|/>)",
+              "name": "meta.lang.$3.astro",
+              "patterns": [
+                {
+                  "include": "#tags-lang-start-attributes"
+                }
+              ]
+            },
+            {
+              "match": ">",
+              "name": "meta.tag.start.astro punctuation.definition.tag.end.astro"
+            }
+          ]
         }
       ]
     },

--- a/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/language-tools/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -514,6 +514,14 @@ repository:
     name: meta.tag.start.astro
     patterns: [include: '#attributes']
 
+  # Parses preceding attributes until a literal lang/type can select an embedded grammar.
+  tags-lang-start-attributes-prescan:
+    begin: \G
+    end: (?=/>)|>|(?=\s*(?:type|lang)\s*=\s*(?:"(?:text/|application/)?[\w\/+]+"|'(?:text/|application/)?[\w\/+]+'|(?:text/|application/)?[\w\/+]+)(?=\s|/?>|$))
+    endCaptures: { 0: { name: punctuation.definition.tag.end.astro } }
+    name: meta.tag.start.astro
+    patterns: [include: '#attributes']
+
   # Matches the beginning (`<name`) section of a tag start node.
   tags-start-node:
     match: (<)([^/\s>/]*)
@@ -554,22 +562,39 @@ repository:
     name: meta.scope.tag.$1.astro meta.$1.astro
     patterns:
       # Injecting into `meta.lang.ld+json` doesn't seem possible, so we set it to `meta.lang.json`
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2)
+      - begin: \G(?=\s*(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2(?=\s|/?>|$))
         end: (?=</|/>)
         name: meta.lang.json.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Treat 'module' as JavaScript
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(module)\2)
+      - begin: \G(?=\s*(type|lang)\s*=\s*(['"]|)(module)\2(?=\s|/?>|$))
         end: (?=</|/>)
         name: meta.lang.javascript.astro
         patterns: [include: '#tags-lang-start-attributes']
       # Tags with a language specified.
-      - begin: \G(?=\s*[^>]*?(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2)
+      - begin: \G(?=\s*(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2(?=\s|/?>|$))
         end: (?=</|/>)
         name: meta.lang.$3.astro
         patterns: [include: '#tags-lang-start-attributes']
-      # Fallback to default language.
-      - include: '#tags-lang-start-attributes'
+      # Parse preceding attributes before selecting a language.
+      - begin: \G
+        end: (?=</|/>)
+        patterns:
+          - include: '#tags-lang-start-attributes-prescan'
+          - begin: (?=\s*(type|lang)\s*=\s*(['"]|)(?:text\/)?(application\/ld\+json)\2(?=\s|/?>|$))
+            end: (?=</|/>)
+            name: meta.lang.json.astro
+            patterns: [include: '#tags-lang-start-attributes']
+          - begin: (?=\s*(type|lang)\s*=\s*(['"]|)(module)\2(?=\s|/?>|$))
+            end: (?=</|/>)
+            name: meta.lang.javascript.astro
+            patterns: [include: '#tags-lang-start-attributes']
+          - begin: (?=\s*(type|lang)\s*=\s*(['"]|)(?:text/|application/)?([\w\/+]+)\2(?=\s|/?>|$))
+            end: (?=</|/>)
+            name: meta.lang.$3.astro
+            patterns: [include: '#tags-lang-start-attributes']
+          - match: '>'
+            name: meta.tag.start.astro punctuation.definition.tag.end.astro
 
   # Void element tags. They must be treated separately due to their lack of end nodes.
   # A void element cannot be differentiated from other tags, unless you look at their name.

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/ts-multiline.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/ts-multiline.astro
@@ -1,0 +1,27 @@
+<script
+	lang="ts"
+>
+	const count: number = 1;
+</script>
+
+<script
+	type="application/ld+json"
+>
+	{ "@context": "https://schema.org" }
+</script>
+
+<script
+	type=module
+>
+	console.log(import.meta.url);
+</script>
+
+<script
+	type=modulex
+>
+	console.log('unknown type');
+</script>
+
+<script type=modulex>
+	console.log('unknown type');
+</script>

--- a/packages/language-tools/vscode/test/grammar/fixtures/script/ts-multiline.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/script/ts-multiline.astro.snap
@@ -1,0 +1,87 @@
+><script
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+>	lang="ts"
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro
+# ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#     ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#      ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#       ^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#         ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	const count: number = 1;
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.ts.astro meta.embedded.block.astro source.ts
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><script
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+>	type="application/ld+json"
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro
+# ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro entity.other.attribute-name.astro
+#     ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro punctuation.separator.key-value.astro
+#      ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.begin.astro
+#       ^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro
+#                          ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro meta.attribute.type.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	{ "@context": "https://schema.org" }
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.json.astro meta.embedded.block.astro source.json
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><script
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+>	type=module
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro
+# ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro entity.other.attribute-name.astro
+#     ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro punctuation.separator.key-value.astro
+#      ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro meta.attribute.type.astro string.unquoted.astro
+>>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	console.log(import.meta.url);
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.javascript.astro meta.embedded.block.astro source.js
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><script
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+>	type=modulex
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro
+# ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro meta.attribute.type.astro entity.other.attribute-name.astro
+#     ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro meta.attribute.type.astro punctuation.separator.key-value.astro
+#      ^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro meta.attribute.type.astro string.unquoted.astro
+>>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	console.log('unknown type');
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><script type=modulex>
+#^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.start.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro
+#        ^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro meta.attribute.type.astro entity.other.attribute-name.astro
+#            ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro meta.attribute.type.astro punctuation.separator.key-value.astro
+#             ^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro meta.attribute.type.astro string.unquoted.astro
+#                    ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	console.log('unknown type');
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.lang.modulex.astro
+></script>
+#^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.script.astro meta.script.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro
@@ -1,0 +1,50 @@
+<style
+	lang="sass"
+	define:vars={{
+		foo: '#fff',
+	}}
+>
+	.bar
+		color: var(--foo)
+</style>
+
+<style data-lang="less" title="use lang=scss" lang=sass>
+	.button
+		color: red
+</style>
+
+<style
+	class="theme"
+	lang='scss'
+>
+	.button {
+		color: red;
+	}
+</style>
+
+<style
+	data-lang="less"
+	title="use lang=sass"
+>
+	.button {
+		color: red;
+	}
+</style>
+
+<style
+	define:vars={{
+		foo: '#fff',
+	}}
+>
+	.button {
+		color: var(--foo);
+	}
+</style>
+
+<style
+	lang={language}
+>
+	.button {
+		color: red;
+	}
+</style>

--- a/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro.snap
+++ b/packages/language-tools/vscode/test/grammar/fixtures/style/sass-multiline.astro.snap
@@ -1,0 +1,199 @@
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>	lang="sass"
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+# ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#     ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#       ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#           ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>	define:vars={{
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+# ^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro entity.other.attribute-name.astro
+#            ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.separator.key-value.astro
+#             ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.begin.astro
+#              ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>		foo: '#fff',
+#^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>	}}
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+# ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.end.astro
+#  ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	.bar
+#^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+>		color: var(--foo)
+#^^^^^^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style data-lang="less" title="use lang=scss" lang=sass>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+#       ^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro entity.other.attribute-name.astro
+#                ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro punctuation.separator.key-value.astro
+#                 ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#                  ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro string.quoted.astro
+#                      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro string.quoted.astro punctuation.definition.string.end.astro
+#                       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+#                        ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro entity.other.attribute-name.astro
+#                             ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro punctuation.separator.key-value.astro
+#                              ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro string.quoted.astro punctuation.definition.string.begin.astro
+#                               ^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro string.quoted.astro
+#                                            ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro string.quoted.astro punctuation.definition.string.end.astro
+#                                             ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro
+#                                              ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#                                                  ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#                                                   ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro meta.attribute.lang.astro string.unquoted.astro
+#                                                       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	.button
+#^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+>		color: red
+#^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.sass.astro meta.embedded.block.astro source.sass
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>	class="theme"
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.class.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.class.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.class.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.class.astro string.quoted.astro
+#             ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.class.astro string.quoted.astro punctuation.definition.string.end.astro
+>	lang='scss'
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro
+# ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#     ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#       ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro
+#           ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro meta.attribute.lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	.button {
+#^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.embedded.block.astro source.css.scss
+>		color: red;
+#^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.embedded.block.astro source.css.scss
+>	}
+#^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.lang.scss.astro meta.embedded.block.astro source.css.scss
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>	data-lang="less"
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+# ^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro entity.other.attribute-name.astro
+#          ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro punctuation.separator.key-value.astro
+#           ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro string.quoted.astro punctuation.definition.string.begin.astro
+#            ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro string.quoted.astro
+#                ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.data-lang.astro string.quoted.astro punctuation.definition.string.end.astro
+>	title="use lang=sass"
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro entity.other.attribute-name.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro punctuation.separator.key-value.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro string.quoted.astro punctuation.definition.string.begin.astro
+#        ^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro string.quoted.astro
+#                     ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.title.astro string.quoted.astro punctuation.definition.string.end.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	.button {
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+# ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#        ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#         ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+>		color: red;
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#       ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#         ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#            ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+>	}
+#^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>	define:vars={{
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+# ^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.define:vars.astro entity.other.attribute-name.astro
+#            ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.separator.key-value.astro
+#             ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.begin.astro
+#              ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>		foo: '#fff',
+#^^^^^^^^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+>	}}
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.define:vars.astro meta.embedded.expression.astro source.tsx
+# ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.define:vars.astro punctuation.section.embedded.end.astro
+#  ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	.button {
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+# ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#        ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#         ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+>		color: var(--foo);
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#       ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#         ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#            ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#               ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#                  ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+>	}
+#^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>
+><style
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro entity.name.tag.astro
+>	lang={language}
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro
+# ^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.lang.astro entity.other.attribute-name.astro
+#     ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.separator.key-value.astro
+#      ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.section.embedded.begin.astro
+#       ^^^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.lang.astro meta.embedded.expression.astro source.tsx
+#               ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro meta.attribute.lang.astro punctuation.section.embedded.end.astro
+>>
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>	.button {
+#^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+# ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#        ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#         ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css
+>		color: red;
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#       ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+#         ^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css entity.name.tag.css
+#            ^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+>	}
+#^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.embedded.block.astro source.css meta.selector.css
+></style>
+#^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^^^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro entity.name.tag.astro
+#       ^ source.astro meta.scope.tag.style.astro meta.style.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>


### PR DESCRIPTION
## Changes

- When `lang` or `type` appeared on a later line of a `<style>` or `<script>` opening tag, VS Code ignored it and highlighted the embedded content as default CSS or JavaScript. Multiline tags now use the requested Sass, TypeScript, JSON-LD, or other language grammar just like single-line tags. Fixes #14657.
- The TextMate grammar now prescans ordinary opening-tag attributes and applies the language scope when it reaches a complete literal `lang` or `type` value. This preserves attribute highlighting without treating dynamic values, unrelated attribute names, or prefixes such as `modulex` as language selectors.

<img width="1728" height="1117" alt="sass-multiline-fixed" src="https://github.com/user-attachments/assets/81d05b5f-012f-4c58-975d-c978e78bd458" />



## Testing

- Added multiline Sass and TypeScript grammar fixtures and snapshots covering preceding attributes, default-language fallbacks, JSON-LD and module scripts, quoted and unquoted values, dynamic values, and lookalike attribute names and values.

## Docs

- No docs update needed because this corrects syntax highlighting for already-valid `<style>` and `<script>` formatting.