### PR TITLE
fix(manifest): strip dead prerendered route styles in SSR manifest generation

### DIFF
--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -163,7 +163,7 @@ function injectManifest(manifest: SerializedSSRManifest, code: string) {
  * the prerendered HTML on disk already contains the `<style>` tags, and the
  * SSR worker never renders these routes.
  */
-function stripPrerenderedRouteStyles(manifest: SerializedSSRManifest): SerializedSSRManifest {
+export function stripPrerenderedRouteStyles(manifest: SerializedSSRManifest): SerializedSSRManifest {
 	let stripped = false;
 	const routes = manifest.routes.map((route) => {
 		if (!route.routeData.prerender || route.styles.length === 0) return route;

--- a/packages/astro/test/units/manifest/strip-prerendered-styles.test.ts
+++ b/packages/astro/test/units/manifest/strip-prerendered-styles.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { stripPrerenderedRouteStyles } from '../../../src/core/build/plugins/plugin-manifest.ts';
+import type { SerializedSSRManifest } from '../../../src/core/app/types.ts';
+
+describe('manifest - stripPrerenderedRouteStyles', () => {
+	it('strips styles from prerendered routes in SSR manifest while preserving on-demand styles', () => {
+		const mockManifest: Partial<SerializedSSRManifest> = {
+			routes: [
+				{
+					file: 'src/pages/index.astro',
+					links: [],
+					scripts: [],
+					styles: ['inline-style-1', 'inline-style-2'],
+					routeData: {
+						prerender: true,
+						route: '/',
+						component: 'src/pages/index.astro',
+					} as any,
+				},
+				{
+					file: 'src/pages/api.astro',
+					links: [],
+					scripts: [],
+					styles: ['ssr-style-1'],
+					routeData: {
+						prerender: false,
+						route: '/api',
+						component: 'src/pages/api.astro',
+					} as any,
+				},
+			],
+		};
+
+		const result = stripPrerenderedRouteStyles(mockManifest as SerializedSSRManifest);
+		assert.equal(result.routes[0].styles.length, 0, 'prerendered route styles should be empty');
+		assert.equal(result.routes[1].styles.length, 1, 'SSR route styles should be preserved');
+		assert.equal(result.routes[1].styles[0], 'ssr-style-1');
+	});
+});


### PR DESCRIPTION
## Description
Prunes dead inline CSS styles for prerendered routes in the SSR manifest (`stripPrerenderedRouteStyles`), keeping the entry chunk small on platforms like Cloudflare Workers and SSR runtimes that re-parse manifests on cold starts.

Fixes #17838
