### PR TITLE
chore(deps): update react to v19 in `0-css` fixture

### DIFF
--- a/packages/astro/test/0-css.test.ts
+++ b/packages/astro/test/0-css.test.ts
@@ -24,7 +24,14 @@ describe('CSS', function () {
 
 		before(
 			async () => {
-				await fixture.build();
+				await fixture.build({}, {
+					// This test file tests both build and dev. Sadly, we cannot run
+					// React v19 in build mode and in dev mode (i.e., with different
+					// NODE_ENV value) in the same process because of issue: https://github.com/react/react/issues/32030.
+					// To work around this, we also run the build tests in dev mode
+					// by setting the `devOutput` option to true.
+					devOutput: true
+				});
 
 				// get bundled CSS (will be hashed, hence DOM query)
 				html = await fixture.readFile('/index.html');

--- a/packages/astro/test/fixtures/0-css/package.json
+++ b/packages/astro/test/fixtures/0-css/package.json
@@ -7,8 +7,8 @@
     "@astrojs/svelte": "workspace:*",
     "@astrojs/vue": "workspace:*",
     "astro": "workspace:*",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2077,11 +2077,11 @@ importers:
         specifier: workspace:*
         version: link:../../..
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.2.4
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
       svelte:
         specifier: ^5.54.0
         version: 5.55.3


### PR DESCRIPTION
## Changes

Update React from v18 to v19 in a test fixture called `0-css`.

After the update, you will see the error `TypeError: dispatcher.getOwner is not a function`. You can find the detailed error message from the CI log in this PR. The reasons are:

1. You cannot run React v19 in dev mode (`NODE_ENV === 'development'`) and in prod mode (`NODE_ENV === 'production'`) in the same process. See https://github.com/react/react/issues/32030 for more details, AND,
2. we're running `dev` and `build` tests in the same file `0-css.test.ts`.

Note that this is only a test issue, not an Astro or `@astrojs/react` bug. A real process is either `astro dev` or `astro build`, never both.

Fix: run the `build` test in `0-css.test.ts` with dev mode too. See my comment in the codebase.

## Testing

Green CI.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
