### PR TITLE
fix(cli): report the package that is actually missing in astro check

### DIFF
--- a/.changeset/check-report-missing-package.md
+++ b/.changeset/check-report-missing-package.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro check` reporting `typescript` as missing when it is installed, and reports the underlying error when a package resolves but fails to load

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -20,9 +20,13 @@ export async function check(flags: Flags): Promise<boolean | void> {
 	const typescript = await getPackage('typescript', logger, getPackageOpts);
 
 	if (!checkPackage || !typescript) {
+		const missing = [
+			checkPackage ? undefined : '`@astrojs/check`',
+			typescript ? undefined : '`typescript`',
+		].filter((name) => name !== undefined);
 		logger.error(
 			'check',
-			'The `@astrojs/check` and `typescript` packages are required for this command to work. Please manually install them into your project and try again.',
+			`The ${missing.join(' and ')} ${missing.length > 1 ? 'packages are' : 'package is'} required for this command to work. Please manually install ${missing.length > 1 ? 'them' : 'it'} into your project and try again.`,
 		);
 		return;
 	}

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -22,12 +22,14 @@ export async function getPackage<T>(
 	options: GetPackageOptions,
 	otherDeps: string[] = [],
 ): Promise<T | undefined> {
+	// Resolve and import in separate steps. Resolution answers "is the package installed",
+	// the import answers "does it load"; folding both into one `catch` reports a package that
+	// is installed but throws on import as if it were missing.
+	let resolved: string;
 	try {
 		// Try to resolve with `createRequire` first to prevent ESM caching of the package
 		// if it errors and fails here
-		const resolved = require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
-		const packageImport = await import(pathToFileURL(resolved).href);
-		return packageImport as T;
+		resolved = require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
 	} catch {
 		if (options.optional) return undefined;
 		let message = `To continue, Astro requires the following dependency to be installed: ${bold(
@@ -46,13 +48,21 @@ export async function getPackage<T>(
 
 		const result = await installPackage([packageName, ...otherDeps], options, logger);
 
-		if (result) {
-			const resolved = require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
-			const packageImport = await import(pathToFileURL(resolved).href);
-			return packageImport;
-		} else {
-			return undefined;
-		}
+		if (!result) return undefined;
+		resolved = require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
+	}
+
+	try {
+		return (await import(pathToFileURL(resolved).href)) as T;
+	} catch (error) {
+		if (options.optional) return undefined;
+		logger.error(
+			'SKIP_FORMAT',
+			`${bold(packageName)} is installed but could not be loaded: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return undefined;
 	}
 }
 

--- a/packages/astro/test/units/cli/install-package.test.ts
+++ b/packages/astro/test/units/cli/install-package.test.ts
@@ -37,4 +37,42 @@ describe('getPackage', () => {
 			await rm(projectDir, { recursive: true, force: true });
 		}
 	});
+
+	it('reports a package that is installed but throws on import', async () => {
+		const projectDir = join(tmpdir(), `astro-test-getpackage-throws-${Date.now()}`);
+		const pkgDir = join(projectDir, 'node_modules', 'throwing-test-pkg');
+
+		try {
+			await mkdir(pkgDir, { recursive: true });
+			await writeFile(
+				join(pkgDir, 'package.json'),
+				JSON.stringify({
+					name: 'throwing-test-pkg',
+					version: '1.0.0',
+					main: 'index.js',
+					type: 'module',
+				}),
+			);
+			await writeFile(join(pkgDir, 'index.js'), "throw new Error('boom');\n");
+
+			const messages: string[] = [];
+			const logger = {
+				...defaultLogger,
+				error: (_label: string, message: string) => messages.push(message),
+			};
+
+			const result = await getPackage('throwing-test-pkg', logger as never, { cwd: projectDir });
+
+			assert.equal(result, undefined, 'Expected getPackage to return undefined');
+			assert.equal(messages.length, 1, 'Expected exactly one error to be logged');
+			assert.match(
+				messages[0],
+				/installed but could not be loaded/,
+				'Expected the error to say the package failed to load, not that it is missing',
+			);
+			assert.match(messages[0], /boom/, 'Expected the underlying error to be reported');
+		} finally {
+			await rm(projectDir, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
Fixes #17268.

`astro check` tells you `typescript` is missing when it is installed. Here is the chain:

1. `@astrojs/check@0.9.10` declares `peerDependencies: { typescript: "^5.0.0 || ^6.0.0" }`, so with TypeScript 7 in the project npm refuses to install it:

```
npm error Found: typescript@7.0.2
npm error Could not resolve dependency:
npm error peer typescript@"^5.0.0 || ^6.0.0" from @astrojs/check@0.9.10
```

2. `check()` then fails to resolve `@astrojs/check` and falls into a branch that names both packages regardless of which one is actually missing, so the message points at `typescript` too. `typescript` is installed and resolves fine — it just no longer exports the compiler API in 7.x, where `require("typescript")` returns only `{ version, versionMajorMinor }`.

Two changes:

- `cli/check/index.ts` now names only the packages that failed to resolve.
- `getPackage` resolves and imports in two separate steps. Resolution answers "is the package installed", the import answers "does it load". Folding both into one `catch` means a package that is installed but throws on import is reported as missing, and Astro offers to install something that is already there. The import failure now reports the underlying error instead.

The second part is not specific to TypeScript — it applies to every package Astro loads this way.

Real TypeScript 7 support in `@astrojs/check` is a separate problem: it needs the compiler API, which Microsoft says returns in 7.1. This PR only makes the failure say what actually happened.

Added a unit test for the load-failure path next to the existing `getPackage` test. `biome lint`, `biome format`, `prettier --check`, `tsc -b` and `test/units/cli` (37 tests) all pass.
