### PR TITLE
Only treat literal script/style content as raw in MDX rendering

### DIFF
--- a/.changeset/open-kings-nail.md
+++ b/.changeset/open-kings-nail.md
@@ -1,0 +1,8 @@
+---
+'astro': patch
+'@astrojs/markdown-remark': patch
+'@astrojs/markdown-satteri': patch
+---
+
+Fixes `<script>`/`<style>` rendering in MDX so that only literal content (including content injected by remark/rehype plugins) is treated as trusted markup. A dynamic value passed as a `<script>`/`<style>` child (e.g. `<script>{value}</script>`) is now escaped like any other element's content instead of being rendered raw. Use `set:html` to explicitly opt a dynamic value back into raw rendering.
+

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -1,5 +1,6 @@
 import { AstroJSX, type AstroVNode, isVNode } from '../../jsx-runtime/index.js';
 import type { SSRResult } from '../../types/public/internal.js';
+import { escapeStyleText } from './escape.js';
 import {
 	escapeHTML,
 	HTMLString,
@@ -207,12 +208,13 @@ async function renderElement(
  * Pre-render the children with the given `tag` information
  */
 function prerenderElementChildren(tag: string, children: any) {
-	// For content within <style> and <script> tags that are plain strings, e.g. injected
-	// by remark/rehype plugins, or if a user explicitly does `<script>{'...'}</script>`,
-	// we mark it as an HTML string to prevent the content from being HTML-escaped.
-	if (typeof children === 'string' && (tag === 'style' || tag === 'script')) {
-		return markHTMLString(children);
-	} else {
-		return children;
+	// Literal `<style>`/`<script>` content (including content injected by remark/rehype
+	// plugins) is collapsed into `set:html` at compile time, so any remaining plain-string
+	// children here are dynamic values that should be escaped like other element content.
+	// `escapeStyleText` only escapes `<`, preserving quotes CSS commonly relies on while
+	// still preventing the value from closing the `<style>` tag early.
+	if (typeof children === 'string' && tag === 'style') {
+		return markHTMLString(escapeStyleText(children));
 	}
+	return children;
 }

--- a/packages/astro/src/runtime/server/render/streaming.ts
+++ b/packages/astro/src/runtime/server/render/streaming.ts
@@ -1,7 +1,13 @@
 import type { SSRResult } from '../../../types/public/internal.js';
 import type { AstroVNode } from '../../../jsx-runtime/index.js';
 import { isVNode } from '../../../jsx-runtime/index.js';
-import { escapeHTML, HTMLString, isHTMLString, markHTMLString } from '../escape.js';
+import {
+	escapeHTML,
+	escapeStyleText,
+	HTMLString,
+	isHTMLString,
+	markHTMLString,
+} from '../escape.js';
 import { spreadAttributes } from '../index.js';
 import { isPromise } from '../util.js';
 import { renderJSX } from '../jsx.js';
@@ -196,9 +202,13 @@ export async function renderStreaming(
 			}
 
 			if (!isVoid && children != null && children !== '') {
-				// `<script>`/`<style>` string content is raw HTML, not escaped.
-				if (typeof children === 'string' && (type === 'style' || type === 'script')) {
-					stack.push(markHTMLString(children));
+				// Literal `<style>` content is collapsed into `set:html` at compile time, so a
+				// remaining plain-string child here is a dynamic value that should be escaped
+				// like other element content. `escapeStyleText` only escapes `<`, preserving
+				// quotes CSS commonly relies on while still preventing the value from closing
+				// the `<style>` tag early.
+				if (typeof children === 'string' && type === 'style') {
+					stack.push(markHTMLString(escapeStyleText(children)));
 				} else {
 					stack.push(children);
 				}

--- a/packages/integrations/mdx/test/fixtures/mdx-basics/src/pages/script-style-dynamic.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-basics/src/pages/script-style-dynamic.mdx
@@ -1,0 +1,6 @@
+export const scriptValue = '</script><script id="script-owned">window.__pwned = true</script>';
+export const styleValue = '</style><script id="style-owned">window.__pwned = true</script>';
+
+<script id="test-script-dynamic">{scriptValue}</script>
+
+<style id="test-style-dynamic">{styleValue}</style>

--- a/packages/integrations/mdx/test/mdx-basics.test.ts
+++ b/packages/integrations/mdx/test/mdx-basics.test.ts
@@ -277,6 +277,19 @@ describe('MDX basics (merged fixture)', () => {
 				assert.equal(document.getElementById('script-text-following'), null);
 				assert.equal(document.getElementById('style-text-following'), null);
 			});
+
+			it('escapes dynamic script and style values instead of rendering them raw', async () => {
+				const html = await fixture.readFile('/script-style-dynamic/index.html');
+				const { document } = parseHTML(html);
+
+				assert.equal(document.getElementById('script-owned'), null);
+				assert.equal(document.getElementById('style-owned'), null);
+				assert.match(
+					document.getElementById('test-script-dynamic')!.textContent,
+					/^&lt;\/script&gt;/,
+				);
+				assert.match(document.getElementById('test-style-dynamic')!.textContent, /^\\3C \/style/);
+			});
 		});
 	});
 
@@ -477,6 +490,22 @@ describe('MDX basics (merged fixture)', () => {
 				assert.match(document.getElementById('style-text')!.textContent, /^&lt;\/style&gt;/);
 				assert.equal(document.getElementById('script-text-following'), null);
 				assert.equal(document.getElementById('style-text-following'), null);
+			});
+
+			it('escapes dynamic script and style values instead of rendering them raw', async () => {
+				const res = await fixture.fetch('/script-style-dynamic');
+				assert.equal(res.status, 200);
+
+				const html = await res.text();
+				const { document } = parseHTML(html);
+
+				assert.equal(document.getElementById('script-owned'), null);
+				assert.equal(document.getElementById('style-owned'), null);
+				assert.match(
+					document.getElementById('test-script-dynamic')!.textContent,
+					/^&lt;\/script&gt;/,
+				);
+				assert.match(document.getElementById('test-style-dynamic')!.textContent, /^\\3C \/style/);
 			});
 		});
 	});

--- a/packages/integrations/mdx/test/mdx-basics.test.ts
+++ b/packages/integrations/mdx/test/mdx-basics.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { unified } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import * as cheerio from 'cheerio';
 import { parseHTML } from 'linkedom';
@@ -508,5 +509,44 @@ describe('MDX basics (merged fixture)', () => {
 				assert.match(document.getElementById('test-style-dynamic')!.textContent, /^\\3C \/style/);
 			});
 		});
+	});
+});
+
+describe('MDX basics with the Unified processor', () => {
+	let fixture: Fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: FIXTURE_ROOT,
+			outDir: './dist/mdx-basics-unified/',
+			integrations: [mdx({ processor: unified() })],
+		});
+		await fixture.build();
+	});
+
+	it('preserves literal and escapes dynamic script and style content', async () => {
+		const rawHtml = await fixture.readFile('/script-style-raw/index.html');
+		const { document: rawDocument } = parseHTML(rawHtml);
+		assert.match(
+			rawDocument.getElementById('test-script')!.innerHTML,
+			/console\.log\('raw script'\)/,
+		);
+		assert.match(
+			rawDocument.getElementById('test-style')!.innerHTML,
+			/h1\[id="script-style-raw"\]/,
+		);
+
+		const dynamicHtml = await fixture.readFile('/script-style-dynamic/index.html');
+		const { document: dynamicDocument } = parseHTML(dynamicHtml);
+		assert.equal(dynamicDocument.getElementById('script-owned'), null);
+		assert.equal(dynamicDocument.getElementById('style-owned'), null);
+		assert.match(
+			dynamicDocument.getElementById('test-script-dynamic')!.textContent,
+			/^&lt;\/script&gt;/,
+		);
+		assert.match(
+			dynamicDocument.getElementById('test-style-dynamic')!.textContent,
+			/^\\3C \/style/,
+		);
 	});
 });

--- a/packages/markdown/remark/src/mdx/create-processor.ts
+++ b/packages/markdown/remark/src/mdx/create-processor.ts
@@ -22,6 +22,7 @@ import { remarkCollectImages } from '../remark-collect-images.js';
 import type { UnifiedResolvedOptions } from '../processor.js';
 import { getAstroMetadata, rehypeAnalyzeAstroMetadata } from './rehype-analyze-astro-metadata.js';
 import { rehypeApplyFrontmatterExport } from './rehype-apply-frontmatter-export.js';
+import { rehypeCollapseScriptStyle } from './rehype-collapse-script-style.js';
 import { rehypeInjectHeadingsExport } from './rehype-inject-headings-export.js';
 import { rehypeImageToComponent } from './rehype-images-to-component.js';
 import rehypeMetaString from './rehype-meta-string.js';
@@ -158,7 +159,11 @@ function getRehypePlugins(mdxOptions: UnifiedMdxOptions): PluggableList {
 		}
 	}
 
-	rehypePlugins.push(...mdxOptions.rehypePlugins, rehypeImageToComponent);
+	rehypePlugins.push(
+		...mdxOptions.rehypePlugins,
+		rehypeImageToComponent,
+		rehypeCollapseScriptStyle,
+	);
 
 	if (!isPerformanceBenchmark) {
 		// getHeadings() is guaranteed by TS, so this must be included.

--- a/packages/markdown/remark/src/mdx/rehype-collapse-script-style.ts
+++ b/packages/markdown/remark/src/mdx/rehype-collapse-script-style.ts
@@ -1,0 +1,97 @@
+import type { RehypePlugin } from '@astrojs/internal-helpers/markdown';
+import type { Expression, Program } from 'estree';
+import type { Element } from 'hast';
+import type {} from 'mdast-util-mdx';
+import type { MdxJsxFlowElementHast, MdxJsxTextElementHast } from 'mdast-util-mdx-jsx';
+import { visit } from 'unist-util-visit';
+
+type ScriptStyleNode = Element | MdxJsxFlowElementHast | MdxJsxTextElementHast;
+
+function isScriptOrStyle(node: unknown): node is ScriptStyleNode {
+	if (!node || typeof node !== 'object') return false;
+	const { type } = node as { type: string };
+	if (type === 'element') {
+		return (node as Element).tagName === 'script' || (node as Element).tagName === 'style';
+	}
+	if (type === 'mdxJsxFlowElement' || type === 'mdxJsxTextElement') {
+		const name = (node as MdxJsxFlowElementHast | MdxJsxTextElementHast).name;
+		return name === 'script' || name === 'style';
+	}
+	return false;
+}
+
+function hasSetDirective(node: ScriptStyleNode) {
+	if (node.type === 'element') {
+		return 'set:html' in node.properties || 'set:text' in node.properties;
+	}
+	return node.attributes.some(
+		(attr) =>
+			attr.type === 'mdxJsxAttribute' && (attr.name === 'set:html' || attr.name === 'set:text'),
+	);
+}
+
+/**
+ * Returns the literal string value of an MDX expression child (e.g. `{'text'}` or
+ * `` {`text`} ``), or `undefined` if the expression isn't a string/template literal
+ * with no interpolated values.
+ */
+function literalExpressionValue(node: { data?: { estree?: Program } }): string | undefined {
+	const statement = node.data?.estree?.body[0];
+	if (statement?.type !== 'ExpressionStatement') return undefined;
+	const expression: Expression = statement.expression;
+	if (expression.type === 'Literal' && typeof expression.value === 'string') {
+		return expression.value;
+	}
+	if (expression.type === 'TemplateLiteral' && expression.expressions.length === 0) {
+		return expression.quasis[0]?.value.cooked ?? undefined;
+	}
+	return undefined;
+}
+
+/**
+ * Collapses the literal string content of a `<script>`/`<style>` element's children
+ * into a `set:html` attribute, matching the literal value of a `{'...'}`/`` {`...`} ``
+ * child that a plugin (e.g. rehype-mathjax) or an author injected as static content.
+ * Returns `undefined` if any child isn't a plain-text or literal-expression node.
+ */
+function collapseLiteralChildren(children: unknown[]): string | undefined {
+	let value = '';
+	for (const child of children) {
+		const node = child as { type: string; value?: string; data?: { estree?: Program } };
+		if (node.type === 'text') {
+			value += node.value;
+		} else if (node.type === 'mdxTextExpression' || node.type === 'mdxFlowExpression') {
+			const literal = literalExpressionValue(node);
+			if (literal === undefined) return undefined;
+			value += literal;
+		} else {
+			return undefined;
+		}
+	}
+	return value;
+}
+
+/**
+ * For MDX `<script>`/`<style>` elements, collapses literal (non-interpolated) string
+ * content into a `set:html` attribute instead of leaving it as JSX children. This lets
+ * the renderer treat literal author- or plugin-authored code/CSS as trusted, the same
+ * way `set:html` already works, while any remaining dynamic children are rendered
+ * (and escaped) normally.
+ */
+export const rehypeCollapseScriptStyle: RehypePlugin = () => {
+	return (tree) => {
+		visit(tree as any, (node: ScriptStyleNode) => {
+			if (!isScriptOrStyle(node) || node.children.length === 0 || hasSetDirective(node)) return;
+
+			const value = collapseLiteralChildren(node.children as unknown[]);
+			if (value === undefined) return;
+
+			if (node.type === 'element') {
+				node.properties['set:html'] = value;
+			} else {
+				node.attributes.push({ type: 'mdxJsxAttribute', name: 'set:html', value });
+			}
+			node.children = [];
+		});
+	};
+};

--- a/packages/markdown/satteri/src/mdx/create-processor.ts
+++ b/packages/markdown/satteri/src/mdx/create-processor.ts
@@ -30,6 +30,10 @@ import {
 } from '../satteri-processor.js';
 import { shouldAddCharset } from './charset.js';
 import { createAstroMetadataPlugin } from './hast-astro-metadata.js';
+import {
+	collapseScriptStyleText,
+	literalizeScriptStyleExpression,
+} from './hast-collapse-script-style.js';
 import { createImageToComponentPlugin, type ImageImportInfo } from './hast-images-to-component.js';
 
 type HighlightFn = (code: string, lang: string, meta?: string) => Promise<HastNode>;
@@ -98,7 +102,13 @@ export function createSatteriMdxProcessor(
 			if (satteriOptions.hastPlugins.length) {
 				hastPlugins.push(...satteriOptions.hastPlugins);
 			}
-			hastPlugins.push(imageToComponent, headingIds, astroMeta);
+			hastPlugins.push(
+				imageToComponent,
+				headingIds,
+				astroMeta,
+				literalizeScriptStyleExpression,
+				collapseScriptStyleText,
+			);
 
 			let optimizeStatic: MdxCompileOptions['optimizeStatic'];
 			if (mdx.optimize) {

--- a/packages/markdown/satteri/src/mdx/hast-collapse-script-style.ts
+++ b/packages/markdown/satteri/src/mdx/hast-collapse-script-style.ts
@@ -4,6 +4,7 @@ import {
 	type EstreeProgram,
 	type HastNode,
 	type HastPluginDefinition,
+	type HastVisitorContext,
 } from 'satteri';
 
 type ScriptStyleNode = Extract<
@@ -85,7 +86,7 @@ export const collapseScriptStyleText: HastPluginDefinition = defineHastPlugin({
 	mdxJsxTextElement: { filter: ['script', 'style'], visit: collapseIfAllText },
 });
 
-function collapseIfAllText(node: ScriptStyleNode, ctx: import('satteri').HastVisitorContext) {
+function collapseIfAllText(node: ScriptStyleNode, ctx: HastVisitorContext) {
 	if (node.children.length === 0 || hasSetDirective(node)) return;
 
 	let value = '';

--- a/packages/markdown/satteri/src/mdx/hast-collapse-script-style.ts
+++ b/packages/markdown/satteri/src/mdx/hast-collapse-script-style.ts
@@ -1,0 +1,101 @@
+import type { Expression } from 'estree';
+import {
+	defineHastPlugin,
+	type EstreeProgram,
+	type HastNode,
+	type HastPluginDefinition,
+} from 'satteri';
+
+type ScriptStyleNode = Extract<
+	HastNode,
+	{ type: 'element' | 'mdxJsxFlowElement' | 'mdxJsxTextElement' }
+>;
+
+function isScriptOrStyle(node: HastNode | undefined): node is ScriptStyleNode {
+	if (!node) return false;
+	if (node.type === 'element') return node.tagName === 'script' || node.tagName === 'style';
+	if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+		return node.name === 'script' || node.name === 'style';
+	}
+	return false;
+}
+
+function hasSetDirective(node: ScriptStyleNode): boolean {
+	if (node.type === 'element') {
+		return Boolean(
+			node.properties && ('set:html' in node.properties || 'set:text' in node.properties),
+		);
+	}
+	return node.attributes.some(
+		(attr) =>
+			attr.type === 'mdxJsxAttribute' && (attr.name === 'set:html' || attr.name === 'set:text'),
+	);
+}
+
+/**
+ * Returns the literal string value of an MDX expression (e.g. `{'text'}` or
+ * `` {`text`} ``), or `undefined` if it isn't a string/template literal with
+ * no interpolated values.
+ */
+function literalExpressionValue(program: EstreeProgram | null): string | undefined {
+	const statement = program?.body[0];
+	if (statement?.type !== 'ExpressionStatement') return undefined;
+	const expression: Expression = statement.expression;
+	if (expression.type === 'Literal' && typeof expression.value === 'string') {
+		return expression.value;
+	}
+	if (expression.type === 'TemplateLiteral' && expression.expressions.length === 0) {
+		return expression.quasis[0]?.value.cooked ?? undefined;
+	}
+	return undefined;
+}
+
+/**
+ * Replaces a `{'...'}`/`` {`...`} `` expression that's a direct child of
+ * `<script>`/`<style>` with a plain text node when the expression is a literal
+ * with no interpolated values, so plugin-independent literal content is later
+ * recognized as static (see `collapseScriptStyleText`).
+ */
+export const literalizeScriptStyleExpression: HastPluginDefinition = defineHastPlugin({
+	name: 'literalize-script-style-expression',
+	mdxFlowExpression: (node, ctx) => {
+		if (!isScriptOrStyle(ctx.parent(node))) return;
+		const value = literalExpressionValue(node.parseExpression());
+		if (value === undefined) return;
+		return { type: 'text', value };
+	},
+	mdxTextExpression: (node, ctx) => {
+		if (!isScriptOrStyle(ctx.parent(node))) return;
+		const value = literalExpressionValue(node.parseExpression());
+		if (value === undefined) return;
+		return { type: 'text', value };
+	},
+});
+
+/**
+ * Collapses `<script>`/`<style>` children into a `set:html` attribute when
+ * every child is now a plain text node (either originally static, or
+ * literalized by `literalizeScriptStyleExpression`). Elements with any other
+ * child (a real dynamic expression or component) are left untouched.
+ */
+export const collapseScriptStyleText: HastPluginDefinition = defineHastPlugin({
+	name: 'collapse-script-style-text',
+	element: { filter: ['script', 'style'], visit: collapseIfAllText },
+	mdxJsxFlowElement: { filter: ['script', 'style'], visit: collapseIfAllText },
+	mdxJsxTextElement: { filter: ['script', 'style'], visit: collapseIfAllText },
+});
+
+function collapseIfAllText(node: ScriptStyleNode, ctx: import('satteri').HastVisitorContext) {
+	if (node.children.length === 0 || hasSetDirective(node)) return;
+
+	let value = '';
+	for (const child of node.children) {
+		if (child.type !== 'text') return;
+		value += child.value;
+	}
+
+	ctx.setProperty(node, 'set:html', value);
+	for (let i = node.children.length - 1; i >= 0; i--) {
+		ctx.removeChildAt(node, i);
+	}
+}


### PR DESCRIPTION
## Changes

- MDX rendering treated any plain-string `<script>`/`<style>` child as raw, unescaped markup, including a dynamic value like `<script>{value}</script>`.
  - Now this is escaped by default.
- Literals get collapsed into a `set:html` attribute at compile time. This allows remark plugins to continue to work.
## Testing

- Adds an MDX fixture/tests (`script-style-dynamic.mdx`) covering dynamic `<script>`/`<style>` children

## Docs

- N/A, bug fix.