### PR TITLE
Prevent generated exports from leaking into Astro source

### DIFF
--- a/.changeset/easy-mammals-film.md
+++ b/.changeset/easy-mammals-film.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixes `source.organizeImports` leaking generated Astro component exports into `.astro` files

--- a/packages/language-tools/language-server/src/core/astro2tsx.ts
+++ b/packages/language-tools/language-server/src/core/astro2tsx.ts
@@ -9,13 +9,14 @@ import { decode } from '@jridgewell/sourcemap-codec';
 import type { CodeMapping, VirtualCode } from '@volar/language-core';
 import { Range } from '@volar/language-server';
 import { TextDocument } from 'vscode-html-languageservice';
-import { patchTSX } from './utils.js';
+import { patchTSXWithMetadata } from './utils.js';
 
 export interface LSPTSXRanges {
 	frontmatter: Range;
 	body: Range;
 	scripts: TSXExtractedScript[];
 	styles: TSXExtractedStyle[];
+	generatedComponentExport?: Range;
 }
 
 export function safeConvertToTSX(content: string, options: ConvertToTSXOptions) {
@@ -84,16 +85,18 @@ export function getTSXRangesAsLSPRanges(tsx: TSXResult): LSPTSXRanges {
 
 export function astro2tsx(input: string, fileName: string) {
 	const tsx = safeConvertToTSX(input, { filename: fileName });
+	const { virtualCode, generatedComponentExport } = getVirtualCodeTSX(input, tsx, fileName);
 
 	return {
-		virtualCode: getVirtualCodeTSX(input, tsx, fileName),
+		virtualCode,
 		diagnostics: tsx.diagnostics,
-		ranges: getTSXRangesAsLSPRanges(tsx),
+		ranges: { ...getTSXRangesAsLSPRanges(tsx), generatedComponentExport },
 	};
 }
 
-function getVirtualCodeTSX(input: string, tsx: TSXResult, fileName: string): VirtualCode {
-	tsx.code = patchTSX(tsx.code, fileName);
+function getVirtualCodeTSX(input: string, tsx: TSXResult, fileName: string) {
+	const patched = patchTSXWithMetadata(tsx.code, fileName);
+	tsx.code = patched.code;
 	const v3Mappings = decode(tsx.map.mappings);
 	const sourcedDoc = TextDocument.create('', 'astro', 0, input);
 	const genDoc = TextDocument.create('', 'typescriptreact', 0, tsx.code);
@@ -161,14 +164,22 @@ function getVirtualCodeTSX(input: string, tsx: TSXResult, fileName: string): Vir
 	}
 
 	return {
-		id: 'tsx',
-		languageId: 'typescriptreact',
-		snapshot: {
-			getText: (start, end) => tsx.code.substring(start, end),
-			getLength: () => tsx.code.length,
-			getChangeRange: () => undefined,
-		},
-		mappings: mappings,
-		embeddedCodes: [],
+		virtualCode: {
+			id: 'tsx',
+			languageId: 'typescriptreact',
+			snapshot: {
+				getText: (start, end) => tsx.code.substring(start, end),
+				getLength: () => tsx.code.length,
+				getChangeRange: () => undefined,
+			},
+			mappings: mappings,
+			embeddedCodes: [],
+		} satisfies VirtualCode,
+		generatedComponentExport: patched.generatedComponentExport
+			? Range.create(
+					genDoc.positionAt(patched.generatedComponentExport.start),
+					genDoc.positionAt(patched.generatedComponentExport.end),
+				)
+			: undefined,
 	};
 }

--- a/packages/language-tools/language-server/src/core/utils.ts
+++ b/packages/language-tools/language-server/src/core/utils.ts
@@ -73,6 +73,10 @@ export function classNameFromFilename(filename: string): string {
 
 // TODO: Patch the upstream packages with these changes
 export function patchTSX(code: string, filePath: string) {
+	return patchTSXWithMetadata(code, filePath).code;
+}
+
+export function patchTSXWithMetadata(code: string, filePath: string) {
 	const url = URI.parse(filePath);
 	const basename = Utils.basename(url).slice(0, -Utils.extname(url).length);
 	const isDynamic = basename.startsWith('[') && basename.endsWith(']');
@@ -93,8 +97,15 @@ export function patchTSX(code: string, filePath: string) {
 	// TypeScript matches auto-imports against export names, so the suffixed name is never offered for `<Component />`
 	const cleanName = classNameFromFilename(filePath);
 	if (!componentNames.has(cleanName)) {
-		return patched;
+		return { code: patched };
 	}
 
-	return `${patched}\nexport { ${cleanName}AstroComponent as ${cleanName} };\n`;
+	const generatedComponentExport = `export { ${cleanName}AstroComponent as ${cleanName} };\n`;
+	return {
+		code: `${patched}\n${generatedComponentExport}`,
+		generatedComponentExport: {
+			start: patched.length + 1,
+			end: patched.length + 1 + generatedComponentExport.length,
+		},
+	};
 }

--- a/packages/language-tools/language-server/src/plugins/typescript/codeActions.ts
+++ b/packages/language-tools/language-server/src/plugins/typescript/codeActions.ts
@@ -1,4 +1,4 @@
-import { TextDocumentEdit } from '@volar/language-server';
+import { type Range, TextDocumentEdit } from '@volar/language-server';
 import type { CodeAction, LanguageServiceContext } from '@volar/language-service';
 import { URI } from 'vscode-uri';
 import { AstroVirtualCode } from '../../core/index.js';
@@ -23,19 +23,46 @@ export function enhancedResolveCodeAction(codeAction: CodeAction, context: Langu
 function mapCodeAction(codeAction: CodeAction, context: LanguageServiceContext) {
 	if (!codeAction.edit || !codeAction.edit.documentChanges) return codeAction;
 
-	codeAction.edit.documentChanges = codeAction.edit.documentChanges.map((change) => {
+	codeAction.edit.documentChanges = codeAction.edit.documentChanges.flatMap((change) => {
 		if (TextDocumentEdit.is(change)) {
 			const decoded = context.decodeEmbeddedDocumentUri(URI.parse(change.textDocument.uri));
 			const sourceScript = decoded && context.language.scripts.get(decoded[0]);
 			const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 			const root = sourceScript?.generated?.root;
-			if (!virtualCode || !(root instanceof AstroVirtualCode)) return change;
+			if (!virtualCode || !(root instanceof AstroVirtualCode)) return [change];
+
+			const hadEdits = change.edits.length > 0;
+			if (virtualCode.id === 'tsx') {
+				const generatedComponentExport = root.astroMeta.tsxRanges.generatedComponentExport;
+				if (generatedComponentExport) {
+					change.edits = change.edits.filter(
+						(edit) => !rangesOverlap(edit.range, generatedComponentExport),
+					);
+				}
+			}
+			if (hadEdits && change.edits.length === 0) return [];
 
 			change.edits = change.edits.map((edit) => mapEdit(edit, root, virtualCode.languageId));
 		}
 
-		return change;
+		return [change];
 	});
 
 	return codeAction;
+}
+
+function rangesOverlap(a: Range, b: Range) {
+	const aIsEmpty = comparePositions(a.start, a.end) === 0;
+	if (aIsEmpty) {
+		return comparePositions(a.start, b.start) >= 0 && comparePositions(a.start, b.end) < 0;
+	}
+
+	return comparePositions(a.start, b.end) < 0 && comparePositions(a.end, b.start) > 0;
+}
+
+function comparePositions(
+	a: { line: number; character: number },
+	b: { line: number; character: number },
+) {
+	return a.line === b.line ? a.character - b.character : a.line - b.line;
 }

--- a/packages/language-tools/language-server/test/fixture/organize-imports/src/components/alpha.astro
+++ b/packages/language-tools/language-server/test/fixture/organize-imports/src/components/alpha.astro
@@ -1,0 +1,1 @@
+<span>alpha</span>

--- a/packages/language-tools/language-server/test/fixture/organize-imports/src/components/beta.astro
+++ b/packages/language-tools/language-server/test/fixture/organize-imports/src/components/beta.astro
@@ -1,0 +1,1 @@
+<span>beta</span>

--- a/packages/language-tools/language-server/test/fixture/organize-imports/src/components/gamma.astro
+++ b/packages/language-tools/language-server/test/fixture/organize-imports/src/components/gamma.astro
@@ -1,0 +1,1 @@
+<span>gamma</span>

--- a/packages/language-tools/language-server/test/fixture/organize-imports/src/lib.ts
+++ b/packages/language-tools/language-server/test/fixture/organize-imports/src/lib.ts
@@ -1,0 +1,2 @@
+export const helperOne = () => 1
+export const helperTwo = () => 2

--- a/packages/language-tools/language-server/test/fixture/organize-imports/src/pages/index.astro
+++ b/packages/language-tools/language-server/test/fixture/organize-imports/src/pages/index.astro
@@ -1,0 +1,21 @@
+---
+import Gamma from '../components/gamma.astro'
+import { helperTwo, helperOne } from '../lib'
+import Alpha from '../components/alpha.astro'
+import Beta from '../components/beta.astro'
+
+const total = helperOne() + helperTwo()
+const UserAstroComponent = () => null
+export { UserAstroComponent as User };
+---
+
+<script>
+	import { helperTwo, helperOne } from '../lib'
+
+	console.log(helperOne(), helperTwo())
+</script>
+
+<Alpha />
+<Beta />
+<Gamma />
+<p>{total}</p>

--- a/packages/language-tools/language-server/test/server.ts
+++ b/packages/language-tools/language-server/test/server.ts
@@ -40,6 +40,13 @@ export async function getLanguageServer(): Promise<LanguageServer> {
 			},
 			{
 				textDocument: {
+					codeAction: {
+						codeActionLiteralSupport: {
+							codeActionKind: { valueSet: ['source.organizeImports', 'quickfix'] },
+						},
+						dataSupport: true,
+						resolveSupport: { properties: ['edit'] },
+					},
 					definition: {
 						linkSupport: true,
 					},

--- a/packages/language-tools/language-server/test/typescript/code-actions.test.ts
+++ b/packages/language-tools/language-server/test/typescript/code-actions.test.ts
@@ -27,9 +27,12 @@ describe('TypeScript - Code Actions', () => {
 			codeAction.title.startsWith('Add import from'),
 		);
 		assert.ok(importAction);
+		const resolvedImportAction =
+			await languageServer.handle.sendCodeActionResolveRequest(importAction);
 
-		const edit = (importAction.edit?.documentChanges?.[0] as { edits: { newText: string }[] })
-			.edits[0];
+		const edit = (
+			resolvedImportAction.edit?.documentChanges?.[0] as { edits: { newText: string }[] }
+		).edits[0];
 		assert.strictEqual(
 			edit.newText.includes('import BlogPost from "./src/components/BlogPost.astro";'),
 			true,

--- a/packages/language-tools/language-server/test/typescript/organize-imports.test.ts
+++ b/packages/language-tools/language-server/test/typescript/organize-imports.test.ts
@@ -1,8 +1,18 @@
 import assert from 'node:assert';
+import path from 'node:path';
 import { before, describe, it } from 'node:test';
-import { Range } from '@volar/language-server';
-import { URI } from 'vscode-uri';
+import { type CodeAction, Range, TextDocumentEdit } from '@volar/language-server';
 import { getLanguageServer, type LanguageServer } from '../server.ts';
+import { fixtureDir } from '../test-utils.ts';
+
+function getTextEdits(codeActions: CodeAction[]) {
+	return codeActions.flatMap(
+		(action) =>
+			action.edit?.documentChanges?.flatMap((change) =>
+				TextDocumentEdit.is(change) ? change.edits : [],
+			) ?? [],
+	);
+}
 
 describe('TypeScript - Organize & Sort Imports', () => {
 	let languageServer: LanguageServer;
@@ -14,7 +24,7 @@ describe('TypeScript - Organize & Sort Imports', () => {
 			`---\n\nimport os from "node:os";\n\nimport fs from "node:fs";\n\n---\n\n`,
 			'astro',
 		);
-		const organizeEdits = await languageServer.handle.sendCodeActionsRequest(
+		const organizeActions = await languageServer.handle.sendCodeActionsRequest(
 			document.uri,
 			Range.create(6, 0, 6, 0),
 			{
@@ -23,63 +33,19 @@ describe('TypeScript - Organize & Sort Imports', () => {
 				triggerKind: 1,
 			},
 		);
-
-		assert.deepStrictEqual(organizeEdits, [
+		const organizeEdits = await Promise.all(
+			(organizeActions as CodeAction[]).map((action) =>
+				languageServer.handle.sendCodeActionResolveRequest(action),
+			),
+		);
+		assert.deepStrictEqual(getTextEdits(organizeEdits), [
 			{
-				data: {
-					original: {
-						edit: {
-							documentChanges: [
-								{
-									edits: [
-										{
-											newText: '',
-											range: Range.create(4, 0, 5, 0),
-										},
-										{
-											newText: '',
-											range: Range.create(6, 0, 7, 0),
-										},
-									],
-									textDocument: {
-										uri: URI.from({
-											scheme: 'volar-embedded-content',
-											authority: 'tsx',
-											path: '/' + encodeURIComponent(document.uri),
-										}).toString(),
-										version: null,
-									},
-								},
-							],
-						},
-					},
-					pluginIndex: 3,
-					uri: document.uri,
-					version: (organizeEdits?.[0] as any).data.version,
-				},
-				diagnostics: [],
-				edit: {
-					documentChanges: [
-						{
-							edits: [
-								{
-									newText: '',
-									range: Range.create(2, 0, 3, 0),
-								},
-								{
-									newText: '',
-									range: Range.create(4, 0, 5, 0),
-								},
-							],
-							textDocument: {
-								uri: document.uri,
-								version: null,
-							},
-						},
-					],
-				},
-				kind: 'source.organizeImports',
-				title: 'Organize Imports',
+				newText: '',
+				range: Range.create(2, 0, 3, 0),
+			},
+			{
+				newText: '',
+				range: Range.create(4, 0, 5, 0),
 			},
 		]);
 	});
@@ -89,7 +55,7 @@ describe('TypeScript - Organize & Sort Imports', () => {
 			`---\r\n\r\nimport os from "node:os";\r\n\r\nimport fs from "node:fs";\r\n\r\n---\r\n\r\n`,
 			'astro',
 		);
-		const organizeEdits = await languageServer.handle.sendCodeActionsRequest(
+		const organizeActions = await languageServer.handle.sendCodeActionsRequest(
 			document.uri,
 			Range.create(6, 0, 6, 0),
 			{
@@ -98,64 +64,70 @@ describe('TypeScript - Organize & Sort Imports', () => {
 				triggerKind: 1,
 			},
 		);
+		const organizeEdits = await Promise.all(
+			(organizeActions as CodeAction[]).map((action) =>
+				languageServer.handle.sendCodeActionResolveRequest(action),
+			),
+		);
 
-		assert.deepStrictEqual(organizeEdits, [
+		assert.deepStrictEqual(getTextEdits(organizeEdits), [
 			{
-				data: {
-					original: {
-						edit: {
-							documentChanges: [
-								{
-									edits: [
-										{
-											newText: '',
-											range: Range.create(4, 0, 5, 0),
-										},
-										{
-											newText: '',
-											range: Range.create(6, 0, 7, 0),
-										},
-									],
-									textDocument: {
-										uri: URI.from({
-											scheme: 'volar-embedded-content',
-											authority: 'tsx',
-											path: '/' + encodeURIComponent(document.uri),
-										}).toString(),
-										version: null,
-									},
-								},
-							],
-						},
-					},
-					pluginIndex: 3,
-					uri: document.uri,
-					version: (organizeEdits?.[0] as any).data.version,
-				},
-				diagnostics: [],
-				edit: {
-					documentChanges: [
-						{
-							edits: [
-								{
-									newText: '',
-									range: Range.create(2, 0, 3, 0),
-								},
-								{
-									newText: '',
-									range: Range.create(4, 0, 5, 0),
-								},
-							],
-							textDocument: {
-								uri: document.uri,
-								version: null,
-							},
-						},
-					],
-				},
-				kind: 'source.organizeImports',
-				title: 'Organize Imports',
+				newText: '',
+				range: Range.create(2, 0, 3, 0),
+			},
+			{
+				newText: '',
+				range: Range.create(4, 0, 5, 0),
 			},
 		]);
+	});
+
+	it('does not return generated component exports', async () => {
+		const document = await languageServer.handle.openTextDocument(
+			path.join(fixtureDir, 'organize-imports/src/pages/index.astro'),
+			'astro',
+		);
+		const organizeActions = await languageServer.handle.sendCodeActionsRequest(
+			document.uri,
+			Range.create(1, 0, 1, 0),
+			{
+				diagnostics: [],
+				only: ['source.organizeImports'],
+				triggerKind: 1,
+			},
+		);
+		const organizeEdits = await Promise.all(
+			(organizeActions as CodeAction[]).map((action) =>
+				languageServer.handle.sendCodeActionResolveRequest(action),
+			),
+		);
+		const returnedText = getTextEdits(organizeEdits).map((edit) => edit.newText);
+
+		assert.ok(!returnedText.some((text) => text.includes('IndexAstroComponent as Index')));
+		assert.ok(returnedText.some((text) => text.includes('UserAstroComponent as User')));
+	});
+
+	it('organizes imports in script tags', async () => {
+		const document = await languageServer.handle.openTextDocument(
+			path.join(fixtureDir, 'organize-imports/src/pages/index.astro'),
+			'astro',
+		);
+		const organizeActions = await languageServer.handle.sendCodeActionsRequest(
+			document.uri,
+			Range.create(12, 1, 12, 1),
+			{
+				diagnostics: [],
+				only: ['source.organizeImports'],
+				triggerKind: 1,
+			},
+		);
+		const organizeEdits = await Promise.all(
+			(organizeActions as CodeAction[]).map((action) =>
+				languageServer.handle.sendCodeActionResolveRequest(action),
+			),
+		);
+		const returnedText = getTextEdits(organizeEdits).map((edit) => edit.newText);
+
+		assert.ok(returnedText.some((text) => text.includes('helperOne, helperTwo')));
 	});
 });

--- a/packages/language-tools/language-server/test/units/utils.test.ts
+++ b/packages/language-tools/language-server/test/units/utils.test.ts
@@ -7,7 +7,7 @@ import * as html from 'vscode-html-languageservice';
 import { getTSXRangesAsLSPRanges, safeConvertToTSX } from '../../dist/core/astro2tsx.js';
 import { addAstroTypes } from '../../dist/core/index.js';
 import { getAstroMetadata } from '../../dist/core/parseAstro.js';
-import { patchTSX } from '../../dist/core/utils.js';
+import { patchTSX, patchTSXWithMetadata } from '../../dist/core/utils.js';
 import {
 	getAlreadyImportedAstroComponentSources,
 	rewriteAstroImportText,
@@ -253,10 +253,14 @@ export default function Image__AstroComponent_(_props: Record<string, any>): any
 
 	it('patchTSX - re-exports the component under its clean name', () => {
 		const input = `export default function Image__AstroComponent_(_props: Record<string, any>): any {}`;
+		const patched = patchTSXWithMetadata(input, 'file:///src/components/Image.astro');
 
-		assert.match(
-			patchTSX(input, 'file:///src/components/Image.astro'),
-			/export \{ ImageAstroComponent as Image \};/,
+		assert.strictEqual(
+			patched.code.slice(
+				patched.generatedComponentExport?.start,
+				patched.generatedComponentExport?.end,
+			),
+			'export { ImageAstroComponent as Image };\n',
 		);
 	});
 


### PR DESCRIPTION
## Changes

- Prevents TypeScript code actions from inserting generated component exports into `.astro` source.
- Tracks the generated export range so user-authored exports and script edits remain unchanged. Fixes #17811.

## Testing

- Adds organize-import coverage for generated exports, matching user exports, and script tags.

### Before

<img width="1440" height="900" alt="vscode-before-organize-imports" src="https://github.com/user-attachments/assets/59622296-1849-4ca7-ac95-6de21e583941" />

### After

<img width="1200" height="800" alt="vscode-after-organize-imports" src="https://github.com/user-attachments/assets/044b8fdf-2a2a-4f26-aceb-b3c36f7a43b5" />


## Docs

- No docs update needed; this restores expected language-server behavior.