### PR TITLE
Prevent astro add cloudflare from generating unsupported compatibility dates

### DIFF
--- a/.changeset/clear-deer-raise.md
+++ b/.changeset/clear-deer-raise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro add cloudflare` generating a compatibility date unsupported by the installed Cloudflare runtime

--- a/packages/astro/src/cli/add/cloudflare.ts
+++ b/packages/astro/src/cli/add/cloudflare.ts
@@ -1,0 +1,21 @@
+// This matches @astrojs/cloudflare's default because workerd rejects dates newer than the
+// maximum supported by its binary. https://github.com/withastro/astro/issues/17796
+const CLOUDFLARE_COMPATIBILITY_DATE = '2026-04-15';
+
+export function createCloudflareWranglerConfig(name: string): string {
+	return `\
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"compatibility_date": ${JSON.stringify(CLOUDFLARE_COMPATIBILITY_DATE)},
+	"compatibility_flags": ["global_fetch_strictly_public"],
+	"name": ${JSON.stringify(name)},
+	"main": "@astrojs/cloudflare/entrypoints/server",
+	"assets": {
+		"directory": "./dist",
+		"binding": "ASSETS"
+	},
+	"observability": {
+		"enabled": true
+	}
+}`;
+}

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -31,6 +31,7 @@ import { eventCliSession, telemetry } from '../../events/index.js';
 import { exec } from '../exec.js';
 import { createLoggerFromFlags, type Flags, flagsToAstroInlineConfig } from '../flags.js';
 import { fetchPackageJson, fetchPackageVersions } from '../install-package.js';
+import { createCloudflareWranglerConfig } from './cloudflare.js';
 
 const { bold, cyan, dim, green, magenta, red, yellow } = colors;
 
@@ -64,21 +65,6 @@ export default {
 # Lit libraries are required to be hoisted due to dependency issues.
 public-hoist-pattern[]=*lit*
 `,
-	CLOUDFLARE_WRANGLER_CONFIG: (name: string, compatibilityDate: string) => `\
-{
-	"$schema": "./node_modules/wrangler/config-schema.json",
-	"compatibility_date": ${JSON.stringify(compatibilityDate)},
-	"compatibility_flags": ["global_fetch_strictly_public"],
-	"name": ${JSON.stringify(name)},
-	"main": "@astrojs/cloudflare/entrypoints/server",
-	"assets": {
-		"directory": "./dist",
-		"binding": "ASSETS"
-	},
-	"observability": {
-		"enabled": true
-	}
-}`,
 };
 
 const OFFICIAL_ADAPTER_TO_IMPORT_MAP: Record<string, string> = {
@@ -200,11 +186,10 @@ export async function add(names: string[], { flags }: AddOptions) {
 
 					if (await askToContinue({ flags, logger })) {
 						const data = await getPackageJson();
-						let compatibilityDate = new Date().toISOString().slice(0, 10);
 
 						await fs.writeFile(
 							wranglerConfigURL,
-							STUBS.CLOUDFLARE_WRANGLER_CONFIG(data?.name ?? 'example', compatibilityDate),
+							createCloudflareWranglerConfig(data?.name ?? 'example'),
 							'utf-8',
 						);
 					}

--- a/packages/astro/test/units/cli/add-cloudflare.test.ts
+++ b/packages/astro/test/units/cli/add-cloudflare.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createCloudflareWranglerConfig } from '../../../dist/cli/add/cloudflare.js';
+
+describe('astro add cloudflare', () => {
+	it('scaffolds a workerd-compatible Wrangler config', () => {
+		const config = JSON.parse(createCloudflareWranglerConfig('my-project'));
+
+		assert.deepEqual(config, {
+			$schema: './node_modules/wrangler/config-schema.json',
+			compatibility_date: '2026-04-15',
+			compatibility_flags: ['global_fetch_strictly_public'],
+			name: 'my-project',
+			main: '@astrojs/cloudflare/entrypoints/server',
+			assets: {
+				directory: './dist',
+				binding: 'ASSETS',
+			},
+			observability: {
+				enabled: true,
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- Uses a known-compatible Cloudflare compatibility date when scaffolding `wrangler.jsonc`, preventing new projects from targeting a date unsupported by their installed workerd runtime.
- Tests the rendered Wrangler configuration rather than the implementation used to produce it.

Closes #17796

## Testing

- Adds CLI unit coverage for the generated Cloudflare Wrangler configuration, including its compatibility date, project name, entrypoint, flags, and assets binding.

## Docs

- No docs update needed because this restores reliable behavior for the existing `astro add cloudflare` workflow.
