### PR TITLE
chore: update biome config

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -149,6 +149,26 @@
       }
     },
     {
+      "includes": ["packages/astro/src/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["astro/_internal", "astro/_internal/**"],
+                    "message": "Internal Astro entrypoints are only available to workspace tests and cannot be imported by production source code."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "includes": ["**/*.astro", "**/client.d.ts", "**/jsx-runtime.d.ts"],
       "linter": {
         "rules": {


### PR DESCRIPTION
## Changes

Adds a new restriction to catch the use of `astro/_internal` in our source code.

Those are for tests, and they are stripped from production.

## Testing

Green CI

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
