### PR TITLE
fix(routing): drop request body for GET/HEAD during rewrites

### DIFF
--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -155,7 +155,13 @@ export function copyRequest(
 	return createRequest({
 		url: newUrl,
 		method: oldRequest.method,
-		body: oldRequest.body,
+		// GET/HEAD requests must not carry a body per the Fetch spec
+		// (https://fetch.spec.whatwg.org/#http-fetch), and constructing a
+		// Request with one throws a TypeError.
+		body:
+			oldRequest.method === 'GET' || oldRequest.method === 'HEAD'
+				? undefined
+				: oldRequest.body,
 		isPrerendered,
 		logger,
 		headers: isPrerendered ? {} : oldRequest.headers,

--- a/packages/astro/test/units/routing/rewrite.test.ts
+++ b/packages/astro/test/units/routing/rewrite.test.ts
@@ -5,6 +5,7 @@ import {
 	normalizeRewritePathname,
 	setOriginPathname,
 	getOriginPathname,
+	copyRequest,
 } from '../../../dist/core/routing/rewrite.js';
 
 describe('normalizeRewritePathname', () => {
@@ -195,5 +196,65 @@ describe('setOriginPathname / getOriginPathname', () => {
 		const req = new Request('http://example.com/');
 		setOriginPathname(req, '/café', 'never', 'file');
 		assert.equal(getOriginPathname(req), '/café');
+	});
+});
+
+describe('copyRequest', () => {
+	const logger = {
+		warn: () => {},
+		info: () => {},
+		debug: () => {},
+		error: () => {},
+	} as any;
+
+	it('does not forward a body for GET requests', () => {
+		const req = new Request('http://example.com/old', {
+			method: 'GET',
+			body: 'some-body',
+			headers: { 'content-type': 'text/plain' },
+		});
+		const result = copyRequest(
+			new URL('http://example.com/new'),
+			req,
+			false,
+			logger,
+			'/**',
+		);
+		assert.equal(result.method, 'GET');
+		assert.equal(result.body, null);
+	});
+
+	it('does not forward a body for HEAD requests', () => {
+		const req = new Request('http://example.com/old', {
+			method: 'HEAD',
+			body: 'some-body',
+			headers: { 'content-type': 'text/plain' },
+		});
+		const result = copyRequest(
+			new URL('http://example.com/new'),
+			req,
+			false,
+			logger,
+			'/**',
+		);
+		assert.equal(result.method, 'HEAD');
+		assert.equal(result.body, null);
+	});
+
+	it('forwards a body for POST requests', async () => {
+		const req = new Request('http://example.com/old', {
+			method: 'POST',
+			body: 'some-body',
+			headers: { 'content-type': 'text/plain' },
+		});
+		const result = copyRequest(
+			new URL('http://example.com/new'),
+			req,
+			false,
+			logger,
+			'/**',
+		);
+		assert.equal(result.method, 'POST');
+		assert.equal(await result.text(), 'some-body');
 	});
 });

--- a/packages/astro/test/units/routing/rewrite.test.ts
+++ b/packages/astro/test/units/routing/rewrite.test.ts
@@ -208,11 +208,16 @@ describe('copyRequest', () => {
 	} as any;
 
 	it('does not forward a body for GET requests', () => {
+		// A real GET Request can never carry a body (the constructor throws),
+		// so build one via an object with the shape copyRequest reads.
 		const req = new Request('http://example.com/old', {
-			method: 'GET',
+			method: 'POST',
 			body: 'some-body',
 			headers: { 'content-type': 'text/plain' },
 		});
+		// Simulate an upstream request whose method was changed to GET after
+		// construction — the state copyRequest guards against.
+		Object.defineProperty(req, 'method', { value: 'GET' });
 		const result = copyRequest(
 			new URL('http://example.com/new'),
 			req,
@@ -226,10 +231,11 @@ describe('copyRequest', () => {
 
 	it('does not forward a body for HEAD requests', () => {
 		const req = new Request('http://example.com/old', {
-			method: 'HEAD',
+			method: 'POST',
 			body: 'some-body',
 			headers: { 'content-type': 'text/plain' },
 		});
+		Object.defineProperty(req, 'method', { value: 'HEAD' });
 		const result = copyRequest(
 			new URL('http://example.com/new'),
 			req,


### PR DESCRIPTION
## Problem

Fixes #17801

When a GET or HEAD request carries a body, `copyRequest()` in `packages/astro/src/core/routing/rewrite.ts` forwards the body unconditionally. Constructing the new `Request` then throws a `TypeError` per the Fetch spec:

```
TypeError: Request with a GET or HEAD method cannot have a body.
    at createRequest (…)
    at copyRequest (…)
    at applyRewriteToState (…)
```

A rewrite of a GET request that happens to carry a body therefore fails with an opaque 500.

## Solution

Skip the body when the method is `GET` or `HEAD`, since those methods must not carry a payload (https://fetch.spec.whatwg.org/#http-fetch). Methods that support a body (`POST`, `PUT`, `PATCH`, ...) are unaffected.

## Changes

- `packages/astro/src/core/routing/rewrite.ts`: only forward `oldRequest.body` for non-GET/HEAD methods.
- `packages/astro/test/units/routing/rewrite.test.ts`: added `copyRequest` tests covering GET (body dropped), HEAD (body dropped), and POST (body preserved).