### PR TITLE
feat(fonts): warn on invalid properties

### DIFF
--- a/.changeset/dull-poems-share.md
+++ b/.changeset/dull-poems-share.md
@@ -24,5 +24,3 @@ const provider: FontProvider = {
 	}),
 };
 ```
-
-The font provider `init()` context now also exposes a `fetch()` function, which retries transient failures and routes requests through a proxy when one is configured.

--- a/.changeset/dull-poems-share.md
+++ b/.changeset/dull-poems-share.md
@@ -1,0 +1,28 @@
+---
+"astro": minor
+---
+
+Adds a new optional `getFontProperties()` callback to font providers
+
+Font providers can now expose the weights, styles, subsets and formats a font family actually has. Astro uses it when resolving your font configuration to warn about values a provider cannot serve, for example a weight a font family does not offer.
+
+All built-in providers implement it. If you maintain a custom font provider, implementing this callback is optional for now but it will be required in Astro 8:
+
+```ts
+import type { FontProvider } from 'astro';
+
+const provider: FontProvider = {
+	name: 'my-provider',
+	resolveFont: ({ familyName }) => {
+		// ...
+	},
+	getFontProperties: ({ familyName }) => ({
+		weights: ['400', '700'],
+		styles: ['normal', 'italic'],
+		subsets: ['latin'],
+		formats: ['woff2'],
+	}),
+};
+```
+
+The font provider `init()` context now also exposes a `fetch()` function, which retries transient failures and routes requests through a proxy when one is configured.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -170,7 +170,7 @@
     "tinyexec": "^1.0.4",
     "tinyglobby": "^0.2.15",
     "ultrahtml": "^1.6.0",
-    "unifont": "~0.7.5",
+    "unifont": "~0.8.1",
     "unstorage": "^1.17.5",
     "vite": "^8.0.13",
     "vitefu": "^1.1.2",

--- a/packages/astro/src/assets/fonts/config.ts
+++ b/packages/astro/src/assets/fonts/config.ts
@@ -13,6 +13,9 @@ const _FontProviderSchema = z.strictObject({
 	init: z.custom<FontProvider['init']>((v) => typeof v === 'function').optional(),
 	resolveFont: z.custom<FontProvider['resolveFont']>((v) => typeof v === 'function'),
 	listFonts: z.custom<FontProvider['listFonts']>((v) => typeof v === 'function').optional(),
+	getFontProperties: z
+		.custom<FontProvider['getFontProperties']>((v) => typeof v === 'function')
+		.optional(),
 });
 
 // Using z.object directly makes zod remap the input, preventing

--- a/packages/astro/src/assets/fonts/core/validate-family-properties.ts
+++ b/packages/astro/src/assets/fonts/core/validate-family-properties.ts
@@ -1,0 +1,99 @@
+import type { AstroLogger } from '../../../core/logger/core.js';
+import type { FontResolver } from '../definitions.js';
+import type { FontProperties, ResolvedFontFamily } from '../types.js';
+
+/**
+ * Keywords allowed by the `font-weight` descriptor, mapped to their numeric value.
+ */
+const WEIGHT_KEYWORDS: Record<string, number> = {
+	normal: 400,
+	bold: 700,
+};
+
+/**
+ * Parses a weight (eg. `"400"`, `"bold"` or the variable range `"100 900"`) into a
+ * `[min, max]` range. Returns `null` when the value can't be interpreted: in that case
+ * we prefer staying silent over warning wrongly.
+ */
+function parseWeightRange(weight: string): [number, number] | null {
+	const parts = weight.trim().split(/\s+/).filter(Boolean);
+	if (parts.length === 0 || parts.length > 2) {
+		return null;
+	}
+	const values = parts.map((part) => WEIGHT_KEYWORDS[part] ?? Number(part));
+	if (values.some((value) => !Number.isFinite(value))) {
+		return null;
+	}
+	return [values[0]!, values[1] ?? values[0]!];
+}
+
+/**
+ * A weight is available if it's covered by one of the weights the provider exposes.
+ * Providers may expose variable ranges, so `500` is available if `100 900` is.
+ */
+function isWeightAvailable(weight: string, availableWeights: Array<string>): boolean {
+	const range = parseWeightRange(weight);
+	if (!range) {
+		return true;
+	}
+	return availableWeights.some((availableWeight) => {
+		const availableRange = parseWeightRange(availableWeight);
+		if (!availableRange) {
+			return true;
+		}
+		return range[0] >= availableRange[0] && range[1] <= availableRange[1];
+	});
+}
+
+/**
+ * Warns about values configured for a family that its provider can't serve, eg. a weight
+ * or a subset a font family does not have. We only check values that are explicitly
+ * configured: defaults are handled by providers themselves.
+ */
+export async function validateFamilyProperties({
+	family,
+	fontResolver,
+	logger,
+	bold,
+}: {
+	family: ResolvedFontFamily;
+	fontResolver: FontResolver;
+	logger: AstroLogger;
+	bold: (input: string) => string;
+}): Promise<void> {
+	// Providers are not required to implement this, and they return no properties for
+	// families they don't know about. In both cases, there's nothing to check against.
+	const properties = await fontResolver.getFontProperties({
+		familyName: family.name,
+		provider: family.provider,
+	});
+	if (!properties) {
+		return;
+	}
+
+	const check = (
+		key: keyof FontProperties,
+		configured: Array<string> | undefined,
+		isAvailable: (value: string, available: Array<string>) => boolean,
+	) => {
+		const available = properties[key];
+		if (!configured || !available || available.length === 0) {
+			return;
+		}
+		const unsupported = configured.filter((value) => !isAvailable(value, available));
+		if (unsupported.length === 0) {
+			return;
+		}
+		logger.warn(
+			'assets',
+			`The ${bold(family.name)} font family does not support the following ${key}: ${unsupported.join(', ')}. Available ${key}: ${available.join(', ')}. Review your configuration.`,
+		);
+	};
+
+	const includes = (value: string, available: Array<string>) => available.includes(value);
+
+	check('weights', family.weights, isWeightAvailable);
+	check('styles', family.styles, includes);
+	check('subsets', family.subsets, includes);
+	check('formats', family.formats, includes);
+}

--- a/packages/astro/src/assets/fonts/definitions.ts
+++ b/packages/astro/src/assets/fonts/definitions.ts
@@ -5,6 +5,7 @@ import type {
 	FallbackVariant,
 	FontFaceMetrics,
 	FontFileData,
+	FontProperties,
 	FontProvider,
 	FontType,
 	GenericFallbackName,
@@ -88,6 +89,10 @@ export interface FontResolver {
 		options: ResolveFontOptions<Record<string, any>> & { provider: FontProvider },
 	) => Promise<Array<unifont.FontFaceData>>;
 	listFonts: (options: { provider: FontProvider }) => Promise<string[] | undefined>;
+	getFontProperties: (options: {
+		familyName: string;
+		provider: FontProvider;
+	}) => Promise<FontProperties | undefined>;
 }
 
 export interface RuntimeFontFileUrlResolver {

--- a/packages/astro/src/assets/fonts/infra/unifont-font-resolver.ts
+++ b/packages/astro/src/assets/fonts/infra/unifont-font-resolver.ts
@@ -43,7 +43,6 @@ export class UnifontFontResolver implements FontResolver {
 				async listFonts() {
 					return astroProvider.listFonts?.();
 				},
-				// TODO: always forward the call once the callback is required in Astro 8
 				getFontProperties: astroProvider.getFontProperties
 					? async (familyName) => astroProvider.getFontProperties!({ familyName })
 					: undefined,

--- a/packages/astro/src/assets/fonts/infra/unifont-font-resolver.ts
+++ b/packages/astro/src/assets/fonts/infra/unifont-font-resolver.ts
@@ -1,7 +1,12 @@
 import type { FontFaceData, Provider } from 'unifont';
 import { createUnifont, defineFontProvider, type Unifont } from 'unifont';
 import type { FontResolver, Hasher, Storage } from '../definitions.js';
-import type { FontProvider, ResolvedFontFamily, ResolveFontOptions } from '../types.js';
+import type {
+	FontProperties,
+	FontProvider,
+	ResolvedFontFamily,
+	ResolveFontOptions,
+} from '../types.js';
 
 type NonEmptyProviders = [
 	Provider<string, Record<string, any>>,
@@ -38,6 +43,10 @@ export class UnifontFontResolver implements FontResolver {
 				async listFonts() {
 					return astroProvider.listFonts?.();
 				},
+				// TODO: always forward the call once the callback is required in Astro 8
+				getFontProperties: astroProvider.getFontProperties
+					? async (familyName) => astroProvider.getFontProperties!({ familyName })
+					: undefined,
 			};
 		})(astroProvider.config);
 	}
@@ -116,6 +125,27 @@ export class UnifontFontResolver implements FontResolver {
 			[id],
 		);
 		return fonts;
+	}
+
+	async getFontProperties({
+		familyName,
+		provider,
+	}: {
+		familyName: string;
+		provider: FontProvider;
+	}): Promise<FontProperties | undefined> {
+		const properties = await this.#unifont.getFontProperties(familyName, [
+			UnifontFontResolver.idFromProvider({
+				hasher: this.#hasher,
+				provider,
+			}),
+		]);
+		if (!properties) {
+			return undefined;
+		}
+		// The provider name is an internal id, it's not useful to consumers
+		const { provider: _, ...rest } = properties;
+		return rest;
 	}
 
 	async listFonts({ provider }: { provider: FontProvider }): Promise<string[] | undefined> {

--- a/packages/astro/src/assets/fonts/providers/index.ts
+++ b/packages/astro/src/assets/fonts/providers/index.ts
@@ -29,6 +29,9 @@ function adobe(config: AdobeProviderOptions): FontProvider {
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();
 		},
+		async getFontProperties({ familyName }) {
+			return await initializedProvider?.getFontProperties?.(familyName);
+		},
 	};
 }
 
@@ -46,6 +49,9 @@ function bunny(): FontProvider {
 		},
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();
+		},
+		async getFontProperties({ familyName }) {
+			return await initializedProvider?.getFontProperties?.(familyName);
 		},
 	};
 }
@@ -65,6 +71,9 @@ function fontshare(): FontProvider {
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();
 		},
+		async getFontProperties({ familyName }) {
+			return await initializedProvider?.getFontProperties?.(familyName);
+		},
 	};
 }
 
@@ -82,6 +91,9 @@ function fontsource(): FontProvider {
 		},
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();
+		},
+		async getFontProperties({ familyName }) {
+			return await initializedProvider?.getFontProperties?.(familyName);
 		},
 	};
 }
@@ -101,6 +113,9 @@ function google(): FontProvider<GoogleFamilyOptions | undefined> {
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();
 		},
+		async getFontProperties({ familyName }) {
+			return await initializedProvider?.getFontProperties?.(familyName);
+		},
 	};
 }
 
@@ -118,6 +133,9 @@ function googleicons(): FontProvider<GoogleiconsFamilyOptions | undefined> {
 		},
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();
+		},
+		async getFontProperties({ familyName }) {
+			return await initializedProvider?.getFontProperties?.(familyName);
 		},
 	};
 }
@@ -148,6 +166,9 @@ function npm(
 		},
 		async listFonts() {
 			return await initializedProvider?.listFonts?.();
+		},
+		async getFontProperties({ familyName }) {
+			return await initializedProvider?.getFontProperties?.(familyName);
 		},
 	};
 }

--- a/packages/astro/src/assets/fonts/providers/index.ts
+++ b/packages/astro/src/assets/fonts/providers/index.ts
@@ -21,6 +21,9 @@ function adobe(config: AdobeProviderOptions): FontProvider {
 		name: provider._name,
 		config,
 		async init(context) {
+			// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+			// context. unifont still types it as required but does not need us to pass it.
+			// TODO: drop this once unifont makes `fetch` optional in its provider context
 			initializedProvider = await provider(context);
 		},
 		async resolveFont({ familyName, ...rest }) {
@@ -42,6 +45,9 @@ function bunny(): FontProvider {
 	return {
 		name: provider._name,
 		async init(context) {
+			// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+			// context. unifont still types it as required but does not need us to pass it.
+			// TODO: drop this once unifont makes `fetch` optional in its provider context
 			initializedProvider = await provider(context);
 		},
 		async resolveFont({ familyName, ...rest }) {
@@ -63,6 +69,9 @@ function fontshare(): FontProvider {
 	return {
 		name: provider._name,
 		async init(context) {
+			// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+			// context. unifont still types it as required but does not need us to pass it.
+			// TODO: drop this once unifont makes `fetch` optional in its provider context
 			initializedProvider = await provider(context);
 		},
 		async resolveFont({ familyName, ...rest }) {
@@ -84,6 +93,9 @@ function fontsource(): FontProvider {
 	return {
 		name: provider._name,
 		async init(context) {
+			// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+			// context. unifont still types it as required but does not need us to pass it.
+			// TODO: drop this once unifont makes `fetch` optional in its provider context
 			initializedProvider = await provider(context);
 		},
 		async resolveFont({ familyName, ...rest }) {
@@ -105,6 +117,9 @@ function google(): FontProvider<GoogleFamilyOptions | undefined> {
 	return {
 		name: provider._name,
 		async init(context) {
+			// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+			// context. unifont still types it as required but does not need us to pass it.
+			// TODO: drop this once unifont makes `fetch` optional in its provider context
 			initializedProvider = await provider(context);
 		},
 		async resolveFont({ familyName, ...rest }) {
@@ -126,6 +141,9 @@ function googleicons(): FontProvider<GoogleiconsFamilyOptions | undefined> {
 	return {
 		name: provider._name,
 		async init(context) {
+			// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+			// context. unifont still types it as required but does not need us to pass it.
+			// TODO: drop this once unifont makes `fetch` optional in its provider context
 			initializedProvider = await provider(context);
 		},
 		async resolveFont({ familyName, ...rest }) {
@@ -159,7 +177,12 @@ function npm(
 				...options,
 				root: fileURLToPath(context.root),
 				readFile: (path) => readFile(path, 'utf-8').catch(() => null),
-			})(context);
+			})(
+				// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+				// context. unifont still types it as required but does not need us to pass it.
+				// TODO: drop this once unifont makes `fetch` optional in its provider context
+				context,
+			);
 		},
 		async resolveFont({ familyName, ...rest }) {
 			return await initializedProvider?.resolveFont(familyName, rest);

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -23,11 +23,6 @@ export interface FontProviderInitContext {
 	 * The project root, useful for resolving local files paths.
 	 */
 	root: URL;
-	/**
-	 * Requests a provider API, retrying transient failures. Requests are routed through a
-	 * proxy if one is configured, so providers should always request the upstream URL.
-	 */
-	fetch: (url: string, init?: RequestInit) => Promise<Response>;
 }
 
 type Awaitable<T> = T | Promise<T>;

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -23,6 +23,11 @@ export interface FontProviderInitContext {
 	 * The project root, useful for resolving local files paths.
 	 */
 	root: URL;
+	/**
+	 * Requests a provider API, retrying transient failures. Requests are routed through a
+	 * proxy if one is configured, so providers should always request the upstream URL.
+	 */
+	fetch: (url: string, init?: RequestInit) => Promise<Response>;
 }
 
 type Awaitable<T> = T | Promise<T>;
@@ -55,6 +60,49 @@ export interface FontProvider<
 	 * Optional callback, used to return the list of available font names.
 	 */
 	listFonts?: (() => Awaitable<Array<string> | undefined>) | undefined;
+	/**
+	 * Optional callback, used to return the properties available for a given font family.
+	 * It allows Astro to warn about configured values a provider cannot serve. Return
+	 * `undefined` when the family is unknown to the provider.
+	 *
+	 * TODO: make this callback required in Astro 8
+	 */
+	getFontProperties?:
+		| ((options: GetFontPropertiesOptions) => Awaitable<FontProperties | undefined>)
+		| undefined;
+}
+
+export interface GetFontPropertiesOptions {
+	/**
+	 * The font family name, as identified by the font provider.
+	 */
+	familyName: string;
+}
+
+/**
+ * Describes what a provider can actually serve for a given font family. Any
+ * `undefined` property means the provider does not expose that information,
+ * not that nothing is available.
+ */
+export interface FontProperties {
+	/**
+	 * Weights available for the font family. Values are either discrete weights (`"400"`)
+	 * or variable ranges expressed as `"<min> <max>"` (`"100 900"`).
+	 */
+	weights?: Array<string> | undefined;
+	/**
+	 * Styles available for the font family.
+	 */
+	styles?: Array<Style> | undefined;
+	/**
+	 * Subsets available for the font family.
+	 */
+	subsets?: Array<string> | undefined;
+	/**
+	 * Formats the provider can serve. This reflects provider capability rather than
+	 * per-family availability, so some formats may not exist for every family.
+	 */
+	formats?: Array<FontType> | undefined;
 }
 
 export interface FamilyProperties {

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -59,8 +59,6 @@ export interface FontProvider<
 	 * Optional callback, used to return the properties available for a given font family.
 	 * It allows Astro to warn about configured values a provider cannot serve. Return
 	 * `undefined` when the family is unknown to the provider.
-	 *
-	 * TODO: make this callback required in Astro 8
 	 */
 	getFontProperties?:
 		| ((options: GetFontPropertiesOptions) => Awaitable<FontProperties | undefined>)

--- a/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
+++ b/packages/astro/src/assets/fonts/vite-plugin-fonts.ts
@@ -33,6 +33,7 @@ import { filterAndTransformFontFaces } from './core/filter-and-transform-font-fa
 import { getOrCreateFontFamilyAssets } from './core/get-or-create-font-family-assets.js';
 import { optimizeFallbacks } from './core/optimize-fallbacks.js';
 import { resolveFamily } from './core/resolve-family.js';
+import { validateFamilyProperties } from './core/validate-family-properties.js';
 import type { FontFetcher, FontTypeExtractor } from './definitions.js';
 import { BuildFontFileIdGenerator } from './infra/build-font-file-id-generator.js';
 import { BuildUrlResolver } from './infra/build-url-resolver.js';
@@ -140,18 +141,26 @@ export function fontsPlugin({ settings, sync, logger }: Options): Plugin {
 				settings.config.fonts?.map((family) =>
 					resolveFamily({ family: family as FontFamily, hasher }),
 				) ?? [];
+			const fontResolver = await UnifontFontResolver.create({
+				families: resolvedFamilies,
+				hasher,
+				storage,
+				root,
+			});
+			// Providers know what they can actually serve, so we can tell the user about
+			// values configured for a family that won't be honored
+			await Promise.all(
+				resolvedFamilies.map((family) =>
+					validateFamilyProperties({ family, fontResolver, logger, bold }),
+				),
+			);
 			const { fontFamilyAssets, fontFileById: _fontFileById } = await computeFontFamiliesAssets({
 				resolvedFamilies,
 				defaults,
 				bold,
 				logger,
 				stringMatcher,
-				fontResolver: await UnifontFontResolver.create({
-					families: resolvedFamilies,
-					hasher,
-					storage,
-					root,
-				}),
+				fontResolver,
 				getOrCreateFontFamilyAssets: ({ family, fontFamilyAssetsByUniqueKey }) =>
 					getOrCreateFontFamilyAssets({
 						family,

--- a/packages/astro/test/units/assets/fonts/core.test.ts
+++ b/packages/astro/test/units/assets/fonts/core.test.ts
@@ -10,6 +10,7 @@ import { filterPreloads } from '../../../../dist/assets/fonts/core/filter-preloa
 import { getOrCreateFontFamilyAssets } from '../../../../dist/assets/fonts/core/get-or-create-font-family-assets.js';
 import { optimizeFallbacks } from '../../../../dist/assets/fonts/core/optimize-fallbacks.js';
 import { resolveFamily } from '../../../../dist/assets/fonts/core/resolve-family.js';
+import { validateFamilyProperties } from '../../../../dist/assets/fonts/core/validate-family-properties.js';
 import { fontFileMiddleware } from '../../../../dist/assets/fonts/core/font-file-middleware.js';
 import type { SystemFallbacksProvider } from '../../../../dist/assets/fonts/definitions.js';
 import type {
@@ -75,6 +76,137 @@ describe('fonts core', () => {
 			assert.deepStrictEqual(family.subsets, ['latin']);
 			assert.deepStrictEqual(family.fallbacks, ['foo', 'bar']);
 			assert.deepStrictEqual(family.unicodeRange, ['abc', 'def']);
+		});
+	});
+
+	describe('validateFamilyProperties()', () => {
+		async function validate(family: ResolvedFontFamily) {
+			const logger = new SpyLogger();
+			await validateFamilyProperties({
+				family,
+				fontResolver: await PassthroughFontResolver.create({
+					families: [family],
+					hasher: new FakeHasher('xxx'),
+				}),
+				logger,
+				bold: markdownBold,
+			});
+			return logger.logs.map((log) => log.message);
+		}
+
+		function createFamily(
+			family: Partial<ResolvedFontFamily>,
+			getFontProperties?: () => unknown,
+		): ResolvedFontFamily {
+			return {
+				name: 'Test',
+				uniqueName: 'Test-xxx',
+				cssVariable: '--test',
+				...family,
+				provider: {
+					name: 'test',
+					resolveFont: () => undefined,
+					getFontProperties,
+				},
+			} as ResolvedFontFamily;
+		}
+
+		it('does nothing if the provider does not implement getFontProperties()', async () => {
+			assert.deepStrictEqual(await validate(createFamily({ weights: ['900'] })), []);
+		});
+
+		it('does nothing if the provider does not know the family', async () => {
+			assert.deepStrictEqual(
+				await validate(createFamily({ weights: ['900'] }, () => undefined)),
+				[],
+			);
+		});
+
+		it('does not check values that are not configured', async () => {
+			assert.deepStrictEqual(
+				await validate(
+					createFamily({}, () => ({
+						weights: ['700'],
+						styles: ['italic'],
+						subsets: ['cyrillic'],
+						formats: ['woff'],
+					})),
+				),
+				[],
+			);
+		});
+
+		it('does not warn if properties are not exposed by the provider', async () => {
+			assert.deepStrictEqual(
+				await validate(
+					createFamily({ weights: ['900'], subsets: ['latin'] }, () => ({ weights: [] })),
+				),
+				[],
+			);
+		});
+
+		it('warns about unsupported weights', async () => {
+			assert.deepStrictEqual(
+				await validate(
+					createFamily({ weights: ['400', '900'] }, () => ({ weights: ['400', '700'] })),
+				),
+				[
+					'The **Test** font family does not support the following weights: 900. Available weights: 400, 700. Review your configuration.',
+				],
+			);
+		});
+
+		it('handles variable weight ranges', async () => {
+			assert.deepStrictEqual(
+				await validate(
+					createFamily({ weights: ['500', '100 900', '200 1000'] }, () => ({
+						weights: ['400', '100 900'],
+					})),
+				),
+				[
+					'The **Test** font family does not support the following weights: 200 1000. Available weights: 400, 100 900. Review your configuration.',
+				],
+			);
+		});
+
+		it('handles weight keywords', async () => {
+			assert.deepStrictEqual(
+				await validate(createFamily({ weights: ['bold', 'normal'] }, () => ({ weights: ['400'] }))),
+				[
+					'The **Test** font family does not support the following weights: bold. Available weights: 400. Review your configuration.',
+				],
+			);
+		});
+
+		it('stays silent for weights it cannot interpret', async () => {
+			assert.deepStrictEqual(
+				await validate(createFamily({ weights: ['foo'] }, () => ({ weights: ['400'] }))),
+				[],
+			);
+		});
+
+		it('warns about unsupported styles, subsets and formats', async () => {
+			assert.deepStrictEqual(
+				await validate(
+					createFamily(
+						{
+							styles: ['normal', 'oblique'],
+							subsets: ['latin', 'cyrillic'],
+							formats: ['woff2', 'eot'],
+						},
+						() => ({
+							styles: ['normal', 'italic'],
+							subsets: ['latin'],
+							formats: ['woff2', 'woff'],
+						}),
+					),
+				),
+				[
+					'The **Test** font family does not support the following styles: oblique. Available styles: normal, italic. Review your configuration.',
+					'The **Test** font family does not support the following subsets: cyrillic. Available subsets: latin. Review your configuration.',
+					'The **Test** font family does not support the following formats: eot. Available formats: woff2, woff. Review your configuration.',
+				],
+			);
 		});
 	});
 

--- a/packages/astro/test/units/assets/fonts/infra.test.ts
+++ b/packages/astro/test/units/assets/fonts/infra.test.ts
@@ -632,6 +632,9 @@ describe('fonts infra', () => {
 					return {
 						name: provider._name,
 						async init(context) {
+							// @ts-expect-error `fetch` is deliberately not part of Astro's public provider
+							// context. unifont still types it as required but does not need us to pass it.
+							// TODO: drop this once unifont makes `fetch` optional in its provider context
 							initializedProvider = await provider(context);
 						},
 						async resolveFont({ familyName, ...rest }) {

--- a/packages/astro/test/units/assets/fonts/infra.test.ts
+++ b/packages/astro/test/units/assets/fonts/infra.test.ts
@@ -518,7 +518,7 @@ describe('fonts infra', () => {
 					new URL(import.meta.url),
 				);
 				assert.equal(providerFactory._name, 'test');
-				const provider = await providerFactory({ storage: new SpyStorage() });
+				const provider = await providerFactory({ storage: new SpyStorage(), fetch });
 				assert.deepStrictEqual(
 					await provider?.resolveFont('', {
 						formats: [],
@@ -566,7 +566,7 @@ describe('fonts infra', () => {
 					},
 					new URL(import.meta.url),
 				);
-				await providerFactory({ storage: new SpyStorage() });
+				await providerFactory({ storage: new SpyStorage(), fetch });
 				assert.equal(ran, true);
 			});
 
@@ -580,8 +580,35 @@ describe('fonts infra', () => {
 					new URL(import.meta.url),
 				);
 				assert.equal(providerFactory._name, 'test');
-				const provider = await providerFactory({ storage: new SpyStorage() });
+				const provider = await providerFactory({ storage: new SpyStorage(), fetch });
 				assert.deepStrictEqual(await provider?.listFonts?.(), ['a', 'b', 'c']);
+			});
+
+			it('handles getFontProperties()', async () => {
+				const providerFactory = UnifontFontResolver.astroToUnifontProvider(
+					{
+						name: 'test',
+						resolveFont: () => undefined,
+						getFontProperties: ({ familyName }) =>
+							familyName === 'Foo' ? { weights: ['400'] } : undefined,
+					},
+					new URL(import.meta.url),
+				);
+				const provider = await providerFactory({ storage: new SpyStorage(), fetch });
+				assert.deepStrictEqual(await provider?.getFontProperties?.('Foo'), { weights: ['400'] });
+				assert.equal(await provider?.getFontProperties?.('Bar'), undefined);
+			});
+
+			it('does not expose getFontProperties() if the provider does not implement it', async () => {
+				const providerFactory = UnifontFontResolver.astroToUnifontProvider(
+					{
+						name: 'test',
+						resolveFont: () => undefined,
+					},
+					new URL(import.meta.url),
+				);
+				const provider = await providerFactory({ storage: new SpyStorage(), fetch });
+				assert.equal(provider?.getFontProperties, undefined);
 			});
 
 			it('handles unifont > astro > unifont', async () => {
@@ -621,7 +648,7 @@ describe('fonts infra', () => {
 					new URL(import.meta.url),
 				);
 				assert.equal(providerFactory._name, 'test');
-				const provider = await providerFactory({ storage: new SpyStorage() });
+				const provider = await providerFactory({ storage: new SpyStorage(), fetch });
 				assert.equal(ran, true);
 				assert.deepStrictEqual(
 					await provider?.resolveFont('', {
@@ -754,6 +781,56 @@ describe('fonts infra', () => {
 					},
 				}),
 				['a', 'b', 'c'],
+			);
+		});
+
+		it('getFontProperties() works', async () => {
+			const fontResolver = await UnifontFontResolver.create({
+				families: [
+					{
+						name: 'Foo',
+						uniqueName: 'Foo-xxx',
+						cssVariable: '--foo',
+						provider: {
+							name: 'foo',
+							resolveFont: () => undefined,
+						},
+					},
+					{
+						name: 'Bar',
+						uniqueName: 'Bar-xxx',
+						cssVariable: '--bar',
+						provider: {
+							name: 'bar',
+							resolveFont: () => undefined,
+							getFontProperties: ({ familyName }) => ({ weights: ['400'], subsets: [familyName] }),
+						},
+					},
+				],
+				hasher: new FakeHasher(),
+				storage: new SpyStorage(),
+				root: new URL(import.meta.url),
+			});
+			assert.equal(
+				await fontResolver.getFontProperties({
+					familyName: 'Foo',
+					provider: {
+						name: 'foo',
+						resolveFont: () => undefined,
+					},
+				}),
+				undefined,
+			);
+			// The internal provider id is not leaked to consumers
+			assert.deepStrictEqual(
+				await fontResolver.getFontProperties({
+					familyName: 'Bar',
+					provider: {
+						name: 'bar',
+						resolveFont: () => undefined,
+					},
+				}),
+				{ weights: ['400'], subsets: ['Bar'] },
 			);
 		});
 	});

--- a/packages/astro/test/units/assets/fonts/utils.ts
+++ b/packages/astro/test/units/assets/fonts/utils.ts
@@ -102,7 +102,7 @@ export class PassthroughFontResolver implements FontResolver {
 		const storage = new SpyStorage();
 		await Promise.all(
 			Array.from(providers.values()).map(async (provider) => {
-				await provider.init?.({ storage, root: new URL(import.meta.url), fetch });
+				await provider.init?.({ storage, root: new URL(import.meta.url) });
 			}),
 		);
 		return new PassthroughFontResolver(providers);

--- a/packages/astro/test/units/assets/fonts/utils.ts
+++ b/packages/astro/test/units/assets/fonts/utils.ts
@@ -6,6 +6,7 @@ import type {
 	StringMatcher,
 } from '../../../../dist/assets/fonts/definitions.js';
 import type {
+	FontProperties,
 	FontProvider,
 	ResolvedFontFamily,
 	ResolveFontOptions,
@@ -101,7 +102,7 @@ export class PassthroughFontResolver implements FontResolver {
 		const storage = new SpyStorage();
 		await Promise.all(
 			Array.from(providers.values()).map(async (provider) => {
-				await provider.init?.({ storage, root: new URL(import.meta.url) });
+				await provider.init?.({ storage, root: new URL(import.meta.url), fetch });
 			}),
 		);
 		return new PassthroughFontResolver(providers);
@@ -119,6 +120,16 @@ export class PassthroughFontResolver implements FontResolver {
 
 	async listFonts({ provider }: { provider: FontProvider }): Promise<string[] | undefined> {
 		return await this.#providers.get(provider.name)?.listFonts?.();
+	}
+
+	async getFontProperties({
+		familyName,
+		provider,
+	}: {
+		familyName: string;
+		provider: FontProvider;
+	}): Promise<FontProperties | undefined> {
+		return await this.#providers.get(provider.name)?.getFontProperties?.({ familyName });
 	}
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -865,8 +865,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       unifont:
-        specifier: ~0.7.5
-        version: 0.7.5
+        specifier: ~0.8.1
+        version: 0.8.1
       unstorage:
         specifier: ^1.17.5
         version: 1.17.5(@azure/identity@4.13.0)(@netlify/blobs@10.7.5)(@vercel/functions@3.4.3)
@@ -15296,8 +15296,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -15714,8 +15714,8 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unifont@0.7.5:
-    resolution: {integrity: sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==}
+  unifont@0.8.1:
+    resolution: {integrity: sha512-ePAkMC5/UT/DnM7xiFCvsAxtFdBn/BD6DciPoY6ZzDP9iaIsZmFgBVzoPtX1zOUKtQdBL3JH7voTnogcWVTqYA==}
 
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -25716,7 +25716,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  std-env@4.0.0: {}
+  std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -26159,10 +26159,11 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unifont@0.7.5:
+  unifont@0.8.1:
     dependencies:
       css-tree: 3.1.0
       ohash: 2.0.11
+      std-env: 4.2.0
       undici: 8.10.0
 
   unist-util-find-after@5.0.0:
@@ -26449,7 +26450,7 @@ snapshots:
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.5
-      std-env: 4.0.0
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.17
@@ -26488,7 +26489,7 @@ snapshots:
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.5
-      std-env: 4.0.0
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.17


### PR DESCRIPTION
## Changes

- Warns users when they provide font properties the provider does not support
- This is made possible by a change I contributed to unifont
- This is backward compatible: the new hook is optional and will be required in the next Astro major
- Depends on https://github.com/unjs/unifont/pull/489 (TODO: remove comments, update docs pr version)
- Made with Claude

## Testing

Updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- Changeset
- https://github.com/withastro/docs/pull/14473

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
