### PR TITLE
ci: use github runner

### DIFF
--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   reply-labeled:
     if: github.repository == 'withastro/astro'
-    runs-on: depot-ubuntu-24.04-arm-small
+    runs-on: ubuntu-latest
     steps:
       - name: Remove triaging label
         if: >-


### PR DESCRIPTION
## Changes

Fix a workflow that still used depot. Changed to use ubuntu-latest

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
