### PR TITLE
Preserve propagated assets in server islands

### DIFF
--- a/.changeset/small-monkeys-grab.md
+++ b/.changeset/small-monkeys-grab.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes missing styles, links, and scripts from content collection entries rendered inside server islands

--- a/packages/astro/src/core/server-islands/endpoint.ts
+++ b/packages/astro/src/core/server-islands/endpoint.ts
@@ -209,6 +209,9 @@ export function createEndpoint(manifest: SSRManifest) {
 			Component.propagation = 'self';
 		}
 
+		// Server island modules are selected at runtime, outside the static propagation graph.
+		// Mark this route as propagating so async slots register head assets before streaming.
+		// https://github.com/withastro/astro/issues/17870
 		result._metadata.routeHasPropagation = true;
 		const renderPropagatedHead = () => markHTMLString(result._metadata.extraHead.join(''));
 		return renderTemplate`${renderPropagatedHead}${renderComponent(result, 'Component', Component, props, slots)}`;

--- a/packages/astro/src/core/server-islands/endpoint.ts
+++ b/packages/astro/src/core/server-islands/endpoint.ts
@@ -1,6 +1,7 @@
 import {
 	type AstroComponentFactory,
 	type ComponentSlots,
+	markHTMLString,
 	renderComponent,
 	renderTemplate,
 } from '../../runtime/server/index.js';
@@ -208,7 +209,9 @@ export function createEndpoint(manifest: SSRManifest) {
 			Component.propagation = 'self';
 		}
 
-		return renderTemplate`${renderComponent(result, 'Component', Component, props, slots)}`;
+		result._metadata.routeHasPropagation = true;
+		const renderPropagatedHead = () => markHTMLString(result._metadata.extraHead.join(''));
+		return renderTemplate`${renderPropagatedHead}${renderComponent(result, 'Component', Component, props, slots)}`;
 	};
 
 	page.isAstroComponentFactory = true;

--- a/packages/astro/test/units/server-islands/endpoint.test.ts
+++ b/packages/astro/test/units/server-islands/endpoint.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { FetchState } from '../../../dist/core/fetch/fetch-state.js';
 import {
 	createEndpoint,
@@ -351,14 +352,14 @@ describe('server island endpoint', () => {
 		const Island = createComponent(
 			(result) => render`${renderComponent(result, 'Content', Content, {}, {})}`,
 		);
-		const html = await renderServerIsland(Island);
+		const $ = cheerio.load(await renderServerIsland(Island), null, false);
 
-		assert.equal(html.match(/<style>/g)?.length, 1);
-		assert.equal(html.match(/<link rel="stylesheet"/g)?.length, 1);
-		assert.equal(html.match(/<script type="module"/g)?.length, 1);
-		assert.ok(html.indexOf('<style>') < html.indexOf('<div class="box">'));
-		assert.ok(html.includes('<div class="box">Island content</div>'));
-		assert.equal(html.includes('<!DOCTYPE html>'), false);
+		assert.equal($('style').length, 1);
+		assert.equal($('style').text(), '.box{color:red}');
+		assert.equal($('link[rel="stylesheet"][href="/content.css"]').length, 1);
+		assert.equal($('script[type="module"][src="/content.js"]').length, 1);
+		assert.equal($('.box').text(), 'Island content');
+		assert.equal($.root().contents().first().is('style'), true);
 	});
 
 	it('waits for async slots before serializing propagated head assets', async () => {
@@ -392,11 +393,10 @@ describe('server island endpoint', () => {
 					},
 				)}`,
 		);
-		const html = await renderServerIsland(Island);
+		const $ = cheerio.load(await renderServerIsland(Island), null, false);
 
-		const styleIndex = html.indexOf('<style>.async');
-		const contentIndex = html.indexOf('<div class="async">');
-		assert.notEqual(styleIndex, -1);
-		assert.ok(styleIndex < contentIndex);
+		assert.equal($('style').text(), '.async{color:red}');
+		assert.equal($('.async').text(), 'Async content');
+		assert.equal($.root().contents().first().is('style'), true);
 	});
 });

--- a/packages/astro/test/units/server-islands/endpoint.test.ts
+++ b/packages/astro/test/units/server-islands/endpoint.test.ts
@@ -1,7 +1,24 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { getRequestData } from '../../../dist/core/server-islands/endpoint.js';
+import { FetchState } from '../../../dist/core/fetch/fetch-state.js';
+import {
+	createEndpoint,
+	getRequestData,
+	SERVER_ISLAND_COMPONENT,
+} from '../../../dist/core/server-islands/endpoint.js';
 import type { RenderOptions } from '../../../dist/core/server-islands/endpoint.js';
+import { createKey, encryptString } from '../../../dist/core/encryption.js';
+import {
+	type AstroComponentFactory,
+	createComponent,
+	createHeadAndContent,
+	maybeRenderHead,
+	render,
+	renderComponent,
+	renderSlot,
+} from '../../../dist/runtime/server/index.js';
+import { createRouteData } from '../mocks.ts';
+import { createBasicPipeline, renderThroughMiddleware } from '../test-utils.ts';
 
 // #region Helpers
 
@@ -288,4 +305,98 @@ describe('getRequestData', () => {
 		}
 	});
 	// #endregion
+});
+
+async function renderServerIsland(Component: AstroComponentFactory) {
+	const key = await createKey();
+	const pipeline = createBasicPipeline({
+		manifest: {
+			key: Promise.resolve(key),
+			serverIslandMappings: async () => ({
+				serverIslandMap: new Map([['ContentIsland', async () => ({ default: Component })]]),
+			}),
+		},
+	});
+	const encryptedExport = await encryptString(key, 'default', 'export:ContentIsland');
+	const url = new URL('http://example.com/_server-islands/ContentIsland');
+	url.searchParams.set('e', encryptedExport);
+	url.searchParams.set('p', '');
+	url.searchParams.set('s', '');
+	const state = new FetchState(pipeline.manifest, new Request(url));
+	state.routeData = createRouteData({
+		route: '/_server-islands/[name]',
+		component: SERVER_ISLAND_COMPONENT,
+		segments: [
+			[{ content: '_server-islands', dynamic: false, spread: false }],
+			[{ content: 'name', dynamic: true, spread: false }],
+		],
+	});
+	state.pathname = url.pathname;
+
+	const response = await renderThroughMiddleware(state, createEndpoint(pipeline.manifest));
+	return response.text();
+}
+
+describe('server island endpoint', () => {
+	it('serializes propagated head assets into the fragment response', async () => {
+		const Content = createComponent({
+			factory() {
+				return createHeadAndContent(
+					'<style>.box{color:red}</style><link rel="stylesheet" href="/content.css"><script type="module" src="/content.js"></script>',
+					render`${maybeRenderHead()}<div class="box">Island content</div>`,
+				);
+			},
+			propagation: 'self',
+		});
+		const Island = createComponent(
+			(result) => render`${renderComponent(result, 'Content', Content, {}, {})}`,
+		);
+		const html = await renderServerIsland(Island);
+
+		assert.equal(html.match(/<style>/g)?.length, 1);
+		assert.equal(html.match(/<link rel="stylesheet"/g)?.length, 1);
+		assert.equal(html.match(/<script type="module"/g)?.length, 1);
+		assert.ok(html.indexOf('<style>') < html.indexOf('<div class="box">'));
+		assert.ok(html.includes('<div class="box">Island content</div>'));
+		assert.equal(html.includes('<!DOCTYPE html>'), false);
+	});
+
+	it('waits for async slots before serializing propagated head assets', async () => {
+		const Content = createComponent({
+			factory() {
+				return createHeadAndContent(
+					'<style>.async{color:red}</style>',
+					render`<div class="async">Async content</div>`,
+				);
+			},
+			propagation: 'self',
+		});
+		const Wrapper = createComponent({
+			factory(result, _props, slots) {
+				return render`<section>${renderSlot(result, slots.default)}</section>`;
+			},
+			propagation: 'in-tree',
+		});
+		const Island = createComponent(
+			(result) =>
+				render`${renderComponent(
+					result,
+					'Wrapper',
+					Wrapper,
+					{},
+					{
+						default: async () => {
+							await new Promise((resolve) => setTimeout(resolve, 10));
+							return render`${renderComponent(result, 'Content', Content, {}, {})}`;
+						},
+					},
+				)}`,
+		);
+		const html = await renderServerIsland(Island);
+
+		const styleIndex = html.indexOf('<style>.async');
+		const contentIndex = html.indexOf('<div class="async">');
+		assert.notEqual(styleIndex, -1);
+		assert.ok(styleIndex < contentIndex);
+	});
 });


### PR DESCRIPTION
Fixes #17870

## Changes

- Normal pages know at build time which components need styles and scripts. Server islands are selected at runtime, so this collects and includes those assets when the island is rendered.
- Regular partial pages are unchanged.

## Testing

- Adds server-island endpoint tests for styles, links, scripts, and content rendered after an async slot.

## Docs

- No docs update needed; this restores expected behavior.