### PR TITLE
Add OpenTelemetry instrumentation support to Vercel integration

### DIFF
--- a/.changeset/0000-vercel-instrumentation.md
+++ b/.changeset/0000-vercel-instrumentation.md
@@ -2,4 +2,4 @@
 '@astrojs/vercel': minor
 ---
 
-Adds automatic loading of project instrumentation files and inbound OpenTelemetry context propagation for Vercel serverless functions
+Adds an `instrumentation` option for loading project instrumentation files and propagating inbound OpenTelemetry context in Vercel serverless functions

--- a/.changeset/0000-vercel-instrumentation.md
+++ b/.changeset/0000-vercel-instrumentation.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Adds automatic loading of project instrumentation files and inbound OpenTelemetry context propagation for Vercel serverless functions

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -34,6 +34,10 @@ import {
 } from './lib/web-analytics.js';
 import { generateEdgeMiddleware, type IsrForwarding } from './serverless/middleware.js';
 import { createConfigPlugin } from './vite-plugin-config.js';
+import {
+	createInstrumentationPlugin,
+	findInstrumentationFile,
+} from './vite-plugin-instrumentation.js';
 
 const PACKAGE_NAME = '@astrojs/vercel';
 
@@ -283,6 +287,8 @@ export default function vercelAdapter({
 		name: PACKAGE_NAME,
 		hooks: {
 			'astro:config:setup': async ({ command, config, updateConfig, injectScript, logger }) => {
+				const instrumentationFile = findInstrumentationFile([config.root, config.srcDir]);
+
 				if (webAnalytics?.enabled) {
 					injectScript(
 						'head-inline',
@@ -325,6 +331,7 @@ export default function vercelAdapter({
 								middlewareSecret,
 								skewProtection,
 							}),
+							createInstrumentationPlugin(instrumentationFile),
 						],
 					},
 					...getAstroImageConfig(

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -179,6 +179,9 @@ export interface VercelServerlessConfig {
 	/** Allows you to configure which image service to use in development when imageService is enabled. */
 	devImageService?: DevImageService;
 
+	/** Whether to load an `instrumentation.*` file and propagate inbound OpenTelemetry context in Serverless Functions. */
+	instrumentation?: boolean;
+
 	/**
 	 * Controls when and how middleware executes.
 	 * - 'classic' (default): Middleware runs for prerendered pages at build time, and for SSR pages at request time.
@@ -244,6 +247,7 @@ export default function vercelAdapter({
 	imageService,
 	imagesConfig,
 	devImageService = 'sharp',
+	instrumentation = false,
 	middlewareMode,
 	edgeMiddleware,
 	maxDuration,
@@ -287,7 +291,9 @@ export default function vercelAdapter({
 		name: PACKAGE_NAME,
 		hooks: {
 			'astro:config:setup': async ({ command, config, updateConfig, injectScript, logger }) => {
-				const instrumentationFile = findInstrumentationFile([config.root, config.srcDir]);
+				const instrumentationFile = instrumentation
+					? findInstrumentationFile([config.root, config.srcDir])
+					: undefined;
 
 				if (webAnalytics?.enabled) {
 					injectScript(

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -1,3 +1,4 @@
+import { runWithInboundTraceContext } from 'virtual:astro-vercel:instrumentation';
 import { setGetEnv } from 'astro/env/setup';
 import {
 	ASTRO_LOCALS_HEADER,
@@ -14,72 +15,76 @@ setGetEnv((key) => process.env[key]);
 
 const app = createApp();
 
-export default {
-	async fetch(request: Request): Promise<Response> {
-		const url = new URL(request.url);
-		const middlewareSecretHeader = request.headers.get(ASTRO_MIDDLEWARE_SECRET_HEADER);
-		const hasValidMiddlewareSecret = middlewareSecretHeader === middlewareSecret;
-		let realPath = undefined;
-		if (hasValidMiddlewareSecret) {
-			realPath = request.headers.get(ASTRO_PATH_HEADER);
-		} else if (url.searchParams.get(ASTRO_PATH_TOKEN_PARAM) === middlewareSecret) {
-			// ISR functions only receive the target path via the URL, so the route
-			// rewrite carries the build's path token alongside it. Only honor the
-			// override when that token matches, otherwise the path is ignored and
-			// the request is served as `/_isr`.
-			realPath = url.searchParams.get(ASTRO_PATH_PARAM);
-		}
-		if (typeof realPath === 'string') {
-			// The header carries the client's whole path, query included; the route
-			// rewrite carries only the pathname and leaves the query on this request.
-			const target = new URL(realPath, url);
-			const search = target.search || url.search;
-			url.pathname = target.pathname;
-			url.search = search;
-			// Remove the internal routing params so they never reach user code.
-			url.searchParams.delete(ASTRO_PATH_PARAM);
-			url.searchParams.delete(ASTRO_PATH_TOKEN_PARAM);
-			request = new Request(url.toString(), {
-				method: request.method,
-				headers: request.headers,
-				...(request.body ? { body: request.body, duplex: 'half' } : {}),
-			});
-		}
-
-		const routeData = app.match(request);
-
-		let locals: Record<string, unknown> = {};
-
-		const astroLocalsHeader = request.headers.get(ASTRO_LOCALS_HEADER);
-		if (astroLocalsHeader) {
-			if (!hasValidMiddlewareSecret) {
-				return new Response('Forbidden', { status: 403 });
-			}
-			locals = JSON.parse(astroLocalsHeader);
-		}
-
-		// hide the secret from the rest of user code
-		if (hasValidMiddlewareSecret) {
-			request.headers.delete(ASTRO_MIDDLEWARE_SECRET_HEADER);
-		}
-
-		// https://vercel.com/docs/deployments/skew-protection#supported-frameworks
-		if (skewProtection && process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1') {
-			request.headers.set('x-deployment-id', process.env.VERCEL_DEPLOYMENT_ID!);
-		}
-
-		const response = await app.render(request, {
-			routeData,
-			clientAddress: getClientIpAddress(request),
-			locals,
+async function handleRequest(request: Request): Promise<Response> {
+	const url = new URL(request.url);
+	const middlewareSecretHeader = request.headers.get(ASTRO_MIDDLEWARE_SECRET_HEADER);
+	const hasValidMiddlewareSecret = middlewareSecretHeader === middlewareSecret;
+	let realPath = undefined;
+	if (hasValidMiddlewareSecret) {
+		realPath = request.headers.get(ASTRO_PATH_HEADER);
+	} else if (url.searchParams.get(ASTRO_PATH_TOKEN_PARAM) === middlewareSecret) {
+		// ISR functions only receive the target path via the URL, so the route
+		// rewrite carries the build's path token alongside it. Only honor the
+		// override when that token matches, otherwise the path is ignored and
+		// the request is served as `/_isr`.
+		realPath = url.searchParams.get(ASTRO_PATH_PARAM);
+	}
+	if (typeof realPath === 'string') {
+		// The header carries the client's whole path, query included; the route
+		// rewrite carries only the pathname and leaves the query on this request.
+		const target = new URL(realPath, url);
+		const search = target.search || url.search;
+		url.pathname = target.pathname;
+		url.search = search;
+		// Remove the internal routing params so they never reach user code.
+		url.searchParams.delete(ASTRO_PATH_PARAM);
+		url.searchParams.delete(ASTRO_PATH_TOKEN_PARAM);
+		request = new Request(url.toString(), {
+			method: request.method,
+			headers: request.headers,
+			...(request.body ? { body: request.body, duplex: 'half' } : {}),
 		});
+	}
 
-		if (app.setCookieHeaders) {
-			for (const setCookieHeader of app.setCookieHeaders(response)) {
-				response.headers.append('Set-Cookie', setCookieHeader);
-			}
+	const routeData = app.match(request);
+
+	let locals: Record<string, unknown> = {};
+
+	const astroLocalsHeader = request.headers.get(ASTRO_LOCALS_HEADER);
+	if (astroLocalsHeader) {
+		if (!hasValidMiddlewareSecret) {
+			return new Response('Forbidden', { status: 403 });
 		}
+		locals = JSON.parse(astroLocalsHeader);
+	}
 
-		return response;
+	// hide the secret from the rest of user code
+	if (hasValidMiddlewareSecret) {
+		request.headers.delete(ASTRO_MIDDLEWARE_SECRET_HEADER);
+	}
+
+	// https://vercel.com/docs/deployments/skew-protection#supported-frameworks
+	if (skewProtection && process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1') {
+		request.headers.set('x-deployment-id', process.env.VERCEL_DEPLOYMENT_ID!);
+	}
+
+	const response = await app.render(request, {
+		routeData,
+		clientAddress: getClientIpAddress(request),
+		locals,
+	});
+
+	if (app.setCookieHeaders) {
+		for (const setCookieHeader of app.setCookieHeaders(response)) {
+			response.headers.append('Set-Cookie', setCookieHeader);
+		}
+	}
+
+	return response;
+}
+
+export default {
+	fetch(request: Request): Promise<Response> {
+		return runWithInboundTraceContext(request.headers, () => handleRequest(request));
 	},
 };

--- a/packages/integrations/vercel/src/vite-plugin-instrumentation.ts
+++ b/packages/integrations/vercel/src/vite-plugin-instrumentation.ts
@@ -1,0 +1,78 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { AstroError } from 'astro/errors';
+import type { PluginOption } from 'vite';
+
+const VIRTUAL_INSTRUMENTATION_ID = 'virtual:astro-vercel:instrumentation';
+const RESOLVED_VIRTUAL_INSTRUMENTATION_ID = `\0${VIRTUAL_INSTRUMENTATION_ID}`;
+const INSTRUMENTATION_FILES = [
+	'instrumentation.ts',
+	'instrumentation.js',
+	'instrumentation.mts',
+	'instrumentation.mjs',
+];
+
+export function findInstrumentationFile(
+	directories: URL[],
+	fileExists: (file: URL) => boolean = existsSync,
+): URL | undefined {
+	const uniqueDirectories = [
+		...new Map(directories.map((directory) => [directory.href, directory])).values(),
+	];
+	const files = uniqueDirectories
+		.flatMap((directory) => INSTRUMENTATION_FILES.map((file) => new URL(file, directory)))
+		.filter(fileExists);
+
+	if (files.length > 1) {
+		throw new AstroError(
+			`Multiple instrumentation files found:\n${files.map((file) => fileURLToPath(file)).join('\n')}`,
+			'Keep only one instrumentation file in the Astro project root or source directory.',
+		);
+	}
+
+	return files[0];
+}
+
+export function createInstrumentationModule(instrumentationFile?: URL): string {
+	if (!instrumentationFile) {
+		return `export function runWithInboundTraceContext(_headers, callback) {
+	return callback();
+}`;
+	}
+
+	return `import { register } from ${JSON.stringify(fileURLToPath(instrumentationFile))};
+import { context, propagation } from '@opentelemetry/api';
+
+await register();
+
+export function runWithInboundTraceContext(headers, callback) {
+	const extractedContext = propagation.extract(
+		context.active(),
+		Object.fromEntries(headers.entries()),
+	);
+
+	return context.with(extractedContext, callback);
+}`;
+}
+
+export function createInstrumentationPlugin(instrumentationFile?: URL): PluginOption {
+	return {
+		name: VIRTUAL_INSTRUMENTATION_ID,
+		resolveId: {
+			filter: {
+				id: new RegExp(`^${VIRTUAL_INSTRUMENTATION_ID}$`),
+			},
+			handler() {
+				return RESOLVED_VIRTUAL_INSTRUMENTATION_ID;
+			},
+		},
+		load: {
+			filter: {
+				id: new RegExp(`^${RESOLVED_VIRTUAL_INSTRUMENTATION_ID}$`),
+			},
+			handler() {
+				return createInstrumentationModule(instrumentationFile);
+			},
+		},
+	};
+}

--- a/packages/integrations/vercel/test/fixtures/instrumentation-disabled/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-disabled/astro.config.mjs
@@ -2,12 +2,6 @@ import vercel from '@astrojs/vercel';
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-	adapter: vercel({
-		instrumentation: true,
-		isr: {
-			exclude: ['/api/context'],
-			expiration: 60,
-		},
-	}),
+	adapter: vercel(),
 	output: 'server',
 });

--- a/packages/integrations/vercel/test/fixtures/instrumentation-disabled/instrumentation.ts
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-disabled/instrumentation.ts
@@ -1,0 +1,1 @@
+throw new Error('Disabled instrumentation file was loaded');

--- a/packages/integrations/vercel/test/fixtures/instrumentation-disabled/package.json
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-disabled/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-vercel-instrumentation-disabled",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/instrumentation-disabled/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-disabled/src/pages/index.astro
@@ -1,0 +1,1 @@
+Instrumentation disabled

--- a/packages/integrations/vercel/test/fixtures/instrumentation-error/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-error/astro.config.mjs
@@ -2,12 +2,6 @@ import vercel from '@astrojs/vercel';
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-	adapter: vercel({
-		instrumentation: true,
-		isr: {
-			exclude: ['/api/context'],
-			expiration: 60,
-		},
-	}),
+	adapter: vercel({ instrumentation: true }),
 	output: 'server',
 });

--- a/packages/integrations/vercel/test/fixtures/instrumentation-error/package.json
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-error/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/astro-vercel-instrumentation-error",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/instrumentation-error/src/instrumentation.ts
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-error/src/instrumentation.ts
@@ -1,0 +1,4 @@
+export async function register() {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	throw new Error('Instrumentation registration failed');
+}

--- a/packages/integrations/vercel/test/fixtures/instrumentation-error/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/instrumentation-error/src/pages/index.astro
@@ -1,0 +1,1 @@
+Instrumentation error

--- a/packages/integrations/vercel/test/fixtures/instrumentation/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/instrumentation/astro.config.mjs
@@ -1,0 +1,12 @@
+import vercel from '@astrojs/vercel';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	adapter: vercel({
+		isr: {
+			exclude: ['/api/context'],
+			expiration: 60,
+		},
+	}),
+	output: 'server',
+});

--- a/packages/integrations/vercel/test/fixtures/instrumentation/package.json
+++ b/packages/integrations/vercel/test/fixtures/instrumentation/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@test/astro-vercel-instrumentation",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-async-hooks": "^2.7.1",
+    "@opentelemetry/core": "^2.7.1",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/instrumentation/src/context-response.ts
+++ b/packages/integrations/vercel/test/fixtures/instrumentation/src/context-response.ts
@@ -1,0 +1,15 @@
+import { context, trace } from '@opentelemetry/api';
+
+export async function contextResponse(): Promise<Response> {
+	const beforeAwait = trace.getSpanContext(context.active());
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	const afterAwait = trace.getSpanContext(context.active());
+
+	return Response.json({
+		contextSurvivedAwait:
+			beforeAwait?.traceId === afterAwait?.traceId && beforeAwait?.spanId === afterAwait?.spanId,
+		instrumentationRuns: globalThis.astroVercelInstrumentationRuns,
+		spanId: afterAwait?.spanId,
+		traceId: afterAwait?.traceId,
+	});
+}

--- a/packages/integrations/vercel/test/fixtures/instrumentation/src/instrumentation.ts
+++ b/packages/integrations/vercel/test/fixtures/instrumentation/src/instrumentation.ts
@@ -1,0 +1,24 @@
+import { context, propagation } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+
+declare global {
+	var astroVercelInstrumentationRuns: number | undefined;
+	var resetAstroVercelOpenTelemetry: (() => void) | undefined;
+}
+
+export async function register() {
+	await Promise.resolve();
+
+	globalThis.astroVercelInstrumentationRuns =
+		(globalThis.astroVercelInstrumentationRuns ?? 0) + 1;
+
+	context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+	propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+
+	globalThis.resetAstroVercelOpenTelemetry = () => {
+		context.disable();
+		propagation.disable();
+		globalThis.astroVercelInstrumentationRuns = undefined;
+	};
+}

--- a/packages/integrations/vercel/test/fixtures/instrumentation/src/instrumentation.ts
+++ b/packages/integrations/vercel/test/fixtures/instrumentation/src/instrumentation.ts
@@ -4,11 +4,14 @@ import { W3CTraceContextPropagator } from '@opentelemetry/core';
 
 declare global {
 	var astroVercelInstrumentationRuns: number | undefined;
+	var notifyAstroVercelInstrumentationStarted: (() => void) | undefined;
 	var resetAstroVercelOpenTelemetry: (() => void) | undefined;
+	var waitForAstroVercelInstrumentation: Promise<void> | undefined;
 }
 
 export async function register() {
-	await Promise.resolve();
+	globalThis.notifyAstroVercelInstrumentationStarted?.();
+	await globalThis.waitForAstroVercelInstrumentation;
 
 	globalThis.astroVercelInstrumentationRuns =
 		(globalThis.astroVercelInstrumentationRuns ?? 0) + 1;

--- a/packages/integrations/vercel/test/fixtures/instrumentation/src/pages/api/context.ts
+++ b/packages/integrations/vercel/test/fixtures/instrumentation/src/pages/api/context.ts
@@ -1,0 +1,6 @@
+import type { APIRoute } from 'astro';
+import { contextResponse } from '../../context-response';
+
+export const prerender = false;
+
+export const GET: APIRoute = contextResponse;

--- a/packages/integrations/vercel/test/fixtures/instrumentation/src/pages/cached.ts
+++ b/packages/integrations/vercel/test/fixtures/instrumentation/src/pages/cached.ts
@@ -1,0 +1,6 @@
+import type { APIRoute } from 'astro';
+import { contextResponse } from '../context-response';
+
+export const prerender = false;
+
+export const GET: APIRoute = contextResponse;

--- a/packages/integrations/vercel/test/instrumentation.test.ts
+++ b/packages/integrations/vercel/test/instrumentation.test.ts
@@ -2,13 +2,22 @@ import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import { type Fixture, loadFixture } from './test-utils.ts';
 
-const traceId = '0af7651916cd43dd8448eb211c80319c';
-const spanId = 'b7ad6b7169203331';
-const traceparent = `00-${traceId}-${spanId}-01`;
+const traceContexts = [
+	{
+		spanId: 'b7ad6b7169203331',
+		traceId: '0af7651916cd43dd8448eb211c80319c',
+	},
+	{
+		spanId: 'c7ad6b7169203332',
+		traceId: '1af7651916cd43dd8448eb211c80319d',
+	},
+];
 
 declare global {
 	var astroVercelInstrumentationRuns: number | undefined;
+	var notifyAstroVercelInstrumentationStarted: (() => void) | undefined;
 	var resetAstroVercelOpenTelemetry: (() => void) | undefined;
+	var waitForAstroVercelInstrumentation: Promise<void> | undefined;
 }
 
 describe('instrumentation', () => {
@@ -25,17 +34,44 @@ describe('instrumentation', () => {
 		globalThis.resetAstroVercelOpenTelemetry?.();
 	});
 
+	async function getFunctionEntry(functionFixture: Fixture, name: '_render' | '_isr') {
+		const functionConfig = JSON.parse(
+			await functionFixture.readFile(`../.vercel/output/functions/${name}.func/.vc-config.json`),
+		);
+		return new URL(
+			`../.vercel/output/functions/${name}.func/${functionConfig.handler}`,
+			functionFixture.config.outDir,
+		);
+	}
+
 	async function loadFunction(name: '_render' | '_isr') {
 		globalThis.resetAstroVercelOpenTelemetry?.();
-		const functionConfig = JSON.parse(
-			await fixture.readFile(`../.vercel/output/functions/${name}.func/.vc-config.json`),
-		);
-		const functionEntry = new URL(
-			`../.vercel/output/functions/${name}.func/${functionConfig.handler}`,
-			fixture.config.outDir,
-		);
+		const functionEntry = await getFunctionEntry(fixture, name);
 
-		return import(`${functionEntry.href}?function=${name}`);
+		let notifyStarted: () => void;
+		const registrationStarted = new Promise<void>((resolve) => {
+			notifyStarted = resolve;
+		});
+		let releaseRegistration: () => void;
+		globalThis.waitForAstroVercelInstrumentation = new Promise<void>((resolve) => {
+			releaseRegistration = resolve;
+		});
+		globalThis.notifyAstroVercelInstrumentationStarted = notifyStarted!;
+
+		let importFinished = false;
+		const functionImport = import(`${functionEntry.href}?function=${name}`).then((module) => {
+			importFinished = true;
+			return module;
+		});
+		await registrationStarted;
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(importFinished, false);
+
+		releaseRegistration!();
+		const serverlessFunction = await functionImport;
+		globalThis.notifyAstroVercelInstrumentationStarted = undefined;
+		globalThis.waitForAstroVercelInstrumentation = undefined;
+		return serverlessFunction;
 	}
 
 	async function expectTraceContext(
@@ -43,12 +79,15 @@ describe('instrumentation', () => {
 		url: string,
 	) {
 		const responses = await Promise.all(
-			Array.from({ length: 2 }, () =>
-				serverlessFunction.default.fetch(new Request(url, { headers: { traceparent } })),
+			traceContexts.map(({ spanId, traceId }) =>
+				serverlessFunction.default.fetch(
+					new Request(url, { headers: { traceparent: `00-${traceId}-${spanId}-01` } }),
+				),
 			),
 		);
 
-		for (const response of responses) {
+		for (const [index, response] of responses.entries()) {
+			const { spanId, traceId } = traceContexts[index]!;
 			assert.equal(response.status, 200);
 			assert.deepEqual(await response.json(), {
 				contextSurvivedAwait: true,
@@ -79,6 +118,33 @@ describe('instrumentation', () => {
 		await expectTraceContext(
 			isrFunction,
 			`https://example.com/_isr?x_astro_path=/cached&x_astro_path_token=${pathToken}`,
+		);
+	});
+
+	it('ignores instrumentation files unless enabled', async () => {
+		const disabledFixture = await loadFixture({
+			root: './fixtures/instrumentation-disabled/',
+		});
+		await disabledFixture.build({});
+		const functionEntry = await getFunctionEntry(disabledFixture, '_render');
+		const serverlessFunction = await import(`${functionEntry.href}?instrumentation=disabled`);
+
+		const response = await serverlessFunction.default.fetch(new Request('https://example.com/'));
+
+		assert.equal(response.status, 200);
+		assert.match(await response.text(), /Instrumentation disabled/);
+	});
+
+	it('rejects function initialization when registration fails', async () => {
+		const errorFixture = await loadFixture({
+			root: './fixtures/instrumentation-error/',
+		});
+		await errorFixture.build({});
+		const functionEntry = await getFunctionEntry(errorFixture, '_render');
+
+		await assert.rejects(
+			import(`${functionEntry.href}?instrumentation=error`),
+			/Instrumentation registration failed/,
 		);
 	});
 });

--- a/packages/integrations/vercel/test/instrumentation.test.ts
+++ b/packages/integrations/vercel/test/instrumentation.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { type Fixture, loadFixture } from './test-utils.ts';
+
+const traceId = '0af7651916cd43dd8448eb211c80319c';
+const spanId = 'b7ad6b7169203331';
+const traceparent = `00-${traceId}-${spanId}-01`;
+
+declare global {
+	var astroVercelInstrumentationRuns: number | undefined;
+	var resetAstroVercelOpenTelemetry: (() => void) | undefined;
+}
+
+describe('instrumentation', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/instrumentation/',
+		});
+		await fixture.build({});
+	});
+
+	after(() => {
+		globalThis.resetAstroVercelOpenTelemetry?.();
+	});
+
+	async function loadFunction(name: '_render' | '_isr') {
+		globalThis.resetAstroVercelOpenTelemetry?.();
+		const functionConfig = JSON.parse(
+			await fixture.readFile(`../.vercel/output/functions/${name}.func/.vc-config.json`),
+		);
+		const functionEntry = new URL(
+			`../.vercel/output/functions/${name}.func/${functionConfig.handler}`,
+			fixture.config.outDir,
+		);
+
+		return import(`${functionEntry.href}?function=${name}`);
+	}
+
+	async function expectTraceContext(
+		serverlessFunction: { default: { fetch(request: Request): Promise<Response> } },
+		url: string,
+	) {
+		const responses = await Promise.all(
+			Array.from({ length: 2 }, () =>
+				serverlessFunction.default.fetch(new Request(url, { headers: { traceparent } })),
+			),
+		);
+
+		for (const response of responses) {
+			assert.equal(response.status, 200);
+			assert.deepEqual(await response.json(), {
+				contextSurvivedAwait: true,
+				instrumentationRuns: 1,
+				spanId,
+				traceId,
+			});
+		}
+	}
+
+	it('loads instrumentation and propagates context through _render', async () => {
+		const renderFunction = await loadFunction('_render');
+
+		await expectTraceContext(renderFunction, 'https://example.com/api/context');
+	});
+
+	it('loads instrumentation and propagates context through _isr', async () => {
+		const isrFunction = await loadFunction('_isr');
+		const deploymentConfig = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
+		const isrRoute = deploymentConfig.routes.find(
+			(route: { dest?: string }) =>
+				typeof route.dest === 'string' && route.dest.startsWith('/_isr?'),
+		);
+		const pathToken = new URL(isrRoute.dest, 'https://example.com').searchParams.get(
+			'x_astro_path_token',
+		);
+
+		await expectTraceContext(
+			isrFunction,
+			`https://example.com/_isr?x_astro_path=/cached&x_astro_path_token=${pathToken}`,
+		);
+	});
+});

--- a/packages/integrations/vercel/test/units/instrumentation.test.ts
+++ b/packages/integrations/vercel/test/units/instrumentation.test.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
 	createInstrumentationModule,
 	findInstrumentationFile,
 } from '../../dist/vite-plugin-instrumentation.js';
+
+const projectRoot = new URL('./fixtures/project/', import.meta.url);
 
 describe('instrumentation', () => {
 	it('uses a pass-through module when no instrumentation file exists', () => {
@@ -14,10 +17,13 @@ describe('instrumentation', () => {
 	});
 
 	it('awaits instrumentation registration before the context helper', () => {
-		const instrumentationFile = new URL('file:///project/instrumentation.ts');
+		const instrumentationFile = new URL('instrumentation.ts', projectRoot);
 		const module = createInstrumentationModule(instrumentationFile);
 
-		assert.match(module, /^import \{ register \} from "\/project\/instrumentation\.ts";/);
+		assert.equal(
+			module.split('\n', 1)[0],
+			`import { register } from ${JSON.stringify(fileURLToPath(instrumentationFile))};`,
+		);
 		assert.match(module, /from '@opentelemetry\/api'/);
 		assert.match(module, /await register\(\);/);
 		assert.match(module, /propagation\.extract/);
@@ -25,19 +31,20 @@ describe('instrumentation', () => {
 	});
 
 	it('finds one supported instrumentation file in the root or source directory', () => {
-		const root = new URL('file:///project/');
-		const srcDir = new URL('source/', root);
-		const rootInstrumentationFile = new URL('instrumentation.ts', root);
+		const srcDir = new URL('source/', projectRoot);
+		const rootInstrumentationFile = new URL('instrumentation.ts', projectRoot);
 		const sourceInstrumentationFile = new URL('instrumentation.mjs', srcDir);
 
 		assert.equal(
-			findInstrumentationFile([root, srcDir], (file) => file.href === rootInstrumentationFile.href)
-				?.href,
+			findInstrumentationFile(
+				[projectRoot, srcDir],
+				(file) => file.href === rootInstrumentationFile.href,
+			)?.href,
 			rootInstrumentationFile.href,
 		);
 		assert.equal(
 			findInstrumentationFile(
-				[root, srcDir],
+				[projectRoot, srcDir],
 				(file) => file.href === sourceInstrumentationFile.href,
 			)?.href,
 			sourceInstrumentationFile.href,
@@ -45,15 +52,14 @@ describe('instrumentation', () => {
 	});
 
 	it('rejects multiple instrumentation files', () => {
-		const root = new URL('file:///project/');
-		const srcDir = new URL('src/', root);
+		const srcDir = new URL('src/', projectRoot);
 		const files = new Set([
-			new URL('instrumentation.ts', root).href,
+			new URL('instrumentation.ts', projectRoot).href,
 			new URL('instrumentation.mjs', srcDir).href,
 		]);
 
 		assert.throws(
-			() => findInstrumentationFile([root, srcDir], (file) => files.has(file.href)),
+			() => findInstrumentationFile([projectRoot, srcDir], (file) => files.has(file.href)),
 			/instrumentation\.ts[\s\S]*instrumentation\.mjs/,
 		);
 	});

--- a/packages/integrations/vercel/test/units/instrumentation.test.ts
+++ b/packages/integrations/vercel/test/units/instrumentation.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	createInstrumentationModule,
+	findInstrumentationFile,
+} from '../../dist/vite-plugin-instrumentation.js';
+
+describe('instrumentation', () => {
+	it('uses a pass-through module when no instrumentation file exists', () => {
+		const module = createInstrumentationModule();
+
+		assert.doesNotMatch(module, /opentelemetry/);
+		assert.match(module, /return callback\(\)/);
+	});
+
+	it('awaits instrumentation registration before the context helper', () => {
+		const instrumentationFile = new URL('file:///project/instrumentation.ts');
+		const module = createInstrumentationModule(instrumentationFile);
+
+		assert.match(module, /^import \{ register \} from "\/project\/instrumentation\.ts";/);
+		assert.match(module, /from '@opentelemetry\/api'/);
+		assert.match(module, /await register\(\);/);
+		assert.match(module, /propagation\.extract/);
+		assert.match(module, /context\.with/);
+	});
+
+	it('finds one supported instrumentation file in the root or source directory', () => {
+		const root = new URL('file:///project/');
+		const srcDir = new URL('source/', root);
+		const rootInstrumentationFile = new URL('instrumentation.ts', root);
+		const sourceInstrumentationFile = new URL('instrumentation.mjs', srcDir);
+
+		assert.equal(
+			findInstrumentationFile([root, srcDir], (file) => file.href === rootInstrumentationFile.href)
+				?.href,
+			rootInstrumentationFile.href,
+		);
+		assert.equal(
+			findInstrumentationFile(
+				[root, srcDir],
+				(file) => file.href === sourceInstrumentationFile.href,
+			)?.href,
+			sourceInstrumentationFile.href,
+		);
+	});
+
+	it('rejects multiple instrumentation files', () => {
+		const root = new URL('file:///project/');
+		const srcDir = new URL('src/', root);
+		const files = new Set([
+			new URL('instrumentation.ts', root).href,
+			new URL('instrumentation.mjs', srcDir).href,
+		]);
+
+		assert.throws(
+			() => findInstrumentationFile([root, srcDir], (file) => files.has(file.href)),
+			/instrumentation\.ts[\s\S]*instrumentation\.mjs/,
+		);
+	});
+});

--- a/packages/integrations/vercel/virtual.d.ts
+++ b/packages/integrations/vercel/virtual.d.ts
@@ -4,3 +4,7 @@ declare module 'virtual:astro-vercel:config' {
 	const config: import('./src/vite-plugin-config.js').Config;
 	export = config;
 }
+
+declare module 'virtual:astro-vercel:instrumentation' {
+	export function runWithInboundTraceContext<T>(headers: Headers, callback: () => T): T;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6362,6 +6362,24 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/instrumentation:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.0)
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/integration-assets:
     dependencies:
       '@astrojs/sitemap':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6380,6 +6380,27 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/instrumentation-disabled:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
+  packages/integrations/vercel/test/fixtures/instrumentation-error:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/integration-assets:
     dependencies:
       '@astrojs/sitemap':


### PR DESCRIPTION
## Problem

- `@astrojs/vercel` serverless functions cannot initialize application instrumentation or continue inbound OpenTelemetry trace context.
- Automatic discovery could unexpectedly load an existing `instrumentation.*` file.

## Solution

- Add an opt-in `instrumentation` adapter option. When enabled, discover `instrumentation.*` in the project root or source directory and await `register()` during function startup.
- Run `_render` and `_isr` requests inside the extracted trace context. The app supplies OpenTelemetry, so the adapter remains dependency-free.

## Testing

- Cover default-off behavior, awaited and rejected registration, and distinct concurrent trace contexts through `_render` and `_isr`.

## Docs

- Follow-up needed for the adapter option, file convention, and application-owned OpenTelemetry dependency.
