### PR TITLE
Respect path-segment boundaries when stripping the base in the dev server

### DIFF
--- a/.changeset/spotty-bees-shout.md
+++ b/.changeset/spotty-bees-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the dev server stripped the configured `base` from URLs that only share a prefix with it. With `base: '/s'`, requests to `/src/...` were rewritten to `/rc/...` and failed, breaking those pages during development.

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -11,9 +11,10 @@ import { writeHtmlResponse } from './response.js';
 /**
  * Outcome of the base-URL evaluation for a dev-server request.
  *
- * - **`rewrite`** — The request URL starts with the configured `base` path.
- *   Strip the base prefix so downstream handlers see a root-relative URL
- *   (e.g. `/docs/about` → `/about` when `base: '/docs'`).
+ * - **`rewrite`** — The request URL is the configured `base` path or lies
+ *   under it at a path-segment boundary. Strip the base prefix so downstream
+ *   handlers see a root-relative URL (e.g. `/docs/about` → `/about` when
+ *   `base: '/docs'`).
  * - **`not-found-subpath`** — The user navigated to `/` or `/index.html` but
  *   the project has a non-root `base`. Respond with a 404 explaining that the
  *   site lives under the base path, so the developer knows to update the URL.
@@ -52,10 +53,10 @@ export function resolveDevRoot(base: string, site?: string) {
 /**
  * Pure decision function for base-URL dev-server rewriting.
  *
- * Evaluates whether the incoming `url` starts with the project's `base` path
- * and returns the action the middleware should take. The async `fs.stat` branch
- * (checking `publicDir`) is represented as `check-public` and must be handled
- * by the caller.
+ * Evaluates whether the incoming `url` is the project's `base` path or lies
+ * under it at a path-segment boundary, and returns the action the middleware
+ * should take. The async `fs.stat` branch (checking `publicDir`) is
+ * represented as `check-public` and must be handled by the caller.
  */
 export function evaluateBaseRewrite(
 	url: string,
@@ -64,7 +65,9 @@ export function evaluateBaseRewrite(
 	devRoot: string,
 	devRootReplacement: string,
 ): BaseRewriteDecision {
-	if (pathname.startsWith(devRoot)) {
+	// Match only at path-segment boundaries so a base like `/s` doesn't
+	// swallow unrelated requests such as `/src/...` (same policy as #17701).
+	if (pathname === devRoot || pathname.startsWith(appendForwardSlash(devRoot))) {
 		let newUrl = url.replace(devRoot, devRootReplacement);
 		if (!newUrl.startsWith('/')) newUrl = prependForwardSlash(newUrl);
 		return { action: 'rewrite', newUrl };

--- a/packages/astro/test/units/dev/base-rewrite.test.ts
+++ b/packages/astro/test/units/dev/base-rewrite.test.ts
@@ -96,6 +96,55 @@ describe('evaluateBaseRewrite — rewrite', () => {
 });
 // #endregion
 
+// #region evaluateBaseRewrite — path-segment boundaries
+describe('evaluateBaseRewrite — path-segment boundaries', () => {
+	it('does not rewrite a URL whose first segment merely starts with the base', () => {
+		// base '/s' must not swallow '/src/...' (e.g. Vite virtual module requests
+		// emitted without the base by the dev server).
+		const result = evaluateBaseRewrite(
+			'/src/pages/index.astro?astro&type=style&index=0&lang.css',
+			'/src/pages/index.astro',
+			undefined,
+			'/s',
+			'',
+		);
+		assert.equal(result.action, 'check-public');
+	});
+
+	it('returns not-found for an HTML request whose first segment merely starts with the base', () => {
+		const result = evaluateBaseRewrite(
+			'/docs-archive/page',
+			'/docs-archive/page',
+			'text/html',
+			'/docs',
+			'',
+		);
+		assert.equal(result.action, 'not-found');
+	});
+
+	it('still rewrites the exact base match', () => {
+		const result = evaluateBaseRewrite('/s', '/s', undefined, '/s', '');
+		assert.equal(result.action, 'rewrite');
+		if (result.action === 'rewrite') {
+			assert.equal(result.newUrl, '/');
+		}
+	});
+
+	it('still rewrites URLs under the base, preserving query params', () => {
+		const result = evaluateBaseRewrite('/s/page?foo=bar', '/s/page', undefined, '/s', '');
+		assert.equal(result.action, 'rewrite');
+		if (result.action === 'rewrite') {
+			assert.equal(result.newUrl, '/page?foo=bar');
+		}
+	});
+
+	it('does not rewrite a prefix-colliding segment when the base has a trailing slash', () => {
+		const result = evaluateBaseRewrite('/docsX/page', '/docsX/page', undefined, '/docs/', '/');
+		assert.equal(result.action, 'check-public');
+	});
+});
+// #endregion
+
 // #region evaluateBaseRewrite — not-found-subpath
 describe('evaluateBaseRewrite — not-found-subpath', () => {
 	it('returns not-found-subpath for / when base is not /', () => {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/17973

- Fixes the dev server base middleware stripping the configured `base` from any request whose pathname merely starts with it as a string, ignoring path-segment boundaries.
- With `base: '/s'`, a request like `/src/pages/index.astro` was treated as being under the base and rewritten to `/rc/pages/index.astro` before reaching Vite, so it could never resolve. Any `base` value that is a non-segment prefix of a served path triggers this (`/s` vs `/src`); bases like `/docs` don't collide and hide the bug.
- This is the same bug class #17701 fixed for `App.removeBase`, `FetchState`, and the i18n domain helper: the dev middleware (`evaluateBaseRewrite` in `vite-plugin-astro-server/base.ts`) was the remaining spot still doing a plain `startsWith` check. It now strips the base only when the pathname is exactly the base or lies under `base + '/'`, matching the policy of `stripRequestBase`.
- Only the match condition changes. The rewrite itself (an `url.replace` that preserves query strings), the exact-base-match behavior (`/s` → `/`), and the `not-found-subpath` / `not-found` / `check-public` branches are unchanged. `stripRequestBase` isn't reused directly because it never strips a `/` base, while this middleware is always installed and must keep passing every request through when `base` is `/`.

### Reproduction

1. `pnpm create astro@latest` (minimal template)
2. Set `base: '/s'` in `astro.config.mjs`
3. Run `astro dev`, then:

   ```bash
   curl -i "http://localhost:4321/src/pages/index.astro"
   ```

   Before this fix the request 404s because the middleware rewrote it to `/rc/pages/index.astro`; after it, Vite serves the module. In practice this broke the root-relative requests the dev server itself emits without the base, taking down every page.

## Testing

Added unit tests to `test/units/dev/base-rewrite.test.ts` covering the segment-boundary cases: with `base: '/s'`, `/src/...` requests are no longer rewritten while `/s` (exact) and `/s/...` still are, query strings are preserved, and `/docs-archive/page` with `base: '/docs'` falls through to `not-found`.

Also verified manually against `examples/minimal` with `base: '/s'`: requests to `/src/...` now pass through to Vite untouched, pages under `/s/` and the base root `/s` render, public assets under the base resolve, and URLs outside the base still 404.

## Docs

No docs needed: this restores the documented behavior of `base` in dev; no user-facing API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
