### PR TITLE
Omit empty `srcset` on content collection Markdown images

### DIFF
--- a/.changeset/content-image-empty-srcset.md
+++ b/.changeset/content-image-empty-srcset.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Markdown images in content collections rendering an empty `srcset` attribute when no responsive candidates are generated.

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -504,7 +504,9 @@ async function updateImageReferencesInBody(html: string, fileName: string) {
 		return Object.entries({
 			...attributes,
 			src: image.src,
-			srcset: image.srcSet.attribute,
+			// An empty `srcset` is invalid HTML, so only emit it when there are
+			// actual candidates. This matches `vite-plugin-markdown/images.ts`.
+			...(image.srcSet.values.length > 0 ? { srcset: image.srcSet.attribute } : {}),
 			// This attribute is used by the toolbar audit
 			...(import.meta.env.DEV ? { 'data-image-component': 'true' } : {}),
 		})

--- a/packages/astro/test/core-image.test.ts
+++ b/packages/astro/test/core-image.test.ts
@@ -1183,6 +1183,22 @@ describe('build ssg', () => {
 		assert.equal($contentImg.attr('alt'), '', 'alt attribute should be empty string, not missing');
 	});
 
+	it('content collection images omit srcset when there are no candidates', async () => {
+		const html = await fixture.readFile('/blog/empty-alt/index.html');
+
+		const $ = cheerio.load(html);
+		const $contentImg = $('img').filter(function () {
+			// Find the image rendered from markdown content (not the frontmatter images)
+			return !$(this).closest('#direct-image, #nested-image').length;
+		});
+		assert.equal($contentImg.length, 1, 'should have one content image');
+		assert.equal(
+			$contentImg.attr('srcset'),
+			undefined,
+			'srcset attribute should be missing, not an empty string',
+		);
+	});
+
 	it('quality attribute produces a different file', async () => {
 		const html = await fixture.readFile('/quality/index.html');
 		const $ = cheerio.load(html);


### PR DESCRIPTION
Fixes #17871

## Changes

- Markdown images rendered through a content collection always got a `srcset` attribute, so an image with no responsive candidates produced `srcset=""`, which is invalid HTML and is flagged by the W3C validator.
- `packages/astro/src/content/runtime.ts` now only adds the attribute when `image.srcSet.values.length > 0`, which is the same guard `packages/astro/src/vite-plugin-markdown/images.ts` already applies. The `<Image />` component behaves this way too.
- The serializer's `value === ''` branch is left alone, since it is what keeps an empty `alt` from being dropped.
- Added a changeset.

## Testing

Added `content collection images omit srcset when there are no candidates` to `packages/astro/test/core-image.test.ts`. It reuses the existing `core-image-ssg` `empty-alt` fixture and the same selector as the neighbouring empty-`alt` test, so the two assertions cover both directions of the serializer's empty-string handling.

Verified against a standalone project on `astro@7.2.9` (https://github.com/jx-grxf/astro-markdown-srcset-repro):

- default config, before: `<img ... src="/_astro/wide...webp" srcset="">`, after: no `srcset`
- `image: { layout: 'constrained' }`, after: `srcset="/_astro/wide...webp 640w, ... 2000w"` — still emitted when there are candidates
- the same Markdown in `src/pages/legacy.md` was already rendering without the attribute, before and after

## Docs

No docs change. This aligns the content layer output with the documented behaviour of the other image paths; nothing user-facing gains or loses an option.
