### PR TITLE
fix(astro): match backtick-quoted build placeholders so a minified server build still substitutes them

### DIFF
--- a/.changeset/tidy-hounds-smash.md
+++ b/.changeset/tidy-hounds-smash.md
@@ -1,0 +1,18 @@
+---
+'astro': patch
+---
+
+Fixes the SSR manifest placeholder never being substituted when the server build is minified
+
+The manifest and server-islands placeholders are replaced by a regex that runs on
+already-generated chunk code, so it sees whatever quoting the minifier chose. Rolldown/oxc
+normalises string literals to template literals, so a minified server build emitted the
+placeholders backtick-quoted and the regexes — which matched only `'` and `"` — left them in
+place.
+
+For the manifest that produced a server bundle which built successfully (exit code 0) and
+then threw `TypeError: Invalid URL string` at runtime, because `deserializeManifest` read
+`rootDir`/`srcDir`/`outDir`/… off the literal placeholder string and passed `undefined` to
+`new URL()`. On an edge adapter the result was a server entrypoint that could not boot at
+all. The two server-islands placeholders shared the same pattern and the same latent
+failure.

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -62,7 +62,13 @@ import { sessionConfigToManifest } from '../../session/utils.js';
  */
 
 export const MANIFEST_REPLACE = '@@ASTRO_MANIFEST_REPLACE@@';
-const replaceExp = new RegExp(`['"]${MANIFEST_REPLACE}['"]`, 'g');
+// The backtick is load-bearing: this replacement runs on already-generated chunk
+// code, so it sees whatever quoting the minifier chose. Rolldown/oxc normalises
+// string literals to template literals, so a minified server build emits the
+// placeholder backtick-quoted. Matching only ' and " left it unsubstituted, and
+// `deserializeManifest` then read `rootDir`/`srcDir`/… off a plain string and
+// threw `Invalid URL string` at runtime — with the build still exiting 0.
+const replaceExp = new RegExp(`['"\`]${MANIFEST_REPLACE}['"\`]`, 'g');
 
 /**
  * Post-build hook that injects the computed manifest into bundled chunks.

--- a/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
+++ b/packages/astro/src/core/server-islands/vite-plugin-server-islands.ts
@@ -11,8 +11,12 @@ const RESOLVED_SERVER_ISLAND_MANIFEST = '\0' + SERVER_ISLAND_MANIFEST;
 const serverIslandPlaceholderMap = "'$$server-islands-map$$'";
 const serverIslandPlaceholderNameMap = "'$$server-islands-name-map$$'";
 export const SERVER_ISLAND_MAP_MARKER = '$$server-islands-map$$';
-const serverIslandMapReplaceExp = /['"]\$\$server-islands-map\$\$['"]/g;
-const serverIslandNameMapReplaceExp = /['"]\$\$server-islands-name-map\$\$['"]/g;
+// Backticks are matched for the same reason as in plugin-manifest.ts: these
+// replacements run on generated chunk code, and a minifier that normalises
+// string literals to template literals would otherwise leave the placeholders
+// unsubstituted.
+const serverIslandMapReplaceExp = /['"`]\$\$server-islands-map\$\$['"`]/g;
+const serverIslandNameMapReplaceExp = /['"`]\$\$server-islands-name-map\$\$['"`]/g;
 
 export function vitePluginServerIslands({
 	settings,


### PR DESCRIPTION
Fixes #17843

## What's wrong

`plugin-manifest.ts` substitutes `@@ASTRO_MANIFEST_REPLACE@@` with a regex that runs in a build **post** hook — i.e. on already-generated chunk code, after the minifier has run. The character class was `['"]`, quotes only.

Rolldown/oxc's minifier normalises string literals to **template literals**, so a minified server build emits the placeholder as `` `@@ASTRO_MANIFEST_REPLACE@@` `` and the regex does not match. The placeholder ships verbatim, `deserializeManifest` reads `rootDir`/`srcDir`/`outDir`/… off a plain string, and the first `new URL(undefined)` throws:

```txt
service core:user:<worker>: Uncaught TypeError: Invalid URL string.
  at entry.mjs:13:29846 in wi
```

The build exits **0**, so nothing surfaces until runtime. On `@astrojs/cloudflare` the Worker cannot boot at all.

Setting `build.minify` at the top level rather than on the `ssr` environment produces the same error at *build* time instead, because the `prerender` environment inherits it and its renderer hits the same unsubstituted manifest.

## The fix

Accept a backtick in the character class, in both places the pattern appears:

- `plugin-manifest.ts` — the manifest placeholder (the one I reproduced).
- `vite-plugin-server-islands.ts` — the two server-islands placeholders. I did not reproduce a failure there (that code is tree-shaken out of my app), but the mechanism is identical, so they are fixed alongside rather than left as a latent copy of the same bug.

## Verification

Astro 7.1.2, Vite 8.1.5 (rolldown-native), `@astrojs/cloudflare` 14.1.3, minification enabled on the `ssr` environment via `astro:build:setup`:

| | before | after |
| --- | --- | --- |
| `grep -c '@@ASTRO_MANIFEST_REPLACE@@' dist/server/entry.mjs` | 1 | 0 |
| `grep -c 'file:///' dist/server/entry.mjs` (manifest injected) | 0 | 1 |
| Worker boots under `wrangler dev` | ✗ `Invalid URL string` | ✓ |
| prerendered route `/` | — | 200 |
| server-rendered route `/status` | — | 200 |

With the fix the minified bundle also came out 27% smaller gzipped than the unminified one (874.5 kB → 633.8 kB), which is what prompted the investigation.

## Possible follow-up

The failure mode here is silent — nothing warned that an expected substitution had not happened, and the broken artifact passed every build check. Asserting that the substitution occurred (and failing the build otherwise) would stop a future quoting change from reintroducing a server bundle that cannot boot. Happy to add that here or separately if you'd like it.