### PR TITLE
ci: enable PR duplicate packages check

### DIFF
--- a/.github/workflows/diff-dependencies.yml
+++ b/.github/workflows/diff-dependencies.yml
@@ -21,6 +21,3 @@ jobs:
 
       - name: Create Diff
         uses: e18e/action-dependency-diff@9a7f09f5f2993256322e0db17ee4c8d9339dab77 # v1.7.1
-        with:
-          # We’re using this package primarily to track size changes, not as worried about duplicates
-          duplicate-threshold: 100


### PR DESCRIPTION
## Changes

 

We have disabled `duplicate-threshold` in `e18e/action-dependency-diff` (by setting it to a large number 100, instead of the default value 1). This PR re-enabled it. 

### Why we disabled it?


If we enable `duplicate-threshold`, the previous version of `e18e/action-dependency-diff` will emit _all_ duplicated packages in the pull request comments. In the `astro` repo, that’s 200+ packages in total. An example bot comment is shown below:

<details>

<summary>link:</summary>

https://github.com/ocavue-forks/astro/pull/36#issuecomment-5419507882


</details>

<details>

<summary>screenshot:</summary>

<img width="700"  src="https://github.com/user-attachments/assets/419b15ff-6218-48d8-a5c0-c617b145e072" />

 
</details>

This information in the comment is too verbose and not useful at all. I guess that's why we disabled it.

### Why enable it now?

In the latest `e18e/action-dependency-diff` v1.7.x, I've [contributed](https://github.com/e18e/action-dependency-diff/pull/172) a feature that changes `duplicate-threshold` to only scan the changed dependency in a pull request.

For example, PR https://github.com/withastro/astro/pull/17450 introduced some duplicated package. Now the CI would comment the following content:


<details>

<summary>link:</summary>

https://github.com/ocavue-forks/astro/pull/38#issuecomment-5419899994

</details>

<details>

<summary>screenshot:</summary>

<img width="700"   src="https://github.com/user-attachments/assets/247b9bef-ea0c-4e91-a960-df585b216aba" />


</details>

The bot comment is much more useful now.


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Green CI

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
