### PR TITLE
perf(runtime): improve rendering performance

### DIFF
--- a/.changeset/fresh-otters-run.md
+++ b/.changeset/fresh-otters-run.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves server-side rendering performance

--- a/.changeset/fresh-otters-run.md
+++ b/.changeset/fresh-otters-run.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves server-side rendering performance
+Improves rendering performance

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -284,7 +284,7 @@ export class FetchState implements AstroFetchState {
 	/** Initial props (from container/error handler). */
 	initialProps: Props = {};
 	/** Memoized Astro page partial. */
-	#astroPagePartial?: Omit<AstroGlobal, 'props' | 'self'>;
+	#astroPagePartial?: Omit<AstroGlobal, 'props' | 'self' | 'slots'>;
 	/**
 	 * Locale-prefixed pathname derived from the Host header for domain-based
 	 * i18n routing (e.g. `/en/boats/1/foo`), or `undefined` when the request
@@ -547,7 +547,7 @@ export class FetchState implements AstroFetchState {
 		Astro.self = null;
 		Astro[slotValuesSymbol] = slotValues;
 
-		return Astro as AstroGlobal;
+		return Astro as unknown as AstroGlobal;
 	}
 
 	/**
@@ -556,7 +556,7 @@ export class FetchState implements AstroFetchState {
 	createAstroPagePartial(
 		result: SSRResult,
 		apiContext: ActionAPIContext,
-	): Omit<AstroGlobal, 'props' | 'self'> {
+	): Omit<AstroGlobal, 'props' | 'self' | 'slots'> {
 		const state = this;
 		const { cookies, locals, params, logger, url } = this;
 		const { response } = result;

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -50,6 +50,9 @@ import { getRouteCache } from '../render/route-cache.js';
 import { getRouteTable, matchAllRoutes, matchRoute } from '../routing/route-table.js';
 import { getServerIslands } from '../server-islands/mappings.js';
 
+const slotValuesSymbol = Symbol('astro.slotValues');
+const slotsSymbol = Symbol('astro.slots');
+
 /**
  * Per-render facade inputs passed by `BaseApp.render`'s fast path to the
  * internal `FetchState` constructor and stored as plain state fields.
@@ -281,7 +284,7 @@ export class FetchState implements AstroFetchState {
 	/** Initial props (from container/error handler). */
 	initialProps: Props = {};
 	/** Memoized Astro page partial. */
-	#astroPagePartial?: Omit<AstroGlobal, 'props' | 'self' | 'slots'>;
+	#astroPagePartial?: Omit<AstroGlobal, 'props' | 'self'>;
 	/**
 	 * Locale-prefixed pathname derived from the Host header for domain-based
 	 * i18n routing (e.g. `/en/boats/1/foo`), or `undefined` when the request
@@ -539,21 +542,10 @@ export class FetchState implements AstroFetchState {
 		}
 		this.#astroPagePartial ??= this.createAstroPagePartial(result, apiContext);
 		astroPagePartial = this.#astroPagePartial;
-		const astroComponentPartial = { props, self: null };
-		const Astro: Omit<AstroGlobal, 'self' | 'slots'> = Object.assign(
-			Object.create(astroPagePartial),
-			astroComponentPartial,
-		);
-
-		let _slots: AstroGlobal['slots'];
-		Object.defineProperty(Astro, 'slots', {
-			get: () => {
-				if (!_slots) {
-					_slots = new Slots(result, slotValues, this.logger) as unknown as AstroGlobal['slots'];
-				}
-				return _slots;
-			},
-		});
+		const Astro: Record<string | symbol, unknown> = Object.create(astroPagePartial);
+		Astro.props = props;
+		Astro.self = null;
+		Astro[slotValuesSymbol] = slotValues;
 
 		return Astro as AstroGlobal;
 	}
@@ -564,7 +556,7 @@ export class FetchState implements AstroFetchState {
 	createAstroPagePartial(
 		result: SSRResult,
 		apiContext: ActionAPIContext,
-	): Omit<AstroGlobal, 'props' | 'self' | 'slots'> {
+	): Omit<AstroGlobal, 'props' | 'self'> {
 		const state = this;
 		const { cookies, locals, params, logger, url } = this;
 		const { response } = result;
@@ -588,6 +580,19 @@ export class FetchState implements AstroFetchState {
 			routePattern: this.routeData!.route,
 			isPrerendered: this.routeData!.prerender,
 			cookies,
+			// On the shared partial, not the instance: a per-component accessor costs measurably.
+			get slots(): AstroGlobal['slots'] {
+				let slots = (this as any)[slotsSymbol];
+				if (slots === undefined) {
+					slots = new Slots(
+						result,
+						(this as any)[slotValuesSymbol],
+						logger,
+					) as unknown as AstroGlobal['slots'];
+					(this as any)[slotsSymbol] = slots;
+				}
+				return slots;
+			},
 			get clientAddress() {
 				return state.getClientAddress();
 			},

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -587,7 +587,6 @@ export class FetchState implements AstroFetchState {
 			routePattern: this.routeData!.route,
 			isPrerendered: this.routeData!.prerender,
 			cookies,
-			// On the shared partial, not the instance: a per-component accessor costs measurably.
 			get slots(): Slots {
 				let slots = slotsByAstro.get(this);
 				if (slots === undefined) {

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -51,7 +51,7 @@ import { getRouteTable, matchAllRoutes, matchRoute } from '../routing/route-tabl
 import { getServerIslands } from '../server-islands/mappings.js';
 
 const slotValuesSymbol = Symbol('astro.slotValues');
-const slotsSymbol = Symbol('astro.slots');
+const slotsByAstro = new WeakMap<object, AstroGlobal['slots']>();
 
 /**
  * Per-render facade inputs passed by `BaseApp.render`'s fast path to the
@@ -582,14 +582,14 @@ export class FetchState implements AstroFetchState {
 			cookies,
 			// On the shared partial, not the instance: a per-component accessor costs measurably.
 			get slots(): AstroGlobal['slots'] {
-				let slots = (this as any)[slotsSymbol];
+				let slots = slotsByAstro.get(this);
 				if (slots === undefined) {
 					slots = new Slots(
 						result,
 						(this as any)[slotValuesSymbol],
 						logger,
 					) as unknown as AstroGlobal['slots'];
-					(this as any)[slotsSymbol] = slots;
+					slotsByAstro.set(this, slots);
 				}
 				return slots;
 			},

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -51,7 +51,13 @@ import { getRouteTable, matchAllRoutes, matchRoute } from '../routing/route-tabl
 import { getServerIslands } from '../server-islands/mappings.js';
 
 const slotValuesSymbol = Symbol('astro.slotValues');
-const slotsByAstro = new WeakMap<object, AstroGlobal['slots']>();
+const slotsByAstro = new WeakMap<object, Slots>();
+
+type AstroSlotValues = {
+	[slotValuesSymbol]: Record<string, any> | null;
+};
+
+type AstroComponentPartial = Omit<AstroGlobal, 'self' | 'slots'> & Partial<AstroSlotValues>;
 
 /**
  * Per-render facade inputs passed by `BaseApp.render`'s fast path to the
@@ -542,12 +548,13 @@ export class FetchState implements AstroFetchState {
 		}
 		this.#astroPagePartial ??= this.createAstroPagePartial(result, apiContext);
 		astroPagePartial = this.#astroPagePartial;
-		const Astro: Record<string | symbol, unknown> = Object.create(astroPagePartial);
-		Astro.props = props;
-		Astro.self = null;
+		const Astro: AstroComponentPartial = Object.assign(Object.create(astroPagePartial), {
+			props,
+			self: null,
+		});
 		Astro[slotValuesSymbol] = slotValues;
 
-		return Astro as unknown as AstroGlobal;
+		return Astro as AstroGlobal;
 	}
 
 	/**
@@ -581,14 +588,14 @@ export class FetchState implements AstroFetchState {
 			isPrerendered: this.routeData!.prerender,
 			cookies,
 			// On the shared partial, not the instance: a per-component accessor costs measurably.
-			get slots(): AstroGlobal['slots'] {
+			get slots(): Slots {
 				let slots = slotsByAstro.get(this);
 				if (slots === undefined) {
 					slots = new Slots(
 						result,
-						(this as any)[slotValuesSymbol],
+						(this as Partial<AstroSlotValues>)[slotValuesSymbol] ?? null,
 						logger,
-					) as unknown as AstroGlobal['slots'];
+					);
 					slotsByAstro.set(this, slots);
 				}
 				return slots;

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -51,7 +51,6 @@ import { getRouteTable, matchAllRoutes, matchRoute } from '../routing/route-tabl
 import { getServerIslands } from '../server-islands/mappings.js';
 
 const slotValuesSymbol = Symbol('astro.slotValues');
-const slotsByAstro = new WeakMap<object, Slots>();
 
 type AstroSlotValues = {
 	[slotValuesSymbol]: Record<string, any> | null;
@@ -588,6 +587,7 @@ export class FetchState implements AstroFetchState {
 			isPrerendered: this.routeData!.prerender,
 			cookies,
 			get slots(): Slots {
+				const slotsByAstro = (result._metadata.slotsByAstro ??= new WeakMap());
 				let slots = slotsByAstro.get(this);
 				if (slots === undefined) {
 					slots = new Slots(

--- a/packages/astro/src/core/fetch/fetch-state.ts
+++ b/packages/astro/src/core/fetch/fetch-state.ts
@@ -551,7 +551,12 @@ export class FetchState implements AstroFetchState {
 			props,
 			self: null,
 		});
-		Astro[slotValuesSymbol] = slotValues;
+		Object.defineProperty(Astro, slotValuesSymbol, {
+			value: slotValues,
+			writable: true,
+			configurable: true,
+			enumerable: false,
+		});
 
 		return Astro as AstroGlobal;
 	}

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -1,4 +1,3 @@
-import { escape } from 'html-escaper';
 import { streamAsyncIterator } from './util.js';
 
 const ESCAPABLE = /[&<>'"]/g;
@@ -18,9 +17,7 @@ function entityFor(code: number): string {
 	}
 }
 
-/** Output-identical to `html-escaper`; non-strings delegate so coercion and errors match. */
-export function escapeHTML(value: any): string {
-	if (typeof value !== 'string') return escape(value);
+export function escapeHTML(value: string): string {
 	ESCAPABLE.lastIndex = 0;
 	if (!ESCAPABLE.test(value)) return value;
 	let output = '';

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -36,9 +36,10 @@ const htmlStringSymbol = Symbol.for('astro:html-string');
  * A "blessed" extension of String that tells Astro that the string
  * has already been escaped. This helps prevent double-escaping of HTML.
  */
-export class HTMLString extends String {
-	[htmlStringSymbol] = true;
-}
+export class HTMLString extends String {}
+
+// On the prototype, not an instance field: a per-instance store costs measurably on every rendered chunk.
+Object.defineProperty(HTMLString.prototype, htmlStringSymbol, { value: true });
 
 type BlessedType = string | HTMLBytes;
 
@@ -64,7 +65,8 @@ export const markHTMLString = (value: any) => {
 };
 
 export function isHTMLString(value: any): value is HTMLString {
-	return !!value?.[htmlStringSymbol];
+	// The `typeof` guard stops primitive strings, the most common argument, from being boxed to miss a symbol lookup.
+	return typeof value === 'object' && value !== null && value[htmlStringSymbol] === true;
 }
 
 function markHTMLBytes(bytes: Uint8Array) {

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -1,8 +1,38 @@
 import { escape } from 'html-escaper';
 import { streamAsyncIterator } from './util.js';
 
-// Leverage the battle-tested `html-escaper` npm package.
-export const escapeHTML = escape;
+const ESCAPABLE = /[&<>'"]/g;
+
+function entityFor(code: number): string {
+	switch (code) {
+		case 38:
+			return '&amp;';
+		case 60:
+			return '&lt;';
+		case 62:
+			return '&gt;';
+		case 39:
+			return '&#39;';
+		default:
+			return '&quot;';
+	}
+}
+
+/** Output-identical to `html-escaper`; non-strings delegate so coercion and errors match. */
+export function escapeHTML(value: any): string {
+	if (typeof value !== 'string') return escape(value);
+	ESCAPABLE.lastIndex = 0;
+	if (!ESCAPABLE.test(value)) return value;
+	let output = '';
+	let last = 0;
+	do {
+		const index = ESCAPABLE.lastIndex - 1;
+		if (last !== index) output += value.slice(last, index);
+		output += entityFor(value.charCodeAt(index));
+		last = index + 1;
+	} while (ESCAPABLE.test(value));
+	return last === value.length ? output : output + value.slice(last);
+}
 
 /**
  * Serializes a value to a JSON string that is safe to embed inside a `<script>` tag.

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -68,7 +68,6 @@ const htmlStringSymbol = Symbol.for('astro:html-string');
  */
 export class HTMLString extends String {}
 
-// On the prototype, not an instance field: a per-instance store costs measurably on every rendered chunk.
 Object.defineProperty(HTMLString.prototype, htmlStringSymbol, { value: true });
 
 type BlessedType = string | HTMLBytes;
@@ -95,7 +94,6 @@ export const markHTMLString = (value: any) => {
 };
 
 export function isHTMLString(value: any): value is HTMLString {
-	// The `typeof` guard stops primitive strings, the most common argument, from being boxed to miss a symbol lookup.
 	return typeof value === 'object' && value !== null && value[htmlStringSymbol] === true;
 }
 

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -24,7 +24,7 @@ interface ExtractedProps {
 	propsWithoutTransitionAttributes: Props;
 }
 
-const transitionDirectivesToCopyOnIsland = Object.freeze([
+const transitionDirectivesToCopyOnIsland = new Set([
 	'data-astro-transition-scope',
 	'data-astro-transition-persist',
 	'data-astro-transition-persist-props',
@@ -42,7 +42,10 @@ export function extractDirectives(
 		props: {},
 		propsWithoutTransitionAttributes: {},
 	};
-	for (const [key, value] of Object.entries(inputProps)) {
+	const keys = Object.keys(inputProps);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		const value = inputProps[key];
 		if (key.startsWith('server:')) {
 			if (key === 'server:root') {
 				extracted.isPage = true;
@@ -101,7 +104,7 @@ export function extractDirectives(
 			}
 		} else {
 			extracted.props[key] = value;
-			if (!transitionDirectivesToCopyOnIsland.includes(key)) {
+			if (!transitionDirectivesToCopyOnIsland.has(key)) {
 				extracted.propsWithoutTransitionAttributes[key] = value;
 			}
 		}

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -42,9 +42,7 @@ export function extractDirectives(
 		props: {},
 		propsWithoutTransitionAttributes: {},
 	};
-	const keys = Object.keys(inputProps);
-	for (let i = 0; i < keys.length; i++) {
-		const key = keys[i];
+	for (const key of Object.keys(inputProps)) {
 		const value = inputProps[key];
 		if (key.startsWith('server:')) {
 			if (key === 'server:root') {

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -149,7 +149,7 @@ export async function generateHydrateScript(
 	// Attach renderer-provided attributes
 	if (attrs) {
 		for (const [key, value] of Object.entries(attrs)) {
-			island.props[key] = escapeHTML(value);
+			island.props[key] = escapeHTML(String(value));
 		}
 	}
 

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -90,9 +90,7 @@ export function spreadAttributes(
 			values.class = scopedClassName;
 		}
 	}
-	const keys = Object.keys(values);
-	for (let i = 0; i < keys.length; i++) {
-		const key = keys[i];
+	for (const key of Object.keys(values)) {
 		output += addAttribute(values[key], key, true, _name);
 	}
 	return markHTMLString(output);

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -90,8 +90,10 @@ export function spreadAttributes(
 			values.class = scopedClassName;
 		}
 	}
-	for (const [key, value] of Object.entries(values)) {
-		output += addAttribute(value, key, true, _name);
+	const keys = Object.keys(values);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		output += addAttribute(values[key], key, true, _name);
 	}
 	return markHTMLString(output);
 }

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -1,7 +1,7 @@
 import { escapeHTML, isHTMLString, markHTMLString } from '../escape.js';
 import { isPromise } from '../util.js';
-import { isAstroComponentInstance, isRenderTemplateResult } from './astro/index.js';
 import { isRenderInstance, type RenderDestination } from './common.js';
+import { isRenderInstruction } from './instruction.js';
 import { SlotString } from './slot.js';
 import { createBufferedRenderer } from './util.js';
 
@@ -11,6 +11,16 @@ export function renderChild(destination: RenderDestination, child: any): void | 
 	if (typeof child === 'string') {
 		destination.write(markHTMLString(escapeHTML(child)));
 		return;
+	}
+
+	// Must precede `isRenderInstance`: a `renderer-hydration-script` instruction has a `render` property.
+	if (isRenderInstruction(child)) {
+		destination.write(child);
+		return;
+	}
+
+	if (isRenderInstance(child)) {
+		return child.render(destination);
 	}
 
 	if (isPromise(child)) {
@@ -41,18 +51,6 @@ export function renderChild(destination: RenderDestination, child: any): void | 
 		// This lets you do {() => ...} without the extra boilerplate
 		// of wrapping it in a function and calling it.
 		return renderChild(destination, child());
-	}
-
-	if (isRenderInstance(child)) {
-		return child.render(destination);
-	}
-
-	if (isRenderTemplateResult(child)) {
-		return child.render(destination);
-	}
-
-	if (isAstroComponentInstance(child)) {
-		return child.render(destination);
 	}
 
 	if (ArrayBuffer.isView(child)) {

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -19,12 +19,12 @@ export function renderChild(destination: RenderDestination, child: any): void | 
 		return;
 	}
 
-	if (isRenderInstance(child)) {
-		return child.render(destination);
-	}
-
 	if (isPromise(child)) {
 		return child.then((x) => renderChild(destination, x));
+	}
+
+	if (isRenderInstance(child)) {
+		return child.render(destination);
 	}
 
 	if (child instanceof SlotString) {

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -28,8 +28,12 @@ export class AstroComponentInstance {
 		this.result = result;
 		this.props = props;
 		this.factory = factory;
-		this.slotValues = {};
+		// Shared until a slot needs wrapping: most components have none, and the copy costs.
+		this.slotValues = slots;
 		for (const name in slots) {
+			if (this.slotValues === slots) {
+				this.slotValues = {};
+			}
 			// prerender the slots eagerly to make collection entries propagate styles and scripts
 			let didRender = false;
 			let value = slots[name](result);

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -28,7 +28,6 @@ export class AstroComponentInstance {
 		this.result = result;
 		this.props = props;
 		this.factory = factory;
-		// Shared until a slot needs wrapping: most components have none, and the copy costs.
 		this.slotValues = slots;
 		for (const name in slots) {
 			if (this.slotValues === slots) {

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -100,9 +100,8 @@ function validateComponentProps(
 	displayName: string,
 ) {
 	if (props != null) {
-		const directives = [...clientDirectives.keys()].map((directive) => `client:${directive}`);
-		for (const prop of Object.keys(props)) {
-			if (directives.includes(prop)) {
+		for (const prop in props) {
+			if (prop.startsWith('client:') && clientDirectives.has(prop.slice(7))) {
 				console.warn(
 					`You are attempting to render <${displayName} ${prop} />, but ${displayName} is an Astro component. Astro components do not render in the client and should not have a hydration directive. Please use a framework component for client rendering.`,
 				);

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -77,6 +77,9 @@ export class AstroComponentInstance {
 		return this.returnValue;
 	}
 
+	// NOTE: This render call can't be pre-invoked outside of this function as it'll also initialize the slots
+	// recursively, which causes each Astro components in the tree to be called bottom-up, and is incorrect.
+	// The slots are initialized eagerly for head propagation.
 	render(destination: RenderDestination): void | Promise<void> {
 		const returnValue = this.init(this.result);
 

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -10,6 +10,7 @@ import { isHeadAndContent } from './head-and-content.js';
 type ComponentProps = Record<string | number, any>;
 
 const astroComponentInstanceSym = Symbol.for('astro.componentInstance');
+const CLIENT_DIRECTIVE_PREFIX = 'client:';
 
 export class AstroComponentInstance {
 	[astroComponentInstanceSym] = true;
@@ -107,7 +108,10 @@ function validateComponentProps(
 ) {
 	if (props != null) {
 		for (const prop in props) {
-			if (prop.startsWith('client:') && clientDirectives.has(prop.slice(7))) {
+			if (
+				prop.startsWith(CLIENT_DIRECTIVE_PREFIX) &&
+				clientDirectives.has(prop.slice(CLIENT_DIRECTIVE_PREFIX.length))
+			) {
 				console.warn(
 					`You are attempting to render <${displayName} ${prop} />, but ${displayName} is an Astro component. Astro components do not render in the client and should not have a hydration directive. Please use a framework component for client rendering.`,
 				);

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -38,7 +38,7 @@ export class RenderTemplateResult {
 	 * Wraps an async expression so the component rethrows only the first error.
 	 * Mutating in place is safe: `renderTemplate`'s rest parameter hands us a fresh array.
 	 */
-	catchExpressionError(index: number, expression: unknown): Promise<void> {
+	catchExpressionError(index: number, expression: unknown): Promise<unknown> {
 		const wrapped = Promise.resolve(expression).catch((err) => {
 			if (!this.error) {
 				this.error = err;

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -31,22 +31,22 @@ export class RenderTemplateResult {
 	constructor(htmlParts: TemplateStringsArray, expressions: unknown[]) {
 		this.htmlParts = htmlParts;
 		this.error = undefined;
-		// Wrap Promise expressions so we can catch errors
-		// There can only be 1 error that we rethrow from an Astro component,
-		// so this keeps track of whether or not we have already done so.
-		// Mutating in place is safe: `renderTemplate`'s rest parameter hands us a fresh array.
-		for (let i = 0; i < expressions.length; i++) {
-			const expression = expressions[i];
-			if (isPromise(expression)) {
-				expressions[i] = Promise.resolve(expression).catch((err) => {
-					if (!this.error) {
-						this.error = err;
-						throw err;
-					}
-				});
-			}
-		}
 		this.expressions = expressions;
+	}
+
+	/**
+	 * Wraps an async expression so the component rethrows only the first error.
+	 * Mutating in place is safe: `renderTemplate`'s rest parameter hands us a fresh array.
+	 */
+	catchExpressionError(index: number, expression: unknown): Promise<void> {
+		const wrapped = Promise.resolve(expression).catch((err) => {
+			if (!this.error) {
+				this.error = err;
+				throw err;
+			}
+		});
+		this.expressions[index] = wrapped;
+		return wrapped;
 	}
 
 	render(destination: RenderDestination): void | Promise<void> {
@@ -70,9 +70,10 @@ export class RenderTemplateResult {
 			// expressions[i] doesn't exist for the last htmlPart
 			if (i >= expressions.length) break;
 
-			const exp = expressions[i];
+			let exp = expressions[i];
 			// Skip render if falsy, except the number 0
 			if (!(exp || exp === 0)) continue;
+			if (isPromise(exp)) exp = this.catchExpressionError(i, exp);
 
 			const result = renderChild(destination, exp);
 
@@ -83,7 +84,8 @@ export class RenderTemplateResult {
 				const remaining = expressions.length - startIdx;
 				const flushers = new Array(remaining);
 				for (let j = 0; j < remaining; j++) {
-					const rExp = expressions[startIdx + j];
+					let rExp = expressions[startIdx + j];
+					if (isPromise(rExp)) rExp = this.catchExpressionError(startIdx + j, rExp);
 					flushers[j] = createBufferedRenderer(destination, (bufferDestination) => {
 						if (rExp || rExp === 0) {
 							return renderChild(bufferDestination, rExp);

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -6,7 +6,6 @@ import { createBufferedRenderer } from '../util.js';
 
 const renderTemplateResultSym = Symbol.for('astro.renderTemplateResult');
 
-// A tagged template's strings array is per call site, so the wrappers can be built once, not per render.
 const markedHtmlParts = new WeakMap<TemplateStringsArray, string[]>();
 
 function markHtmlParts(htmlParts: TemplateStringsArray): string[] {
@@ -35,10 +34,6 @@ export class RenderTemplateResult {
 		this.expressions = expressions;
 	}
 
-	/**
-	 * Wraps an async expression so the component rethrows only the first error.
-	 * Mutating in place is safe: `renderTemplate`'s rest parameter hands us a fresh array.
-	 */
 	catchExpressionError(index: number, expression: unknown): Promise<unknown> {
 		// Re-wrapping hits the `this.error` guard and resolves, swallowing the rejection.
 		if (this.wrapped?.has(index)) return expression as Promise<unknown>;

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -28,6 +28,7 @@ export class RenderTemplateResult {
 	readonly htmlParts: TemplateStringsArray;
 	public expressions: any[];
 	private error: Error | undefined;
+	private wrapped: Set<number> | undefined;
 	constructor(htmlParts: TemplateStringsArray, expressions: unknown[]) {
 		this.htmlParts = htmlParts;
 		this.error = undefined;
@@ -39,12 +40,15 @@ export class RenderTemplateResult {
 	 * Mutating in place is safe: `renderTemplate`'s rest parameter hands us a fresh array.
 	 */
 	catchExpressionError(index: number, expression: unknown): Promise<unknown> {
+		// Re-wrapping hits the `this.error` guard and resolves, swallowing the rejection.
+		if (this.wrapped?.has(index)) return expression as Promise<unknown>;
 		const wrapped = Promise.resolve(expression).catch((err) => {
 			if (!this.error) {
 				this.error = err;
 				throw err;
 			}
 		});
+		(this.wrapped ??= new Set()).add(index);
 		this.expressions[index] = wrapped;
 		return wrapped;
 	}

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -6,6 +6,21 @@ import { createBufferedRenderer } from '../util.js';
 
 const renderTemplateResultSym = Symbol.for('astro.renderTemplateResult');
 
+// A tagged template's strings array is per call site, so the wrappers can be built once, not per render.
+const markedHtmlParts = new WeakMap<TemplateStringsArray, string[]>();
+
+function markHtmlParts(htmlParts: TemplateStringsArray): string[] {
+	let marked = markedHtmlParts.get(htmlParts);
+	if (marked === undefined) {
+		marked = new Array(htmlParts.length);
+		for (let i = 0; i < htmlParts.length; i++) {
+			marked[i] = htmlParts[i] ? markHTMLString(htmlParts[i]) : htmlParts[i];
+		}
+		markedHtmlParts.set(htmlParts, marked);
+	}
+	return marked;
+}
+
 // The return value when rendering a component.
 // This is the result of calling render(), should this be named to RenderResult or...?
 export class RenderTemplateResult {
@@ -16,20 +31,22 @@ export class RenderTemplateResult {
 	constructor(htmlParts: TemplateStringsArray, expressions: unknown[]) {
 		this.htmlParts = htmlParts;
 		this.error = undefined;
-		this.expressions = expressions.map((expression) => {
-			// Wrap Promise expressions so we can catch errors
-			// There can only be 1 error that we rethrow from an Astro component,
-			// so this keeps track of whether or not we have already done so.
+		// Wrap Promise expressions so we can catch errors
+		// There can only be 1 error that we rethrow from an Astro component,
+		// so this keeps track of whether or not we have already done so.
+		// Mutating in place is safe: `renderTemplate`'s rest parameter hands us a fresh array.
+		for (let i = 0; i < expressions.length; i++) {
+			const expression = expressions[i];
 			if (isPromise(expression)) {
-				return Promise.resolve(expression).catch((err) => {
+				expressions[i] = Promise.resolve(expression).catch((err) => {
 					if (!this.error) {
 						this.error = err;
 						throw err;
 					}
 				});
 			}
-			return expression;
-		});
+		}
+		this.expressions = expressions;
 	}
 
 	render(destination: RenderDestination): void | Promise<void> {
@@ -41,12 +58,13 @@ export class RenderTemplateResult {
 		//
 		// Template structure: html[0] exp[0] html[1] exp[1] ... html[N]
 		// (htmlParts.length === expressions.length + 1)
-		const { htmlParts, expressions } = this;
+		const { expressions } = this;
+		const htmlParts = markHtmlParts(this.htmlParts);
 
 		for (let i = 0; i < htmlParts.length; i++) {
 			const html = htmlParts[i];
 			if (html) {
-				destination.write(markHTMLString(html));
+				destination.write(html);
 			}
 
 			// expressions[i] doesn't exist for the last htmlPart
@@ -80,7 +98,7 @@ export class RenderTemplateResult {
 							// Write the HTML part that precedes this expression
 							const rHtml = htmlParts[startIdx + k];
 							if (rHtml) {
-								destination.write(markHTMLString(rHtml));
+								destination.write(rHtml);
 							}
 
 							const flushResult = flushers[k++].flush();
@@ -91,7 +109,7 @@ export class RenderTemplateResult {
 						// Write the final trailing HTML part
 						const lastHtml = htmlParts[htmlParts.length - 1];
 						if (lastHtml) {
-							destination.write(markHTMLString(lastHtml));
+							destination.write(lastHtml);
 						}
 					};
 					return iterate();

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -35,6 +35,9 @@ export class RenderTemplateResult {
 	}
 
 	catchExpressionError(index: number, expression: unknown): Promise<unknown> {
+		// Wrap Promise expressions so we can catch errors
+		// There can only be 1 error that we rethrow from an Astro component,
+		// so this keeps track of whether or not we have already done so.
 		// Re-wrapping hits the `this.error` guard and resolves, swallowing the rejection.
 		if (this.wrapped?.has(index)) return expression as Promise<unknown>;
 		const wrapped = Promise.resolve(expression).catch((err) => {

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -142,6 +142,8 @@ async function renderStreamToAsyncIterable(
 	let error: Error | null = null;
 	let next: ReturnType<typeof promiseWithResolvers<void>> | null = null;
 	const buffer: Array<Uint8Array | string> = [];
+	let hasBytes = false;
+	let lastIsString = false;
 	let renderingComplete = false;
 
 	// Buffer propagated head content (and run `propagation: 'self'` components,
@@ -170,43 +172,52 @@ async function renderStreamToAsyncIterable(
 				throw error;
 			}
 
-			// Merge buffer into single Uint8Array
-			let length = 0;
-			let stringToEncode = '';
-			for (let i = 0, len = buffer.length; i < len; i++) {
-				const bufferEntry = buffer[i];
+			// All-string buffers encode straight into the result, skipping the merge copy.
+			let mergedArray: Uint8Array;
+			if (!hasBytes) {
+				let text = '';
+				for (let i = 0, len = buffer.length; i < len; i++) text += buffer[i] as string;
+				mergedArray = encoder.encode(text);
+			} else {
+				let length = 0;
+				let stringToEncode = '';
+				for (let i = 0, len = buffer.length; i < len; i++) {
+					const bufferEntry = buffer[i];
 
-				if (typeof bufferEntry === 'string') {
-					const nextIsString = i + 1 < len && typeof buffer[i + 1] === 'string';
-					stringToEncode += bufferEntry;
-					if (!nextIsString) {
-						const encoded = encoder.encode(stringToEncode);
-						length += encoded.length;
-						stringToEncode = '';
-						buffer[i] = encoded;
+					if (typeof bufferEntry === 'string') {
+						const nextIsString = i + 1 < len && typeof buffer[i + 1] === 'string';
+						stringToEncode += bufferEntry;
+						if (!nextIsString) {
+							const encoded = encoder.encode(stringToEncode);
+							length += encoded.length;
+							stringToEncode = '';
+							buffer[i] = encoded;
+						} else {
+							buffer[i] = '';
+						}
 					} else {
-						buffer[i] = '';
+						length += bufferEntry.length;
 					}
-				} else {
-					length += bufferEntry.length;
 				}
-			}
 
-			const mergedArray = new Uint8Array(length);
-			let offset = 0;
-			for (let i = 0, len = buffer.length; i < len; i++) {
-				const item = buffer[i];
-				if (item === '') {
-					continue;
+				mergedArray = new Uint8Array(length);
+				let offset = 0;
+				for (let i = 0, len = buffer.length; i < len; i++) {
+					const item = buffer[i];
+					if (item === '') {
+						continue;
+					}
+					mergedArray.set(item as Uint8Array, offset);
+					offset += (item as Uint8Array).length;
 				}
-				mergedArray.set(item as Uint8Array, offset);
-				offset += (item as Uint8Array).length;
 			}
 
 			buffer.length = 0;
+			hasBytes = false;
+			lastIsString = false;
 
 			const returnValue = {
-				done: length === 0 && renderingComplete,
+				done: mergedArray.length === 0 && renderingComplete,
 				value: mergedArray,
 			};
 
@@ -224,7 +235,8 @@ async function renderStreamToAsyncIterable(
 				renderedFirstPageChunk = true;
 				if (!result.partial && !DOCTYPE_EXP.test(String(chunk))) {
 					const doctype = result.compressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n';
-					buffer.push(encoder.encode(doctype));
+					buffer.push(doctype);
+					lastIsString = true;
 				}
 			}
 			if (chunk instanceof Response) {
@@ -232,7 +244,19 @@ async function renderStreamToAsyncIterable(
 			}
 			const bytes = chunkToByteArrayOrString(result, chunk);
 			if (bytes.length > 0) {
-				buffer.push(bytes);
+				if (typeof bytes === 'string') {
+					// Appending to the previous entry keeps the all-strings merge on one rope.
+					if (lastIsString) {
+						buffer[buffer.length - 1] = (buffer[buffer.length - 1] as string) + bytes;
+					} else {
+						buffer.push(bytes);
+						lastIsString = true;
+					}
+				} else {
+					buffer.push(bytes);
+					hasBytes = true;
+					lastIsString = false;
+				}
 				next?.resolve();
 			} else if (buffer.length > 0) {
 				next?.resolve();

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -172,6 +172,7 @@ async function renderStreamToAsyncIterable(
 				throw error;
 			}
 
+			// Merge buffer into single Uint8Array
 			let mergedArray: Uint8Array;
 			if (!hasBytes) {
 				let text = '';

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -172,7 +172,6 @@ async function renderStreamToAsyncIterable(
 				throw error;
 			}
 
-			// All-string buffers encode straight into the result, skipping the merge copy.
 			let mergedArray: Uint8Array;
 			if (!hasBytes) {
 				let text = '';
@@ -245,7 +244,6 @@ async function renderStreamToAsyncIterable(
 			const bytes = chunkToByteArrayOrString(result, chunk);
 			if (bytes.length > 0) {
 				if (typeof bytes === 'string') {
-					// Appending to the previous entry keeps the all-strings merge on one rope.
 					if (lastIsString) {
 						buffer[buffer.length - 1] = (buffer[buffer.length - 1] as string) + bytes;
 					} else {

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -56,6 +56,9 @@ function stringifyChunk(
 	result: SSRResult,
 	chunk: string | HTMLString | SlotString | RenderInstruction,
 ): string {
+	// Primitive strings are the bulk of the stream; the checks below would each box them.
+	if (typeof chunk === 'string') return chunk;
+
 	if (isRenderInstruction(chunk)) {
 		const instruction = chunk;
 		switch (instruction.type) {

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -206,5 +206,5 @@ export function chunkToByteArrayOrString(
 }
 
 export function isRenderInstance(obj: unknown): obj is RenderInstance {
-	return !!obj && typeof obj === 'object' && 'render' in obj && typeof obj.render === 'function';
+	return typeof obj === 'object' && obj !== null && typeof (obj as any).render === 'function';
 }

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -56,7 +56,6 @@ function stringifyChunk(
 	result: SSRResult,
 	chunk: string | HTMLString | SlotString | RenderInstruction,
 ): string {
-	// Primitive strings are the bulk of the stream; the checks below would each box them.
 	if (typeof chunk === 'string') return chunk;
 
 	if (isRenderInstruction(chunk)) {

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -205,5 +205,9 @@ export function chunkToByteArrayOrString(
 }
 
 export function isRenderInstance(obj: unknown): obj is RenderInstance {
-	return typeof obj === 'object' && obj !== null && typeof (obj as any).render === 'function';
+	return (
+		typeof obj === 'object' &&
+		obj !== null &&
+		typeof (obj as { render?: unknown }).render === 'function'
+	);
 }

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -472,6 +472,11 @@ export function renderComponent(
 	props: Record<string | number, any>,
 	slots: ComponentSlots = {},
 ): RenderInstance | Promise<RenderInstance> {
+	// `.astro` components dominate; none of the checks below can match a factory.
+	if (isAstroComponentFactory(Component)) {
+		return renderAstroComponent(result, displayName, Component, normalizeProps(props), slots);
+	}
+
 	if (isPromise(Component)) {
 		return Component.catch(handleCancellation).then((x) => {
 			return renderComponent(result, displayName, x, props, slots);
@@ -488,10 +493,6 @@ export function renderComponent(
 	// .html components
 	if (isHTMLComponent(Component)) {
 		return renderHTMLComponent(result, Component, props, slots).catch(handleCancellation);
-	}
-
-	if (isAstroComponentFactory(Component)) {
-		return renderAstroComponent(result, displayName, Component, props, slots);
 	}
 
 	return renderFrameworkComponent(result, displayName, Component, props, slots).catch(

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -321,9 +321,11 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 				if (isPage || renderer?.name === 'astro:jsx') {
 					destination.write(html);
 				} else if (html && html.length > 0) {
-					destination.write(
-						markHTMLString(removeStaticAstroSlot(html, renderer?.ssr?.supportsAstroStaticSlot)),
-					);
+					// Only renderer output can carry `<astro-static-slot>`; Astro's own markup never does.
+					const output = renderer
+						? removeStaticAstroSlot(html, renderer.ssr?.supportsAstroStaticSlot)
+						: html;
+					destination.write(markHTMLString(output));
 				}
 			},
 		};

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -461,16 +461,8 @@ function renderAstroComponent(
 		return serverIslandComponent;
 	}
 
-	const instance = createAstroComponentInstance(result, displayName, Component, props, slots);
-
-	return {
-		render(destination: RenderDestination): Promise<void> | void {
-			// NOTE: This render call can't be pre-invoked outside of this function as it'll also initialize the slots
-			// recursively, which causes each Astro components in the tree to be called bottom-up, and is incorrect.
-			// The slots are initialized eagerly for head propagation.
-			return instance.render(destination);
-		},
-	};
+	// `instance.render` must stay deferred: invoking it here would initialize slots bottom-up.
+	return createAstroComponentInstance(result, displayName, Component, props, slots);
 }
 
 export function renderComponent(

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -463,7 +463,6 @@ function renderAstroComponent(
 		return serverIslandComponent;
 	}
 
-	// `instance.render` must stay deferred: invoking it here would initialize slots bottom-up.
 	return createAstroComponentInstance(result, displayName, Component, props, slots);
 }
 

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -474,7 +474,6 @@ export function renderComponent(
 	props: Record<string | number, any>,
 	slots: ComponentSlots = {},
 ): RenderInstance | Promise<RenderInstance> {
-	// `.astro` components dominate; none of the checks below can match a factory.
 	if (isAstroComponentFactory(Component)) {
 		return renderAstroComponent(result, displayName, Component, normalizeProps(props), slots);
 	}

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -89,8 +89,14 @@ export function renderAllHeadContent(result: SSRResult) {
 	return markHTMLString(content);
 }
 
+// Stateless, so one shared object saves an allocation per component render.
+const HEAD_INSTRUCTION = createRenderInstruction({ type: 'head' } as RenderHeadInstruction);
+const MAYBE_HEAD_INSTRUCTION = createRenderInstruction({
+	type: 'maybe-head',
+} as MaybeRenderHeadInstruction);
+
 export function renderHead(): RenderHeadInstruction {
-	return createRenderInstruction({ type: 'head' });
+	return HEAD_INSTRUCTION;
 }
 
 // This function is called by Astro components that do not contain a <head> component
@@ -100,5 +106,5 @@ export function renderHead(): RenderHeadInstruction {
 export function maybeRenderHead(): MaybeRenderHeadInstruction {
 	// This is an instruction informing the page rendering that head might need rendering.
 	// This allows the page to deduplicate head injections.
-	return createRenderInstruction({ type: 'maybe-head' });
+	return MAYBE_HEAD_INSTRUCTION;
 }

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -89,7 +89,6 @@ export function renderAllHeadContent(result: SSRResult) {
 	return markHTMLString(content);
 }
 
-// Stateless, so one shared object saves an allocation per component render.
 const HEAD_INSTRUCTION = Object.freeze(
 	createRenderInstruction({ type: 'head' } as RenderHeadInstruction),
 );

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -90,10 +90,12 @@ export function renderAllHeadContent(result: SSRResult) {
 }
 
 // Stateless, so one shared object saves an allocation per component render.
-const HEAD_INSTRUCTION = createRenderInstruction({ type: 'head' } as RenderHeadInstruction);
-const MAYBE_HEAD_INSTRUCTION = createRenderInstruction({
-	type: 'maybe-head',
-} as MaybeRenderHeadInstruction);
+const HEAD_INSTRUCTION = Object.freeze(
+	createRenderInstruction({ type: 'head' } as RenderHeadInstruction),
+);
+const MAYBE_HEAD_INSTRUCTION = Object.freeze(
+	createRenderInstruction({ type: 'maybe-head' } as MaybeRenderHeadInstruction),
+);
 
 export function renderHead(): RenderHeadInstruction {
 	return HEAD_INSTRUCTION;

--- a/packages/astro/src/runtime/server/render/instruction.ts
+++ b/packages/astro/src/runtime/server/render/instruction.ts
@@ -54,9 +54,9 @@ export type RenderInstruction =
 	| TemplateExitInstruction;
 
 export function createRenderInstruction<T extends RenderInstruction>(instruction: T): T {
-	return Object.defineProperty(instruction as T, RenderInstructionSymbol, {
-		value: true,
-	});
+	// Plain assignment, not `Object.defineProperty`: the latter is a runtime call per instruction.
+	(instruction as any)[RenderInstructionSymbol] = true;
+	return instruction;
 }
 
 export function isRenderInstruction(chunk: any): chunk is RenderInstruction {

--- a/packages/astro/src/runtime/server/render/instruction.ts
+++ b/packages/astro/src/runtime/server/render/instruction.ts
@@ -54,7 +54,6 @@ export type RenderInstruction =
 	| TemplateExitInstruction;
 
 export function createRenderInstruction<T extends RenderInstruction>(instruction: T): T {
-	// Plain assignment, not `Object.defineProperty`: the latter is a runtime call per instruction.
 	(instruction as any)[RenderInstructionSymbol] = true;
 	return instruction;
 }

--- a/packages/astro/src/runtime/server/render/instruction.ts
+++ b/packages/astro/src/runtime/server/render/instruction.ts
@@ -43,7 +43,9 @@ export type TemplateExitInstruction = {
 	type: 'template-exit';
 };
 
-export type RenderInstruction =
+export type RenderInstruction = {
+	[RenderInstructionSymbol]?: true;
+} & (
 	| RenderDirectiveInstruction
 	| RenderHeadInstruction
 	| MaybeRenderHeadInstruction
@@ -51,10 +53,11 @@ export type RenderInstruction =
 	| ServerIslandRuntimeInstruction
 	| RenderScriptInstruction
 	| TemplateEnterInstruction
-	| TemplateExitInstruction;
+	| TemplateExitInstruction
+);
 
 export function createRenderInstruction<T extends RenderInstruction>(instruction: T): T {
-	(instruction as any)[RenderInstructionSymbol] = true;
+	instruction[RenderInstructionSymbol] = true;
 	return instruction;
 }
 

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -65,6 +65,27 @@ export function mergeSlotInstructions(
 	return target;
 }
 
+export class SlotRenderInstance implements RenderInstance {
+	private readonly result: SSRResult;
+	private readonly slotted: ComponentSlotValue | RenderTemplateResult;
+
+	constructor(result: SSRResult, slotted: ComponentSlotValue | RenderTemplateResult) {
+		this.result = result;
+		this.slotted = slotted;
+	}
+
+	/** Evaluates the slot to its content. Must be called at most once per instance. */
+	evaluate(): unknown {
+		const { slotted } = this;
+		return typeof slotted === 'function' ? slotted(this.result) : slotted;
+	}
+
+	// Not `async`: that would return a promise even for sync slots, forcing the enclosing template to buffer.
+	render(destination: RenderDestination): void | Promise<void> {
+		return renderChild(destination, this.evaluate());
+	}
+}
+
 export function renderSlot(
 	result: SSRResult,
 	slotted: ComponentSlotValue | RenderTemplateResult,
@@ -73,12 +94,7 @@ export function renderSlot(
 	if (!slotted && fallback) {
 		return renderSlot(result, fallback);
 	}
-	return {
-		// Not `async`: that would return a promise even for sync slots, forcing the enclosing template to buffer.
-		render(destination) {
-			return renderChild(destination, typeof slotted === 'function' ? slotted(result) : slotted);
-		},
-	};
+	return new SlotRenderInstance(result, slotted);
 }
 
 export async function renderSlotToString(

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -74,8 +74,9 @@ export function renderSlot(
 		return renderSlot(result, fallback);
 	}
 	return {
-		async render(destination) {
-			await renderChild(destination, typeof slotted === 'function' ? slotted(result) : slotted);
+		// Not `async`: that would return a promise even for sync slots, forcing the enclosing template to buffer.
+		render(destination) {
+			return renderChild(destination, typeof slotted === 'function' ? slotted(result) : slotted);
 		},
 	};
 }

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -74,7 +74,7 @@ export class SlotRenderInstance implements RenderInstance {
 		this.slotted = slotted;
 	}
 
-	/** Evaluates the slot to its content. Must be called at most once per instance. */
+	/** Must be called at most once per instance. */
 	evaluate(): unknown {
 		const { slotted } = this;
 		return typeof slotted === 'function' ? slotted(this.result) : slotted;

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -289,7 +289,11 @@ export async function renderStreaming(
 				// Complex expression: resume this frame after processing it.
 				node.storeCursor(i);
 				stack.push(node);
-				stack.push(expression);
+				stack.push(
+					isPromise(expression)
+						? node.templateResult.catchExpressionError(i - 1, expression)
+						: expression,
+				);
 				break;
 			}
 			continue;

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -67,15 +67,15 @@ class TemplateFrame {
  * Head propagation is handled by the caller (`bufferHeadContent`) before this
  * runs.
  */
-class EngineState {
-	batch = '';
-	buffered = false;
-	tailStatic = '';
+class StreamingRenderState {
+	pendingStaticOutput = '';
+	isBuffering = false;
+	bufferedStaticOutput = '';
 
-	emitStatic(s: string) {
-		if (!s) return;
-		if (this.buffered) this.tailStatic += s;
-		else this.batch += s;
+	appendStatic(output: string) {
+		if (!output) return;
+		if (this.isBuffering) this.bufferedStaticOutput += output;
+		else this.pendingStaticOutput += output;
 	}
 }
 
@@ -103,14 +103,14 @@ export async function renderStreaming(
 		return tag;
 	};
 
-	const st = new EngineState();
-	let firstAsync: Promise<void> | null = null;
-	const tail: Array<string | RendererFlusher> = [];
+	const streamingState = new StreamingRenderState();
+	let firstAsyncRender: Promise<void> | null = null;
+	const bufferedTail: Array<string | RendererFlusher> = [];
 
-	const flushTailStatic = () => {
-		if (st.tailStatic) {
-			tail.push(st.tailStatic);
-			st.tailStatic = '';
+	const flushBufferedStaticOutput = () => {
+		if (streamingState.bufferedStaticOutput) {
+			bufferedTail.push(streamingState.bufferedStaticOutput);
+			streamingState.bufferedStaticOutput = '';
 		}
 	};
 
@@ -188,7 +188,7 @@ export async function renderStreaming(
 					openTag = isVoid ? `<${type}/>` : `<${type}>`;
 					openTagCache.set(key, openTag);
 				}
-				st.emitStatic(openTag);
+				streamingState.appendStatic(openTag);
 				if (!isVoid) {
 					// Push close tag first so it is emitted after the children.
 					stack.push(closeTagFor(type));
@@ -196,10 +196,10 @@ export async function renderStreaming(
 			} else {
 				const attrs = spreadElementAttributes(props!);
 				if (isVoid) {
-					st.emitStatic(`<${type}${attrs}/>`);
+					streamingState.appendStatic(`<${type}${attrs}/>`);
 					return;
 				}
-				st.emitStatic(`<${type}${attrs}>`);
+				streamingState.appendStatic(`<${type}${attrs}>`);
 				stack.push(closeTagFor(type));
 			}
 
@@ -247,7 +247,7 @@ export async function renderStreaming(
 			let i = node.cursor;
 			while (i < htmlParts.length) {
 				if (htmlParts[i]) {
-					st.emitStatic(htmlParts[i]);
+					streamingState.appendStatic(htmlParts[i]);
 				}
 				// `htmlParts.length === expressions.length + 1`, so the final HTML
 				// part has no expression after it. This break must come *after*
@@ -265,7 +265,7 @@ export async function renderStreaming(
 				if (expression == null || expression === false) continue;
 				const expressionType = typeof expression;
 				if (expressionType === 'string') {
-					st.emitStatic(escapeHTML(expression as string));
+					streamingState.appendStatic(escapeHTML(expression as string));
 					continue;
 				}
 				if (
@@ -273,12 +273,12 @@ export async function renderStreaming(
 					expressionType === 'bigint' ||
 					expressionType === 'boolean'
 				) {
-					st.emitStatic(String(expression));
+					streamingState.appendStatic(String(expression));
 					continue;
 				}
 				if (expression instanceof HTMLString || isHTMLString(expression)) {
 					if (!(expression instanceof SlotString)) {
-						st.emitStatic((expression as HTMLString).toString());
+						streamingState.appendStatic((expression as HTMLString).toString());
 						continue;
 					}
 				}
@@ -297,17 +297,17 @@ export async function renderStreaming(
 
 		const nodeType = typeof node;
 		if (nodeType === 'string') {
-			st.emitStatic(escapeHTML(node as string));
+			streamingState.appendStatic(escapeHTML(node as string));
 			continue;
 		}
 		if (nodeType === 'number' || nodeType === 'bigint' || nodeType === 'boolean') {
-			st.emitStatic(String(node));
+			streamingState.appendStatic(String(node));
 			continue;
 		}
 		if (node instanceof HTMLString || isHTMLString(node)) {
 			// SlotString metadata is lost when coerced to a string.
 			if (!(node instanceof SlotString)) {
-				st.emitStatic((node as HTMLString).toString());
+				streamingState.appendStatic((node as HTMLString).toString());
 				continue;
 			}
 		}
@@ -338,10 +338,10 @@ export async function renderStreaming(
 		// Dynamic node: component instance, render instance, promise, JSX vnode,
 		// render instruction, iterable, etc. Rendered via renderChild — streamed
 		// directly while synchronous, buffered once a node renders asynchronously.
-		if (!st.buffered) {
-			if (st.batch) {
-				destination.write(st.batch);
-				st.batch = '';
+		if (!streamingState.isBuffering) {
+			if (streamingState.pendingStaticOutput) {
+				destination.write(streamingState.pendingStaticOutput);
+				streamingState.pendingStaticOutput = '';
 			}
 			// Write the node's output straight to `destination`. It renders
 			// synchronously and in order, so putting it in a temporary buffer
@@ -350,33 +350,33 @@ export async function renderStreaming(
 			const rendered = renderDynamic(node)(destination);
 			if (isPromise(rendered)) {
 				// First async node: stream stops here. Buffer the remaining tail.
-				st.buffered = true;
-				firstAsync = rendered;
+				streamingState.isBuffering = true;
+				firstAsyncRender = rendered;
 			}
 		} else {
-			flushTailStatic();
+			flushBufferedStaticOutput();
 			// createBufferedRenderer starts the work right away, so async nodes run in parallel.
-			tail.push(createBufferedRenderer(destination, renderDynamic(node)));
+			bufferedTail.push(createBufferedRenderer(destination, renderDynamic(node)));
 		}
 	}
 
-	if (!st.buffered) {
-		if (st.batch) {
-			destination.write(st.batch);
+	if (!streamingState.isBuffering) {
+		if (streamingState.pendingStaticOutput) {
+			destination.write(streamingState.pendingStaticOutput);
 		}
 		return;
 	}
 
 	// Wait for the first async node to finish writing to `destination`, then
 	// flush the buffered tail in order.
-	await firstAsync;
-	flushTailStatic();
-	for (const seg of tail) {
-		if (typeof seg === 'string') {
-			destination.write(seg);
+	await firstAsyncRender;
+	flushBufferedStaticOutput();
+	for (const segment of bufferedTail) {
+		if (typeof segment === 'string') {
+			destination.write(segment);
 		} else {
-			const r = seg.flush();
-			if (isPromise(r)) await r;
+			const flushResult = segment.flush();
+			if (isPromise(flushResult)) await flushResult;
 		}
 	}
 }

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -68,8 +68,11 @@ class TemplateFrame {
  * runs.
  */
 class StreamingRenderState {
+	// Streaming-mode buffer (written directly to `destination`).
 	pendingStaticOutput = '';
+	// Buffered-tail mode (entered on the first async dynamic node).
 	isBuffering = false;
+	// Static text collected while in buffered-tail mode.
 	bufferedStaticOutput = '';
 
 	appendStatic(output: string) {
@@ -169,6 +172,9 @@ export async function renderStreaming(
 		// HTML element (e.g. 'div', 'span').
 		if (typeof type === 'string' && type !== ClientOnlyPlaceholder) {
 			const props = vnode.props;
+			// Check for attributes without copying props into a new object.
+			// Markdown/MDX is mostly elements with no attributes (<p>, <li>,
+			// <strong>…), for which we skip both that copy and `spreadAttributes`.
 			let hasAttrs = false;
 			if (props) {
 				for (const key in props) {
@@ -182,6 +188,8 @@ export async function renderStreaming(
 			const isVoid = (children == null || children === '') && voidElementNames.test(type);
 
 			if (!hasAttrs) {
+				// No attributes: skip the props copy and `spreadAttributes` entirely,
+				// and reuse the cached (constant) open/close tag strings for this tag.
 				const key = isVoid ? `${type}/` : type;
 				let openTag = openTagCache.get(key);
 				if (openTag === undefined) {

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -15,9 +15,11 @@ import { renderChild } from './any.js';
 import { Fragment, type RenderDestination } from './common.js';
 import { createBufferedRenderer, type RendererFlusher, voidElementNames } from './util.js';
 import { isAstroComponentFactory } from './astro/factory.js';
-import { createAstroComponentInstance } from './astro/instance.js';
+import { isHeadAndContent } from './astro/head-and-content.js';
+import { createAstroComponentInstance, isAstroComponentInstance } from './astro/instance.js';
 import { isRenderTemplateResult, type RenderTemplateResult } from './astro/render-template.js';
 import { containsServerDirective, ServerIslandComponent } from './server-islands.js';
+import { SlotRenderInstance } from './slot.js';
 
 const ClientOnlyPlaceholder = 'astro-client-only';
 
@@ -311,6 +313,20 @@ export async function renderStreaming(
 		if (isVNode(node)) {
 			handleVNode(node as AstroVNode);
 			continue;
+		}
+		// Expanded onto the stack rather than rendered via `renderChild` so their static
+		// markup joins the surrounding batch instead of one write per template part.
+		if (node instanceof SlotRenderInstance) {
+			stack.push(node.evaluate());
+			continue;
+		}
+		if (isAstroComponentInstance(node)) {
+			const returnValue = node.init(result);
+			if (!isPromise(returnValue)) {
+				stack.push(isHeadAndContent(returnValue) ? returnValue.content : returnValue);
+				continue;
+			}
+			// `init` memoizes, so the dynamic path below re-uses this same promise.
 		}
 		// Dynamic node: component instance, render instance, promise, JSX vnode,
 		// render instruction, iterable, etc. Rendered via renderChild — streamed

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -8,12 +8,16 @@ import {
 	isHTMLString,
 	markHTMLString,
 } from '../escape.js';
-import { spreadAttributes } from '../index.js';
 import { isPromise } from '../util.js';
 import { renderJSX } from '../jsx.js';
 import { renderChild } from './any.js';
 import { Fragment, type RenderDestination } from './common.js';
-import { createBufferedRenderer, type RendererFlusher, voidElementNames } from './util.js';
+import {
+	createBufferedRenderer,
+	type RendererFlusher,
+	spreadElementAttributes,
+	voidElementNames,
+} from './util.js';
 import { isAstroComponentFactory } from './astro/factory.js';
 import { isHeadAndContent } from './astro/head-and-content.js';
 import { createAstroComponentInstance, isAstroComponentInstance } from './astro/instance.js';
@@ -169,9 +173,6 @@ export async function renderStreaming(
 		// HTML element (e.g. 'div', 'span').
 		if (typeof type === 'string' && type !== ClientOnlyPlaceholder) {
 			const props = vnode.props;
-			// Check for attributes without copying props into a new object.
-			// Markdown/MDX is mostly elements with no attributes (<p>, <li>,
-			// <strong>…), for which we skip both that copy and `spreadAttributes`.
 			let hasAttrs = false;
 			if (props) {
 				for (const key in props) {
@@ -185,8 +186,7 @@ export async function renderStreaming(
 			const isVoid = (children == null || children === '') && voidElementNames.test(type);
 
 			if (!hasAttrs) {
-				// No attributes: skip the props copy and `spreadAttributes` entirely,
-				// and reuse the cached (constant) open/close tag strings for this tag.
+				// Without attributes the open tag depends only on the tag name, so it can be cached.
 				const key = isVoid ? `${type}/` : type;
 				let openTag = openTagCache.get(key);
 				if (openTag === undefined) {
@@ -199,14 +199,13 @@ export async function renderStreaming(
 					stack.push(closeTagFor(type));
 				}
 			} else {
-				const { children: _children, ...attrsProps } = props ?? {};
-				const attrs = spreadAttributes(attrsProps);
+				const attrs = spreadElementAttributes(props!);
 				if (isVoid) {
 					st.emitStatic(`<${type}${attrs}/>`);
 					return;
 				}
 				st.emitStatic(`<${type}${attrs}>`);
-				stack.push(markHTMLString(`</${type}>`));
+				stack.push(closeTagFor(type));
 			}
 
 			if (!isVoid && children != null && children !== '') {

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -339,7 +339,7 @@ export async function renderStreaming(
 		// directly while synchronous, buffered once a node renders asynchronously.
 		if (!st.buffered) {
 			if (st.batch) {
-				destination.write(markHTMLString(st.batch));
+				destination.write(st.batch);
 				st.batch = '';
 			}
 			// Write the node's output straight to `destination`. It renders
@@ -361,7 +361,7 @@ export async function renderStreaming(
 
 	if (!st.buffered) {
 		if (st.batch) {
-			destination.write(markHTMLString(st.batch));
+			destination.write(st.batch);
 		}
 		return;
 	}
@@ -372,7 +372,7 @@ export async function renderStreaming(
 	flushTailStatic();
 	for (const seg of tail) {
 		if (typeof seg === 'string') {
-			destination.write(markHTMLString(seg));
+			destination.write(seg);
 		} else {
 			const r = seg.flush();
 			if (isPromise(r)) await r;

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -67,13 +67,9 @@ class TemplateFrame {
  * Head propagation is handled by the caller (`bufferHeadContent`) before this
  * runs.
  */
-// A class: per-render `emitStatic` closures give call sites a fresh callee each render, deoptimizing them.
 class EngineState {
-	// Streaming-mode buffer (written directly to `destination`).
 	batch = '';
-	// Buffered-tail mode (entered on the first async dynamic node).
 	buffered = false;
-	// Static text collected while in buffered-tail mode.
 	tailStatic = '';
 
 	emitStatic(s: string) {
@@ -186,7 +182,6 @@ export async function renderStreaming(
 			const isVoid = (children == null || children === '') && voidElementNames.test(type);
 
 			if (!hasAttrs) {
-				// Without attributes the open tag depends only on the tag name, so it can be cached.
 				const key = isVoid ? `${type}/` : type;
 				let openTag = openTagCache.get(key);
 				if (openTag === undefined) {
@@ -310,8 +305,7 @@ export async function renderStreaming(
 			continue;
 		}
 		if (node instanceof HTMLString || isHTMLString(node)) {
-			// A SlotString's `instructions`/`chunks` are dropped by `toString()`; they only
-			// materialise when the object itself reaches the destination.
+			// SlotString metadata is lost when coerced to a string.
 			if (!(node instanceof SlotString)) {
 				st.emitStatic((node as HTMLString).toString());
 				continue;
@@ -329,8 +323,6 @@ export async function renderStreaming(
 			handleVNode(node as AstroVNode);
 			continue;
 		}
-		// Expanded onto the stack rather than rendered via `renderChild` so their static
-		// markup joins the surrounding batch instead of one write per template part.
 		if (node instanceof SlotRenderInstance) {
 			stack.push(node.evaluate());
 			continue;

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -63,6 +63,22 @@ class TemplateFrame {
  * Head propagation is handled by the caller (`bufferHeadContent`) before this
  * runs.
  */
+// A class: per-render `emitStatic` closures give call sites a fresh callee each render, deoptimizing them.
+class EngineState {
+	// Streaming-mode buffer (written directly to `destination`).
+	batch = '';
+	// Buffered-tail mode (entered on the first async dynamic node).
+	buffered = false;
+	// Static text collected while in buffered-tail mode.
+	tailStatic = '';
+
+	emitStatic(s: string) {
+		if (!s) return;
+		if (this.buffered) this.tailStatic += s;
+		else this.batch += s;
+	}
+}
+
 export async function renderStreaming(
 	root: unknown,
 	result: SSRResult,
@@ -87,24 +103,14 @@ export async function renderStreaming(
 		return tag;
 	};
 
-	// Streaming-mode buffer (written directly to `destination`).
-	let batch = '';
-	// Buffered-tail mode (entered on the first async dynamic node).
-	let buffered = false;
+	const st = new EngineState();
 	let firstAsync: Promise<void> | null = null;
 	const tail: Array<string | RendererFlusher> = [];
-	// Static text collected while in buffered-tail mode.
-	let tailStatic = '';
 
-	const emitStatic = (s: string) => {
-		if (!s) return;
-		if (buffered) tailStatic += s;
-		else batch += s;
-	};
 	const flushTailStatic = () => {
-		if (tailStatic) {
-			tail.push(tailStatic);
-			tailStatic = '';
+		if (st.tailStatic) {
+			tail.push(st.tailStatic);
+			st.tailStatic = '';
 		}
 	};
 
@@ -187,7 +193,7 @@ export async function renderStreaming(
 					openTag = isVoid ? `<${type}/>` : `<${type}>`;
 					openTagCache.set(key, openTag);
 				}
-				emitStatic(openTag);
+				st.emitStatic(openTag);
 				if (!isVoid) {
 					// Push close tag first so it is emitted after the children.
 					stack.push(closeTagFor(type));
@@ -196,10 +202,10 @@ export async function renderStreaming(
 				const { children: _children, ...attrsProps } = props ?? {};
 				const attrs = spreadAttributes(attrsProps);
 				if (isVoid) {
-					emitStatic(`<${type}${attrs}/>`);
+					st.emitStatic(`<${type}${attrs}/>`);
 					return;
 				}
-				emitStatic(`<${type}${attrs}>`);
+				st.emitStatic(`<${type}${attrs}>`);
 				stack.push(markHTMLString(`</${type}>`));
 			}
 
@@ -247,7 +253,7 @@ export async function renderStreaming(
 			let i = node.cursor;
 			while (i < htmlParts.length) {
 				if (htmlParts[i]) {
-					emitStatic(htmlParts[i]);
+					st.emitStatic(htmlParts[i]);
 				}
 				// `htmlParts.length === expressions.length + 1`, so the final HTML
 				// part has no expression after it. This break must come *after*
@@ -265,7 +271,7 @@ export async function renderStreaming(
 				if (expression == null || expression === false) continue;
 				const expressionType = typeof expression;
 				if (expressionType === 'string') {
-					emitStatic(escapeHTML(expression as string));
+					st.emitStatic(escapeHTML(expression as string));
 					continue;
 				}
 				if (
@@ -273,11 +279,11 @@ export async function renderStreaming(
 					expressionType === 'bigint' ||
 					expressionType === 'boolean'
 				) {
-					emitStatic(String(expression));
+					st.emitStatic(String(expression));
 					continue;
 				}
 				if (expression instanceof HTMLString || isHTMLString(expression)) {
-					emitStatic((expression as HTMLString).toString());
+					st.emitStatic((expression as HTMLString).toString());
 					continue;
 				}
 				// Complex expression: resume this frame after processing it.
@@ -291,15 +297,15 @@ export async function renderStreaming(
 
 		const nodeType = typeof node;
 		if (nodeType === 'string') {
-			emitStatic(escapeHTML(node as string));
+			st.emitStatic(escapeHTML(node as string));
 			continue;
 		}
 		if (nodeType === 'number' || nodeType === 'bigint' || nodeType === 'boolean') {
-			emitStatic(String(node));
+			st.emitStatic(String(node));
 			continue;
 		}
 		if (node instanceof HTMLString || isHTMLString(node)) {
-			emitStatic((node as HTMLString).toString());
+			st.emitStatic((node as HTMLString).toString());
 			continue;
 		}
 		if (Array.isArray(node)) {
@@ -331,10 +337,10 @@ export async function renderStreaming(
 		// Dynamic node: component instance, render instance, promise, JSX vnode,
 		// render instruction, iterable, etc. Rendered via renderChild — streamed
 		// directly while synchronous, buffered once a node renders asynchronously.
-		if (!buffered) {
-			if (batch) {
-				destination.write(markHTMLString(batch));
-				batch = '';
+		if (!st.buffered) {
+			if (st.batch) {
+				destination.write(markHTMLString(st.batch));
+				st.batch = '';
 			}
 			// Write the node's output straight to `destination`. It renders
 			// synchronously and in order, so putting it in a temporary buffer
@@ -343,7 +349,7 @@ export async function renderStreaming(
 			const rendered = renderDynamic(node)(destination);
 			if (isPromise(rendered)) {
 				// First async node: stream stops here. Buffer the remaining tail.
-				buffered = true;
+				st.buffered = true;
 				firstAsync = rendered;
 			}
 		} else {
@@ -353,9 +359,9 @@ export async function renderStreaming(
 		}
 	}
 
-	if (!buffered) {
-		if (batch) {
-			destination.write(markHTMLString(batch));
+	if (!st.buffered) {
+		if (st.batch) {
+			destination.write(markHTMLString(st.batch));
 		}
 		return;
 	}

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -23,7 +23,7 @@ import { isHeadAndContent } from './astro/head-and-content.js';
 import { createAstroComponentInstance, isAstroComponentInstance } from './astro/instance.js';
 import { isRenderTemplateResult, type RenderTemplateResult } from './astro/render-template.js';
 import { containsServerDirective, ServerIslandComponent } from './server-islands.js';
-import { SlotRenderInstance } from './slot.js';
+import { SlotRenderInstance, SlotString } from './slot.js';
 
 const ClientOnlyPlaceholder = 'astro-client-only';
 
@@ -282,8 +282,10 @@ export async function renderStreaming(
 					continue;
 				}
 				if (expression instanceof HTMLString || isHTMLString(expression)) {
-					st.emitStatic((expression as HTMLString).toString());
-					continue;
+					if (!(expression instanceof SlotString)) {
+						st.emitStatic((expression as HTMLString).toString());
+						continue;
+					}
 				}
 				// Complex expression: resume this frame after processing it.
 				node.storeCursor(i);
@@ -308,8 +310,12 @@ export async function renderStreaming(
 			continue;
 		}
 		if (node instanceof HTMLString || isHTMLString(node)) {
-			st.emitStatic((node as HTMLString).toString());
-			continue;
+			// A SlotString's `instructions`/`chunks` are dropped by `toString()`; they only
+			// materialise when the object itself reaches the destination.
+			if (!(node instanceof SlotString)) {
+				st.emitStatic((node as HTMLString).toString());
+				continue;
+			}
 		}
 		if (Array.isArray(node)) {
 			for (let i = node.length - 1; i >= 0; i--) stack.push(node[i]);

--- a/packages/astro/src/runtime/server/render/template-depth.ts
+++ b/packages/astro/src/runtime/server/render/template-depth.ts
@@ -1,16 +1,20 @@
 import type { SSRResult } from '../../../types/public/internal.js';
 import { createRenderInstruction } from './instruction.js';
 
+// Stateless, so one shared object saves an allocation per `<template>` boundary.
+const TEMPLATE_ENTER = createRenderInstruction({ type: 'template-enter' } as const);
+const TEMPLATE_EXIT = createRenderInstruction({ type: 'template-exit' } as const);
+
 /**
  * Emitted by the compiler when entering an HTML `<template>` element.
  */
 export function templateEnter(_result: SSRResult) {
-	return createRenderInstruction({ type: 'template-enter' });
+	return TEMPLATE_ENTER;
 }
 
 /**
  * Emitted by the compiler when exiting an HTML `<template>` element.
  */
 export function templateExit(_result: SSRResult) {
-	return createRenderInstruction({ type: 'template-exit' });
+	return TEMPLATE_EXIT;
 }

--- a/packages/astro/src/runtime/server/render/template-depth.ts
+++ b/packages/astro/src/runtime/server/render/template-depth.ts
@@ -1,7 +1,6 @@
 import type { SSRResult } from '../../../types/public/internal.js';
 import { createRenderInstruction } from './instruction.js';
 
-// Stateless, so one shared object saves an allocation per `<template>` boundary.
 const TEMPLATE_ENTER = Object.freeze(createRenderInstruction({ type: 'template-enter' } as const));
 const TEMPLATE_EXIT = Object.freeze(createRenderInstruction({ type: 'template-exit' } as const));
 

--- a/packages/astro/src/runtime/server/render/template-depth.ts
+++ b/packages/astro/src/runtime/server/render/template-depth.ts
@@ -2,8 +2,8 @@ import type { SSRResult } from '../../../types/public/internal.js';
 import { createRenderInstruction } from './instruction.js';
 
 // Stateless, so one shared object saves an allocation per `<template>` boundary.
-const TEMPLATE_ENTER = createRenderInstruction({ type: 'template-enter' } as const);
-const TEMPLATE_EXIT = createRenderInstruction({ type: 'template-exit' } as const);
+const TEMPLATE_ENTER = Object.freeze(createRenderInstruction({ type: 'template-enter' } as const));
+const TEMPLATE_EXIT = Object.freeze(createRenderInstruction({ type: 'template-exit' } as const));
 
 /**
  * Emitted by the compiler when entering an HTML `<template>` element.

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -189,6 +189,17 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 	return markHTMLString(` ${key}="${toAttributeString(value, shouldEscape)}"`);
 }
 
+export function spreadElementAttributes(values: Record<string, any>): string {
+	let output = '';
+	const keys = Object.keys(values);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		if (key === 'children') continue;
+		output += addAttribute(values[key], key, true);
+	}
+	return output;
+}
+
 // Adds support for `<Component {...value} />
 export function internalSpreadAttributes(
 	values: Record<any, any>,

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -27,7 +27,7 @@ const toIdent = (k: string) =>
 export const toAttributeString = (value: any, shouldEscape = true) => {
 	if (!shouldEscape) return value;
 	const str = String(value);
-	if (str.indexOf('&') === -1 && str.indexOf('"') === -1) return str;
+	if (!str.includes('&') && !str.includes('"')) return str;
 	return str.replace(AMPERSAND_REGEX, '&amp;').replace(DOUBLE_QUOTE_REGEX, '&quot;');
 };
 
@@ -191,9 +191,7 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 
 export function spreadElementAttributes(values: Record<string, any>): string {
 	let output = '';
-	const keys = Object.keys(values);
-	for (let i = 0; i < keys.length; i++) {
-		const key = keys[i];
+	for (const key of Object.keys(values)) {
 		if (key === 'children') continue;
 		output += addAttribute(values[key], key, true);
 	}
@@ -207,9 +205,7 @@ export function internalSpreadAttributes(
 	tagName: string,
 ) {
 	let output = '';
-	const keys = Object.keys(values);
-	for (let i = 0; i < keys.length; i++) {
-		const key = keys[i];
+	for (const key of Object.keys(values)) {
 		output += addAttribute(values[key], key, shouldEscape, tagName);
 	}
 	return markHTMLString(output);

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -105,6 +105,7 @@ function classifyAttribute(key: string): number {
 	if (key === 'style') return ATTRIBUTE_STYLE;
 	if (key === 'className') return ATTRIBUTE_CLASS_NAME;
 	if (htmlBooleanAttributes.test(key)) return ATTRIBUTE_BOOLEAN;
+	// We cannot add it to htmlBooleanAttributes because it can be: boolean | "auto" | "manual"
 	if (key === 'popover' || key === 'download' || key === 'hidden') {
 		return ATTRIBUTE_BOOLEAN_IF_BOOLEAN;
 	}
@@ -131,15 +132,18 @@ export function addAttribute(value: any, key: string, shouldEscape = true, tagNa
 	}
 
 	switch (attributeKind(key)) {
+		// Reject attribute names with characters that could break out of the attribute context.
 		case ATTRIBUTE_INVALID_NAME:
 			return '';
 
+		// compiler directives cannot be applied dynamically, log a warning and ignore.
 		case ATTRIBUTE_STATIC_DIRECTIVE:
 			console.warn(`[astro] The "${key}" directive cannot be applied dynamically at runtime. It will not be rendered as an attribute.
 
 Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the dynamic spread syntax (\`{...{ "${key}": value }}\`).`);
 			return '';
 
+		// support "class" from an expression passed into an element (#782)
 		case ATTRIBUTE_CLASS_LIST: {
 			const listValue = toAttributeString(clsx(value), shouldEscape);
 			if (listValue === '') {
@@ -148,6 +152,7 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 			return markHTMLString(` class="${listValue}"`);
 		}
 
+		// support object styles for better JSX compat
 		case ATTRIBUTE_STYLE:
 			if (!(value instanceof HTMLString)) {
 				if (Array.isArray(value) && value.length === 2) {
@@ -163,9 +168,11 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 			}
 			break;
 
+		// support `className` for better JSX compat
 		case ATTRIBUTE_CLASS_NAME:
 			return markHTMLString(` class="${toAttributeString(value, shouldEscape)}"`);
 
+		// Boolean values only need the key
 		case ATTRIBUTE_BOOLEAN:
 			return handleBooleanAttribute(key, value, shouldEscape, tagName);
 

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -34,14 +34,16 @@ export const toAttributeString = (value: any, shouldEscape = true) => {
 const kebab = (k: string) =>
 	k.toLowerCase() === k ? k : k.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
 
-export const toStyleString = (obj: Record<string, any>) =>
-	Object.entries(obj)
-		.filter(([_, v]) => (typeof v === 'string' && v.trim()) || typeof v === 'number')
-		.map(([k, v]) => {
-			if (k[0] !== '-' && k[1] !== '-') return `${kebab(k)}:${v}`;
-			return `${k}:${v}`;
-		})
-		.join(';');
+export const toStyleString = (obj: Record<string, any>) => {
+	let output = '';
+	for (const key of Object.keys(obj)) {
+		const value = obj[key];
+		if (!((typeof value === 'string' && value.trim()) || typeof value === 'number')) continue;
+		if (output) output += ';';
+		output += key[0] !== '-' && key[1] !== '-' ? `${kebab(key)}:${value}` : `${key}:${value}`;
+	}
+	return output;
+};
 
 // Adds variables to an inline script.
 export function defineScriptVars(vars: Record<any, any>) {
@@ -164,8 +166,10 @@ export function internalSpreadAttributes(
 	tagName: string,
 ) {
 	let output = '';
-	for (const [key, value] of Object.entries(values)) {
-		output += addAttribute(value, key, shouldEscape, tagName);
+	const keys = Object.keys(values);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		output += addAttribute(values[key], key, shouldEscape, tagName);
 	}
 	return markHTMLString(output);
 }

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -87,6 +87,41 @@ function handleBooleanAttribute(
 	return markHTMLString(value ? ` ${key}` : '');
 }
 
+const ATTRIBUTE_ORDINARY = 0;
+const ATTRIBUTE_INVALID_NAME = 1;
+const ATTRIBUTE_STATIC_DIRECTIVE = 2;
+const ATTRIBUTE_CLASS_LIST = 3;
+const ATTRIBUTE_STYLE = 4;
+const ATTRIBUTE_CLASS_NAME = 5;
+const ATTRIBUTE_BOOLEAN = 6;
+// `popover`, `download` and `hidden` accept strings too, so they are only boolean when the value is.
+const ATTRIBUTE_BOOLEAN_IF_BOOLEAN = 7;
+
+const attributeKinds = new Map<string, number>();
+
+function classifyAttribute(key: string): number {
+	if (INVALID_ATTR_NAME_CHAR.test(key)) return ATTRIBUTE_INVALID_NAME;
+	if (STATIC_DIRECTIVES.has(key)) return ATTRIBUTE_STATIC_DIRECTIVE;
+	if (key === 'class:list') return ATTRIBUTE_CLASS_LIST;
+	if (key === 'style') return ATTRIBUTE_STYLE;
+	if (key === 'className') return ATTRIBUTE_CLASS_NAME;
+	if (htmlBooleanAttributes.test(key)) return ATTRIBUTE_BOOLEAN;
+	if (key === 'popover' || key === 'download' || key === 'hidden') {
+		return ATTRIBUTE_BOOLEAN_IF_BOOLEAN;
+	}
+	return ATTRIBUTE_ORDINARY;
+}
+
+function attributeKind(key: string): number {
+	let kind = attributeKinds.get(key);
+	if (kind === undefined) {
+		kind = classifyAttribute(key);
+		// Spreads can carry attribute names from user data, so the cache is capped.
+		if (attributeKinds.size < 1024) attributeKinds.set(key, kind);
+	}
+	return kind;
+}
+
 // A helper used to turn expressions into attribute key/value
 // In the compiler, addAttribute is only printed to process attributes of elements
 // that may contain dynamic values. We don't need to pass tagName to addAttribute
@@ -96,64 +131,59 @@ export function addAttribute(value: any, key: string, shouldEscape = true, tagNa
 		return '';
 	}
 
-	// Reject attribute names with characters that could break out of the attribute context.
-	if (INVALID_ATTR_NAME_CHAR.test(key)) {
-		return '';
-	}
+	switch (attributeKind(key)) {
+		// Attribute names with characters that could break out of the attribute context.
+		case ATTRIBUTE_INVALID_NAME:
+			return '';
 
-	// compiler directives cannot be applied dynamically, log a warning and ignore.
-	if (STATIC_DIRECTIVES.has(key)) {
-		console.warn(`[astro] The "${key}" directive cannot be applied dynamically at runtime. It will not be rendered as an attribute.
+		// compiler directives cannot be applied dynamically, log a warning and ignore.
+		case ATTRIBUTE_STATIC_DIRECTIVE:
+			console.warn(`[astro] The "${key}" directive cannot be applied dynamically at runtime. It will not be rendered as an attribute.
 
 Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the dynamic spread syntax (\`{...{ "${key}": value }}\`).`);
-		return '';
-	}
-
-	// support "class" from an expression passed into an element (#782)
-	if (key === 'class:list') {
-		const listValue = toAttributeString(clsx(value), shouldEscape);
-		if (listValue === '') {
 			return '';
-		}
-		return markHTMLString(` ${key.slice(0, -5)}="${listValue}"`);
-	}
 
-	// support object styles for better JSX compat
-	if (key === 'style' && !(value instanceof HTMLString)) {
-		if (Array.isArray(value) && value.length === 2) {
-			return markHTMLString(
-				` ${key}="${toAttributeString(`${toStyleString(value[0])};${value[1]}`, shouldEscape)}"`,
-			);
+		// support "class" from an expression passed into an element (#782)
+		case ATTRIBUTE_CLASS_LIST: {
+			const listValue = toAttributeString(clsx(value), shouldEscape);
+			if (listValue === '') {
+				return '';
+			}
+			return markHTMLString(` class="${listValue}"`);
 		}
-		if (typeof value === 'object') {
-			return markHTMLString(` ${key}="${toAttributeString(toStyleString(value), shouldEscape)}"`);
-		}
-	}
 
-	// support `className` for better JSX compat
-	if (key === 'className') {
-		return markHTMLString(` class="${toAttributeString(value, shouldEscape)}"`);
-	}
+		// support object styles for better JSX compat
+		case ATTRIBUTE_STYLE:
+			if (!(value instanceof HTMLString)) {
+				if (Array.isArray(value) && value.length === 2) {
+					return markHTMLString(
+						` style="${toAttributeString(`${toStyleString(value[0])};${value[1]}`, shouldEscape)}"`,
+					);
+				}
+				if (typeof value === 'object') {
+					return markHTMLString(` style="${toAttributeString(toStyleString(value), shouldEscape)}"`);
+				}
+			}
+			break;
 
-	// Boolean values only need the key
-	if (htmlBooleanAttributes.test(key)) {
-		return handleBooleanAttribute(key, value, shouldEscape, tagName);
+		// support `className` for better JSX compat
+		case ATTRIBUTE_CLASS_NAME:
+			return markHTMLString(` class="${toAttributeString(value, shouldEscape)}"`);
+
+		// Boolean values only need the key
+		case ATTRIBUTE_BOOLEAN:
+			return handleBooleanAttribute(key, value, shouldEscape, tagName);
+
+		case ATTRIBUTE_BOOLEAN_IF_BOOLEAN:
+			if (typeof value === 'boolean') {
+				return handleBooleanAttribute(key, value, shouldEscape, tagName);
+			}
+			break;
 	}
 
 	// Other attributes with an empty string value can omit rendering the value
 	if (value === '') {
 		return markHTMLString(` ${key}`);
-	}
-
-	// We cannot add it to htmlBooleanAttributes because it can be: boolean | "auto" | "manual"
-	if (key === 'popover' && typeof value === 'boolean') {
-		return handleBooleanAttribute(key, value, shouldEscape, tagName);
-	}
-	if (key === 'download' && typeof value === 'boolean') {
-		return handleBooleanAttribute(key, value, shouldEscape, tagName);
-	}
-	if (key === 'hidden' && typeof value === 'boolean') {
-		return handleBooleanAttribute(key, value, shouldEscape, tagName);
 	}
 
 	return markHTMLString(` ${key}="${toAttributeString(value, shouldEscape)}"`);

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -94,7 +94,6 @@ const ATTRIBUTE_CLASS_LIST = 3;
 const ATTRIBUTE_STYLE = 4;
 const ATTRIBUTE_CLASS_NAME = 5;
 const ATTRIBUTE_BOOLEAN = 6;
-// `popover`, `download` and `hidden` accept strings too, so they are only boolean when the value is.
 const ATTRIBUTE_BOOLEAN_IF_BOOLEAN = 7;
 
 const attributeKinds = new Map<string, number>();
@@ -132,18 +131,15 @@ export function addAttribute(value: any, key: string, shouldEscape = true, tagNa
 	}
 
 	switch (attributeKind(key)) {
-		// Attribute names with characters that could break out of the attribute context.
 		case ATTRIBUTE_INVALID_NAME:
 			return '';
 
-		// compiler directives cannot be applied dynamically, log a warning and ignore.
 		case ATTRIBUTE_STATIC_DIRECTIVE:
 			console.warn(`[astro] The "${key}" directive cannot be applied dynamically at runtime. It will not be rendered as an attribute.
 
 Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the dynamic spread syntax (\`{...{ "${key}": value }}\`).`);
 			return '';
 
-		// support "class" from an expression passed into an element (#782)
 		case ATTRIBUTE_CLASS_LIST: {
 			const listValue = toAttributeString(clsx(value), shouldEscape);
 			if (listValue === '') {
@@ -152,7 +148,6 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 			return markHTMLString(` class="${listValue}"`);
 		}
 
-		// support object styles for better JSX compat
 		case ATTRIBUTE_STYLE:
 			if (!(value instanceof HTMLString)) {
 				if (Array.isArray(value) && value.length === 2) {
@@ -161,16 +156,16 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 					);
 				}
 				if (typeof value === 'object') {
-					return markHTMLString(` style="${toAttributeString(toStyleString(value), shouldEscape)}"`);
+					return markHTMLString(
+						` style="${toAttributeString(toStyleString(value), shouldEscape)}"`,
+					);
 				}
 			}
 			break;
 
-		// support `className` for better JSX compat
 		case ATTRIBUTE_CLASS_NAME:
 			return markHTMLString(` class="${toAttributeString(value, shouldEscape)}"`);
 
-		// Boolean values only need the key
 		case ATTRIBUTE_BOOLEAN:
 			return handleBooleanAttribute(key, value, shouldEscape, tagName);
 

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -24,10 +24,12 @@ const toIdent = (k: string) =>
 		return index === 0 ? match : match.toUpperCase();
 	});
 
-export const toAttributeString = (value: any, shouldEscape = true) =>
-	shouldEscape
-		? String(value).replace(AMPERSAND_REGEX, '&amp;').replace(DOUBLE_QUOTE_REGEX, '&quot;')
-		: value;
+export const toAttributeString = (value: any, shouldEscape = true) => {
+	if (!shouldEscape) return value;
+	const str = String(value);
+	if (str.indexOf('&') === -1 && str.indexOf('"') === -1) return str;
+	return str.replace(AMPERSAND_REGEX, '&amp;').replace(DOUBLE_QUOTE_REGEX, '&quot;');
+};
 
 const kebab = (k: string) =>
 	k.toLowerCase() === k ? k : k.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -100,8 +100,6 @@ const ATTRIBUTE_KIND = {
 
 type AttributeKind = (typeof ATTRIBUTE_KIND)[keyof typeof ATTRIBUTE_KIND];
 
-const attributeKinds = new Map<string, AttributeKind>();
-
 function classifyAttribute(key: string): AttributeKind {
 	if (INVALID_ATTR_NAME_CHAR.test(key)) return ATTRIBUTE_KIND.INVALID_NAME;
 	if (STATIC_DIRECTIVES.has(key)) return ATTRIBUTE_KIND.STATIC_DIRECTIVE;
@@ -116,16 +114,6 @@ function classifyAttribute(key: string): AttributeKind {
 	return ATTRIBUTE_KIND.ORDINARY;
 }
 
-function attributeKind(key: string): AttributeKind {
-	let kind = attributeKinds.get(key);
-	if (kind === undefined) {
-		kind = classifyAttribute(key);
-		// Spreads can carry attribute names from user data, so the cache is capped.
-		if (attributeKinds.size < 1024) attributeKinds.set(key, kind);
-	}
-	return kind;
-}
-
 // A helper used to turn expressions into attribute key/value
 // In the compiler, addAttribute is only printed to process attributes of elements
 // that may contain dynamic values. We don't need to pass tagName to addAttribute
@@ -135,7 +123,7 @@ export function addAttribute(value: any, key: string, shouldEscape = true, tagNa
 		return '';
 	}
 
-	const kind = attributeKind(key);
+	const kind = classifyAttribute(key);
 	switch (kind) {
 		// Reject attribute names with characters that could break out of the attribute context.
 		case ATTRIBUTE_KIND.INVALID_NAME:

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -87,32 +87,36 @@ function handleBooleanAttribute(
 	return markHTMLString(value ? ` ${key}` : '');
 }
 
-const ATTRIBUTE_ORDINARY = 0;
-const ATTRIBUTE_INVALID_NAME = 1;
-const ATTRIBUTE_STATIC_DIRECTIVE = 2;
-const ATTRIBUTE_CLASS_LIST = 3;
-const ATTRIBUTE_STYLE = 4;
-const ATTRIBUTE_CLASS_NAME = 5;
-const ATTRIBUTE_BOOLEAN = 6;
-const ATTRIBUTE_BOOLEAN_IF_BOOLEAN = 7;
+const ATTRIBUTE_KIND = {
+	ORDINARY: 0,
+	INVALID_NAME: 1,
+	STATIC_DIRECTIVE: 2,
+	CLASS_LIST: 3,
+	STYLE: 4,
+	CLASS_NAME: 5,
+	BOOLEAN: 6,
+	BOOLEAN_IF_BOOLEAN: 7,
+} as const;
 
-const attributeKinds = new Map<string, number>();
+type AttributeKind = (typeof ATTRIBUTE_KIND)[keyof typeof ATTRIBUTE_KIND];
 
-function classifyAttribute(key: string): number {
-	if (INVALID_ATTR_NAME_CHAR.test(key)) return ATTRIBUTE_INVALID_NAME;
-	if (STATIC_DIRECTIVES.has(key)) return ATTRIBUTE_STATIC_DIRECTIVE;
-	if (key === 'class:list') return ATTRIBUTE_CLASS_LIST;
-	if (key === 'style') return ATTRIBUTE_STYLE;
-	if (key === 'className') return ATTRIBUTE_CLASS_NAME;
-	if (htmlBooleanAttributes.test(key)) return ATTRIBUTE_BOOLEAN;
+const attributeKinds = new Map<string, AttributeKind>();
+
+function classifyAttribute(key: string): AttributeKind {
+	if (INVALID_ATTR_NAME_CHAR.test(key)) return ATTRIBUTE_KIND.INVALID_NAME;
+	if (STATIC_DIRECTIVES.has(key)) return ATTRIBUTE_KIND.STATIC_DIRECTIVE;
+	if (key === 'class:list') return ATTRIBUTE_KIND.CLASS_LIST;
+	if (key === 'style') return ATTRIBUTE_KIND.STYLE;
+	if (key === 'className') return ATTRIBUTE_KIND.CLASS_NAME;
+	if (htmlBooleanAttributes.test(key)) return ATTRIBUTE_KIND.BOOLEAN;
 	// We cannot add it to htmlBooleanAttributes because it can be: boolean | "auto" | "manual"
 	if (key === 'popover' || key === 'download' || key === 'hidden') {
-		return ATTRIBUTE_BOOLEAN_IF_BOOLEAN;
+		return ATTRIBUTE_KIND.BOOLEAN_IF_BOOLEAN;
 	}
-	return ATTRIBUTE_ORDINARY;
+	return ATTRIBUTE_KIND.ORDINARY;
 }
 
-function attributeKind(key: string): number {
+function attributeKind(key: string): AttributeKind {
 	let kind = attributeKinds.get(key);
 	if (kind === undefined) {
 		kind = classifyAttribute(key);
@@ -131,20 +135,21 @@ export function addAttribute(value: any, key: string, shouldEscape = true, tagNa
 		return '';
 	}
 
-	switch (attributeKind(key)) {
+	const kind = attributeKind(key);
+	switch (kind) {
 		// Reject attribute names with characters that could break out of the attribute context.
-		case ATTRIBUTE_INVALID_NAME:
+		case ATTRIBUTE_KIND.INVALID_NAME:
 			return '';
 
 		// compiler directives cannot be applied dynamically, log a warning and ignore.
-		case ATTRIBUTE_STATIC_DIRECTIVE:
+		case ATTRIBUTE_KIND.STATIC_DIRECTIVE:
 			console.warn(`[astro] The "${key}" directive cannot be applied dynamically at runtime. It will not be rendered as an attribute.
 
 Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the dynamic spread syntax (\`{...{ "${key}": value }}\`).`);
 			return '';
 
 		// support "class" from an expression passed into an element (#782)
-		case ATTRIBUTE_CLASS_LIST: {
+		case ATTRIBUTE_KIND.CLASS_LIST: {
 			const listValue = toAttributeString(clsx(value), shouldEscape);
 			if (listValue === '') {
 				return '';
@@ -153,7 +158,7 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 		}
 
 		// support object styles for better JSX compat
-		case ATTRIBUTE_STYLE:
+		case ATTRIBUTE_KIND.STYLE:
 			if (!(value instanceof HTMLString)) {
 				if (Array.isArray(value) && value.length === 2) {
 					return markHTMLString(
@@ -169,18 +174,24 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 			break;
 
 		// support `className` for better JSX compat
-		case ATTRIBUTE_CLASS_NAME:
+		case ATTRIBUTE_KIND.CLASS_NAME:
 			return markHTMLString(` class="${toAttributeString(value, shouldEscape)}"`);
 
 		// Boolean values only need the key
-		case ATTRIBUTE_BOOLEAN:
+		case ATTRIBUTE_KIND.BOOLEAN:
 			return handleBooleanAttribute(key, value, shouldEscape, tagName);
 
-		case ATTRIBUTE_BOOLEAN_IF_BOOLEAN:
+		case ATTRIBUTE_KIND.BOOLEAN_IF_BOOLEAN:
 			if (typeof value === 'boolean') {
 				return handleBooleanAttribute(key, value, shouldEscape, tagName);
 			}
 			break;
+
+		case ATTRIBUTE_KIND.ORDINARY:
+			break;
+
+		default:
+			kind satisfies never;
 	}
 
 	// Other attributes with an empty string value can omit rendering the value

--- a/packages/astro/src/runtime/server/util.ts
+++ b/packages/astro/src/runtime/server/util.ts
@@ -1,7 +1,5 @@
 export function isPromise<T = any>(value: any): value is Promise<T> {
-	return (
-		!!value && typeof value === 'object' && 'then' in value && typeof value.then === 'function'
-	);
+	return typeof value === 'object' && value !== null && typeof value.then === 'function';
 }
 
 export async function* streamAsyncIterator(stream: ReadableStream) {

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -3,6 +3,7 @@
 import type { ErrorPayload as ViteErrorPayload } from 'vite';
 import type { SSRManifestCSP } from '../../core/app/types.js';
 import type { AstroCookies } from '../../core/cookies/cookies.js';
+import type { Slots } from '../../core/render/slots.js';
 import type { AstroComponentInstance, ServerIslandComponent } from '../../runtime/server/index.js';
 import type { Params } from './common.js';
 import type { AstroConfig, RedirectConfig } from './config.js';
@@ -321,6 +322,7 @@ export interface SSRMetadata {
 	 * head content is flushed. Only populated when `routeHasPropagation` is true.
 	 */
 	pendingSlotEvaluations: Promise<unknown>[];
+	slotsByAstro?: WeakMap<object, Slots>;
 	/**
 	 * Tracks nesting depth of HTML `<template>` elements during rendering.
 	 * Scripts rendered inside `<template>` tags should not be deduplicated,

--- a/packages/astro/test/units/render/astro-global.test.ts
+++ b/packages/astro/test/units/render/astro-global.test.ts
@@ -243,6 +243,22 @@ describe('Astro Global', () => {
 });
 
 describe('Astro Global Defaults', () => {
+	it('can access slots after the Astro global is frozen', async () => {
+		const Slotted = createComponent((result: any, props: any, slots: any) => {
+			const Astro = result.createAstro(props, slots);
+			Object.freeze(Astro);
+			return render`<p>${Astro.slots.has('default')}</p>`;
+		});
+		const page = createComponent(
+			(result: any) =>
+				render`${renderComponent(result, 'Slotted', Slotted, {}, { default: () => render`slot content` })}`,
+		);
+		const app = createTestApp([createPage(page, { route: '/', isIndex: true })]);
+		const response = await app.render(new Request('https://example.com/'));
+
+		assert.match(await response.text(), /<p>true<\/p>/);
+	});
+
 	it('Astro.request.url with no site or base', async () => {
 		const page = createIndexPage();
 		const app = createTestApp([createPage(page, { route: '/', isIndex: true })]);

--- a/packages/astro/test/units/render/head.test.ts
+++ b/packages/astro/test/units/render/head.test.ts
@@ -10,6 +10,8 @@ import {
 	renderComponent,
 	renderHead,
 	renderSlot,
+	templateEnter,
+	templateExit,
 } from '../../../dist/runtime/server/index.js';
 import type { AstroComponentFactory } from '../../../dist/runtime/server/render/index.js';
 import type { TestPipeline } from '../test-utils.ts';
@@ -19,6 +21,28 @@ import { createBasicPipeline, renderThroughMiddleware } from '../test-utils.ts';
 const createAstroModule = (AstroComponent: AstroComponentFactory) => ({ default: AstroComponent });
 
 describe('core/render', () => {
+	it('isolates mutations to render instructions', () => {
+		const instructions = [
+			{ create: () => renderHead(), type: 'head' },
+			{ create: () => maybeRenderHead(), type: 'maybe-head' },
+			{ create: () => templateEnter({} as any), type: 'template-enter' },
+			{ create: () => templateExit({} as any), type: 'template-exit' },
+		];
+		const originals = instructions.map(({ create }) => create());
+		for (const instruction of originals) Reflect.set(instruction, 'type', 'invalid');
+
+		try {
+			assert.deepEqual(
+				instructions.map(({ create }) => create().type),
+				instructions.map(({ type }) => type),
+			);
+		} finally {
+			for (let i = 0; i < originals.length; i++) {
+				Reflect.set(originals[i], 'type', instructions[i].type);
+			}
+		}
+	});
+
 	describe('Injected head contents', () => {
 		let pipeline: TestPipeline;
 		before(async () => {

--- a/packages/astro/test/units/render/head.test.ts
+++ b/packages/astro/test/units/render/head.test.ts
@@ -14,6 +14,7 @@ import {
 	templateExit,
 } from '../../../dist/runtime/server/index.js';
 import type { AstroComponentFactory } from '../../../dist/runtime/server/render/index.js';
+import type { SSRResult } from '../../../dist/types/public/internal.js';
 import type { TestPipeline } from '../test-utils.ts';
 import { getEnvironment, setEnvironment } from '../../../dist/core/environment/index.js';
 import { createBasicPipeline, renderThroughMiddleware } from '../test-utils.ts';
@@ -25,8 +26,8 @@ describe('core/render', () => {
 		const instructions = [
 			{ create: () => renderHead(), type: 'head' },
 			{ create: () => maybeRenderHead(), type: 'maybe-head' },
-			{ create: () => templateEnter({} as any), type: 'template-enter' },
-			{ create: () => templateExit({} as any), type: 'template-exit' },
+			{ create: () => templateEnter({} as SSRResult), type: 'template-enter' },
+			{ create: () => templateExit({} as SSRResult), type: 'template-exit' },
 		];
 		const originals = instructions.map(({ create }) => create());
 		for (const instruction of originals) Reflect.set(instruction, 'type', 'invalid');

--- a/packages/astro/test/units/render/hydration.test.ts
+++ b/packages/astro/test/units/render/hydration.test.ts
@@ -181,4 +181,39 @@ describe('generateHydrateScript', () => {
 		);
 		assert.ok(!html.includes(`data-astro-transition-persist="${payload}"`));
 	});
+
+	it('coerces renderer attributes before escaping them', async () => {
+		const payload = '"><img src=x onerror=alert(1)>';
+		let coercions = 0;
+		const value = {
+			toString() {
+				coercions++;
+				return coercions === 1 ? 'safe' : payload;
+			},
+		};
+		const island = await generateHydrateScript(
+			{
+				renderer: {
+					clientEntrypoint: 'renderer.js',
+				} as any,
+				result: {
+					resolve: async (path: string) => path,
+				} as any,
+				astroId: 'abc123',
+				props: {},
+				attrs: { 'data-renderer': value } as any,
+			},
+			{
+				hydrate: 'load',
+				componentUrl: 'component.jsx',
+				componentExport: { value: 'default' },
+				displayName: 'Island',
+			} as any,
+		);
+		const html = renderElement('astro-island', island, false);
+
+		assert.equal(coercions, 1);
+		assert.ok(html.includes('data-renderer="safe"'));
+		assert.ok(!html.includes(payload));
+	});
 });

--- a/packages/astro/test/units/render/rendering.test.ts
+++ b/packages/astro/test/units/render/rendering.test.ts
@@ -247,6 +247,18 @@ describe('rendering', () => {
 			'root/last',
 		]);
 	});
+
+	it('awaits thenables that also have a render method', async () => {
+		const thenable = Object.assign(Promise.resolve('expected'), {
+			render(destination: RenderDestination) {
+				destination.write('unexpected');
+			},
+		});
+
+		const result = await renderToString(renderTemplate`${[thenable]}`);
+
+		assert.equal(result, 'expected');
+	});
 });
 
 function renderToString(item: any): string | Promise<string> {

--- a/packages/astro/test/units/render/sync-expansion.test.ts
+++ b/packages/astro/test/units/render/sync-expansion.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { experimental_AstroContainer } from '../../../dist/container/index.js';
+import {
+	createComponent,
+	render,
+	renderComponent,
+	renderSlotToString,
+} from '../../../dist/runtime/server/index.js';
+import { createRenderInstruction } from '../../../dist/runtime/server/render/instruction.js';
+
+// The engine expands sync subtrees inline; these lock it to the buffered path it replaces.
+describe('sync subtree expansion', () => {
+	it('keeps scripts carried alongside a slot rendered into a sync component', async () => {
+		const Child = createComponent((_result, props) => render`<div>${props.content}</div>`);
+		const Page = createComponent(async (result) => {
+			const content = await renderSlotToString(
+				result,
+				() =>
+					render`<p>slot</p>${createRenderInstruction({
+						type: 'script',
+						id: 'sync-expansion-script',
+						content: '<script type="module">/* island */</script>',
+					})}`,
+			);
+			return render`<main>${renderComponent(result, 'Child', Child, { content }, {})}</main>`;
+		});
+
+		const container = await experimental_AstroContainer.create();
+		const html = await container.renderToString(Page);
+
+		assert.ok(html.includes('<p>slot</p>'), `slot content missing: ${html}`);
+		assert.ok(html.includes('/* island */'), `script carried by the slot was dropped: ${html}`);
+	});
+
+	// The engine stringifies `NaN`/`0n` where the buffered path drops them, and predates this PR.
+	it('skips only null, undefined and false', async () => {
+		const Page = createComponent(
+			() =>
+				render`<p>${Number.NaN}</p><p>${0n}</p><p>${0}</p><p>${''}</p><p>${false}</p><p>${null}</p>`,
+		);
+
+		const container = await experimental_AstroContainer.create();
+		const html = await container.renderToString(Page);
+
+		assert.equal(html, '<p>NaN</p><p>0</p><p>0</p><p></p><p></p><p></p>');
+	});
+
+	it('rethrows when the same template is rendered twice', async () => {
+		const template = render`<p>${Promise.reject(new Error('boom'))}</p>`;
+		const Page = createComponent(() => template);
+
+		const container = await experimental_AstroContainer.create();
+		await assert.rejects(() => container.renderToString(Page), /boom/);
+		await assert.rejects(() => container.renderToString(Page), /boom/);
+	});
+});

--- a/packages/astro/test/units/render/sync-expansion.test.ts
+++ b/packages/astro/test/units/render/sync-expansion.test.ts
@@ -9,7 +9,6 @@ import {
 } from '../../../dist/runtime/server/index.js';
 import { createRenderInstruction } from '../../../dist/runtime/server/render/instruction.js';
 
-// The engine expands sync subtrees inline; these lock it to the buffered path it replaces.
 describe('sync subtree expansion', () => {
 	it('keeps scripts carried alongside a slot rendered into a sync component', async () => {
 		const Child = createComponent((_result, props) => render`<div>${props.content}</div>`);
@@ -33,7 +32,6 @@ describe('sync subtree expansion', () => {
 		assert.ok(html.includes('/* island */'), `script carried by the slot was dropped: ${html}`);
 	});
 
-	// The engine stringifies `NaN`/`0n` where the buffered path drops them, and predates this PR.
 	it('skips only null, undefined and false', async () => {
 		const Page = createComponent(
 			() =>


### PR DESCRIPTION
## Changes

This PR improves the overall performance of our rendering pipeline, without changing the entire structure or anything, just mostly focused on reducing allocations, preventing V8 de-opt, and/or just faster code in some places.

This of course mostly improves SSR performance, but nonetheless, in local this makes the docs build 2s faster on my computer. In SSR stress benchmarks, this has resulted in a up to 70% improvement in raw ops/s, but it's of course not representing real work.

## Testing

Tests should pass. Also added some tests for behavior that I found easy to regress by accident while working on this.

## Docs

N/A
