### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     "config:recommended",
     "schedule:weekly",
     ":disablePeerDependencies",
+    ":disableDependencyDashboard",
     "customManagers:biomeVersions",
     "helpers:pinGitHubActionDigestsToSemver"
   ],


### PR DESCRIPTION
## Changes

- Adds the `:disableDependencyDashboard` preset to `.github/renovate.json5`. `config:recommended` enables the dashboard by default. So this disables it.
- Issue not needed, you can go to https://developer.mend.io/

## Testing

- N/A

## Docs

- N/A