### PR TITLE
feat(node): add a keepAliveTimeout option to the standalone server

### DIFF
--- a/.changeset/tall-donkeys-shave.md
+++ b/.changeset/tall-donkeys-shave.md
@@ -1,0 +1,22 @@
+---
+'@astrojs/node': minor
+---
+
+Adds a `keepAliveTimeout` option to configure how long the standalone server keeps an idle connection open
+
+Node.js closes idle keep-alive connections after 5 seconds by default, which is shorter than the idle timeout of most reverse proxies and load balancers (AWS Application Load Balancer, for instance, defaults to 60 seconds). When the proxy outlives the server on a pooled connection, it can send a request onto a socket the server has already closed and answer the client with a `502`. The failure only shows up on low-traffic servers, where connections stay idle long enough to reach the timeout.
+
+The adapter now accepts a `keepAliveTimeout` in milliseconds, applied to the server before it starts listening:
+
+```js
+import node from '@astrojs/node';
+
+export default defineConfig({
+  adapter: node({
+    mode: 'standalone',
+    keepAliveTimeout: 65_000,
+  }),
+});
+```
+
+Leaving the option unset keeps the current behavior.

--- a/.changeset/tall-donkeys-shave.md
+++ b/.changeset/tall-donkeys-shave.md
@@ -4,17 +4,18 @@
 
 Adds a `keepAliveTimeout` option to configure how long the standalone server keeps an idle connection open
 
-Node.js closes idle keep-alive connections after 5 seconds by default, which is shorter than the idle timeout of most reverse proxies and load balancers (AWS Application Load Balancer, for instance, defaults to 60 seconds). When the proxy outlives the server on a pooled connection, it can send a request onto a socket the server has already closed and answer the client with a `502`. The failure only shows up on low-traffic servers, where connections stay idle long enough to reach the timeout.
+Node.js closes an idle keep-alive connection after 5 seconds by default, which is shorter than the idle timeout of most reverse proxies and load balancers (an AWS Application Load Balancer, for instance, defaults to 60 seconds). When the proxy's idle timeout is longer than the server's, the proxy can send a request onto a socket the server has already closed. An Application Load Balancer answers the client with a `502` when that happens. It is most visible on low-traffic servers, where connections routinely stay idle long enough to reach the timeout.
 
-The adapter now accepts a `keepAliveTimeout` in milliseconds, applied to the server before it starts listening:
+The adapter now accepts a `keepAliveTimeout` in milliseconds:
 
 ```js
 import node from '@astrojs/node';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   adapter: node({
     mode: 'standalone',
-    keepAliveTimeout: 65_000,
+    keepAliveTimeout: 65000,
   }),
 });
 ```

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -34,6 +34,20 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 		throw new AstroError(`Setting the 'mode' option is required.`);
 	}
 
+	// Validated here rather than at the server: options cross a JSON boundary on their way
+	// to the built entrypoint, which turns `Infinity` and `NaN` into `null`, and Node.js
+	// assigns any value to `keepAliveTimeout` without complaint. Both would silently
+	// disable the timeout — the opposite of what the option is for.
+	const { keepAliveTimeout } = userOptions;
+	if (
+		keepAliveTimeout !== undefined &&
+		(!Number.isFinite(keepAliveTimeout) || keepAliveTimeout < 0)
+	) {
+		throw new AstroError(
+			`The 'keepAliveTimeout' option must be a finite, non-negative number of milliseconds.`,
+		);
+	}
+
 	let _config: AstroConfig | undefined = undefined;
 	let _routeToHeaders: RouteToHeaders | undefined = undefined;
 	return {
@@ -77,6 +91,9 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 								staticHeaders: userOptions.staticHeaders ?? false,
 								bodySizeLimit: userOptions.bodySizeLimit ?? 1024 * 1024 * 1024,
 								experimentalDisableStreaming: userOptions.experimentalDisableStreaming ?? false,
+								// Passed explicitly so the virtual config module always declares the export,
+								// even when unset — the server reads it off a module namespace object.
+								keepAliveTimeout: userOptions.keepAliveTimeout,
 							}),
 						],
 					},

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -29,7 +29,7 @@ export default function standalone(
 	// We spread a new object because `options` may be a frozen module namespace.
 	const resolvedOptions = { ...options, port };
 	const handler = createStandaloneHandler(app, resolvedOptions, headersMap);
-	const server = createServer(handler, host, port);
+	const server = createServer(handler, host, port, options.keepAliveTimeout);
 	server.server.listen(port, host);
 	if (process.env.ASTRO_NODE_LOGGING !== 'disabled') {
 		// Resolve the logger before the 'listening' event fires so the startup message
@@ -68,7 +68,12 @@ export function createStandaloneHandler(
 }
 
 // also used by preview entrypoint
-export function createServer(listener: http.RequestListener, host: string, port: number) {
+export function createServer(
+	listener: http.RequestListener,
+	host: string,
+	port: number,
+	keepAliveTimeout?: number,
+) {
 	let httpServer: http.Server | https.Server;
 
 	if (process.env.SERVER_CERT_PATH && process.env.SERVER_KEY_PATH) {
@@ -82,6 +87,13 @@ export function createServer(listener: http.RequestListener, host: string, port:
 	} else {
 		httpServer = http.createServer(listener);
 	}
+	// Must be set before the server starts listening: Node.js sets the socket timeout
+	// logic up on connection, so a later assignment would not apply to connections that
+	// are already open.
+	if (keepAliveTimeout !== undefined) {
+		httpServer.keepAliveTimeout = keepAliveTimeout;
+	}
+
 	enableDestroy(httpServer);
 
 	// Resolves once the server is closed

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -87,9 +87,11 @@ export function createServer(
 	} else {
 		httpServer = http.createServer(listener);
 	}
-	// Must be set before the server starts listening: Node.js sets the socket timeout
-	// logic up on connection, so a later assignment would not apply to connections that
-	// are already open.
+	// Assigned here rather than by the caller so every connection this server accepts is
+	// served with the configured value: Node.js reads `keepAliveTimeout` when it arms a
+	// socket's idle timer, so an assignment made later would leave sockets that are
+	// already idling on the previous value. The guard matters — writing `undefined` would
+	// poison Node's timer arithmetic instead of preserving its default.
 	if (keepAliveTimeout !== undefined) {
 		httpServer.keepAliveTimeout = keepAliveTimeout;
 	}

--- a/packages/integrations/node/src/types.ts
+++ b/packages/integrations/node/src/types.ts
@@ -32,17 +32,26 @@ export interface UserOptions {
 	bodySizeLimit?: number;
 
 	/**
-	 * The number of milliseconds of inactivity the server waits before destroying an idle
-	 * keep-alive connection. Maps to
+	 * The number of milliseconds of inactivity the server waits for further data on a
+	 * connection after it has finished writing the last response, before destroying the
+	 * socket. Maps to
 	 * [`server.keepAliveTimeout`](https://nodejs.org/api/http.html#serverkeepalivetimeout).
 	 *
 	 * When the server runs behind a reverse proxy or load balancer, this should be set
 	 * **higher** than the proxy's own idle timeout. Otherwise the server can close a pooled
-	 * connection that the proxy still believes is usable, and the proxy answers the next
-	 * request with a `502`. AWS Application Load Balancer, for example, defaults to a
-	 * 60 second idle timeout, so `65000` is a common value.
+	 * connection that the proxy still believes is usable, and the next request the proxy
+	 * sends over it fails — an AWS Application Load Balancer, for example, answers the
+	 * client with a `502`. Its idle timeout defaults to 60 seconds, so `65000` is a
+	 * common value.
 	 *
-	 * Only applies in `standalone` mode. Leave unset to keep the Node.js default.
+	 * Set to `0` to disable the timeout entirely, keeping idle connections open
+	 * indefinitely.
+	 *
+	 * Applies to the standalone server started by the built entrypoint. It does not
+	 * affect `astro preview`, and in `middleware` mode you own the Node.js server, so
+	 * set `server.keepAliveTimeout` on it directly.
+	 *
+	 * @default {undefined} Node.js's own default (5 seconds today)
 	 */
 	keepAliveTimeout?: number;
 }

--- a/packages/integrations/node/src/types.ts
+++ b/packages/integrations/node/src/types.ts
@@ -30,6 +30,21 @@ export interface UserOptions {
 	 * @default {1073741824} 1GB
 	 */
 	bodySizeLimit?: number;
+
+	/**
+	 * The number of milliseconds of inactivity the server waits before destroying an idle
+	 * keep-alive connection. Maps to
+	 * [`server.keepAliveTimeout`](https://nodejs.org/api/http.html#serverkeepalivetimeout).
+	 *
+	 * When the server runs behind a reverse proxy or load balancer, this should be set
+	 * **higher** than the proxy's own idle timeout. Otherwise the server can close a pooled
+	 * connection that the proxy still believes is usable, and the proxy answers the next
+	 * request with a `502`. AWS Application Load Balancer, for example, defaults to a
+	 * 60 second idle timeout, so `65000` is a common value.
+	 *
+	 * Only applies in `standalone` mode. Leave unset to keep the Node.js default.
+	 */
+	keepAliveTimeout?: number;
 }
 
 export interface Options extends UserOptions {

--- a/packages/integrations/node/test/keep-alive-timeout.test.ts
+++ b/packages/integrations/node/test/keep-alive-timeout.test.ts
@@ -30,7 +30,7 @@ describe('keepAliveTimeout', () => {
 		// time, and only reaches the HTTP server through the built entrypoint. The header is
 		// also what a reverse proxy actually reads.
 		const agent = new http.Agent({ keepAlive: true });
-		const keepAlive = await new Promise<string | undefined>((resolve, reject) => {
+		const keepAlive = await new Promise<string | string[] | undefined>((resolve, reject) => {
 			const request = http.request(
 				{ host: server.host, port: server.port, path: '/', agent },
 				(response) => {

--- a/packages/integrations/node/test/keep-alive-timeout.test.ts
+++ b/packages/integrations/node/test/keep-alive-timeout.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { after, before, describe, it } from 'node:test';
+import nodejs from '../dist/index.js';
+import { type AdapterServer, type Fixture, loadFixture, waitServerListen } from './test-utils.ts';
+
+describe('keepAliveTimeout', () => {
+	let fixture: Fixture;
+	let server: AdapterServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/api-route/',
+			adapter: nodejs({ mode: 'standalone', keepAliveTimeout: 65000 }),
+		});
+		await fixture.build();
+		const { startServer } = await fixture.loadAdapterEntryModule();
+		server = startServer().server;
+		await waitServerListen(server.server);
+	});
+
+	after(async () => {
+		await server.stop();
+		await fixture.clean();
+	});
+
+	it('advertises the configured timeout to clients', async () => {
+		// Asserted on the wire rather than on `server.keepAliveTimeout` so the whole path is
+		// covered: the adapter option is serialized into the virtual config module at build
+		// time, and only reaches the HTTP server through the built entrypoint. The header is
+		// also what a reverse proxy actually reads.
+		const agent = new http.Agent({ keepAlive: true });
+		const keepAlive = await new Promise<string | undefined>((resolve, reject) => {
+			const request = http.request(
+				{ host: server.host, port: server.port, path: '/', agent },
+				(response) => {
+					response.resume();
+					response.on('end', () => resolve(response.headers['keep-alive']));
+				},
+			);
+			request.on('error', reject);
+			request.end();
+		});
+		agent.destroy();
+
+		assert.equal(keepAlive, 'timeout=65');
+	});
+});

--- a/packages/integrations/node/test/units/keep-alive-timeout.test.ts
+++ b/packages/integrations/node/test/units/keep-alive-timeout.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import { describe, it } from 'node:test';
+import nodejs from '../../dist/index.js';
 import { createServer } from '../../dist/standalone.js';
 
 const noopListener: http.RequestListener = () => {};
@@ -15,8 +16,23 @@ describe('keepAliveTimeout', () => {
 	});
 
 	it('applies the configured value to the underlying server', () => {
-		const { server } = createServer(noopListener, 'localhost', 0, 65_000);
+		const { server } = createServer(noopListener, 'localhost', 0, 65000);
 
-		assert.equal(server.keepAliveTimeout, 65_000);
+		assert.equal(server.keepAliveTimeout, 65000);
+	});
+
+	// Node.js assigns any value to `keepAliveTimeout` without complaint, and every value
+	// rejected here would silently disable the timeout instead of extending it.
+	for (const value of [-1, Number.POSITIVE_INFINITY, Number.NaN]) {
+		it(`rejects ${value}`, () => {
+			assert.throws(
+				() => nodejs({ mode: 'standalone', keepAliveTimeout: value }),
+				/keepAliveTimeout/,
+			);
+		});
+	}
+
+	it('allows 0, which disables the timeout', () => {
+		assert.doesNotThrow(() => nodejs({ mode: 'standalone', keepAliveTimeout: 0 }));
 	});
 });

--- a/packages/integrations/node/test/units/keep-alive-timeout.test.ts
+++ b/packages/integrations/node/test/units/keep-alive-timeout.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { describe, it } from 'node:test';
+import { createServer } from '../../dist/standalone.js';
+
+const noopListener: http.RequestListener = () => {};
+
+describe('keepAliveTimeout', () => {
+	it('keeps the Node.js default when the option is not set', () => {
+		const { server } = createServer(noopListener, 'localhost', 0);
+
+		// Compared against a freshly created server instead of a hardcoded number so the
+		// test keeps passing when Node.js changes its own default.
+		assert.equal(server.keepAliveTimeout, http.createServer().keepAliveTimeout);
+	});
+
+	it('applies the configured value to the underlying server', () => {
+		const { server } = createServer(noopListener, 'localhost', 0, 65_000);
+
+		assert.equal(server.keepAliveTimeout, 65_000);
+	});
+});


### PR DESCRIPTION
## Changes

- Adds a `keepAliveTimeout` option to `@astrojs/node`, applied to the standalone server's `http.Server` **before it starts listening**.
- Leaving it unset keeps today's behavior exactly (whatever Node.js defaults to).

```js
export default defineConfig({
  adapter: node({ mode: 'standalone', keepAliveTimeout: 65_000 }),
});
```

### Why

Node.js destroys an idle keep-alive connection after 5 seconds by default ([`server.keepAliveTimeout`](https://nodejs.org/api/http.html#serverkeepalivetimeout)), which is shorter than the idle timeout of most reverse proxies and load balancers — an AWS Application Load Balancer, for instance, defaults to [60 seconds](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html) (`idle_timeout.timeout_seconds`). AWS names this exact case in its [ALB troubleshooting guide for HTTP 502](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html#http-502-issues): the target closed the connection with a TCP RST or FIN while the load balancer still had an outstanding request to it, and the guide tells you to check whether the keep-alive duration of the target is shorter than the load balancer's idle timeout.

The standalone adapter calls `http.createServer(listener)` and never touches `keepAliveTimeout`, so every standalone deployment behind a proxy sits on the wrong side of that ordering. The symptom is easy to misread: connections only stay idle long enough to reach the 5 second window when the server is *quiet*, so the 502 rate goes **up** as traffic goes down, and a busy deployment can look completely healthy.

There is currently no supported way for a user to configure this:

- Adapter options are JSON-serialized into a virtual module (`vite-plugin-config.ts`), so a callback such as `configureServer(server)` cannot be passed through.
- In standalone mode the built entry starts the server as a side effect of being imported, so there is no window in which to configure it.
- What is left is `ASTRO_NODE_AUTOSTART=disabled` plus a custom launcher that imports `startServer()` and mutates `server.server.keepAliveTimeout` — depending on the shape of the adapter's return value, and assigning after `listen()`.

Prior art: Next.js exposes this as a first-class flag for the same reason (`next start --keepAliveTimeout <ms>`, assigned to `server.keepAliveTimeout` in its `start-server`). Node.js itself has since raised the default to 65 seconds on `main` ([nodejs/node#62782](https://github.com/nodejs/node/pull/62782)) — but that is semver-major and unreleased, and every current release line still ships `5000`.

I kept the scope to the single option behind the 502s. Happy to extend it to `headersTimeout` / `requestTimeout` if you'd prefer a broader surface.

### Validation

The option crosses a JSON boundary on its way to the built entrypoint (`vite-plugin-config.ts` serializes adapter options into a virtual module), and `JSON.stringify` maps `Infinity` and `NaN` to `null`. Node then assigns anything to `keepAliveTimeout` without complaint, and gates on `> 0` — so both values would have *disabled* the timeout, the exact opposite of the option's purpose, with no warning. Measured on Node v24.16.0:

| value | `Keep-Alive` response header |
| --- | --- |
| unset | `timeout=5` |
| `65000` | `timeout=65` |
| `0` | absent — timeout disabled (documented) |
| `Infinity` / `NaN` → serialized as `null` | absent — timeout disabled (now rejected) |
| `-1` | `timeout=-1` (now rejected) |

So the adapter rejects non-finite and negative values at build time, next to the existing `mode` check. This follows `@astrojs/vercel`, which validates `maxDuration` the same way.

### Open question

`createServer(listener, host, port, keepAliveTimeout?)` adds a fourth positional parameter. It keeps `preview.ts` compiling unchanged, but the obvious follow-ups to this issue (`headersTimeout`, `requestTimeout`) would each add another slot. Happy to switch to an options bag — `createServer(listener, host, port, { keepAliveTimeout })` — if you'd prefer; I left it positional to keep the diff small.

`astro preview` deliberately does not apply the option, and the JSDoc says so. Preview isn't sitting behind a load balancer, and threading it through would mean reading the built config out of the imported server module. Say the word if you'd rather have it consistent.

## Testing

`packages/integrations/node/test/keep-alive-timeout.test.ts` builds a fixture in standalone mode and asserts what reaches the wire:

```
✔ advertises the configured timeout to clients   →  Keep-Alive: timeout=65
```

It is asserted on the response header rather than on `server.keepAliveTimeout` so it covers the whole path — adapter option → virtual config module → built entrypoint → `http.Server` — and because the header is what a reverse proxy actually reads. I verified it fails for the right reason: removing the argument at `standalone.ts:32` turns it red with `timeout=5`.

`packages/integrations/node/test/units/keep-alive-timeout.test.ts` covers the unit level:

```
✔ keeps the Node.js default when the option is not set
✔ applies the configured value to the underlying server
✔ rejects -1
✔ rejects Infinity
✔ rejects NaN
✔ allows 0, which disables the timeout
```

The first case is asserted against a freshly created `http.createServer()` rather than a hardcoded `5000`, so it survives Node changing its own default.

The rest of the package's suite passes (`pnpm --filter @astrojs/node test`); the only failure in my run was `preview-host.test.ts` losing port 4321 to an unrelated process on my machine, which fails identically on a clean checkout.

## Docs

This adds a user-facing adapter option, so it needs an entry alongside the other `@astrojs/node` options. I'm glad to open the PR on `withastro/docs` — just say the word.

<!-- /cc @withastro/maintainers-docs for feedback! -->
