### PR TITLE
fix(i18n): only swap whole locale segments when generating fallback routes

### DIFF
--- a/.changeset/tall-crabs-attack.md
+++ b/.changeset/tall-crabs-attack.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes i18n fallback routes being generated with a corrupted path when the locale code also appears at the start of a later path segment. A page such as `src/pages/en/enterprise.astro` with `fallback: { es: 'en' }` produced the route `/es/esterprise` instead of `/es/enterprise`, so the fallback never matched the intended URL. Only the leading locale segment is rewritten now.

--- a/packages/astro/src/core/routing/create-manifest.ts
+++ b/packages/astro/src/core/routing/create-manifest.ts
@@ -1008,7 +1008,17 @@ function joinSegments(segments: RoutePart[][]): string {
 	return `/${arr.join('/')}`;
 }
 
+/**
+ * Swaps the first `from` locale segment of a route for `to`. Routes that already carry the
+ * `to` locale, and routes with no `from` segment, are returned unchanged. Matching is done on
+ * whole segments — the same way routes are grouped by locale above — so a locale code that is
+ * merely a prefix of another segment (`/en/enterprise`) is left alone.
+ */
 function replaceOrKeep(original: string, from: string, to: string): string {
 	if (original.startsWith(`/${to}/`) || original === `/${to}`) return original;
-	return original.replace(`/${from}/`, `/${to}/`).replace(`/${from}`, `/${to}`);
+	const segments = original.split('/');
+	const index = segments.indexOf(from);
+	if (index === -1) return original;
+	segments[index] = to;
+	return segments.join('/');
 }

--- a/packages/astro/test/units/i18n/create-manifest.test.ts
+++ b/packages/astro/test/units/i18n/create-manifest.test.ts
@@ -124,3 +124,74 @@ describe('createI18nFallbackRoutes — no fallback config', () => {
 		assert.equal(routes.length, 1);
 	});
 });
+
+describe('createI18nFallbackRoutes — locale code appearing inside a path segment', () => {
+	it('rewrites only the leading locale segment when falling back to a non-default locale', () => {
+		const esRoute = createRouteData({
+			route: '/es/estudio',
+			pathname: '/es/estudio',
+			type: 'page',
+		});
+		const routes = [esRoute];
+
+		createI18nFallbackRoutes(
+			routes,
+			makeI18n({
+				locales: ['en', 'es', 'fr'],
+				fallback: { fr: 'es' },
+			}),
+			BASE_CONFIG,
+		);
+
+		const fallback = esRoute.fallbackRoutes.find((r) => r.type === 'fallback');
+		assert.ok(fallback, 'expected a fallback route for the fr locale');
+		assert.equal(fallback.route, '/fr/estudio');
+		assert.equal(fallback.pathname, '/fr/estudio');
+	});
+
+	it('rewrites only the leading locale segment under prefix-always', () => {
+		const enRoute = createRouteData({
+			route: '/en/enterprise',
+			pathname: '/en/enterprise',
+			type: 'page',
+		});
+		const routes = [enRoute];
+
+		createI18nFallbackRoutes(
+			routes,
+			makeI18n({
+				routing: { prefixDefaultLocale: true },
+				fallback: { es: 'en' },
+			}),
+			BASE_CONFIG,
+		);
+
+		const fallback = enRoute.fallbackRoutes.find((r) => r.type === 'fallback');
+		assert.ok(fallback, 'expected a fallback route for the es locale');
+		assert.equal(fallback.route, '/es/enterprise');
+		assert.equal(fallback.pathname, '/es/enterprise');
+	});
+
+	it('leaves a locale code in a deeper segment untouched', () => {
+		const enRoute = createRouteData({
+			route: '/en/blog/entry',
+			pathname: '/en/blog/entry',
+			type: 'page',
+		});
+		const routes = [enRoute];
+
+		createI18nFallbackRoutes(
+			routes,
+			makeI18n({
+				routing: { prefixDefaultLocale: true },
+				fallback: { es: 'en' },
+			}),
+			BASE_CONFIG,
+		);
+
+		const fallback = enRoute.fallbackRoutes.find((r) => r.type === 'fallback');
+		assert.ok(fallback, 'expected a fallback route for the es locale');
+		assert.equal(fallback.route, '/es/blog/entry');
+		assert.equal(fallback.pathname, '/es/blog/entry');
+	});
+});


### PR DESCRIPTION
## Changes

- `createI18nFallbackRoutes` builds each fallback route by swapping the source locale segment for the target one via `replaceOrKeep`. That helper chained two unanchored `String.prototype.replace` calls:

  ```ts
  return original.replace(`/${from}/`, `/${to}/`).replace(`/${from}`, `/${to}`);
  ```

  The first call rewrites the leading segment; the second then runs on the *already rewritten* string and matches `/${from}` anywhere in it. Whenever a later path segment happens to start with the locale code, the second call corrupts it:

  | route | fallback | produced | expected |
  | --- | --- | --- | --- |
  | `/en/enterprise` | `{ es: 'en' }` | `/es/esterprise` | `/es/enterprise` |
  | `/en/blog/entry` | `{ es: 'en' }` | `/es/blog/estry` | `/es/blog/entry` |
  | `/es/estudio` | `{ fr: 'es' }` | `/fr/frtudio` | `/fr/estudio` |

  The resulting `type: 'fallback'` `RouteData` carries the mangled `route`/`pathname`, and its `pattern` is compiled from them — so the fallback never matches the URL it was meant to cover.

- Match on whole path segments instead. This mirrors how routes are grouped by locale earlier in the same function (`route.route.split('/').includes(locale)`), so the two stay consistent.

- Changeset added (`astro`, patch).

Both code paths that reach `replaceOrKeep` are affected: `fallback` targeting a non-default locale (e.g. `{ fr: 'es' }`), and any `fallback` under `prefixDefaultLocale: true`.

Related: #14020 introduced `replaceOrKeep`; #14690 fixed the neighbouring "filename starts with a locale key" case for the default-locale branch, which does not go through this helper.

## Testing

Three cases added to `packages/astro/test/units/i18n/create-manifest.test.ts`, all failing before the change and passing after:

Before (unmodified `main`):

```
✖ rewrites only the leading locale segment when falling back to a non-default locale
  + '/fr/frtudio'   - '/fr/estudio'
✖ rewrites only the leading locale segment under prefix-always
  + '/es/esterprise' - '/es/enterprise'
✖ leaves a locale code in a deeper segment untouched
  + '/es/blog/estry' - '/es/blog/entry'
ℹ tests 10 / pass 7 / fail 3
```

After:

```
ℹ tests 10 / pass 10 / fail 0
```

I also diffed the old and new helper across the inputs the existing tests and fixtures exercise (`/es/about`, `/en`, `/about`, `/start`, `/blog/en/post`, `/en/[slug]`, `/en/index`, `/es/other`, `/spanish/x`) — the two agree on every one of them; only the corrupted cases above change.

Suites run locally (Windows, Node 22.15, pnpm 11.13.1):

- `pnpm --filter astro run test:unit` — 3445 tests, 0 failures
- `pnpm --filter astro run test:integration` — 1257 tests, 2 failures: `Content Collections > Handles symlinked content` and `> Handles symlinked data`. Both are pre-existing and unrelated — I stashed the whole change, rebuilt, and re-ran that file on a clean tree, where they fail identically (Windows symlink permissions).
- `pnpm typecheck` — clean
- `biome check` / `biome lint` / `eslint` on the changed files — clean

## Docs

No docs change needed — this restores the documented `i18n.fallback` behaviour rather than altering it.
