### PR TITLE
Configure Factory to use Astro's PR writer skill

### DIFF
--- a/.github/factory.yml
+++ b/.github/factory.yml
@@ -20,6 +20,7 @@ review:
 triage:
   enabled: true
   skill: .agents/skills/triage
+  prWriterSkill: .agents/skills/astro-pr-writer
   model: anthropic/claude-opus-4-6
   verificationModel: anthropic/claude-sonnet-4-6
   autoPrOnFix: false


### PR DESCRIPTION
## Changes

- Configures Factory triage to activate Astro's `astro-pr-writer` skill when drafting pull requests, adding the repository-specific PR rules to Factory's built-in template.

## Testing

- No tests added; this is a one-line repository configuration change, and the YAML parses successfully with a skill path matching its metadata name.

## Docs

- No docs update needed; this only changes internal Factory bot configuration.