### PR TITLE
fix: dont use internal paths

### DIFF
--- a/.agents/skills/astro-code-review/SKILL.md
+++ b/.agents/skills/astro-code-review/SKILL.md
@@ -207,6 +207,8 @@ When exports change:
 - Workspace-only internals belong under an explicit `./_internal/*` subpath and only in the monorepo export map.
 - Other workspace packages should use declared subpaths instead of deep relative imports into another package.
 
+Whenever production code, publishable templates, or emitted virtual modules reference an `astro/*` subpath, verify that the subpath is present in `publishConfig.exports`, not merely the monorepo `exports` map. Code shipped to or emitted into user projects must not import workspace-only `./_internal/*` entrypoints. Include imports embedded in generated source strings in this check because workspace fixtures resolve against the broader monorepo map and can hide failures that occur only with the published package.
+
 Follow the "Public vs. internal API" section in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md).
 
 #### Dependencies and Project References

--- a/.changeset/few-dots-walk.md
+++ b/.changeset/few-dots-walk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an error that prevented projects using `astro:assets` from starting or building

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -138,11 +138,14 @@ const addStaticImageFactory = (
  */
 const RUNTIME_LOGGER_SETUP = `
 	import { createConsoleLogger as _createConsoleLogger } from "astro/logger/console";
-	import { astroToRuntimeLogger as _astroToRuntimeLogger } from "astro/_internal/logger";
 	import _loggerDestination, { level as _loggerLevel } from "virtual:astro:logger";
 	const _astroLogger = _createConsoleLogger({ level: _loggerLevel });
 	if (_loggerDestination) _astroLogger.setDestination(_loggerDestination);
-	const _runtimeLogger = _astroToRuntimeLogger(_astroLogger);
+	const _runtimeLogger = {
+		info: (message) => _astroLogger.info(null, message),
+		warn: (message) => _astroLogger.warn(null, message),
+		error: (message) => _astroLogger.error(null, message),
+	};
 `;
 
 /**

--- a/packages/astro/test/units/exports.test.ts
+++ b/packages/astro/test/units/exports.test.ts
@@ -1,13 +1,45 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { it } from 'node:test';
+import { glob } from 'tinyglobby';
 
 it('"exports" and "publishConfig.exports" should be the same except for internal API', async () => {
 	const { default: pkgJson } = await import('../../package.json', { with: { type: 'json' } });
-	const exports: Record<string, unknown> = pkgJson.exports;
+	const exports: Record<string, unknown> = { ...pkgJson.exports };
 	const publishConfigExports: Record<string, unknown> = pkgJson.publishConfig.exports;
 	const internal = Object.keys(exports).filter((key) => key.startsWith('./_internal/'));
 	for (const key of internal) {
 		delete exports[key];
 	}
 	assert.deepEqual(exports, publishConfigExports);
+});
+
+it('publishable source should not reference workspace-only exports', async () => {
+	const { default: pkgJson } = await import('../../package.json', { with: { type: 'json' } });
+	const workspaceOnlyExports = Object.keys(pkgJson.exports).filter(
+		(key) => !(key in pkgJson.publishConfig.exports),
+	);
+	const packageRoot = new URL('../../', import.meta.url);
+	const files = await glob(
+		[
+			'bin/**/*.{js,mjs}',
+			'components/**/*.{astro,js,mjs,ts}',
+			'src/**/*.{js,mjs,ts}',
+			'templates/**/*.{astro,js,mjs,ts}',
+		],
+		{ cwd: fileURLToPath(packageRoot) },
+	);
+
+	for (const file of files) {
+		const source = await readFile(new URL(file, packageRoot), 'utf-8');
+		for (const entrypoint of workspaceOnlyExports) {
+			const specifier = `astro${entrypoint.slice(1)}`;
+			assert.equal(
+				source.includes(specifier),
+				false,
+				`${file} references workspace-only export ${specifier}`,
+			);
+		}
+	}
 });


### PR DESCRIPTION
## Changes

Closes  https://github.com/withastro/astro/issues/17897
Closes  https://github.com/withastro/astro/issues/17898

We were using an internal path in our runtime. Removed it in favour of an internal runtime object.

## Testing

Tested locally in one of the reproductions. Will do a preview release too.

I update our review skill to check for those.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
