### PR TITLE
perf(routes): avoid quadratic route lookup when transforming pages

### DIFF
--- a/.changeset/olive-spoons-wander.md
+++ b/.changeset/olive-spoons-wander.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves build performance for sites with a large number of pages

--- a/.changeset/olive-spoons-wander.md
+++ b/.changeset/olive-spoons-wander.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves build performance for sites with a large number of pages
+Improves build performance for sites with a large number of pages coming from a large amount of different modules.

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -81,6 +81,15 @@ export default async function astroPluginRoutes({
 
 	const normalizedSrcDir = normalizePath(fileURLToPath(settings.config.srcDir));
 
+	function findRouteByFilename(filename: string) {
+		return initialRoutesList.routes.find(
+			(route) =>
+				normalizePath(fileURLToPath(new URL(`./${route.component}`, settings.config.root))) ===
+				filename,
+		);
+	}
+
+	// Only built in `build` environments, where the route list is fixed for the whole run
 	let routeByFilename: Map<string, RoutesList['routes'][number]> | null = null;
 	function getRouteByFilename(): Map<string, RoutesList['routes'][number]> {
 		if (routeByFilename === null) {
@@ -119,7 +128,6 @@ export default async function astroPluginRoutes({
 			// at creation time, so we must mutate the array in place rather than replacing it.
 			initialRoutesList.routes.length = 0;
 			initialRoutesList.routes.push(...newRoutesList.routes);
-			routeByFilename = null;
 
 			serializedRouteInfo = initialRoutesList.routes.map((r): SerializedRouteInfo => {
 				return {
@@ -229,7 +237,10 @@ export default async function astroPluginRoutes({
 			const fileIsPage = isPage(fileURL, settings);
 			const fileIsEndpoint = isEndpoint(fileURL, settings);
 			if (!(fileIsPage || fileIsEndpoint)) return;
-			const route = getRouteByFilename().get(filename);
+			const route =
+				this.environment.mode === 'build'
+					? getRouteByFilename().get(filename)
+					: findRouteByFilename(filename);
 
 			if (!route) {
 				return;
@@ -281,7 +292,7 @@ export default async function astroPluginRoutes({
 			const fileIsEndpoint = isEndpoint(fileURL, settings);
 			if (!(fileIsPage || fileIsEndpoint)) return;
 
-			const route = getRouteByFilename().get(filename);
+			const route = findRouteByFilename(filename);
 
 			if (!route) {
 				return;

--- a/packages/astro/src/vite-plugin-routes/index.ts
+++ b/packages/astro/src/vite-plugin-routes/index.ts
@@ -81,6 +81,23 @@ export default async function astroPluginRoutes({
 
 	const normalizedSrcDir = normalizePath(fileURLToPath(settings.config.srcDir));
 
+	let routeByFilename: Map<string, RoutesList['routes'][number]> | null = null;
+	function getRouteByFilename(): Map<string, RoutesList['routes'][number]> {
+		if (routeByFilename === null) {
+			routeByFilename = new Map();
+			for (const route of initialRoutesList.routes) {
+				const filename = normalizePath(
+					fileURLToPath(new URL(`./${route.component}`, settings.config.root)),
+				);
+				// Several routes can share a component, and the first one owns the filename
+				if (!routeByFilename.has(filename)) {
+					routeByFilename.set(filename, route);
+				}
+			}
+		}
+		return routeByFilename;
+	}
+
 	async function rebuildRoutes(path: string | null = null, server: ViteDevServer) {
 		if (path != null && normalizePath(path).startsWith(normalizedSrcDir)) {
 			logger.debug(
@@ -102,6 +119,7 @@ export default async function astroPluginRoutes({
 			// at creation time, so we must mutate the array in place rather than replacing it.
 			initialRoutesList.routes.length = 0;
 			initialRoutesList.routes.push(...newRoutesList.routes);
+			routeByFilename = null;
 
 			serializedRouteInfo = initialRoutesList.routes.map((r): SerializedRouteInfo => {
 				return {
@@ -211,10 +229,7 @@ export default async function astroPluginRoutes({
 			const fileIsPage = isPage(fileURL, settings);
 			const fileIsEndpoint = isEndpoint(fileURL, settings);
 			if (!(fileIsPage || fileIsEndpoint)) return;
-			const route = initialRoutesList.routes.find((r) => {
-				const filePath = new URL(`./${r.component}`, settings.config.root);
-				return normalizePath(fileURLToPath(filePath)) === filename;
-			});
+			const route = getRouteByFilename().get(filename);
 
 			if (!route) {
 				return;
@@ -266,10 +281,7 @@ export default async function astroPluginRoutes({
 			const fileIsEndpoint = isEndpoint(fileURL, settings);
 			if (!(fileIsPage || fileIsEndpoint)) return;
 
-			const route = initialRoutesList.routes.find((r) => {
-				const filePath = new URL(`./${r.component}`, settings.config.root);
-				return normalizePath(fileURLToPath(filePath)) === filename;
-			});
+			const route = getRouteByFilename().get(filename);
 
 			if (!route) {
 				return;


### PR DESCRIPTION
## Changes

This function runs for every single page module and does a few expensive call, we can do them only once and re-use the map for lookups.

On a benchmark where pages are not very expensive, but there's a lot of them, this roughly cut the build time in half.

## Testing

Tests should pass

## Docs

N/A