### PR TITLE
fix(cache): prevent browser heuristic freshness on cached routes

### DIFF
--- a/.changeset/fix-cache-browser-heuristic.md
+++ b/.changeset/fix-cache-browser-heuristic.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds `Cache-Control: public, max-age=0, must-revalidate` to cached route responses that carry a validator (`Last-Modified` or `ETag`) but no browser-facing `Cache-Control` header. This prevents browsers from applying RFC 9111 §4.2.2 heuristic freshness, which silently caches pages based on the validator's age and makes tag-based invalidation and redeployments ineffective for affected visitors.

--- a/packages/astro/src/core/cache/provider-utils.ts
+++ b/packages/astro/src/core/cache/provider-utils.ts
@@ -63,6 +63,12 @@ export function setConditionalHeaders(headers: Headers, options: CacheOptions): 
 	if (options.etag) {
 		headers.set('ETag', options.etag);
 	}
+	// Prevent browser heuristic freshness (RFC 9111 §4.2.2) when a validator
+	// is present but no browser-facing Cache-Control has been set.
+	const hasValidator = headers.has('Last-Modified') || headers.has('ETag');
+	if (hasValidator && !headers.has('Cache-Control')) {
+		headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
+	}
 }
 
 /**

--- a/packages/astro/src/core/cache/runtime/utils.ts
+++ b/packages/astro/src/core/cache/runtime/utils.ts
@@ -34,6 +34,15 @@ export function defaultSetHeaders(options: CacheOptions): Headers {
 		headers.set('ETag', options.etag);
 	}
 
+	// Prevent browser heuristic freshness (RFC 9111 §4.2.2) when a validator
+	// is present but no browser-facing Cache-Control has been set. Without this,
+	// browsers cache the response silently based on Last-Modified age, making
+	// tag-based invalidation and redeployments ineffective for affected visitors.
+	const hasValidator = headers.has('Last-Modified') || headers.has('ETag');
+	if (hasValidator && !headers.has('Cache-Control')) {
+		headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
+	}
+
 	return headers;
 }
 

--- a/packages/astro/test/units/cache/provider-utils.test.ts
+++ b/packages/astro/test/units/cache/provider-utils.test.ts
@@ -86,6 +86,31 @@ describe('cache provider-utils', () => {
 			setConditionalHeaders(headers, {});
 			assert.equal([...headers.entries()].length, 0);
 		});
+
+		it('adds Cache-Control when Last-Modified is set', () => {
+			const headers = new Headers();
+			setConditionalHeaders(headers, { lastModified: new Date('2026-08-01T00:00:00Z') });
+			assert.equal(headers.get('Cache-Control'), 'public, max-age=0, must-revalidate');
+		});
+
+		it('adds Cache-Control when ETag is set', () => {
+			const headers = new Headers();
+			setConditionalHeaders(headers, { etag: '"v1"' });
+			assert.equal(headers.get('Cache-Control'), 'public, max-age=0, must-revalidate');
+		});
+
+		it('does not override existing Cache-Control', () => {
+			const headers = new Headers();
+			headers.set('Cache-Control', 'private, no-store');
+			setConditionalHeaders(headers, { lastModified: new Date() });
+			assert.equal(headers.get('Cache-Control'), 'private, no-store');
+		});
+
+		it('no Cache-Control without validators', () => {
+			const headers = new Headers();
+			setConditionalHeaders(headers, {});
+			assert.equal(headers.get('Cache-Control'), null);
+		});
 	});
 
 	describe('normalizeTags', () => {

--- a/packages/astro/test/units/cache/utils.test.ts
+++ b/packages/astro/test/units/cache/utils.test.ts
@@ -49,6 +49,29 @@ describe('defaultSetHeaders()', () => {
 		assert.equal(headers.get('Cache-Tag'), 'a');
 		assert.equal(headers.get('CDN-Cache-Control'), null);
 	});
+
+	it('adds Cache-Control when Last-Modified is present', () => {
+		const headers = defaultSetHeaders({
+			maxAge: 300,
+			lastModified: new Date('2026-08-01T00:00:00Z'),
+		});
+		assert.equal(headers.get('Cache-Control'), 'public, max-age=0, must-revalidate');
+	});
+
+	it('adds Cache-Control when ETag is present', () => {
+		const headers = defaultSetHeaders({ maxAge: 300, etag: '"v1"' });
+		assert.equal(headers.get('Cache-Control'), 'public, max-age=0, must-revalidate');
+	});
+
+	it('no Cache-Control when no validator is present', () => {
+		const headers = defaultSetHeaders({ maxAge: 300 });
+		assert.equal(headers.get('Cache-Control'), null);
+	});
+
+	it('no Cache-Control when no options at all', () => {
+		const headers = defaultSetHeaders({});
+		assert.equal(headers.get('Cache-Control'), null);
+	});
 });
 
 describe('isCacheHint()', () => {


### PR DESCRIPTION
## Summary

Fixes #17803 — cached routes emit `Last-Modified` with no browser-facing `Cache-Control`, putting every cached route on [RFC 9111 §4.2.2 heuristic freshness](https://www.rfc-editor.org/rfc/rfc9111#name-calculating-heuristic-fresh). Browsers silently serve stale pages from disk cache based on the validator's age, defeating tag-based invalidation and redeployments.

**Root cause:** `defaultSetHeaders` (used by `memoryCache` and any provider without custom `setHeaders`) and the shared `setConditionalHeaders` helper (used by all vendor providers) emit `CDN-Cache-Control` and validators but never `Cache-Control`. After the adapter strips CDN headers, the browser receives a validator and nothing else — the exact input to heuristic freshness.

**Fix:** After setting validators, check whether `Cache-Control` is absent and add `public, max-age=0, must-revalidate`. This forces the browser to revalidate on every navigation while leaving CDN-side freshness (`CDN-Cache-Control`, `Cloudflare-CDN-Cache-Control`, etc.) untouched. The existing `304` path already works correctly; the fix ensures browsers actually use it.

Applied in two places so all providers are covered:
- `packages/astro/src/core/cache/runtime/utils.ts` — `defaultSetHeaders` (generic/memory provider)
- `packages/astro/src/core/cache/provider-utils.ts` — `setConditionalHeaders` (Cloudflare, Netlify, Vercel)

## Test plan

- [x] `node --test test/units/cache/utils.test.ts` — 15 passed (4 new)
- [x] `node --test test/units/cache/provider-utils.test.ts` — 25 passed (4 new)
- [x] `node --test test/units/cache/app-cache.test.ts` — 21 passed (no changes)
- [x] Build passes (`pnpm run build --filter astro`)

New test cases:
- Validator present → `Cache-Control` added
- No validator → no `Cache-Control`
- Existing `Cache-Control` not overridden
- Both `Last-Modified` and `ETag` paths covered