### PR TITLE
feat(solid): Solid 2.0 support — @astrojs/solid-js v8

### DIFF
--- a/.changeset/solid-2-adapter.md
+++ b/.changeset/solid-2-adapter.md
@@ -1,0 +1,15 @@
+---
+'@astrojs/solid-js': major
+---
+
+Adds support for Solid 2.0 (requires `solid-js@^2.0.0-rc.5` and `@solidjs/web@^2.0.0-rc.5`)
+
+This major version supports Solid 2.0 only; use `@astrojs/solid-js@7` for Solid 1.x projects.
+
+Highlights:
+
+- Compiles through `@solidjs/vite-plugin` (replacing `vite-plugin-solid`), with an optional `compiler` option to select the native or Babel backend.
+- Islands render through Solid 2.0's first-class async model (`renderToStream`), with no Suspense wrapper: async islands settle fully on the server, and error boundaries (`Errored`) contain both sync and async errors.
+- Threads an asset manifest into server renders so `lazy()` boundary modules inside islands resolve their module URLs, hydrate through serialized asset maps, and have their CSS inlined into the island markup (deduped per page) — in dev via the plugin's live resolver, in production via the client build manifest.
+- Component detection (`check()`) now probe-renders through the stream renderer with per-component caching, rejects foreign framework vnodes explicitly, and no longer breaks on Proxy-based components.
+- Removes the `solid-devtools` integration option (the Solid 2.0 devtools story is not settled yet).

--- a/.changeset/solid-server-components.md
+++ b/.changeset/solid-server-components.md
@@ -1,0 +1,28 @@
+---
+'@astrojs/solid-js': minor
+---
+
+Adds support for Solid server components (experimental)
+
+Enable with `serverFunctions: { components: true }` — `"use server"` functions that return a component, riding the server-function endpoint:
+
+```jsx
+// src/frames/panel.jsx
+'use server';
+
+export async function getPanel(name) {
+  return (props) => (
+    <section>
+      <h2>panel:{name}</h2>
+      {props.children}
+    </section>
+  );
+}
+```
+
+```jsx
+// inside an island
+const Panel = dynamic(() => getPanel(name()));
+```
+
+Server components render inline during island SSR and are adopted at boot with zero endpoint requests; re-evaluations stream over the endpoint and morph the boundary in place, preserving client slot state and DOM identity. The integration wires all the pieces: the frames render plugin and direct-call transform on the server, the endpoint response transform through the handler, and `installServerComponents()` via Astro's `before-hydration` stage on the client.

--- a/.changeset/solid-server-functions.md
+++ b/.changeset/solid-server-functions.md
@@ -1,0 +1,22 @@
+---
+'@astrojs/solid-js': minor
+---
+
+Adds support for Solid server functions (experimental)
+
+Enable with the `serverFunctions` option (requires an adapter — server functions need a server at runtime):
+
+```js
+import { defineConfig } from 'astro/config';
+import solid from '@astrojs/solid-js';
+
+export default defineConfig({
+  integrations: [solid({ serverFunctions: true })],
+});
+```
+
+`"use server"` functions imported by Solid islands are compiled to typed RPC calls. The integration injects the transport endpoint (default `/_server`) as an Astro route, so server-function requests flow through Astro's middleware pipeline — the same auth guards and `locals` decoration pages get — in dev and production alike. Inside a server function, Solid's `getRequestEvent()` exposes the request, Astro's `locals`, and the full Astro API context as `nativeEvent`.
+
+Island SSR now also runs inside a Solid request-event scope, so `getRequestEvent()` and direct in-process server function calls work during server rendering.
+
+Pass an options object instead of `true` to customize (endpoint path, argument codec, etc.) — it is forwarded to `@solidjs/vite-plugin`.

--- a/.changeset/solid-tsconfig-import-source.md
+++ b/.changeset/solid-tsconfig-import-source.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates the Solid tsconfig preset for Solid 2.0: `astro add solid-js` now writes `jsxImportSource: "@solidjs/web"` (renderer packages own their JSX namespaces and `jsx-runtime` type entries in 2.0; `solid-js` no longer exports one)

--- a/knip.js
+++ b/knip.js
@@ -114,8 +114,6 @@ export default {
 		'packages/integrations/solid': {
 			entry: [srcEntry, dtsEntry, testEntry],
 			project,
-			// It's an optional peer dep (triggers a warning) but it's fine in this case
-			ignoreDependencies: ['solid-devtools'],
 		},
 		'packages/integrations/svelte': {
 			entry: [srcEntry, dtsEntry, testEntry],

--- a/packages/astro/e2e/fixtures/client-only/package.json
+++ b/packages/astro/e2e/fixtures/client-only/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/errors/package.json
+++ b/packages/astro/e2e/fixtures/errors/package.json
@@ -8,12 +8,13 @@
     "@astrojs/solid-js": "workspace:*",
     "@astrojs/svelte": "workspace:*",
     "@astrojs/vue": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sass": "^1.98.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/errors/src/components/solid/SolidRuntimeError.jsx
+++ b/packages/astro/e2e/fixtures/errors/src/components/solid/SolidRuntimeError.jsx
@@ -1,5 +1,3 @@
-import { h } from 'solid-js/web';
-
 export default function SolidRuntimeError({shouldThrow = true}) {
   if (shouldThrow) throw new Error('SolidRuntimeError')
   return <div>I shouldn’t be here</div>;

--- a/packages/astro/e2e/fixtures/errors/src/components/solid/SolidSyntaxError.jsx
+++ b/packages/astro/e2e/fixtures/errors/src/components/solid/SolidSyntaxError.jsx
@@ -1,5 +1,3 @@
-import { h } from 'solid-js/web'
-
 export default function ReactSyntaxError() {
   return (<div></div></div>);
 }

--- a/packages/astro/e2e/fixtures/multiple-frameworks/package.json
+++ b/packages/astro/e2e/fixtures/multiple-frameworks/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/nested-in-preact/package.json
+++ b/packages/astro/e2e/fixtures/nested-in-preact/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/nested-in-react/package.json
+++ b/packages/astro/e2e/fixtures/nested-in-react/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/nested-in-solid/package.json
+++ b/packages/astro/e2e/fixtures/nested-in-solid/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/nested-in-svelte/package.json
+++ b/packages/astro/e2e/fixtures/nested-in-svelte/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/nested-in-vue/package.json
+++ b/packages/astro/e2e/fixtures/nested-in-vue/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/fixtures/nested-recursive/package.json
+++ b/packages/astro/e2e/fixtures/nested-recursive/package.json
@@ -11,10 +11,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   },

--- a/packages/astro/e2e/fixtures/solid-circular/package.json
+++ b/packages/astro/e2e/fixtures/solid-circular/package.json
@@ -7,6 +7,7 @@
     "astro": "workspace:*"
   },
   "devDependencies": {
-    "solid-js": "^1.9.11"
+    "@solidjs/web": "^2.0.0-rc.5",
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/e2e/fixtures/solid-circular/src/components/ContextProvider.tsx
+++ b/packages/astro/e2e/fixtures/solid-circular/src/components/ContextProvider.tsx
@@ -6,8 +6,8 @@ export const ApplicationContext = createContext([{ lng: 'en' }, {}]);
 
 export const ContextProvider: Component = () => {
   return (
-    <ApplicationContext.Provider value={[{ lng: 'fr' }]}>
+    <ApplicationContext value={[{ lng: 'fr' }]}>
       <SimpleDiv />
-    </ApplicationContext.Provider>
+    </ApplicationContext>
   );
 };

--- a/packages/astro/e2e/fixtures/solid-component/package.json
+++ b/packages/astro/e2e/fixtures/solid-component/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@astrojs/mdx": "workspace:*",
     "@astrojs/solid-js": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
-    "solid-js": "^1.9.11"
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/e2e/fixtures/solid-recurse/package.json
+++ b/packages/astro/e2e/fixtures/solid-recurse/package.json
@@ -7,6 +7,7 @@
     "astro": "workspace:*"
   },
   "devDependencies": {
-    "solid-js": "^1.9.11"
+    "@solidjs/web": "^2.0.0-rc.5",
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/e2e/fixtures/solid-server-functions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/solid-server-functions/astro.config.mjs
@@ -1,0 +1,7 @@
+import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [solid({ serverFunctions: true })],
+});

--- a/packages/astro/e2e/fixtures/solid-server-functions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/solid-server-functions/astro.config.mjs
@@ -3,5 +3,5 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [solid({ serverFunctions: true })],
+	integrations: [solid({ serverFunctions: { components: true } })],
 });

--- a/packages/astro/e2e/fixtures/solid-server-functions/package.json
+++ b/packages/astro/e2e/fixtures/solid-server-functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@e2e/solid-server-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/solid-js": "workspace:*",
+    "astro": "workspace:*"
+  },
+  "devDependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
+    "solid-js": "^2.0.0-rc.5"
+  }
+}

--- a/packages/astro/e2e/fixtures/solid-server-functions/src/components/ServerComponentDemo.jsx
+++ b/packages/astro/e2e/fixtures/solid-server-functions/src/components/ServerComponentDemo.jsx
@@ -1,0 +1,24 @@
+import { createSignal, Loading } from 'solid-js';
+import { dynamic } from '@solidjs/web';
+import { getPanel } from '../frames/panel.jsx';
+
+export default function ServerComponentDemo() {
+	const [name, setName] = createSignal('alpha');
+	// The whole client surface for server components: `dynamic` over a server
+	// function call. The SSR'd boundary is adopted at boot with zero endpoint
+	// requests; re-evaluations stream over the endpoint and morph in place.
+	const Panel = dynamic(() => getPanel(name()));
+
+	return (
+		<div id="sc-demo">
+			<button id="sc-rename" type="button" onClick={() => setName('beta')}>
+				Rename
+			</button>
+			<Loading fallback={<p id="sc-loading">loading…</p>}>
+				<Panel>
+					<input id="sc-draft" placeholder="client slot state" />
+				</Panel>
+			</Loading>
+		</div>
+	);
+}

--- a/packages/astro/e2e/fixtures/solid-server-functions/src/components/ServerFunctionDemo.jsx
+++ b/packages/astro/e2e/fixtures/solid-server-functions/src/components/ServerFunctionDemo.jsx
@@ -1,0 +1,24 @@
+import { createMemo, createSignal } from 'solid-js';
+import { double, whoami } from '../functions/api.js';
+
+export default function ServerFunctionDemo() {
+	const [value, setValue] = createSignal(1);
+	const [user, setUser] = createSignal('');
+	// Runs as a direct in-process call during island SSR; over the transport
+	// when the memo re-evaluates on the client.
+	const ssrUser = createMemo(() => whoami());
+
+	return (
+		<div id="sf-demo">
+			<span id="sf-ssr-user">{ssrUser()}</span>
+			<span id="sf-value">{value()}</span>
+			<span id="sf-user">{user()}</span>
+			<button id="sf-double" type="button" onClick={async () => setValue(await double(value()))}>
+				Double
+			</button>
+			<button id="sf-whoami" type="button" onClick={async () => setUser(await whoami())}>
+				Who am I
+			</button>
+		</div>
+	);
+}

--- a/packages/astro/e2e/fixtures/solid-server-functions/src/frames/panel.jsx
+++ b/packages/astro/e2e/fixtures/solid-server-functions/src/frames/panel.jsx
@@ -1,0 +1,17 @@
+'use server';
+// Server components: "use server" functions that RETURN a function. The
+// returned component's props are client positions (slots); the function's
+// arguments are the server's inputs. The whole module is replaced by
+// reference proxies in the client build.
+
+const SERVER_ONLY_TEXT = 'rendered-on-the-server';
+
+export async function getPanel(name) {
+	return (props) => (
+		<section id="sc-panel">
+			<h2 id="sc-name">panel:{name}</h2>
+			<p id="sc-secret">{SERVER_ONLY_TEXT}</p>
+			{props.children}
+		</section>
+	);
+}

--- a/packages/astro/e2e/fixtures/solid-server-functions/src/functions/api.js
+++ b/packages/astro/e2e/fixtures/solid-server-functions/src/functions/api.js
@@ -1,0 +1,15 @@
+import { getRequestEvent } from '@solidjs/web';
+
+export async function double(n) {
+	'use server';
+	return n * 2;
+}
+
+// Reads the Solid request event: on endpoint dispatch the injected route
+// threads Astro's locals in; on direct SSR calls the renderer's
+// provideRequestEvent scope supplies the same event.
+export async function whoami() {
+	'use server';
+	const event = getRequestEvent();
+	return String(event?.locals?.user ?? 'missing');
+}

--- a/packages/astro/e2e/fixtures/solid-server-functions/src/middleware.js
+++ b/packages/astro/e2e/fixtures/solid-server-functions/src/middleware.js
@@ -1,0 +1,4 @@
+export function onRequest(context, next) {
+	context.locals.user = 'astro-middleware';
+	return next();
+}

--- a/packages/astro/e2e/fixtures/solid-server-functions/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/solid-server-functions/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import ServerFunctionDemo from '../components/ServerFunctionDemo.jsx';
+import ServerComponentDemo from '../components/ServerComponentDemo.jsx';
 ---
 
 <html>
@@ -8,5 +9,6 @@ import ServerFunctionDemo from '../components/ServerFunctionDemo.jsx';
 	</head>
 	<body>
 		<ServerFunctionDemo client:load />
+		<ServerComponentDemo client:load />
 	</body>
 </html>

--- a/packages/astro/e2e/fixtures/solid-server-functions/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/solid-server-functions/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import ServerFunctionDemo from '../components/ServerFunctionDemo.jsx';
+---
+
+<html>
+	<head>
+		<title>Solid server functions</title>
+	</head>
+	<body>
+		<ServerFunctionDemo client:load />
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/view-transitions/package.json
+++ b/packages/astro/e2e/fixtures/view-transitions/package.json
@@ -8,10 +8,11 @@
     "@astrojs/solid-js": "workspace:*",
     "@astrojs/svelte": "workspace:*",
     "@astrojs/vue": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/e2e/solid-server-functions.test.ts
+++ b/packages/astro/e2e/solid-server-functions.test.ts
@@ -49,4 +49,40 @@ test.describe('Solid server functions', () => {
 		await page.locator('#sf-whoami').click();
 		await expect(page.locator('#sf-user')).toHaveText('astro-middleware');
 	});
+
+	test('server components SSR at t=0 and are adopted without endpoint requests', async ({
+		astro,
+		page,
+	}) => {
+		const endpointRequests: string[] = [];
+		page.on('request', (request) => {
+			if (new URL(request.url()).pathname.startsWith('/_server')) {
+				endpointRequests.push(request.url());
+			}
+		});
+
+		await page.goto(astro.resolveUrl('/'));
+
+		// Rendered inline during island SSR through the frames render plugin.
+		await expect(page.locator('#sc-name')).toHaveText('panel:alpha');
+		await expect(page.locator('#sc-secret')).toHaveText('rendered-on-the-server');
+
+		const demo = page.locator('#sc-demo');
+		await waitForHydrate(page, demo);
+
+		// Boot adopted the SSR'd boundary — no endpoint traffic.
+		expect(endpointRequests).toHaveLength(0);
+
+		// Client slot state to carry across the morph.
+		await page.locator('#sc-draft').fill('draft survives');
+
+		// Re-evaluating the call streams the new panel over the endpoint and
+		// morphs the boundary in place.
+		await page.locator('#sc-rename').click();
+		await expect(page.locator('#sc-name')).toHaveText('panel:beta');
+		expect(endpointRequests.length).toBeGreaterThan(0);
+
+		// The client slot kept its DOM identity through the morph.
+		await expect(page.locator('#sc-draft')).toHaveValue('draft survives');
+	});
 });

--- a/packages/astro/e2e/solid-server-functions.test.ts
+++ b/packages/astro/e2e/solid-server-functions.test.ts
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test';
+import { type DevServer, testFactory, waitForHydrate } from './test-utils.ts';
+
+const test = testFactory(import.meta.url, { root: './fixtures/solid-server-functions/' });
+
+let devServer: DevServer;
+
+test.beforeAll(async ({ astro }) => {
+	devServer = await astro.startDevServer();
+});
+
+test.afterAll(async () => {
+	await devServer.stop();
+});
+
+test.describe('Solid server functions', () => {
+	test('client island round trip through the endpoint', async ({ astro, page }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const demo = page.locator('#sf-demo');
+		await expect(demo, 'island is visible').toBeVisible();
+		await waitForHydrate(page, demo);
+
+		const value = page.locator('#sf-value');
+		await expect(value, 'initial value is 1').toHaveText('1');
+
+		await page.locator('#sf-double').click();
+		await expect(value, 'doubled on the server').toHaveText('2');
+
+		await page.locator('#sf-double').click();
+		await expect(value, 'doubled again').toHaveText('4');
+	});
+
+	test('server functions see Astro middleware locals via the request event', async ({
+		astro,
+		page,
+	}) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		// Direct in-process call during island SSR: the renderer's request-event
+		// scope carries the page request (middleware ran before the render).
+		await expect(page.locator('#sf-ssr-user')).toHaveText('astro-middleware');
+
+		const demo = page.locator('#sf-demo');
+		await waitForHydrate(page, demo);
+
+		// Endpoint dispatch: the injected route threads context.locals into the
+		// event, and the request passed through Astro's middleware pipeline.
+		await page.locator('#sf-whoami').click();
+		await expect(page.locator('#sf-user')).toHaveText('astro-middleware');
+	});
+});

--- a/packages/astro/src/core/config/tsconfig.ts
+++ b/packages/astro/src/core/config/tsconfig.ts
@@ -37,11 +37,13 @@ export const presets = new Map<frameworkWithTSSettings, TSConfig>([
 		},
 	],
 	[
-		'solid-js', // https://www.solidjs.com/guides/typescript#configuring-typescript
+		// In Solid 2.0 renderer packages own their JSX namespaces and
+		// jsx-runtime type entries; `solid-js` no longer exports one.
+		'solid-js',
 		{
 			compilerOptions: {
 				jsx: 'preserve',
-				jsxImportSource: 'solid-js',
+				jsxImportSource: '@solidjs/web',
 			},
 		},
 	],

--- a/packages/astro/test/fixtures/astro-slots-nested/package.json
+++ b/packages/astro/test/fixtures/astro-slots-nested/package.json
@@ -8,11 +8,12 @@
     "@astrojs/solid-js": "workspace:*",
     "@astrojs/svelte": "workspace:*",
     "@astrojs/vue": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/test/fixtures/jsx/package.json
+++ b/packages/astro/test/fixtures/jsx/package.json
@@ -12,10 +12,11 @@
     "astro": "workspace:*"
   },
   "dependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "preact": "^10.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   }

--- a/packages/astro/test/fixtures/large-array/package.json
+++ b/packages/astro/test/fixtures/large-array/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "dependencies": {
     "@astrojs/solid-js": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
-    "solid-js": "^1.9.11"
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/test/fixtures/postcss/package.json
+++ b/packages/astro/test/fixtures/postcss/package.json
@@ -6,10 +6,11 @@
     "@astrojs/solid-js": "workspace:*",
     "@astrojs/svelte": "workspace:*",
     "@astrojs/vue": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
     "autoprefixer": "^10.4.27",
     "postcss": "^8.5.8",
-    "solid-js": "^1.9.11",
+    "solid-js": "^2.0.0-rc.5",
     "svelte": "^5.54.0",
     "vue": "^3.5.30"
   },

--- a/packages/astro/test/fixtures/postcss/src/components/Solid.jsx
+++ b/packages/astro/test/fixtures/postcss/src/components/Solid.jsx
@@ -1,4 +1,3 @@
-import { h } from 'solid-js';
 import './Solid.css';
 
 export default function Counter() {

--- a/packages/astro/test/fixtures/react-and-solid/package.json
+++ b/packages/astro/test/fixtures/react-and-solid/package.json
@@ -4,9 +4,10 @@
   "dependencies": {
     "@astrojs/react": "workspace:*",
     "@astrojs/solid-js": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^1.9.11"
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/test/fixtures/react-and-solid/tsconfig.json
+++ b/packages/astro/test/fixtures/react-and-solid/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "jsxImportSource": "solid-js",
+    "jsxImportSource": "@solidjs/web",
     "types": ["astro/client"]
   },
   "include": [".astro/types.d.ts", "**/*"],

--- a/packages/astro/test/fixtures/slots-solid/package.json
+++ b/packages/astro/test/fixtures/slots-solid/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@astrojs/mdx": "workspace:*",
     "@astrojs/solid-js": "workspace:*",
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
-    "solid-js": "^1.9.11"
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/package.json
+++ b/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/package.json
@@ -10,6 +10,7 @@
     }
   },
   "dependencies": {
-    "solid-js": "^1.9.11"
+    "@solidjs/web": "^2.0.0-rc.5",
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/test/fixtures/solid-component/package.json
+++ b/packages/astro/test/fixtures/solid-component/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "dependencies": {
     "@astrojs/solid-js": "workspace:*",
-    "@solidjs/router": "^0.16.1",
+    "@solidjs/web": "^2.0.0-rc.5",
     "@test/solid-jsx-component": "file:./deps/solid-jsx-component",
     "astro": "workspace:*",
-    "solid-js": "^1.9.11"
+    "solid-js": "^2.0.0-rc.5"
   }
 }

--- a/packages/astro/test/fixtures/solid-component/src/components/Counter.css
+++ b/packages/astro/test/fixtures/solid-component/src/components/Counter.css
@@ -1,0 +1,3 @@
+.lazy-counter-style {
+	color: rgb(0, 128, 0);
+}

--- a/packages/astro/test/fixtures/solid-component/src/components/Counter.jsx
+++ b/packages/astro/test/fixtures/solid-component/src/components/Counter.jsx
@@ -1,6 +1,9 @@
 // Based on reproduction from https://github.com/withastro/astro/issues/6912
 
 import { For, Match, Switch } from 'solid-js';
+// CSS on a lazily-loaded module: only reachable through the renderer's
+// manifest-resolved head channel, which must inline it into the island.
+import './Counter.css';
 
 export default function Counter(props) {
 	return (

--- a/packages/astro/test/fixtures/solid-component/src/components/ProxyComponent.jsx
+++ b/packages/astro/test/fixtures/solid-component/src/components/ProxyComponent.jsx
@@ -1,4 +1,4 @@
-import { Dynamic } from 'solid-js/web'
+import { Dynamic } from '@solidjs/web'
 
 const BaseComponent = ({ tag } = {}) => {
   return <Dynamic id="proxy-component" component={tag || 'div'}>Hello world</Dynamic>;

--- a/packages/astro/test/fixtures/solid-component/src/components/async-components.jsx
+++ b/packages/astro/test/fixtures/solid-component/src/components/async-components.jsx
@@ -1,4 +1,4 @@
-import { ErrorBoundary, Show, createResource, createSignal, createUniqueId } from 'solid-js';
+import { Errored, Show, createMemo, createSignal, createUniqueId } from 'solid-js';
 
 // It may be good to try long and short sleep times.
 // But short is faster for testing.
@@ -9,7 +9,9 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 export function AsyncComponent(props) {
 	const id = createUniqueId();
 
-	const [data] = createResource(async () => {
+	// Async is first-class in Solid 2.0: an async memo suspends readers until
+	// it resolves (the createResource equivalent).
+	const data = createMemo(async () => {
 		// console.log("Start rendering async component " + props.title);
 		await sleep(props.delay ?? SLEEP_MS);
 		// console.log("Finish rendering async component " + props.title);
@@ -41,7 +43,7 @@ export function AsyncComponent(props) {
 }
 
 export function AsyncErrorComponent() {
-	const [data] = createResource(async () => {
+	const data = createMemo(async () => {
 		await sleep(SLEEP_MS);
 		throw new Error('Async error thrown!');
 	});
@@ -51,9 +53,9 @@ export function AsyncErrorComponent() {
 
 export function AsyncErrorInErrorBoundary() {
 	return (
-		<ErrorBoundary fallback={<div>Async error boundary fallback</div>}>
+		<Errored fallback={<div>Async error boundary fallback</div>}>
 			<AsyncErrorComponent />
-		</ErrorBoundary>
+		</Errored>
 	);
 }
 
@@ -63,8 +65,8 @@ export function SyncErrorComponent() {
 
 export function SyncErrorInErrorBoundary() {
 	return (
-		<ErrorBoundary fallback={<div>Sync error boundary fallback</div>}>
+		<Errored fallback={<div>Sync error boundary fallback</div>}>
 			<SyncErrorComponent />
-		</ErrorBoundary>
+		</Errored>
 	);
 }

--- a/packages/astro/test/fixtures/solid-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/solid-component/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import { Router } from "@solidjs/router";
 import { Counter as DepCounter } from '@test/solid-jsx-component';
 import Hello from '../components/Hello.jsx';
 import ProxyComponent from '../components/ProxyComponent.jsx';
@@ -11,7 +10,6 @@ import WithNewlines from '../components/WithNewlines.jsx';
   <div>
     <Hello client:load />
 		<WithNewlines client:load />
-    <Router />
     <ProxyComponent client:load />
     <DepCounter client:load />
   </div>

--- a/packages/astro/test/solid-component.test.ts
+++ b/packages/astro/test/solid-component.test.ts
@@ -3,7 +3,7 @@ import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { type DevServer, type Fixture, isWindows, loadFixture } from './test-utils.ts';
 
-describe.skip('Solid component build', { todo: 'Check why an error is thrown.' }, () => {
+describe('Solid component build', () => {
 	let fixture: Fixture;
 	before(async () => {
 		fixture = await loadFixture({
@@ -42,6 +42,27 @@ describe.skip('Solid component build', { todo: 'Check why an error is thrown.' }
 		assert.equal($('button').length, 5);
 	});
 
+	it('Inlines CSS of lazy components into the island markup', async () => {
+		// Counter.css is only reachable through the lazy() boundary — the
+		// renderer resolves it via the client manifest and must inline it
+		// (style tag or stylesheet link) where the island renders, once per page.
+		for (const path of ['ssr-client-none/index.html', 'ssr-client-load/index.html']) {
+			const html = await fixture.readFile(path);
+			const $ = cheerio.load(html);
+			let occurrences = 0;
+			for (const el of $('style').toArray()) {
+				if ($(el).text().includes('.lazy-counter-style')) occurrences++;
+			}
+			for (const el of $('link[rel="stylesheet"]').toArray()) {
+				const href = $(el).attr('href');
+				if (!href) continue;
+				const css = await fixture.readFile(new URL(href, 'http://example.com/').pathname);
+				if (css?.includes('.lazy-counter-style')) occurrences++;
+			}
+			assert.equal(occurrences, 1, `lazy CSS delivered exactly once in ${path}`);
+		}
+	});
+
 	// ssr-client-none-throwing.astro
 	it('Supports server only components with error boundaries', async () => {
 		const html = await fixture.readFile('ssr-client-none-throwing/index.html');
@@ -77,8 +98,7 @@ describe.skip('Solid component build', { todo: 'Check why an error is thrown.' }
 		assert.equal(html.includes('Async error boundary fallback'), true);
 		assert.equal(html.includes('Sync error boundary fallback'), true);
 		const hydrationEventsCount = countHydrationEvents(html);
-		// @ts-expect-error: test is in describe.skip
-		assert.equal(hydrationEventsCount.length > 1, true);
+		assert.equal(hydrationEventsCount >= 1, true);
 	});
 
 	// ssr-client-only.astro
@@ -97,16 +117,14 @@ describe.skip('Solid component build', { todo: 'Check why an error is thrown.' }
 		const html = await fixture.readFile('nested/index.html');
 
 		const firstHydrationScriptAt = getFirstHydrationScriptLocation(html);
-		// @ts-expect-error: test is in describe.skip
-		assert.equal(firstHydrationScriptAt.length, 0);
+		assert.equal(typeof firstHydrationScriptAt === 'number' && firstHydrationScriptAt > 0, true);
 
 		const firstHydrationEventAt = getFirstHydrationEventLocation(html);
-		// @ts-expect-error: test is in describe.skip
-		assert.equal(firstHydrationEventAt.length, 0);
+		assert.equal(typeof firstHydrationEventAt === 'number' && firstHydrationEventAt > 0, true);
 
 		assert.equal(
-			// @ts-expect-error: test is in describe.skip
-			firstHydrationScriptAt < firstHydrationEventAt,
+			firstHydrationScriptAt! < firstHydrationEventAt!,
+			true,
 			'Position of first hydration event',
 		);
 	});
@@ -115,24 +133,22 @@ describe.skip('Solid component build', { todo: 'Check why an error is thrown.' }
 		const html = await fixture.readFile('deferred/index.html');
 
 		const firstHydrationScriptAt = getFirstHydrationScriptLocation(html);
-		// @ts-expect-error: test is in describe.skip
-		assert.equal(firstHydrationScriptAt > 0, true);
+		assert.equal(typeof firstHydrationScriptAt === 'number' && firstHydrationScriptAt > 0, true);
 
 		const firstHydrationEventAt = getFirstHydrationEventLocation(html);
-		// @ts-expect-error: test is in describe.skip
-		assert.equal(firstHydrationEventAt > 0, true);
+		assert.equal(typeof firstHydrationEventAt === 'number' && firstHydrationEventAt > 0, true);
 
 		const hydrationScriptCount = countHydrationScripts(html);
 		assert.equal(hydrationScriptCount, 1);
 		assert.equal(
-			// @ts-expect-error: test is in describe.skip
-			firstHydrationScriptAt < firstHydrationEventAt,
+			firstHydrationScriptAt! < firstHydrationEventAt!,
+			true,
 			'Position of first hydration event',
 		);
 	});
 });
 
-describe.skip('Solid component dev', { todo: 'Check why the test hangs.', skip: isWindows }, () => {
+describe('Solid component dev', { skip: isWindows }, () => {
 	let devServer: DevServer;
 	let fixture: Fixture;
 

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -21,8 +21,9 @@
   "exports": {
     ".": "./dist/index.js",
     "./container-renderer": "./dist/container-renderer.js",
-    "./client.js": "./dist/client.js",
-    "./server.js": "./dist/server.js",
+		"./client.js": "./dist/client.js",
+		"./server.js": "./dist/server.js",
+		"./server-function-endpoint.js": "./dist/server-function-endpoint.js",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrojs/solid-js",
-  "version": "7.0.2",
+  "version": "8.0.0-beta.0",
   "description": "Use Solid components within Astro",
   "type": "module",
   "author": "withastro",
@@ -34,23 +34,19 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
+    "@solidjs/vite-plugin": "^3.0.0-next.37",
     "vite": "^8.0.13",
-    "vite-plugin-solid": "^2.11.12",
     "vitefu": "^1.1.2"
   },
   "devDependencies": {
+    "@solidjs/web": "^2.0.0-rc.5",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "solid-js": "^1.9.13"
+    "solid-js": "^2.0.0-rc.5"
   },
   "peerDependencies": {
-    "solid-devtools": "^0.34.5",
-    "solid-js": "^1.9.13"
-  },
-  "peerDependenciesMeta": {
-    "solid-devtools": {
-      "optional": true
-    }
+    "@solidjs/web": "^2.0.0-rc.5",
+    "solid-js": "^2.0.0-rc.5"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/packages/integrations/solid/src/client.ts
+++ b/packages/integrations/solid/src/client.ts
@@ -1,6 +1,5 @@
-import { Suspense } from 'solid-js';
-import { createStore, reconcile } from 'solid-js/store';
-import { createComponent, hydrate, render } from 'solid-js/web';
+import { createStore, reconcile } from 'solid-js';
+import { createComponent, hydrate, render } from '@solidjs/web';
 
 const alreadyInitializedElements = new WeakMap<Element, any>();
 
@@ -52,22 +51,12 @@ export default (element: HTMLElement) =>
 			// store the function to update the current mounted component
 			alreadyInitializedElements.set(element, setStore);
 
-			const fn = () => {
-				const inner = () => createComponent(Component, store);
+			// No boundary wrapper: the server render ships fully-settled HTML with
+			// no boundary of its own, and hydration structure must match. Async is
+			// first-class in Solid 2.0; components that want a fallback bring
+			// their own Loading boundary (present in both renders).
+			const fn = () => createComponent(Component, store);
 
-				if (isHydrate) {
-					return createComponent(Suspense, {
-						get children() {
-							return inner();
-						},
-					});
-				} else {
-					return inner();
-				}
-			};
-
-			// hydrate and render have different signatures for their third argument,
-			// so we call them separately instead of unifying into a single `bootstrap` call.
 			let dispose: () => void;
 			if (isHydrate) {
 				dispose = hydrate(fn, element, { renderId });

--- a/packages/integrations/solid/src/context.ts
+++ b/packages/integrations/solid/src/context.ts
@@ -3,6 +3,8 @@ import type { RendererContext } from './types.js';
 type Context = {
 	id: string;
 	c: number;
+	/** Style dedupe keys already emitted into an island on this page render. */
+	styles: Set<string>;
 };
 
 const contexts = new WeakMap<RendererContext['result'], Context>();
@@ -13,6 +15,7 @@ export function getContext(result: RendererContext['result']): Context {
 	}
 	let ctx: Context = {
 		c: 0,
+		styles: new Set<string>(),
 		get id() {
 			return 's' + this.c.toString();
 		},

--- a/packages/integrations/solid/src/context.ts
+++ b/packages/integrations/solid/src/context.ts
@@ -5,6 +5,11 @@ type Context = {
 	c: number;
 	/** Style dedupe keys already emitted into an island on this page render. */
 	styles: Set<string>;
+	/**
+	 * Solid request event for this page render (`getRequestEvent()`), shared
+	 * across islands so server functions called during SSR see one `locals`.
+	 */
+	event?: { request: Request; locals: Record<string, unknown> };
 };
 
 const contexts = new WeakMap<RendererContext['result'], Context>();

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -1,61 +1,20 @@
-import type { AstroIntegration, AstroIntegrationLogger, AstroRenderer } from 'astro';
 import { fileURLToPath } from 'node:url';
-import type { PluginOption, Plugin } from 'vite';
-import solid, { type Options as ViteSolidPluginOptions } from 'vite-plugin-solid';
+import type { Options as ViteSolidPluginOptions } from '@solidjs/vite-plugin';
+import solid from '@solidjs/vite-plugin';
+import type { AstroIntegration, AstroRenderer } from 'astro';
+import type { Plugin, PluginOption } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
 import { getContainerRenderer as getContainerRendererImpl } from './container-renderer.js';
 
-// TODO: keep in sync with https://github.com/thetarnav/solid-devtools/blob/main/packages/main/src/vite/index.ts#L7
-type DevtoolsPluginOptions = {
-	/** Add automatic name when creating signals, memos, stores, or mutables */
-	autoname?: boolean;
-	locator?:
-		| boolean
-		| {
-				/** Choose in which IDE the component source code should be revealed. */
-				targetIDE?: string;
-				/**
-				 * Holding which key should enable the locator overlay?
-				 * @default 'Alt'
-				 */
-				key?: string;
-				/** Inject location attributes to jsx templates */
-				jsxLocation?: boolean;
-				/** Inject location information to component declarations */
-				componentLocation?: boolean;
-		  };
-};
-type DevtoolsPlugin = (_options?: DevtoolsPluginOptions) => PluginOption;
-
-async function getDevtoolsPlugin(logger: AstroIntegrationLogger, retrieve: boolean) {
-	if (!retrieve) {
-		return null;
-	}
-
-	try {
-		// @ts-ignore
-		return (await import('solid-devtools/vite')).default as DevtoolsPlugin;
-	} catch (_) {
-		logger.warn(
-			'Solid Devtools requires `solid-devtools` as a peer dependency, add it to your project.',
-		);
-		return null;
-	}
-}
-
 function getViteConfiguration(
-	{ include, exclude }: Options,
-	devtoolsPlugin: DevtoolsPlugin | null,
+	{ include, exclude, compiler }: Options,
 	solidNoExternal: string[],
+	manifestSource: ManifestSource,
 ) {
 	const plugins: PluginOption[] = [
-		solid({ include, exclude, ssr: true }),
-		configEnvironmentPlugin(solidNoExternal),
+		solid({ include, exclude, compiler, ssr: true }),
+		configEnvironmentPlugin(solidNoExternal, manifestSource),
 	];
-
-	if (devtoolsPlugin) {
-		plugins.push(devtoolsPlugin({ autoname: true }));
-	}
 
 	return { plugins };
 }
@@ -70,27 +29,23 @@ export function getContainerRenderer(): AstroRenderer {
 	return getContainerRendererImpl();
 }
 
-export interface Options extends Pick<ViteSolidPluginOptions, 'include' | 'exclude'> {
-	devtools?: boolean;
-}
+export interface Options extends Pick<ViteSolidPluginOptions, 'include' | 'exclude' | 'compiler'> {}
 
 export default function (options: Options = {}): AstroIntegration {
+	// Filled in during `astro:config:done` (before dev/build starts) and read
+	// by the manifest virtual module's load hook.
+	const manifestSource: ManifestSource = {
+		command: 'dev',
+		clientDirs: [],
+		serverDir: null,
+		base: '/',
+	};
+
 	return {
 		name: '@astrojs/solid-js',
 		hooks: {
-			'astro:config:setup': async ({
-				command,
-				config,
-				addRenderer,
-				updateConfig,
-				injectScript,
-				logger,
-			}) => {
-				const devtoolsPlugin = await getDevtoolsPlugin(
-					logger,
-					!!options.devtools && command === 'dev',
-				);
-
+			'astro:config:setup': async ({ command, config, addRenderer, updateConfig }) => {
+				manifestSource.command = command;
 				// Solid component libraries that ship pre-compiled browser
 				// artifacts via the `exports.solid` condition must go through
 				// Vite's transform pipeline in non-client environments.
@@ -101,20 +56,29 @@ export default function (options: Options = {}): AstroIntegration {
 					root: fileURLToPath(config.root),
 					isBuild: false,
 					isFrameworkPkgByJson(pkgJson) {
-						return !!pkgJson.peerDependencies?.['solid-js'];
+						return !!(
+							pkgJson.peerDependencies?.['solid-js'] ||
+							pkgJson.peerDependencies?.['@solidjs/web']
+						);
 					},
 				});
 
 				addRenderer(getContainerRendererImpl());
 				updateConfig({
-					vite: getViteConfiguration(options, devtoolsPlugin, solidPackages.ssr.noExternal),
+					vite: getViteConfiguration(options, solidPackages.ssr.noExternal, manifestSource),
 				});
-
-				if (devtoolsPlugin) {
-					injectScript('page', 'import "solid-devtools";');
-				}
 			},
 			'astro:config:done': ({ logger, config }) => {
+				// Where the client build's `.vite/manifest.json` will land. For
+				// `output: 'server'` client assets go to `build.client`; for static
+				// output they go to `outDir` directly. Record both candidates and
+				// probe at runtime, mirroring @solidjs/vite-plugin's own fallback.
+				manifestSource.clientDirs = [
+					...new Set([fileURLToPath(config.build.client), fileURLToPath(config.outDir)]),
+				];
+				manifestSource.serverDir =
+					config.output === 'server' ? fileURLToPath(config.build.server) : null;
+				manifestSource.base = config.base;
 				const knownJsxRenderers = ['@astrojs/react', '@astrojs/preact', '@astrojs/solid-js'];
 				const enabledKnownJsxRenderers = config.integrations.filter((renderer) =>
 					knownJsxRenderers.includes(renderer.name),
@@ -130,12 +94,39 @@ export default function (options: Options = {}): AstroIntegration {
 	};
 }
 
-function configEnvironmentPlugin(solidNoExternal: string[]): Plugin {
+export type ManifestSource = {
+	command: string;
+	clientDirs: string[];
+	serverDir: string | null;
+	base: string;
+};
+
+const VIRTUAL_MANIFEST_ID = 'virtual:astro-solid-manifest';
+const RESOLVED_VIRTUAL_MANIFEST_ID = '\0' + VIRTUAL_MANIFEST_ID;
+
+// Handoff channel between the client build (which produces the manifest) and
+// prerendering, which imports the server bundle in the same process. Astro
+// deletes every environment's `.vite` folder right after write (see its
+// `astro:ssr-assets` plugin), so the manifest cannot be read from disk later.
+const MANIFEST_REGISTRY_KEY = '@astrojs/solid-js:client-manifest';
+const PERSISTED_MANIFEST_NAME = 'solid-manifest.json';
+
+// Key the registry per project output so multiple builds in one process
+// (e.g. test runners building several fixtures) don't read each other's
+// manifests.
+function manifestRegistryKey(manifestSource: ManifestSource): string {
+	return `${MANIFEST_REGISTRY_KEY}:${manifestSource.clientDirs[0] ?? ''}`;
+}
+
+function configEnvironmentPlugin(solidNoExternal: string[], manifestSource: ManifestSource): Plugin {
 	return {
 		name: '@astrojs/solid:config-environment',
 		configEnvironment(environmentName) {
 			if (environmentName === 'client') {
 				return {
+					// Emit .vite/manifest.json in the client build so the server
+					// render can resolve lazy boundary module assets at runtime.
+					build: { manifest: true },
 					optimizeDeps: {
 						include: ['@astrojs/solid-js/client.js'],
 						exclude: ['@astrojs/solid-js/server.js'],
@@ -143,11 +134,84 @@ function configEnvironmentPlugin(solidNoExternal: string[]): Plugin {
 				};
 			}
 			return {
-				resolve: { noExternal: solidNoExternal },
+				// The integration itself must go through Vite in server
+				// environments so `virtual:astro-solid-manifest` resolves inside
+				// server.js (a bare Node import of it degrades gracefully).
+				resolve: { noExternal: [...solidNoExternal, '@astrojs/solid-js'] },
 				optimizeDeps: {
 					exclude: ['@astrojs/solid-js/server.js'],
 				},
 			};
+		},
+		resolveId(id) {
+			if (id === VIRTUAL_MANIFEST_ID) return RESOLVED_VIRTUAL_MANIFEST_ID;
+		},
+		load(id) {
+			if (id !== RESOLVED_VIRTUAL_MANIFEST_ID) return;
+			if (manifestSource.command !== 'build') {
+				// Dev: @solidjs/vite-plugin's virtual manifest exports a live
+				// resolver backed by the dev server's module graph; hand it
+				// through verbatim (renderToStream accepts resolvers directly).
+				return (
+					`import manifest from 'virtual:solid-manifest';\n` +
+					`export function loadManifest() { return manifest; }\n`
+				);
+			}
+			// Build: the server/prerender bundles are created before the client
+			// build produces the manifest, so it cannot be baked in. Resolve it
+			// lazily at render time: prerendering runs in the build process and
+			// finds it in the globalThis registry; a deployed server reads the
+			// copy persisted next to the server bundle.
+			const fileCandidates = [
+				...(manifestSource.serverDir
+					? [JSON.stringify(manifestSource.serverDir + PERSISTED_MANIFEST_NAME)]
+					: []),
+				`new URL(${JSON.stringify('./' + PERSISTED_MANIFEST_NAME)}, import.meta.url)`,
+				`new URL(${JSON.stringify('../' + PERSISTED_MANIFEST_NAME)}, import.meta.url)`,
+			];
+			return (
+				`import { readFileSync } from 'node:fs';\n` +
+				`const base = ${JSON.stringify(manifestSource.base)};\n` +
+				`let manifest;\n` +
+				`export function loadManifest() {\n` +
+				`  if (manifest !== undefined) return manifest;\n` +
+				`  manifest = globalThis[Symbol.for(${JSON.stringify(manifestRegistryKey(manifestSource))})];\n` +
+				`  if (manifest === undefined) {\n` +
+				`    for (const candidate of [${fileCandidates.join(', ')}]) {\n` +
+				`      try {\n` +
+				`        manifest = JSON.parse(readFileSync(candidate, 'utf-8'));\n` +
+				`        break;\n` +
+				`      } catch {}\n` +
+				`    }\n` +
+				`  }\n` +
+				`  if (manifest == null) return (manifest = null);\n` +
+				`  manifest._base = base;\n` +
+				`  return manifest;\n` +
+				`}\n`
+			);
+		},
+		writeBundle: {
+			sequential: true,
+			async handler() {
+				// Capture the client manifest before Astro's `astro:ssr-assets`
+				// plugin ('post' order) deletes the .vite folder.
+				if (this.environment.name !== 'client') return;
+				const { readFile, writeFile } = await import('node:fs/promises');
+				const { join } = await import('node:path');
+				for (const dir of manifestSource.clientDirs) {
+					try {
+						const raw = await readFile(join(dir, '.vite/manifest.json'), 'utf-8');
+						(globalThis as any)[Symbol.for(manifestRegistryKey(manifestSource))] = JSON.parse(raw);
+						if (manifestSource.serverDir) {
+							// Persist for deployed SSR runtimes, which cannot use the
+							// in-process registry. Lives next to the server bundle, so
+							// it is not publicly served.
+							await writeFile(join(manifestSource.serverDir, PERSISTED_MANIFEST_NAME), raw);
+						}
+						return;
+					} catch {}
+				}
+			},
 		},
 	};
 }

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -7,16 +7,34 @@ import { crawlFrameworkPkgs } from 'vitefu';
 import { getContainerRenderer as getContainerRendererImpl } from './container-renderer.js';
 
 function getViteConfiguration(
-	{ include, exclude, compiler }: Options,
+	{ include, exclude, compiler, serverFunctions }: Options,
 	solidNoExternal: string[],
 	manifestSource: ManifestSource,
 ) {
 	const plugins: PluginOption[] = [
-		solid({ include, exclude, compiler, ssr: true }),
+		solid({
+			include,
+			exclude,
+			compiler,
+			ssr: true,
+			// The integration owns endpoint dispatch through an injected Astro
+			// route (see server-function-endpoint.ts), so server-function
+			// requests flow through Astro's middleware pipeline in dev too —
+			// stand the plugin's own dev middleware down.
+			serverFunctions: serverFunctions
+				? { ...(serverFunctions === true ? {} : serverFunctions), devMiddleware: false }
+				: undefined,
+		}),
 		configEnvironmentPlugin(solidNoExternal, manifestSource),
 	];
 
 	return { plugins };
+}
+
+function serverFunctionsEndpoint(serverFunctions: Options['serverFunctions']): string {
+	const endpoint =
+		(typeof serverFunctions === 'object' && serverFunctions.endpoint) || '/_server';
+	return endpoint.endsWith('/') ? endpoint.slice(0, -1) : endpoint;
 }
 
 /**
@@ -29,7 +47,8 @@ export function getContainerRenderer(): AstroRenderer {
 	return getContainerRendererImpl();
 }
 
-export interface Options extends Pick<ViteSolidPluginOptions, 'include' | 'exclude' | 'compiler'> {}
+export interface Options
+	extends Pick<ViteSolidPluginOptions, 'include' | 'exclude' | 'compiler' | 'serverFunctions'> {}
 
 export default function (options: Options = {}): AstroIntegration {
 	// Filled in during `astro:config:done` (before dev/build starts) and read
@@ -44,8 +63,18 @@ export default function (options: Options = {}): AstroIntegration {
 	return {
 		name: '@astrojs/solid-js',
 		hooks: {
-			'astro:config:setup': async ({ command, config, addRenderer, updateConfig }) => {
+			'astro:config:setup': async ({ command, config, addRenderer, updateConfig, injectRoute }) => {
 				manifestSource.command = command;
+				if (options.serverFunctions) {
+					// The transport posts to `<endpoint>/<id>` and
+					// `<endpoint>/data/<id>` — a rest route covers both (and the
+					// bare mount, which the runtime handler answers with a 404).
+					injectRoute({
+						pattern: `${serverFunctionsEndpoint(options.serverFunctions)}/[...solidServerFunction]`,
+						entrypoint: '@astrojs/solid-js/server-function-endpoint.js',
+						prerender: false,
+					});
+				}
 				// Solid component libraries that ship pre-compiled browser
 				// artifacts via the `exports.solid` condition must go through
 				// Vite's transform pipeline in non-client environments.
@@ -79,6 +108,14 @@ export default function (options: Options = {}): AstroIntegration {
 				manifestSource.serverDir =
 					config.output === 'server' ? fileURLToPath(config.build.server) : null;
 				manifestSource.base = config.base;
+
+				if (options.serverFunctions && manifestSource.command === 'build' && !config.adapter) {
+					throw new Error(
+						'[@astrojs/solid-js] `serverFunctions` needs a server to answer function calls at runtime. ' +
+							'Install an adapter (e.g. @astrojs/node) to build with server functions enabled.',
+					);
+				}
+
 				const knownJsxRenderers = ['@astrojs/react', '@astrojs/preact', '@astrojs/solid-js'];
 				const enabledKnownJsxRenderers = config.integrations.filter((renderer) =>
 					knownJsxRenderers.includes(renderer.name),

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -51,6 +51,8 @@ export interface Options
 	extends Pick<ViteSolidPluginOptions, 'include' | 'exclude' | 'compiler' | 'serverFunctions'> {}
 
 export default function (options: Options = {}): AstroIntegration {
+	const serverComponents =
+		typeof options.serverFunctions === 'object' && !!options.serverFunctions.components;
 	// Filled in during `astro:config:done` (before dev/build starts) and read
 	// by the manifest virtual module's load hook.
 	const manifestSource: ManifestSource = {
@@ -58,12 +60,20 @@ export default function (options: Options = {}): AstroIntegration {
 		clientDirs: [],
 		serverDir: null,
 		base: '/',
+		serverComponents,
 	};
 
 	return {
 		name: '@astrojs/solid-js',
 		hooks: {
-			'astro:config:setup': async ({ command, config, addRenderer, updateConfig, injectRoute }) => {
+			'astro:config:setup': async ({
+				command,
+				config,
+				addRenderer,
+				updateConfig,
+				injectRoute,
+				injectScript,
+			}) => {
 				manifestSource.command = command;
 				if (options.serverFunctions) {
 					// The transport posts to `<endpoint>/<id>` and
@@ -74,6 +84,18 @@ export default function (options: Options = {}): AstroIntegration {
 						entrypoint: '@astrojs/solid-js/server-function-endpoint.js',
 						prerender: false,
 					});
+				}
+				if (serverComponents) {
+					// Installs the t=0 document-adoption registry and the transport
+					// policy (component responses morph their boundary instead of
+					// decoding as data). Astro's before-hydration stage runs it
+					// ahead of every island hydration. The server-side halves live
+					// in server.ts (render plugin, direct-call transform) and the
+					// endpoint handler virtual (response transform).
+					injectScript(
+						'before-hydration',
+						`import { installServerComponents } from '@solidjs/web/frames';\ninstallServerComponents();`,
+					);
 				}
 				// Solid component libraries that ship pre-compiled browser
 				// artifacts via the `exports.solid` condition must go through
@@ -136,6 +158,7 @@ export type ManifestSource = {
 	clientDirs: string[];
 	serverDir: string | null;
 	base: string;
+	serverComponents: boolean;
 };
 
 const VIRTUAL_MANIFEST_ID = 'virtual:astro-solid-manifest';
@@ -185,11 +208,13 @@ function configEnvironmentPlugin(solidNoExternal: string[], manifestSource: Mani
 		},
 		load(id) {
 			if (id !== RESOLVED_VIRTUAL_MANIFEST_ID) return;
+			const flags = `export const serverComponents = ${manifestSource.serverComponents};\n`;
 			if (manifestSource.command !== 'build') {
 				// Dev: @solidjs/vite-plugin's virtual manifest exports a live
 				// resolver backed by the dev server's module graph; hand it
 				// through verbatim (renderToStream accepts resolvers directly).
 				return (
+					flags +
 					`import manifest from 'virtual:solid-manifest';\n` +
 					`export function loadManifest() { return manifest; }\n`
 				);
@@ -207,6 +232,7 @@ function configEnvironmentPlugin(solidNoExternal: string[], manifestSource: Mani
 				`new URL(${JSON.stringify('../' + PERSISTED_MANIFEST_NAME)}, import.meta.url)`,
 			];
 			return (
+				flags +
 				`import { readFileSync } from 'node:fs';\n` +
 				`const base = ${JSON.stringify(manifestSource.base)};\n` +
 				`let manifest;\n` +

--- a/packages/integrations/solid/src/server-function-endpoint.ts
+++ b/packages/integrations/solid/src/server-function-endpoint.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from 'astro';
+// Eagerly import every module containing server functions so their
+// registrations exist before dispatch. Required in dev — functions referenced
+// only by client code are never loaded by the SSR render itself; in builds
+// the handler virtual already inlines the same manifest (the import dedupes).
+import 'virtual:solid-server-function-manifest';
+import { handleServerFunctionRequest } from 'virtual:solid-server-function-handler';
+
+export const prerender = false;
+
+// The transport addresses functions as `<endpoint>/<id>` (or
+// `<endpoint>/data/<id>` for the scripted transport); this route is injected
+// at `<endpoint>/[...] ` by the integration. Dispatching through an injected
+// Astro route (instead of a raw Vite middleware) means server-function
+// requests flow through Astro's middleware pipeline — the same auth guards
+// and locals decoration pages get — in dev and production alike.
+export const ALL: APIRoute = (context) => {
+	let request = context.request;
+	// Node-to-web request conversions attach a body stream to every POST,
+	// including bodyless ones (zero-argument calls send `Content-Length: 0`),
+	// but the runtime reads "no arguments" from `request.body === null`.
+	// Rebuild the empty case so it parses as a zero-argument call.
+	if (request.body !== null && request.headers.get('content-length') === '0') {
+		request = new Request(request.url, { method: request.method, headers: request.headers });
+	}
+	return handleServerFunctionRequest(request, {
+		// Extends the Solid request event (`getRequestEvent()`): Astro's
+		// per-request locals, plus the full API context as the platform event.
+		event: { locals: context.locals, nativeEvent: context },
+	});
+};

--- a/packages/integrations/solid/src/server.ts
+++ b/packages/integrations/solid/src/server.ts
@@ -1,19 +1,70 @@
-import type { NamedSSRLoadedRendererValue } from 'astro';
 import {
 	createComponent,
 	generateHydrationScript,
 	NoHydration,
-	renderToString,
-	renderToStringAsync,
-	Suspense,
+	renderToStream,
 	ssr,
-} from 'solid-js/web';
+} from '@solidjs/web';
+import type { NamedSSRLoadedRendererValue } from 'astro';
 import { getContext, incrementId } from './context.js';
 import type { RendererContext } from './types.js';
 
 const slotName = (str: string) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w.toUpperCase());
 
-type RenderStrategy = 'sync' | 'async';
+type RenderStrategy = 'default' | 'probe';
+
+// Asset manifest for resolving lazy boundary module URLs (preloads and the
+// serialized per-render asset maps consumed during hydration). Resolved
+// through the integration's virtual module: a live dev-server resolver in
+// dev, the client build's manifest in production. Outside Vite (e.g. the
+// Container API) the import fails and rendering proceeds without asset
+// resolution.
+let manifestLoader: (() => unknown) | null | undefined;
+async function getManifest(): Promise<unknown> {
+	if (manifestLoader === undefined) {
+		try {
+			manifestLoader = (await import('virtual:astro-solid-manifest')).loadManifest;
+		} catch {
+			manifestLoader = null;
+		}
+	}
+	return manifestLoader ? manifestLoader() : undefined;
+}
+
+// Probe verdicts are stable per component function: cache them so the probe
+// render's async work runs at most once per component type.
+const checkCache = new WeakMap<any, boolean>();
+
+const STYLE_OR_LINK_RE = /<style\b[^>]*>[\s\S]*?<\/style>|<link\b[^>]*>/gi;
+
+// Islands render without a document, so Solid delivers head-bound output via
+// onHead. Astro owns the document head and its build pipeline already handles
+// statically-imported island CSS, but CSS belonging to lazy() boundary modules
+// only exists in this channel — dropping it would leave server-rendered lazy
+// content unstyled until the client loads the chunk. Keep the style-bearing
+// tags (`<style>` and `<link rel="stylesheet">`, both manifest-resolved and
+// dev inline styles) and inline them at the start of the island; drop
+// everything else (preload/modulepreload hints, useHead tags, title
+// machinery). Dedupe across islands on the same page via the per-result
+// context so a shared lazy chunk's CSS ships once.
+function extractIslandStyles(head: string, seen: Set<string>): string {
+	let out = '';
+	for (const tag of head.match(STYLE_OR_LINK_RE) ?? []) {
+		let key: string;
+		if (tag.startsWith('<link')) {
+			if (!/rel=(?:"stylesheet"|'stylesheet'|stylesheet\b)/i.test(tag)) continue;
+			const href = /href=(?:"([^"]*)"|'([^']*)')/i.exec(tag);
+			key = href ? (href[1] ?? href[2]) : tag;
+		} else {
+			const devId = /data-vite-dev-id=(?:"([^"]*)"|'([^']*)')/i.exec(tag);
+			key = devId ? (devId[1] ?? devId[2]) : tag;
+		}
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out += tag;
+	}
+	return out;
+}
 
 async function check(
 	this: RendererContext,
@@ -22,30 +73,50 @@ async function check(
 	children: any,
 ) {
 	if (typeof Component !== 'function') return false;
-	if (Component.name === 'QwikComponent') return false;
-	// Svelte component renders fine by Solid as an empty string. The only way to detect
-	// if this isn't a Solid but Svelte component is to unfortunately copy the check
-	// implementation of the Svelte renderer.
-	// `$$payload` is the legacy prop name; `$$renderer` is the name used since Svelte 5.x.
-	const componentStr = Component.toString();
-	if (componentStr.includes('$$payload') || componentStr.includes('$$renderer')) return false;
+	const cached = checkCache.get(Component);
+	if (cached !== undefined) return cached;
 
-	// There is nothing particularly special about Solid components. Basically they are just functions.
-	// In general, components from other frameworks (eg, MDX, React, etc.) tend to render as "undefined",
-	// so we take advantage of this trick to decide if this is a Solid component or not.
+	let result = false;
+	if (Component.name === 'QwikComponent') {
+		result = false;
+	} else {
+		// Svelte component renders fine by Solid as an empty string. The only way to detect
+		// if this isn't a Solid but Svelte component is to unfortunately copy the check
+		// implementation of the Svelte renderer.
+		// `$$payload` is the legacy prop name; `$$renderer` is the name used since Svelte 5.x.
+		// Read the source reflectively: `Component.toString()` would trip `get`
+		// traps on Proxy-based components (e.g. Motion One's `<Motion.div>`).
+		let componentStr = '';
+		try {
+			componentStr = Function.prototype.toString.call(Component);
+		} catch {}
+		if (componentStr.includes('$$payload') || componentStr.includes('$$renderer')) {
+			result = false;
+		} else {
+			// There is nothing particularly special about Solid components — they are just
+			// functions. Probe-render the component and reject anything that errors,
+			// including the foreign-vnode guard in renderToStaticMarkup tripping on
+			// React/Preact elements. The probe must be a stream render: Solid 2.0's
+			// async model only contains async work (and async errors) inside
+			// renderToStream — a sync render of an async component would throw and
+			// leave orphaned promise rejections behind.
+			let errored = false;
+			try {
+				const { html } = await renderToStaticMarkup.call(this, Component, props, children, {
+					renderStrategy: 'probe' as RenderStrategy,
+					onProbeError() {
+						errored = true;
+					},
+				});
+				result = typeof html === 'string' && !errored;
+			} catch {
+				result = false;
+			}
+		}
+	}
 
-	let html: string | undefined;
-	try {
-		const result = await renderToStaticMarkup.call(this, Component, props, children, {
-			// The purpose of check() is just to validate that this is a Solid component and not
-			// React, etc. We should render in sync mode which should skip Suspense boundaries
-			// or loading resources like external API calls.
-			renderStrategy: 'sync' as RenderStrategy,
-		});
-		html = result.html;
-	} catch {}
-
-	return typeof html === 'string';
+	checkCache.set(Component, result);
+	return result;
 }
 
 // AsyncRendererComponentFn
@@ -61,7 +132,7 @@ async function renderToStaticMarkup(
 	const needsHydrate = metadata?.astroStaticSlot ? !!metadata.hydrate : true;
 	const tagName = needsHydrate ? 'astro-slot' : 'astro-static-slot';
 
-	const renderStrategy = (metadata?.renderStrategy ?? 'async') as RenderStrategy;
+	const isProbe = metadata?.renderStrategy === 'probe';
 
 	const renderFn = () => {
 		const slots: Record<string, any> = {};
@@ -77,60 +148,69 @@ async function renderToStaticMarkup(
 			children: children != null ? ssr(`<${tagName}>${children}</${tagName}>`) : children,
 		};
 
-		if (renderStrategy === 'sync') {
-			// Sync Render:
-			// <Component />
-			// This render mode is not exposed directly to the end user. It is only
-			// used in the check() function.
-			return createComponent(Component, newProps);
-		} else {
-			if (needsHydrate) {
-				// Hydrate + Async Render:
-				// <Suspense>
-				//   <Component />
-				// </Suspense>
-				return createComponent(Suspense, {
-					get children() {
-						return createComponent(Component, newProps);
-					},
-				});
-			} else {
-				// Static + Async Render
-				// <NoHydration>
-				//   <Suspense>
-				//     <Component />
-				// 	 </Suspense>
-				// </NoHydration>
-				return createComponent(NoHydration, {
-					get children() {
-						return createComponent(Suspense, {
-							get children() {
-								return createComponent(Component, newProps);
-							},
-						});
-					},
-				});
-			}
+		// Async is first-class in Solid 2.0 — no Suspense wrapper needed; the
+		// stream settles every boundary before the awaited HTML resolves.
+		const value = createComponent(Component, newProps);
+
+		// 2.0's SSR resolver renders unknown objects as inert markers instead of
+		// throwing, so a foreign component could survive the check() probe.
+		// Reject framework vnodes (React/Preact `$$typeof`) explicitly; the
+		// error routes through onError and fails the probe.
+		if (value != null && typeof value === 'object' && '$$typeof' in value) {
+			throw new Error('Not a Solid component: rendered a foreign framework vnode');
 		}
+
+		if (needsHydrate) {
+			return value;
+		}
+		// Static render — ship no hydration markers or serialized data.
+		return createComponent(NoHydration, {
+			get children() {
+				return value;
+			},
+		});
 	};
 
-	const componentHtml =
-		renderStrategy === 'async'
-			? await renderToStringAsync(renderFn, {
-					renderId,
-					// New setting since Solid 1.8.4 that fixes an errant hydration event appearing in
-					// server only components. Not available in TypeScript types yet.
-					// https://github.com/solidjs/solid/issues/1931
-					// https://github.com/ryansolid/dom-expressions/commit/e09e255ac725fd59195aa0f3918065d4bd974e6b
-					...({ noScripts: !needsHydrate } as any),
-				})
-			: renderToString(renderFn, { renderId });
+	// Buffered stream render: awaiting the renderToStream thenable resolves
+	// with the complete HTML once every boundary settles. The stream never
+	// rejects — uncontained render errors surface through onError (errors
+	// handled by an Errored boundary do not reach it) and are rethrown below
+	// for real renders so Astro can report them.
+	let errored = false;
+	let renderError: unknown;
+	let head = '';
+	const componentHtml = await renderToStream(renderFn, {
+		renderId,
+		noScripts: !needsHydrate || isProbe,
+		manifest: (await getManifest()) as any,
+		onError(err: unknown) {
+			if (isProbe) {
+				metadata!.onProbeError();
+			} else if (!errored) {
+				errored = true;
+				renderError = err;
+			}
+		},
+		// Capture head-bound output. Probe renders discard it — they must not
+		// consume style dedupe keys the real render needs.
+		onHead: isProbe
+			? () => {}
+			: (h: string) => {
+					head += h;
+				},
+	});
+	if (errored) throw renderError;
+
+	// Inline style-bearing head output (lazy boundary CSS, dev styles) at the
+	// island start; see extractIslandStyles. Serializer scripts already ride
+	// inside island markup, so extra non-marker nodes are safe for hydration.
+	const styles = head && !isProbe ? extractIslandStyles(head, ctx.styles) : '';
 
 	return {
 		attrs: {
 			'data-solid-render-id': renderId,
 		},
-		html: componentHtml,
+		html: styles + componentHtml,
 	};
 }
 

--- a/packages/integrations/solid/src/server.ts
+++ b/packages/integrations/solid/src/server.ts
@@ -5,6 +5,7 @@ import {
 	renderToStream,
 	ssr,
 } from '@solidjs/web';
+import { provideRequestEvent } from '@solidjs/web/storage';
 import type { NamedSSRLoadedRendererValue } from 'astro';
 import { getContext, incrementId } from './context.js';
 import type { RendererContext } from './types.js';
@@ -179,26 +180,41 @@ async function renderToStaticMarkup(
 	let errored = false;
 	let renderError: unknown;
 	let head = '';
-	const componentHtml = await renderToStream(renderFn, {
-		renderId,
-		noScripts: !needsHydrate || isProbe,
-		manifest: (await getManifest()) as any,
-		onError(err: unknown) {
-			if (isProbe) {
-				metadata!.onProbeError();
-			} else if (!errored) {
-				errored = true;
-				renderError = err;
-			}
-		},
-		// Capture head-bound output. Probe renders discard it — they must not
-		// consume style dedupe keys the real render needs.
-		onHead: isProbe
-			? () => {}
-			: (h: string) => {
-					head += h;
-				},
-	});
+	const doRender = async () =>
+		renderToStream(renderFn, {
+			renderId,
+			noScripts: !needsHydrate || isProbe,
+			manifest: (await getManifest()) as any,
+			onError(err: unknown) {
+				if (isProbe) {
+					metadata!.onProbeError();
+				} else if (!errored) {
+					errored = true;
+					renderError = err;
+				}
+			},
+			// Capture head-bound output. Probe renders discard it — they must not
+			// consume style dedupe keys the real render needs.
+			onHead: isProbe
+				? () => {}
+				: (h: string) => {
+						head += h;
+					},
+		});
+
+	// Scope the render to a Solid request event so `getRequestEvent()` (and
+	// server functions called directly during SSR) see the page's request.
+	// One event per page render, shared across islands. Astro's middleware
+	// locals ride along — reached through the Astro global, whose page
+	// partial the result caches per request anyway.
+	const request = this.result?.request;
+	if (request && !ctx.event) {
+		const locals = this.result.createAstro({}, null).locals as
+			| Record<string, unknown>
+			| undefined;
+		ctx.event = { request, locals: locals ?? {} };
+	}
+	const componentHtml = await (ctx.event ? provideRequestEvent(ctx.event, doRender) : doRender());
 	if (errored) throw renderError;
 
 	// Inline style-bearing head output (lazy boundary CSS, dev styles) at the

--- a/packages/integrations/solid/src/server.ts
+++ b/packages/integrations/solid/src/server.ts
@@ -14,22 +14,43 @@ const slotName = (str: string) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w
 
 type RenderStrategy = 'default' | 'probe';
 
-// Asset manifest for resolving lazy boundary module URLs (preloads and the
-// serialized per-render asset maps consumed during hydration). Resolved
-// through the integration's virtual module: a live dev-server resolver in
-// dev, the client build's manifest in production. Outside Vite (e.g. the
-// Container API) the import fails and rendering proceeds without asset
-// resolution.
-let manifestLoader: (() => unknown) | null | undefined;
-async function getManifest(): Promise<unknown> {
-	if (manifestLoader === undefined) {
+// Render environment resolved through the integration's virtual module:
+// the asset manifest loader (a live dev-server resolver in dev, the client
+// build's manifest in production — resolves lazy boundary module URLs for
+// preloads and the serialized per-render asset maps consumed during
+// hydration), and, with server components enabled, the frames render plugin.
+// Outside Vite (e.g. the Container API) the import fails and rendering
+// proceeds without either.
+type RenderExtras = {
+	loadManifest: (() => unknown) | null;
+	plugins: unknown[] | undefined;
+};
+let renderExtras: Promise<RenderExtras> | undefined;
+function getRenderExtras(): Promise<RenderExtras> {
+	return (renderExtras ??= (async () => {
+		let loadManifest: RenderExtras['loadManifest'] = null;
+		let plugins: RenderExtras['plugins'];
 		try {
-			manifestLoader = (await import('virtual:astro-solid-manifest')).loadManifest;
-		} catch {
-			manifestLoader = null;
-		}
-	}
-	return manifestLoader ? manifestLoader() : undefined;
+			const mod = await import('virtual:astro-solid-manifest');
+			loadManifest = mod.loadManifest;
+			if (mod.serverComponents) {
+				const [frames, serverFunctions] = await Promise.all([
+					import('@solidjs/web/frames'),
+					import('@solidjs/web/server-functions'),
+				]);
+				// Direct (in-process) server-function calls during island SSR must
+				// resolve to inline-renderable components branded with the call
+				// address the client matches boundaries against. The endpoint's
+				// response transform is installed by the handler virtual; config
+				// merges per key.
+				serverFunctions.configureServerFunctionsServer({
+					transformDirectResult: frames.frameTransformDirectResult,
+				});
+				plugins = [frames.ServerComponentPlugin];
+			}
+		} catch {}
+		return { loadManifest, plugins };
+	})());
 }
 
 // Probe verdicts are stable per component function: cache them so the probe
@@ -180,11 +201,13 @@ async function renderToStaticMarkup(
 	let errored = false;
 	let renderError: unknown;
 	let head = '';
-	const doRender = async () =>
-		renderToStream(renderFn, {
+	const doRender = async () => {
+		const { loadManifest, plugins } = await getRenderExtras();
+		return renderToStream(renderFn, {
 			renderId,
 			noScripts: !needsHydrate || isProbe,
-			manifest: (await getManifest()) as any,
+			manifest: loadManifest?.() as any,
+			plugins: plugins as any,
 			onError(err: unknown) {
 				if (isProbe) {
 					metadata!.onProbeError();
@@ -201,6 +224,7 @@ async function renderToStaticMarkup(
 						head += h;
 					},
 		});
+	};
 
 	// Scope the render to a Solid request event so `getRequestEvent()` (and
 	// server functions called directly during SSR) see the page's request.

--- a/packages/integrations/solid/src/virtual.d.ts
+++ b/packages/integrations/solid/src/virtual.d.ts
@@ -1,0 +1,6 @@
+// Provided by the integration's Vite plugin (see configEnvironmentPlugin in
+// index.ts). Only resolvable when server.js is processed by Vite; the runtime
+// import in server.ts degrades gracefully when it isn't.
+declare module 'virtual:astro-solid-manifest' {
+	export function loadManifest(): unknown;
+}

--- a/packages/integrations/solid/src/virtual.d.ts
+++ b/packages/integrations/solid/src/virtual.d.ts
@@ -3,6 +3,8 @@
 // import in server.ts degrades gracefully when it isn't.
 declare module 'virtual:astro-solid-manifest' {
 	export function loadManifest(): unknown;
+	/** Whether `serverFunctions.components` is enabled. */
+	export const serverComponents: boolean;
 }
 
 // Provided by @solidjs/vite-plugin when the `serverFunctions` option is

--- a/packages/integrations/solid/src/virtual.d.ts
+++ b/packages/integrations/solid/src/virtual.d.ts
@@ -4,3 +4,19 @@
 declare module 'virtual:astro-solid-manifest' {
 	export function loadManifest(): unknown;
 }
+
+// Provided by @solidjs/vite-plugin when the `serverFunctions` option is
+// enabled. Server-only: dispatches transport requests to registered server
+// functions (and installs endpoint/server-component config on import).
+declare module 'virtual:solid-server-function-handler' {
+	export const endpoint: string;
+	export function handleServerFunctionRequest(
+		request: Request,
+		options?: { event?: Record<string, unknown> } & Record<string, unknown>,
+	): Promise<Response>;
+}
+
+// Side-effect module: eagerly imports every module containing server
+// functions so their registrations exist before dispatch (needed in dev,
+// where the handler virtual doesn't inline it).
+declare module 'virtual:solid-server-function-manifest';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,7 +479,7 @@ importers:
         version: link:../../packages/integrations/react
       '@astrojs/solid-js':
         specifier: ^7.0.2
-        version: link:../../packages/integrations/solid
+        version: 7.0.2(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.98.0)(solid-js@1.9.13)(tsx@4.22.3)(yaml@2.9.0)
       '@astrojs/svelte':
         specifier: ^9.0.1
         version: link:../../packages/integrations/svelte
@@ -554,7 +554,7 @@ importers:
     dependencies:
       '@astrojs/solid-js':
         specifier: ^7.0.2
-        version: link:../../packages/integrations/solid
+        version: 7.0.2(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.98.0)(solid-js@1.9.13)(tsx@4.22.3)(yaml@2.9.0)
       astro:
         specifier: ^7.2.10
         version: link:../../packages/astro
@@ -1133,6 +1133,9 @@ importers:
 
   packages/astro/e2e/fixtures/client-only:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1143,8 +1146,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1334,6 +1337,9 @@ importers:
       '@astrojs/vue':
         specifier: workspace:*
         version: link:../../../../integrations/vue
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -1350,8 +1356,8 @@ importers:
         specifier: ^1.98.0
         version: 1.98.0
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1398,6 +1404,9 @@ importers:
 
   packages/astro/e2e/fixtures/multiple-frameworks:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1408,8 +1417,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1454,6 +1463,9 @@ importers:
 
   packages/astro/e2e/fixtures/nested-in-preact:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1464,8 +1476,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1494,6 +1506,9 @@ importers:
 
   packages/astro/e2e/fixtures/nested-in-react:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1504,8 +1519,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1534,6 +1549,9 @@ importers:
 
   packages/astro/e2e/fixtures/nested-in-solid:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1544,8 +1562,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1574,6 +1592,9 @@ importers:
 
   packages/astro/e2e/fixtures/nested-in-svelte:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1584,8 +1605,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1614,6 +1635,9 @@ importers:
 
   packages/astro/e2e/fixtures/nested-in-vue:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1624,8 +1648,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1654,6 +1678,9 @@ importers:
 
   packages/astro/e2e/fixtures/nested-recursive:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -1664,8 +1691,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -1841,9 +1868,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
     devDependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/e2e/fixtures/solid-component:
     dependencies:
@@ -1853,12 +1883,15 @@ importers:
       '@astrojs/solid-js':
         specifier: workspace:*
         version: link:../../../../integrations/solid
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/e2e/fixtures/solid-recurse:
     dependencies:
@@ -1869,9 +1902,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
     devDependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/e2e/fixtures/svelte-component:
     dependencies:
@@ -1932,6 +1968,9 @@ importers:
       '@astrojs/vue':
         specifier: workspace:*
         version: link:../../../../integrations/vue
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -1942,8 +1981,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -2611,6 +2650,9 @@ importers:
       '@astrojs/vue':
         specifier: workspace:*
         version: link:../../../../integrations/vue
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -2624,8 +2666,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -3604,6 +3646,9 @@ importers:
 
   packages/astro/test/fixtures/jsx:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       preact:
         specifier: ^10.29.0
         version: 10.29.8(preact-render-to-string@6.6.6)
@@ -3614,8 +3659,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -3659,12 +3704,15 @@ importers:
       '@astrojs/solid-js':
         specifier: workspace:*
         version: link:../../../../integrations/solid
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/test/fixtures/lazy-layout:
     dependencies:
@@ -3861,6 +3909,9 @@ importers:
       '@astrojs/vue':
         specifier: workspace:*
         version: link:../../../../integrations/vue
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -3871,8 +3922,8 @@ importers:
         specifier: ^8.5.8
         version: 8.5.26
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       svelte:
         specifier: ^5.54.0
         version: 5.55.3
@@ -3946,6 +3997,9 @@ importers:
       '@astrojs/solid-js':
         specifier: workspace:*
         version: link:../../../../integrations/solid
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
@@ -3956,8 +4010,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/test/fixtures/react-jsx-export:
     dependencies:
@@ -4121,12 +4175,15 @@ importers:
       '@astrojs/solid-js':
         specifier: workspace:*
         version: link:../../../../integrations/solid
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../..
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/test/fixtures/slots-svelte:
     dependencies:
@@ -4163,9 +4220,9 @@ importers:
       '@astrojs/solid-js':
         specifier: workspace:*
         version: link:../../../../integrations/solid
-      '@solidjs/router':
-        specifier: ^0.16.1
-        version: 0.16.1(solid-js@1.9.13)
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       '@test/solid-jsx-component':
         specifier: file:./deps/solid-jsx-component
         version: link:deps/solid-jsx-component
@@ -4173,14 +4230,17 @@ importers:
         specifier: workspace:*
         version: link:../../..
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/test/fixtures/solid-component/deps/solid-jsx-component:
     dependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
-        specifier: ^1.9.11
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/astro/test/fixtures/sourcemap:
     dependencies:
@@ -6193,16 +6253,19 @@ importers:
 
   packages/integrations/solid:
     dependencies:
+      '@solidjs/vite-plugin':
+        specifier: ^3.0.0-next.37
+        version: 3.0.0-next.37(@solidjs/web@2.0.0-rc.5)(solid-js@2.0.0-rc.5)(vite@8.2.1)
       vite:
         specifier: ^8.0.13
         version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
-      vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(solid-js@1.9.13)(vite@8.2.1)
       vitefu:
         specifier: ^1.1.2
         version: 1.1.2(vite@8.2.1)
     devDependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       astro:
         specifier: workspace:*
         version: link:../../astro
@@ -6210,8 +6273,8 @@ importers:
         specifier: workspace:*
         version: link:../../../scripts
       solid-js:
-        specifier: ^1.9.13
-        version: 1.9.13
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
 
   packages/integrations/svelte:
     dependencies:
@@ -7195,6 +7258,10 @@ importers:
 
 packages:
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
@@ -7310,6 +7377,16 @@ packages:
 
   '@astrojs/compiler@2.13.1':
     resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
+
+  '@astrojs/solid-js@7.0.2':
+    resolution: {integrity: sha512-4Sk28a4HId176eXqEIrkuLmd+VFePwGSS/smL0ZdiUlb8cBAm5E5Gg0iSQIy/7bYuoj2xN398TcdtSZLl4regA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      solid-devtools: ^0.34.5
+      solid-js: ^1.9.13
+    peerDependenciesMeta:
+      solid-devtools:
+        optional: true
 
   '@atcute/atproto@4.0.3':
     resolution: {integrity: sha512-BNylfO7nK0yYBpSpnGhOYgrJTeZWrXHPrb6tOQmp9A3Am0epctIWm6/5lPC4ZNPHpUbwr5w/LzH/v7kjAoKEDg==}
@@ -8275,6 +8352,9 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
+
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
@@ -8283,6 +8363,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@envelop/instrumentation@1.0.0':
     resolution: {integrity: sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==}
@@ -10413,10 +10496,67 @@ packages:
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
-  '@solidjs/router@0.16.1':
-    resolution: {integrity: sha512-IhyjedgC6LRpw/8CPGGI89FrV+r0xTHzOl2c4CRyzYQ1bLepJxbVI1LLKvsavMWY5TRBRacV7hAeOhuTXkjiqg==}
+  '@solidjs/babel-plugin@2.0.0-rc.5':
+    resolution: {integrity: sha512-Wd2cHNSRBxisVXTsl0Nq+21+0DFVYeKLQxnZqQqxCqXM8cEnijv6tfcIUzlSEp3esEyQD0gXnbQpSOyoLkHCwg==}
     peerDependencies:
-      solid-js: ^1.8.6
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.5':
+    resolution: {integrity: sha512-rCSbArP+hLkYeUPdw6OisdQD313VxP+oaI7FOLohSx1FfiEOVwyAvKgYqGROe4T0ZZXjgTkSZUKHBzbG468j4A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.5':
+    resolution: {integrity: sha512-l1P0zal1yKy2k/TNMqnh2jFf7CkCr2Iu/AM45Rai65NW2n7zgPO+2LY6kDKCO/ooU4ZZ3FdnTKpwza6mT1xqUQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.5':
+    resolution: {integrity: sha512-G2BBNzwIUJHtAxPISMjtMi+IsgyCWfJ29tS4MxfUC+Q4aEykTV55ybItAAffwF9YgeHA6JtQY3iVU002QGJDuw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.5':
+    resolution: {integrity: sha512-3ckN7cot0FiUiGUSnnKJON+sOJgIS8zuEXUPUv/ijjE+gA9pEepX8u06/DXzvEXkrDzPHGWrFx+v19Aogl+l5g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.5':
+    resolution: {integrity: sha512-1l35k2lCYtpIV/RZBqpy9y7JNMruGAlMBZVxjIHDxCJDs9vKLue/7WPT0qg7cm3dCqa69hVxRNBQYqRHLa4P2g==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.5':
+    resolution: {integrity: sha512-ZYumQABKyBWv0iEonwcMnrjOt1cKWdjdBeKc9xQ0eNxqMlJsOQvRFMB3Ow7OS2U2aYKfAIzfcPCKgsXv9JbIvA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.5':
+    resolution: {integrity: sha512-DQF24zYiTW4GDhhOTITEjjK1PGvPGx8P3qR6ogWBeaXggeMN6vV2s0oqyrYoJr2g2ufJj1vf2FIdLVDu8Ip7zw==}
+
+  '@solidjs/signals@2.0.0-rc.5':
+    resolution: {integrity: sha512-Ks+97LbyN2vYqPEHWpy2YY+MYgoSCge0kHOUFN/Bzdz1Ex/M9Is1HIyBZGBVhf5y35394List5WWlU44yEnm4w==}
+
+  '@solidjs/vite-plugin@3.0.0-next.37':
+    resolution: {integrity: sha512-P1mWQ4TnqZexlVJHGHRlsVRLXfOklx7HrGgC4KBvPZX5v3MUYBNnmIrpxi+nOac5//Qo2pJHzhLj4J5Fx6Mh9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@solidjs/start-devtools': ^1.0.0-next.2
+      '@solidjs/web': ^2.0.0-rc.0
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^2.0.0-rc.0
+      vite: ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      '@solidjs/start-devtools':
+        optional: true
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.5':
+    resolution: {integrity: sha512-0Q9QNJXgXDTl4dH8Nr972XdL3ET+GBV/UlxhBG1ZV7U54/PP2yhTJggWxubJNqfeWel8p/W8laNgtS3nLiZpbw==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.5
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
@@ -15320,8 +15460,18 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.5.6:
+    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.5.0:
     resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
+    engines: {node: '>=10'}
+
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   serve-static@2.2.1:
@@ -15452,6 +15602,9 @@ packages:
 
   solid-js@1.9.13:
     resolution: {integrity: sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==}
+
+  solid-js@2.0.0-rc.5:
+    resolution: {integrity: sha512-AI9ndOlUtXXeFf0/MUADM5HfMYwXtxfitIayOkjBCZl67ZyD4ct5+4kqv0EF2xeyIrUwlsrFTuKpHs54BNA6iw==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -16120,6 +16273,9 @@ packages:
       typescript:
         optional: true
 
+  validate-html-nesting@1.2.4:
+    resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -16687,6 +16843,11 @@ packages:
 
 snapshots:
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -16814,6 +16975,28 @@ snapshots:
       - '@emnapi/runtime'
 
   '@astrojs/compiler@2.13.1': {}
+
+  '@astrojs/solid-js@7.0.2(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.98.0)(solid-js@1.9.13)(tsx@4.22.3)(yaml@2.9.0)':
+    dependencies:
+      solid-js: 1.9.13
+      vite: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite-plugin-solid: 2.11.12(solid-js@1.9.13)(vite@8.2.1)
+      vitefu: 1.1.2(vite@8.2.1)
+    transitivePeerDependencies:
+      - '@testing-library/jest-dom'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   '@atcute/atproto@4.0.3':
     dependencies:
@@ -18097,6 +18280,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.3
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
@@ -18108,6 +18297,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -18807,7 +19001,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-wasm32@0.35.2':
@@ -19015,7 +19209,7 @@ snapshots:
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -19023,6 +19217,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -19977,9 +20178,69 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
-  '@solidjs/router@0.16.1(solid-js@1.9.13)':
+  '@solidjs/babel-plugin@2.0.0-rc.5(@babel/core@7.29.0)':
     dependencies:
-      solid-js: 1.9.13
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.5':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.5':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.5':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.5':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.5':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.5':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.5':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.5
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.5
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.5
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.5
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.5
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.5
+
+  '@solidjs/signals@2.0.0-rc.5': {}
+
+  '@solidjs/vite-plugin@3.0.0-next.37(@solidjs/web@2.0.0-rc.5)(solid-js@2.0.0-rc.5)(vite@8.2.1)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.29.0
+      '@solidjs/babel-plugin': 2.0.0-rc.5(@babel/core@7.29.0)
+      '@solidjs/compiler': 2.0.0-rc.5
+      '@solidjs/web': 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+      '@types/babel__core': 7.20.5
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.5
+      vite: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.98.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@8.2.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5)':
+    dependencies:
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+      solid-js: 2.0.0-rc.5
 
   '@speed-highlight/core@1.2.14': {}
 
@@ -25847,7 +26108,13 @@ snapshots:
     dependencies:
       seroval: 1.5.0
 
+  seroval-plugins@1.5.6(seroval@1.5.6):
+    dependencies:
+      seroval: 1.5.6
+
   seroval@1.5.0: {}
+
+  seroval@1.5.6: {}
 
   serve-static@2.2.1:
     dependencies:
@@ -26073,6 +26340,13 @@ snapshots:
       csstype: 3.2.3
       seroval: 1.5.0
       seroval-plugins: 1.5.0(seroval@1.5.0)
+
+  solid-js@2.0.0-rc.5:
+    dependencies:
+      '@solidjs/signals': 2.0.0-rc.5
+      csstype: 3.2.3
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
 
   solid-refresh@0.6.3(solid-js@1.9.13):
     dependencies:
@@ -26723,6 +26997,8 @@ snapshots:
   valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
+
+  validate-html-nesting@1.2.4: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1909,6 +1909,22 @@ importers:
         specifier: ^2.0.0-rc.5
         version: 2.0.0-rc.5
 
+  packages/astro/e2e/fixtures/solid-server-functions:
+    dependencies:
+      '@astrojs/solid-js':
+        specifier: workspace:*
+        version: link:../../../../integrations/solid
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+    devDependencies:
+      '@solidjs/web':
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+      solid-js:
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
+
   packages/astro/e2e/fixtures/svelte-component:
     dependencies:
       '@astrojs/mdx':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,9 @@ minimumReleaseAgeExclude:
   # TODO: remove once more stable
   - '@flue/*'
   - '@astrojs/*'
+  # Solid 2.0 prereleases (this branch tracks them closely)
+  - '@solidjs/*'
+  - solid-js
   - '@cloudflare/*'
   - workerd
   - miniflare


### PR DESCRIPTION
## Changes

Rewrites `@astrojs/solid-js` for Solid 2.0 as a new major (v8), following the `@astrojs/svelte` precedent for major framework transitions: v8 supports Solid 2.0 only (`solid-js@^2.0.0-rc.5` + `@solidjs/web@^2.0.0-rc.5` — caret ranges, so 2.0 stable satisfies them when it ships); v7 remains for Solid 1.x.

### Core (first commit)

- Compiles through `@solidjs/vite-plugin` (replacing `vite-plugin-solid`), with a `compiler` option for the native (Oxc) or Babel backend.
- Islands render through Solid 2.0's first-class async model (`renderToStream`, no Suspense wrapper): async islands settle fully on the server; `Errored` boundaries contain sync and async errors.
- Threads an asset manifest into server renders so `lazy()` boundaries inside islands resolve module URLs, hydrate through serialized asset maps, and get their CSS inlined into island markup (deduped per page) — a live dev resolver in dev, the client build manifest in production (captured before the `.vite` cleanup for prerendering; persisted next to the server bundle for deployed SSR).
- `check()` probe-renders through the stream renderer with per-component caching, rejects foreign framework vnodes explicitly, and is Proxy-safe (fixes the class of issues behind #12354).
- Drops the `solid-devtools` option (its 2.0 story is unsettled).
- All Solid fixtures ported to 2.0; the previously-skipped `solid-component` suite is re-enabled with new lazy-CSS coverage.
- `astro add solid-js` tsconfig preset now writes `jsxImportSource: "@solidjs/web"` (2.0 moves JSX types to renderer packages).

### Server functions (experimental, second commit)

`solid({ serverFunctions: true })` compiles `"use server"` functions in islands to typed RPC calls. The transport endpoint (default `/_server`) is injected as an Astro route, so requests flow through Astro's middleware pipeline — same auth guards and `locals` — in dev and production alike; `getRequestEvent()` inside a function exposes the request, Astro `locals`, and the API context. Island SSR runs inside a request-event scope, so direct in-process calls work during rendering. Requires an adapter (build fails with a clear error otherwise).

### Server components (experimental, third commit)

`serverFunctions: { components: true }` enables `"use server"` functions returning components. They SSR inline in islands, are adopted at boot with zero endpoint requests, and later re-evaluations stream over the endpoint and morph in place, preserving client slot state and DOM identity.

## Testing

- e2e: `solid-component`, `solid-circular`, `solid-recurse`, `nested-in-solid`, plus a new `solid-server-functions` suite (endpoint round trip, middleware locals through the request event, t=0 server-component adoption + morph) — 26 tests.
- unit: `solid-component` (13, includes 3 pre-existing assertion bug fixes), `slots-solid`, `react-and-solid`, `astro-slots-nested`.

## Notes for review

- **Versioning**: `package.json` is set to `8.0.0-beta.0` with a `major` changeset; happy to adjust to whatever release flow you prefer (Solid 2.0 itself is in RC).
- **`examples/framework-solid`** is intentionally untouched: its component code is already 2.0-compatible, and its published-range `package.json` (create-astro templates install from the registry) should bump at release, adding `@solidjs/web` (2.0 compiled output imports it).
- **`pnpm-workspace.yaml`** adds `@solidjs/*`/`solid-js` to `minimumReleaseAgeExclude` so freshly published RCs install past the age gate — needs a policy sign-off.
- No existing Solid 2.0 issues/PRs found in the tracker; this is the first migration work filed.

Made with [Cursor](https://cursor.com)