### PR TITLE
fix(content): don't mutate frozen entry data when stripping image reference prefixes

### DIFF
--- a/.changeset/frozen-readonly-content-schemas.md
+++ b/.changeset/frozen-readonly-content-schemas.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a `TypeError` crash when a Content Collection schema applies Zod `.readonly()` (or otherwise freezes parsed data) on objects containing `image()` fields. The Content Layer now strips image reference prefixes immutably instead of mutating the parsed entry data in place.

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fs, type PathLike } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import * as devalue from 'devalue';
-import { map } from 'neotraverse';
+import { map as traverseMap } from 'neotraverse';
 import { imageSrcToImportId } from '../assets/utils/resolveImports.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { DATA_STORE_MANIFEST_FILE, IMAGE_IMPORT_PREFIX } from './consts.js';
@@ -395,7 +395,7 @@ export default new Map([\n${lines.join(',\n')}]);
 				// in-place write throw a TypeError. `map` writes replacements into
 				// copies, leaving the caller's object untouched.
 				let hasImageImports = false;
-				const strippedData = map(inputData, function (ctx, val) {
+				const strippedData = traverseMap(inputData, function (ctx, val) {
 					if (typeof val === 'string' && val.startsWith(IMAGE_IMPORT_PREFIX)) {
 						hasImageImports = true;
 						const src = val.replace(IMAGE_IMPORT_PREFIX, '');

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fs, type PathLike } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import * as devalue from 'devalue';
-import { forEach } from 'neotraverse';
+import { map } from 'neotraverse';
 import { imageSrcToImportId } from '../assets/utils/resolveImports.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { DATA_STORE_MANIFEST_FILE, IMAGE_IMPORT_PREFIX } from './consts.js';
@@ -363,7 +363,16 @@ export default new Map([\n${lines.join(',\n')}]);
 			entries: () => this.entries(collectionName),
 			values: () => this.values(collectionName),
 			keys: () => this.keys(collectionName),
-			set: ({ id: key, data, body, filePath, deferredRender, digest, rendered, assetImports }) => {
+			set: ({
+				id: key,
+				data: inputData,
+				body,
+				filePath,
+				deferredRender,
+				digest,
+				rendered,
+				assetImports,
+			}) => {
 				if (!key) {
 					throw new Error(`ID must be a non-empty string`);
 				}
@@ -380,14 +389,22 @@ export default new Map([\n${lines.join(',\n')}]);
 				// strip the prefix so the stored data holds a plain, devalue-serializable src
 				// string. The recorded paths let read-time resolution rewrite only these fields
 				// without traversing or cloning the rest of the data.
-				forEach(data, function (ctx, val) {
+				// Traverse immutably with `map` instead of mutating in place with
+				// `forEach` + `ctx.update`: parsed data may be frozen at runtime (e.g.
+				// Zod `.readonly()` schemas call `Object.freeze`), which would make the
+				// in-place write throw a TypeError. `map` writes replacements into
+				// copies, leaving the caller's object untouched.
+				let hasImageImports = false;
+				const strippedData = map(inputData, function (ctx, val) {
 					if (typeof val === 'string' && val.startsWith(IMAGE_IMPORT_PREFIX)) {
+						hasImageImports = true;
 						const src = val.replace(IMAGE_IMPORT_PREFIX, '');
 						foundAssets.add(src);
 						imageImports.push(ctx.path.map((segment) => segment as string | number));
-						ctx.update(src);
+						return src;
 					}
 				});
+				const data = hasImageImports ? strippedData : inputData;
 
 				const entry: DataEntry = {
 					id,

--- a/packages/astro/test/units/content-collections/mutable-data-store.test.ts
+++ b/packages/astro/test/units/content-collections/mutable-data-store.test.ts
@@ -316,6 +316,41 @@ describe('MutableDataStore', () => {
 		assert.deepEqual(new Set(entry.assetImports), new Set(['./hero.png', './a.png', './icon.png']));
 	});
 
+	it('strips image prefixes from frozen data without mutating it (Zod .readonly() schemas, issue #17793)', () => {
+		const store = new MutableDataStore();
+		const scoped = store.scopedStore('blog');
+
+		// Zod's `.readonly()` applies `Object.freeze` to parsed data at runtime,
+		// so the store must not mutate the caller's object in place.
+		const data = Object.freeze({
+			title: 'Hello',
+			nested: Object.freeze({
+				hero: '__ASTRO_IMAGE_./hero.png',
+				gallery: Object.freeze(['__ASTRO_IMAGE_./a.png']),
+			}),
+		});
+
+		scoped.set({ id: 'frozen', data });
+
+		const entry = store.get('blog', 'frozen') as any;
+
+		// The stored (copied) data holds plain, serializable src strings — no prefixes.
+		assert.equal(entry.data.nested.hero, './hero.png');
+		assert.equal(entry.data.nested.gallery[0], './a.png');
+		assert.equal(entry.data.title, 'Hello');
+
+		// The original frozen object must be left untouched.
+		assert.equal(data.nested.hero, '__ASTRO_IMAGE_./hero.png');
+		assert.equal(data.nested.gallery[0], '__ASTRO_IMAGE_./a.png');
+
+		// The image field locations are recorded out-of-band.
+		assert.deepEqual(entry.imageImports, [
+			['nested', 'hero'],
+			['nested', 'gallery', 0],
+		]);
+		assert.deepEqual(new Set(entry.assetImports), new Set(['./hero.png', './a.png']));
+	});
+
 	it('does not set imageImports when the entry has no images', () => {
 		const store = new MutableDataStore();
 		const scoped = store.scopedStore('blog');


### PR DESCRIPTION
## Changes

- Fixes a `TypeError: Cannot assign to read only property` crash in the Content Layer when a content collection schema applies Zod `.readonly()` (which freezes parsed data at runtime) to objects containing `image()` fields.
- Root cause: `MutableDataStore.scopedStore().set()` stripped the `IMAGE_IMPORT_PREFIX` from image values **in place** using neotraverse's `forEach` + `ctx.update()`, which performs direct property assignment (`safe_set`). On runtime-frozen objects this throws.
- This is a regression from #17631, which moved prefix-stripping from read-time (`structuredClone`) to store-time (in-place mutation).
- Fix: traverse immutably with neotraverse's `map` instead of mutating via `forEach`. Replacements are written into copies, so frozen data is handled without reverting to `structuredClone` (avoiding the class-instance serialization problems #17631 fixed). When no image references are found, the original object is stored unchanged, preserving the previous zero-copy behavior for entries without images.

Closes #17793

## Testing

- Added a regression test in `packages/astro/test/units/content-collections/mutable-data-store.test.ts`: `strips image prefixes from frozen data without mutating it (Zod .readonly() schemas, issue #17793)`. It asserts that prefixed image values are stripped in the stored entry, that the caller's frozen object is left untouched, and that `imageImports`/`assetImports` are recorded correctly.
- Verified red/green locally:
  - Without the fix, the new test fails with exactly the reported error: `TypeError: Cannot assign to read only property 'hero' of object '#<Object>'` at `safe_set` → `ctx.update`.
  - With the fix, all 42 tests in `test/units/content-collections/` pass (`pnpm exec astro-scripts test "test/units/content-collections/**/*.test.ts" --strip-types --teardown ./test/units/teardown.ts` → `tests 42, pass 42, fail 0`).
- Changeset added (`.changeset/frozen-readonly-content-schemas.md`, `astro: patch`).

## Docs

No docs changes needed — this makes an already-valid Zod schema pattern (`.readonly()` + `image()`) work as users would expect; no behavior or API surface changed otherwise.