### PR TITLE
Make the SvgOptimizer optimize() path parameter optional

### DIFF
--- a/.changeset/ninety-singers-serve.md
+++ b/.changeset/ninety-singers-serve.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Makes the `path` parameter of the experimental `SvgOptimizer.optimize()` method optional so existing custom optimizers keep compiling without changes

--- a/packages/astro/src/assets/svg/types.ts
+++ b/packages/astro/src/assets/svg/types.ts
@@ -1,4 +1,4 @@
 export interface SvgOptimizer {
 	name: string;
-	optimize: (contents: string, path: string) => string | Promise<string>;
+	optimize: (contents: string, path?: string) => string | Promise<string>;
 }


### PR DESCRIPTION
## Changes

- `SvgOptimizer.optimize()` gained a required `path` parameter in #17816. Custom optimizers written before that change (`optimize: (contents) => ...`) still compile against a required second parameter, but any code that calls `optimize()` directly with a single argument would now fail to type-check.
- Makes `path` optional (`path?: string`) on the `SvgOptimizer` interface. The built-in `svgoOptimizer()` still receives the actual file path from `parseSvg()` on every call, so behavior is unchanged.

## Testing

- Existing `test/core-image-svg.test.ts` suite (including the `prefixIds` per-file prefix test added in #17816) continues to pass with the parameter marked optional.

## Docs

- Docs update needed for the `optimize()` signature shown at https://docs.astro.build/en/reference/experimental-flags/svg-optimization/#optimize.
