### PR TITLE
fix(cloudflare): require astro ^7.3.0 as peer dependency

### DIFF
--- a/.changeset/wise-pugs-hammer.md
+++ b/.changeset/wise-pugs-hammer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes the `astro` peer dependency range, which allowed the adapter to be installed alongside Astro 7.2.x. Since v14.3.0 the adapter imports `renderForPrerender` from `astro/app`, an export added in Astro 7.3.0, so building against 7.2.x failed with `[MISSING_EXPORT] "renderForPrerender" is not exported by "node_modules/astro/dist/core/app/entrypoints/index.js"`. The range is now `^7.3.0`, so package managers resolve a compatible adapter version instead of installing one that cannot build.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -52,7 +52,7 @@
     "vite": "^8.0.13"
   },
   "peerDependencies": {
-    "astro": "^7.2.0",
+    "astro": "^7.3.0",
     "wrangler": "^4.125.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes

`@astrojs/cloudflare@14.3.0` imports `renderForPrerender` from `astro/app`, but its `astro` peer range is still `^7.2.0`. That export was added in Astro 7.3.0, so npm/pnpm install 14.3.0 on top of Astro 7.2.x with no peer warning, and the build fails:

```
[MISSING_EXPORT] "renderForPrerender" is not exported by "node_modules/astro/dist/core/app/entrypoints/index.js".
   ╭─[ node_modules/@astrojs/cloudflare/dist/utils/prerender.js:1:10 ]
 1 │ import { renderForPrerender } from "astro/app";
```

Verified against the published tarballs:

| package | `renderForPrerender` |
| --- | --- |
| `astro@7.2.4`, `astro@7.2.10` | not exported from `dist/core/app/entrypoints/index.js` |
| `astro@7.3.0` | exported |
| `@astrojs/cloudflare@14.2.6` | not imported |
| `@astrojs/cloudflare@14.3.0` | imported in `dist/utils/prerender.js` |

Both sides were introduced together in #17795 (core + adapter) and released as `astro@7.3.0` / `@astrojs/cloudflare@14.3.0`, but the peer range wasn't bumped. CI doesn't catch this because the monorepo resolves `astro` as `workspace:*`, so the declared range is never exercised.

This is easy to hit in practice: `wrangler deploy` auto-config runs `astro add cloudflare` on a project whose lockfile pins Astro 7.2.x, installs 14.3.0, and the deploy fails.

### Testing

Peer-range-only change; no runtime behavior affected.

### Docs

No docs change needed.