### PR TITLE
fix(astro): type .html imports outside of .astro files

### DIFF
--- a/.changeset/brave-otters-search.md
+++ b/.changeset/brave-otters-search.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes importing `.html` files not being typed outside of `.astro` files

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -282,6 +282,11 @@ declare module '*.mdx' {
 	export default load;
 }
 
+declare module '*.html' {
+	const Component: (opts?: { slots?: Record<string, string> }) => string;
+	export default Component;
+}
+
 declare module 'astro:static-paths' {
 	export const StaticPaths: typeof import('./dist/runtime/prerender/static-paths.js').StaticPaths;
 }

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -16,8 +16,3 @@ type Astro = import('./dist/types/public/context.js').AstroGlobal;
 declare const Astro: Readonly<Astro>;
 
 declare const Fragment: any;
-
-declare module '*.html' {
-	const Component: (opts?: { slots?: Record<string, string> }) => string;
-	export default Component;
-}


### PR DESCRIPTION
## Changes

You can in theory import HTML files inside .ts files, re-export them, use them inside Astro files etc. Found while messing around with content mappers.

## Testing

Tested manually

## Docs

N/A