### PR TITLE
Skip unsupported Vary responses in the memory cache

### DIFF
--- a/.changeset/late-clouds-dress.md
+++ b/.changeset/late-clouds-dress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the memory cache provider to skip responses with `Vary: Cookie` or `Vary: *`

--- a/packages/astro/src/core/cache/memory-provider.ts
+++ b/packages/astro/src/core/cache/memory-provider.ts
@@ -277,12 +277,6 @@ function warnSkippedSetCookie(url: URL): void {
 	);
 }
 
-function warnSkippedVary(url: URL, header: 'Cookie' | '*'): void {
-	console.warn(
-		`[astro:cache] Skipping cache for ${url.pathname}${url.search} because response includes Vary: ${header}.`,
-	);
-}
-
 /**
  * Simple LRU cache backed by a Map (insertion-order iteration).
  * When the cache exceeds `max` entries, the oldest entry is evicted.
@@ -465,7 +459,6 @@ const memoryProvider = ((config): CacheProvider => {
 									const uncacheableVary = getUncacheableVaryHeader(freshResponse);
 									if (uncacheableVary) {
 										cache.delete(key);
-										warnSkippedVary(requestUrl, uncacheableVary);
 										return;
 									}
 									const newTags = parseCacheTags(freshResponse.headers.get('Cache-Tag'));
@@ -515,7 +508,6 @@ const memoryProvider = ((config): CacheProvider => {
 				const uncacheableVary = getUncacheableVaryHeader(response);
 				if (uncacheableVary) {
 					cache.delete(key);
-					warnSkippedVary(requestUrl, uncacheableVary);
 					return response;
 				}
 				const tags = parseCacheTags(response.headers.get('Cache-Tag'));

--- a/packages/astro/src/core/cache/memory-provider.ts
+++ b/packages/astro/src/core/cache/memory-provider.ts
@@ -211,14 +211,19 @@ function getPathFromCacheKey(key: string, queryConfig: NormalizedQueryConfig): s
 	return `${url.pathname}${buildQueryString(url, queryConfig)}`;
 }
 
-/**
- * Headers that should not be used for Vary-based cache key discrimination.
- * `cookie` is excluded because it has extremely high cardinality (every user
- * has different cookies), making it effectively uncacheable. Use config-level
- * cookie-based vary instead when that is supported.
- * `set-cookie` is a response header and should never appear in Vary.
- */
-const IGNORED_VARY_HEADERS = new Set(['cookie', 'set-cookie']);
+/** `set-cookie` is a response header and should never appear in Vary. */
+const IGNORED_VARY_HEADERS = new Set(['set-cookie']);
+
+function getUncacheableVaryHeader(response: Response): 'Cookie' | '*' | undefined {
+	const vary = response.headers.get('Vary');
+	if (!vary) return undefined;
+	for (const header of vary.split(',')) {
+		const normalized = header.trim().toLowerCase();
+		if (normalized === 'cookie') return 'Cookie';
+		if (normalized === '*') return '*';
+	}
+	return undefined;
+}
 
 /**
  * Parse the Vary header into an array of lowercased header names.
@@ -269,6 +274,12 @@ function hasSetCookieHeader(response: Response): boolean {
 function warnSkippedSetCookie(url: URL): void {
 	console.warn(
 		`[astro:cache] Skipping cache for ${url.pathname}${url.search} because response includes Set-Cookie.`,
+	);
+}
+
+function warnSkippedVary(url: URL, header: 'Cookie' | '*'): void {
+	console.warn(
+		`[astro:cache] Skipping cache for ${url.pathname}${url.search} because response includes Vary: ${header}.`,
 	);
 }
 
@@ -451,6 +462,12 @@ const memoryProvider = ((config): CacheProvider => {
 										warnSkippedSetCookie(requestUrl);
 										return;
 									}
+									const uncacheableVary = getUncacheableVaryHeader(freshResponse);
+									if (uncacheableVary) {
+										cache.delete(key);
+										warnSkippedVary(requestUrl, uncacheableVary);
+										return;
+									}
 									const newTags = parseCacheTags(freshResponse.headers.get('Cache-Tag'));
 									const newEntry = await serializeResponse(
 										freshResponse,
@@ -493,6 +510,12 @@ const memoryProvider = ((config): CacheProvider => {
 			if (maxAge > 0) {
 				if (hasSetCookieHeader(response)) {
 					warnSkippedSetCookie(requestUrl);
+					return response;
+				}
+				const uncacheableVary = getUncacheableVaryHeader(response);
+				if (uncacheableVary) {
+					cache.delete(key);
+					warnSkippedVary(requestUrl, uncacheableVary);
 					return response;
 				}
 				const tags = parseCacheTags(response.headers.get('Cache-Tag'));

--- a/packages/astro/test/units/cache/memory-provider.test.ts
+++ b/packages/astro/test/units/cache/memory-provider.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import type { CacheProvider } from '../../../dist/core/cache/types.js';
 import type { MemoryCacheProviderOptions } from '../../../dist/core/cache/memory-provider.js';
 import memoryProvider from '../../../dist/core/cache/memory-provider.js';
@@ -353,23 +353,24 @@ describe('memory-provider Vary header', () => {
 		assert.equal(await res3.text(), 'english');
 	});
 
-	it('ignores Cookie in Vary header', async () => {
-		const provider = createProvider();
-		const url = 'http://localhost/page';
+	it('does not cache responses when Vary contains Cookie or *', async () => {
+		for (const vary of ['Cookie', '*', 'Accept-Language, Cookie']) {
+			const provider = createProvider();
+			const url = 'http://localhost/page';
+			const req1 = makeRequest(url, { Cookie: 'user=a' });
+			const res1 = await provider.onRequest!(
+				{ request: req1, url: new URL(req1.url) },
+				makeNext({ maxAge: 60, body: 'first', headers: { Vary: vary } }),
+			);
+			assert.equal(res1.headers.has('X-Astro-Cache'), false);
 
-		const req1 = makeRequest(url, { Cookie: 'user=a' });
-		await provider.onRequest!(
-			{ request: req1, url: new URL(req1.url) },
-			makeNext({ maxAge: 60, body: 'first', headers: { Vary: 'Cookie' } }),
-		);
-
-		// Different cookie — should still HIT (Cookie is ignored in Vary)
-		const req2 = makeRequest(url, { Cookie: 'user=b' });
-		const res2 = await provider.onRequest!(
-			{ request: req2, url: new URL(req2.url) },
-			makeNext({ maxAge: 60, body: 'second' }),
-		);
-		assert.equal(res2.headers.get('X-Astro-Cache'), 'HIT');
+			const req2 = makeRequest(url, { Cookie: 'user=b' });
+			const res2 = await provider.onRequest!(
+				{ request: req2, url: new URL(req2.url) },
+				makeNext({ body: 'second' }),
+			);
+			assert.equal(await res2.text(), 'second');
+		}
 	});
 });
 
@@ -553,6 +554,35 @@ describe('memory-provider SWR', () => {
 			makeNext({ maxAge: 60, body: 'should-not-see' }),
 		);
 		assert.equal(res3.headers.get('X-Astro-Cache'), 'HIT');
+		assert.equal(await res3.text(), 'fresh-body');
+	});
+
+	it('removes stale entries when revalidation returns an uncacheable Vary header', async (t) => {
+		t.mock.timers.enable({ apis: ['Date'], now: 1_000 });
+		t.after(() => mock.timers.reset());
+		const provider = createProvider();
+		const url = 'http://localhost/page';
+		const req1 = makeRequest(url);
+		await provider.onRequest!(
+			{ request: req1, url: new URL(req1.url) },
+			makeNext({ maxAge: 1, swr: 60, body: 'stale-body' }),
+		);
+
+		t.mock.timers.tick(2_000);
+		const req2 = makeRequest(url);
+		const res2 = await provider.onRequest!(
+			{ request: req2, url: new URL(req2.url) },
+			makeNext({ maxAge: 60, body: 'uncached-body', headers: { Vary: 'Cookie' } }),
+		);
+		assert.equal(res2.headers.get('X-Astro-Cache'), 'STALE');
+		await Promise.resolve();
+
+		const req3 = makeRequest(url);
+		const res3 = await provider.onRequest!(
+			{ request: req3, url: new URL(req3.url) },
+			makeNext({ body: 'fresh-body' }),
+		);
+		assert.equal(res3.headers.has('X-Astro-Cache'), false);
 		assert.equal(await res3.text(), 'fresh-body');
 	});
 });


### PR DESCRIPTION
## Changes

- Skips storing memory-cache responses when `Vary` contains `Cookie` or `*`, rather than dropping those values during cache-key construction.
- Removes stale entries when background revalidation returns an unsupported variant.

## Testing

- Updates `Vary` coverage for `Cookie`, `*`, and combined header values.
- Adds regression coverage for stale-while-revalidate entries.

## Docs

- A follow-up docs update is needed to clarify how the memory provider handles these `Vary` values.