### PR TITLE
Fix first-request Cloudflare SSR with JSON logging

### DIFF
--- a/.changeset/nine-streets-retire.md
+++ b/.changeset/nine-streets-retire.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes React SSR failures on the first Cloudflare dev request when JSON logging is enabled

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -359,6 +359,9 @@ export default function createIntegration({
 													...(prebundleContentRuntime ? (['astro/content/runtime'] as const) : []),
 													'astro/compiler-runtime',
 													'astro/jsx-runtime',
+													...(config.logger?.entrypoint === 'astro/logger/json'
+														? ['astro/logger/json']
+														: []),
 													'astro/app/entrypoint/dev',
 													'astro/middleware',
 													'astro/virtual-modules/middleware.js',

--- a/packages/integrations/cloudflare/test/typegen-phase.test.ts
+++ b/packages/integrations/cloudflare/test/typegen-phase.test.ts
@@ -17,7 +17,10 @@ interface OptimizeDepsPatch {
 	optimizeDeps?: { noDiscovery?: boolean; include?: string[]; exclude?: string[] };
 }
 
-async function runConfigSetup(command: 'dev' | 'build' | 'sync') {
+async function runConfigSetup(
+	command: 'dev' | 'build' | 'sync',
+	loggerConfig?: { entrypoint: string },
+) {
 	const integration = cloudflare();
 	let updatedConfig: { vite: { plugins: unknown[] } } | undefined;
 
@@ -31,6 +34,7 @@ async function runConfigSetup(command: 'dev' | 'build' | 'sync') {
 			experimental: {},
 			vite: {},
 			image: {},
+			logger: loggerConfig,
 		},
 		updateConfig(config: { vite: { plugins: unknown[] } }) {
 			updatedConfig = config;
@@ -115,6 +119,22 @@ describe('type generation phase (build and sync)', () => {
 			// entrypoints (#16933); losing them reintroduces mid-request discovery.
 			assert.ok(include.includes('astro/actions/runtime/entrypoints/server.js'));
 			assert.ok(include.includes('astro/actions/runtime/entrypoints/route.js'));
+		});
+
+		it('only prebundles the JSON logger when it is enabled', async () => {
+			const defaultConfig = await runConfigSetup('dev');
+			const defaultInclude =
+				defaultConfig.configEnvironment('ssr', {})?.optimizeDeps?.include ?? [];
+			assert.ok(!defaultInclude.includes('astro/logger/json'));
+
+			const consoleConfig = await runConfigSetup('dev', { entrypoint: 'astro/logger/console' });
+			const consoleInclude =
+				consoleConfig.configEnvironment('ssr', {})?.optimizeDeps?.include ?? [];
+			assert.ok(!consoleInclude.includes('astro/logger/json'));
+
+			const jsonConfig = await runConfigSetup('dev', { entrypoint: 'astro/logger/json' });
+			const jsonInclude = jsonConfig.configEnvironment('ssr', {})?.optimizeDeps?.include ?? [];
+			assert.ok(jsonInclude.includes('astro/logger/json'));
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Prebundles `astro/logger/json` in Cloudflare server environments only when JSON logging is active, avoiding a mid-request optimizer reload that can break first-request React SSR. Fixes #17834.

## Testing

- Extends Cloudflare config tests to cover default, console, and JSON logger optimization.

## Docs

- No docs update needed because this corrects internal dev-server dependency optimization.