### PR TITLE
Prevent FetchState manifest errors in development

### DIFF
--- a/.changeset/calm-maps-travel.md
+++ b/.changeset/calm-maps-travel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where `new FetchState(request)` could fail in development when server dependencies were optimized

--- a/packages/astro/src/manifest/serialized.ts
+++ b/packages/astro/src/manifest/serialized.ts
@@ -77,6 +77,24 @@ export function serializedManifestPlugin({
 	return {
 		name: SERIALIZED_MANIFEST_ID,
 		enforce: 'pre',
+		// Dependency optimization runs as a nested Rolldown build that cannot load Vite virtual
+		// modules. Keep this import external so the server module graph resolves it below.
+		configEnvironment(environmentName) {
+			if (
+				command === 'dev' &&
+				(environmentName === ASTRO_VITE_ENVIRONMENT_NAMES.astro ||
+					environmentName === ASTRO_VITE_ENVIRONMENT_NAMES.ssr ||
+					environmentName === ASTRO_VITE_ENVIRONMENT_NAMES.prerender)
+			) {
+				return {
+					optimizeDeps: {
+						rolldownOptions: {
+							external: [AMBIENT_MANIFEST_SPECIFIER],
+						},
+					},
+				};
+			}
+		},
 		configureServer(server) {
 			server.watcher.on('add', (path) => reloadManifest(path, server));
 			server.watcher.on('unlink', (path) => reloadManifest(path, server));

--- a/packages/integrations/cloudflare/test/custom-entryfile-fetch-state.test.ts
+++ b/packages/integrations/cloudflare/test/custom-entryfile-fetch-state.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'node:assert/strict';
+import { rmSync } from 'node:fs';
 import { after, before, describe, it } from 'node:test';
-import { type Fixture, loadFixture, type PreviewServer } from './test-utils.ts';
+import { fileURLToPath } from 'node:url';
+import { type DevServer, type Fixture, loadFixture, type PreviewServer } from './test-utils.ts';
 
 // Regression test for https://github.com/withastro/astro/issues/17591:
 // a custom worker entryfile that builds its own request state with
@@ -36,5 +38,32 @@ describe('Custom entry file using astro/fetch', () => {
 			'true',
 			'Expected the custom worker to add X-Fetch-State-Entrypoint header',
 		);
+	});
+});
+
+describe('Custom entry file using astro/fetch in dev', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/custom-entryfile-fetch-state/',
+		});
+		// Optimizer plugins are not included in Vite's cache key.
+		const viteCacheDir = new URL('./node_modules/.vite/', fixture.config.root);
+		rmSync(fileURLToPath(viteCacheDir), { recursive: true, force: true });
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('renders an SSR page from a state built with new FetchState(request)', async () => {
+		const response = await fixture.fetch('/');
+		const html = await response.text();
+		assert.equal(response.status, 200, html);
+		assert.equal(response.headers.get('X-Fetch-State-Entrypoint'), 'true');
+		assert.match(html, /astro-cloudflare-custom-entryfile-fetch-state/);
 	});
 });


### PR DESCRIPTION
## Changes

- The ambient manifest was getting resolved to the fallback. This fixes it by externalizing that import so that Vite resolves it like it normally does, not during the optimization phase.


## Testing

- I added Cloudflare dev coverage for a custom worker using `FetchState`. Was missing a dev test here.

Fixes astro.build dev

<img width="1300" height="959" alt="Screenshot 2026-08-24 at 10 28 50 AM" src="https://github.com/user-attachments/assets/619513c3-7a73-4bbf-b148-2e162e9253f1" />



## Docs

- No docs update needed because this restores expected behavior.