### PR TITLE
ci: use smaller runner for small jobs

### DIFF
--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   reply-labeled:
     if: github.repository == 'withastro/astro'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Remove triaging label
         if: >-

--- a/.github/workflows/issue-state-issue.yml
+++ b/.github/workflows/issue-state-issue.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   close-issues:
     if: github.repository == 'withastro/astro'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/issue-wontfix.yml
+++ b/.github/workflows/issue-wontfix.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   wontfix:
     if: github.event.label.name == 'wontfix'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Comment and close issue
         env:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository_owner == 'withastro'
     steps:
     - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0


### PR DESCRIPTION
## Changes

Changes some workflows (mostly the label ones) to use the [`ubuntu-slim`](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md) image.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
