### PR TITLE
Remove: Unnecessary string.raw wraped call

### DIFF
--- a/.changeset/fancy-foxes-stay.md
+++ b/.changeset/fancy-foxes-stay.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Although 'extractStringFromFunction' already returns a formatted string, an extra 'String.raw' wrapper was applied. This change removes the redundant wrapper and directly returns it.

--- a/.changeset/fancy-foxes-stay.md
+++ b/.changeset/fancy-foxes-stay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Although 'extractStringFromFunction' already returns a formatted string, an extra 'String.raw' wrapper was applied. This change removes the redundant wrapper and directly returns it.

--- a/packages/astro/src/events/error.ts
+++ b/packages/astro/src/events/error.ts
@@ -87,9 +87,7 @@ function getSafeErrorMessage(message: string | Function): string {
 	if (typeof message === 'string') {
 		return message;
 	} else {
-		return String.raw({
-			raw: extractStringFromFunction(message.toString()),
-		});
+		return extractStringFromFunction(message.toString());
 	}
 
 	function extractStringFromFunction(func: string) {


### PR DESCRIPTION
## Changes

This PR `getSafeErrorMessage` by removing the redundant `String.raw` wrapper around the return value of `extractStringFromFunction`.
