### PR TITLE
fix(check): correct argument handling, watch mode output and project inference

### DIFF
--- a/.changeset/plain-cups-invent.md
+++ b/.changeset/plain-cups-invent.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixes `astro check` checking `.astro` files inside nested `node_modules` directories when no `tsconfig.json` or `jsconfig.json` is found. Only the `node_modules` directory at the root of the project was excluded.

--- a/.changeset/tidy-moons-clap.md
+++ b/.changeset/tidy-moons-clap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/check': patch
+---
+
+Fixes the `astro-check` binary dropping the first two arguments it is given, which made flags such as `--watch`, `--root` and `--minimumFailingSeverity` silently fall back to their default values. Running `astro check` through the Astro CLI was not affected.

--- a/.changeset/tidy-moons-clap.md
+++ b/.changeset/tidy-moons-clap.md
@@ -3,3 +3,5 @@
 ---
 
 Fixes the `astro-check` binary dropping the first two arguments it is given, which made flags such as `--watch`, `--root` and `--minimumFailingSeverity` silently fall back to their default values. Running `astro check` through the Astro CLI was not affected.
+
+Scripts that worked around this by padding the command line, such as `astro-check -- -- --tsconfig ./tsconfig.json`, must drop the padding: the arguments are now read as written, and a leading `--` ends the flags.

--- a/.changeset/warm-hoops-melt.md
+++ b/.changeset/warm-hoops-melt.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/check': patch
+---
+
+Fixes `astro check --watch` printing a result summary for a check that was cancelled by a newer file change, and ignoring the entire project when its path contains a `node_modules` or `.git` segment. The `--help` description of `--preserveWatchOutput` now matches what the flag does.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -109,7 +109,7 @@
   ],
   "scripts": {
     "prebuild": "astro-scripts prebuild --to-string \"src/runtime/server/astro-island.ts\" \"src/runtime/client/{idle,load,media,only,visible}.ts\"",
-    "build": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm && tsc -b && astro-check -- -- --tsconfig ./tsconfig.components.json",
+    "build": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm && tsc -b && astro-check --tsconfig ./tsconfig.components.json",
     "build:ci": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" --copy-wasm",
     "dev": "astro-scripts dev --copy-wasm --prebuild \"src/runtime/server/astro-island.ts\" --prebuild \"src/runtime/client/{idle,load,media,only,visible}.ts\" \"src/**/*.{ts,js}\"",
     "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:types",

--- a/packages/language-tools/astro-check/bin/astro-check.js
+++ b/packages/language-tools/astro-check/bin/astro-check.js
@@ -3,7 +3,7 @@
 import path from 'node:path';
 import { check, parseArgsAsCheckConfig } from '../dist/index.js';
 
-const args = parseArgsAsCheckConfig(process.argv.slice(2));
+const args = parseArgsAsCheckConfig(process.argv);
 
 console.info(`Getting diagnostics for Astro files in ${path.resolve(args.root)}...`);
 

--- a/packages/language-tools/astro-check/src/index.ts
+++ b/packages/language-tools/astro-check/src/index.ts
@@ -8,10 +8,11 @@ import { hideBin } from 'yargs/helpers';
 import { options } from './options.js';
 
 /**
- * Given a list of arguments from the command line (such as `process.argv`), return parsed and processed options
+ * Given a full `process.argv`, return parsed and processed options. The node binary and the script
+ * path are skipped, so the arguments must not be sliced beforehand.
  */
-export function parseArgsAsCheckConfig(args: string[]) {
-	return yargs(hideBin(args)).options(options).parseSync();
+export function parseArgsAsCheckConfig(argv: string[]) {
+	return yargs(hideBin(argv)).options(options).parseSync();
 }
 
 export type Flags = Pick<ReturnType<typeof parseArgsAsCheckConfig>, keyof typeof options>;

--- a/packages/language-tools/astro-check/src/index.ts
+++ b/packages/language-tools/astro-check/src/index.ts
@@ -34,7 +34,8 @@ export async function check(flags: Partial<Flags>): Promise<boolean | void> {
 		function createWatcher(rootPath: string, extensions: string[]) {
 			return watch(rootPath, {
 				ignored(pathStr, stats) {
-					if (pathStr.includes('node_modules') || pathStr.includes('.git')) return true;
+					const segments = path.relative(rootPath, pathStr).split(path.sep);
+					if (segments.includes('node_modules') || segments.includes('.git')) return true;
 					if (stats?.isFile() && !extensions.includes(path.extname(pathStr))) return true;
 					return false;
 				},
@@ -79,6 +80,8 @@ export async function check(flags: Partial<Flags>): Promise<boolean | void> {
 			},
 			cancel: isCanceled,
 		});
+		if (result.status === 'cancelled') return;
+
 		console.info(
 			[
 				bold(`Result (${result.fileChecked} file${result.fileChecked === 1 ? '' : 's'}): `),

--- a/packages/language-tools/astro-check/src/options.ts
+++ b/packages/language-tools/astro-check/src/options.ts
@@ -26,7 +26,7 @@ export const options = {
 	},
 	preserveWatchOutput: {
 		type: 'boolean',
-		description: "If set to false, output won't be cleared between checks in watch mode.",
+		description: "If set to true, output won't be cleared between checks in watch mode.",
 		default: false,
 	},
 } as const;

--- a/packages/language-tools/astro-check/test/bin.test.ts
+++ b/packages/language-tools/astro-check/test/bin.test.ts
@@ -4,20 +4,45 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
+const pkgPath = fileURLToPath(new URL('..', import.meta.url));
+const binPath = path.join(pkgPath, 'bin', 'astro-check.js');
+const testPath = path.join(pkgPath, 'test');
+const fixturePath = path.join(testPath, 'fixture');
+
+function runBinary(args: string[], cwd: string) {
+	const childProcess = spawnSync('node', [binPath, ...args], { cwd });
+	return { status: childProcess.status, stdout: childProcess.stdout.toString() };
+}
+
 describe('astro-check - binary', async () => {
 	it('Can run the binary', async () => {
-		const pkgPath = fileURLToPath(new URL('..', import.meta.url));
-		const binPath = path.join(pkgPath, 'bin', 'astro-check.js');
-		const fixturePath = path.join(pkgPath, 'test', 'fixture');
-		const childProcess = spawnSync('node', [binPath], {
-			// Set the working directory to the fixture directory so that `astro check` can use the tsconfig in the fixture directory.
-			cwd: fixturePath,
-		});
+		// Set the working directory to the fixture directory so that `astro check` can use the tsconfig in the fixture directory.
+		const { status, stdout } = runBinary([], fixturePath);
 
-		assert.strictEqual(childProcess.status, 1);
-		assert.ok(childProcess.stdout.toString().includes('Getting diagnostics for Astro files in'));
-		assert.ok(childProcess.stdout.toString().includes('1 error'));
-		assert.ok(childProcess.stdout.toString().includes('1 warning'));
-		assert.ok(childProcess.stdout.toString().includes('1 hint'));
+		assert.strictEqual(status, 1);
+		assert.ok(stdout.includes('Getting diagnostics for Astro files in'));
+		assert.ok(stdout.includes('1 error'));
+		assert.ok(stdout.includes('1 warning'));
+		assert.ok(stdout.includes('1 hint'));
+	});
+
+	it('Checks the directory given by `--root`', async () => {
+		const { status, stdout } = runBinary(['--root', './fixture'], testPath);
+
+		assert.strictEqual(status, 1);
+		assert.ok(
+			stdout.includes(`Getting diagnostics for Astro files in ${fixturePath}`),
+			`Expected the fixture directory to be checked, got:\n${stdout}`,
+		);
+		assert.ok(stdout.includes('1 error'));
+	});
+
+	it('Applies the flags given as the first arguments', async () => {
+		const { status, stdout } = runBinary(['--minimumSeverity', 'error'], fixturePath);
+
+		assert.strictEqual(status, 1);
+		assert.ok(stdout.includes('1 error'));
+		assert.ok(!stdout.includes('1 warning'), `Expected warnings to be hidden, got:\n${stdout}`);
+		assert.ok(!stdout.includes('1 hint'), `Expected hints to be hidden, got:\n${stdout}`);
 	});
 });

--- a/packages/language-tools/astro-check/test/parseArgs.test.ts
+++ b/packages/language-tools/astro-check/test/parseArgs.test.ts
@@ -2,6 +2,9 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { parseArgsAsCheckConfig } from '../dist/index.js';
 
+/** Build a `process.argv`, whose two first entries are the node binary and the script path. */
+const argv = (...args: string[]) => ['node', 'astro-check', ...args];
+
 describe('astro-check - Arguments parser', async () => {
 	it('Can parse an empty array', async () => {
 		const result = parseArgsAsCheckConfig([]);
@@ -13,18 +16,29 @@ describe('astro-check - Arguments parser', async () => {
 	});
 
 	it('Can parse boolean', async () => {
-		const result = parseArgsAsCheckConfig(['', '', '--watch', '--preserveWatchOutput']);
+		const result = parseArgsAsCheckConfig(argv('--watch', '--preserveWatchOutput'));
 		assert.strictEqual(result.watch, true);
 		assert.strictEqual(result.preserveWatchOutput, true);
 	});
 
 	it('Can parse string', async () => {
-		const result = parseArgsAsCheckConfig(['', '', '--root', 'foo']);
+		const result = parseArgsAsCheckConfig(argv('--root', 'foo'));
 		assert.strictEqual(result.root, 'foo');
 	});
 
 	it('Can parse string with choice', async () => {
-		const result = parseArgsAsCheckConfig(['', '', '--minimumSeverity', 'error']);
+		const result = parseArgsAsCheckConfig(argv('--minimumSeverity', 'error'));
 		assert.strictEqual(result.minimumSeverity, 'error');
+	});
+
+	it('Only skips the node binary and the script path', async () => {
+		const result = parseArgsAsCheckConfig(
+			argv('--watch', '--root', 'foo', '--minimumFailingSeverity', 'hint'),
+		);
+
+		assert.strictEqual(result.watch, true);
+		assert.strictEqual(result.root, 'foo');
+		assert.strictEqual(result.minimumFailingSeverity, 'hint');
+		assert.deepStrictEqual(result._, []);
 	});
 });

--- a/packages/language-tools/language-server/src/check.ts
+++ b/packages/language-tools/language-server/src/check.ts
@@ -204,7 +204,7 @@ export class AstroCheck {
 				() => {
 					return globSync('**/*.astro', {
 						cwd: this.workspacePath,
-						ignore: ['node_modules'],
+						ignore: ['**/node_modules/**'],
 						absolute: true,
 						// Required to avoid tinyglobby running eternally
 						expandDirectories: false,

--- a/packages/language-tools/language-server/test/check/check.test.ts
+++ b/packages/language-tools/language-server/test/check/check.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert';
+import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
-import { before, describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import type { CheckResult } from '../../dist/check.js';
 import { AstroCheck } from '../../dist/check.js';
@@ -106,5 +107,41 @@ describe('AstroCheck with an incompatible TypeScript', () => {
 				return true;
 			},
 		);
+	});
+});
+
+describe('AstroCheck without a tsconfig', () => {
+	let workspaceDir: string;
+
+	before(() => {
+		workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astro-check-inferred-'));
+		fs.mkdirSync(path.join(workspaceDir, 'packages/app/node_modules/a-dependency'), {
+			recursive: true,
+		});
+		fs.writeFileSync(path.join(workspaceDir, 'packages/app/index.astro'), '---\n---\n');
+		fs.writeFileSync(
+			path.join(workspaceDir, 'packages/app/node_modules/a-dependency/index.astro'),
+			'---\n---\n',
+		);
+	});
+
+	after(() => {
+		fs.rmSync(workspaceDir, { recursive: true, force: true });
+	});
+
+	it('Ignores .astro files inside nested node_modules directories', () => {
+		const checker = new AstroCheck(
+			workspaceDir,
+			require.resolve('typescript/lib/typescript.js'),
+			undefined,
+		);
+
+		const rootFileNames = checker.linter.getRootFileNames();
+
+		assert.deepStrictEqual(
+			rootFileNames.filter((fileName) => fileName.includes('node_modules')),
+			[],
+		);
+		assert.strictEqual(rootFileNames.length, 1);
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes the `astro-check` binary dropping the first two arguments it is given. `astro-check --watch` ran a single check and exited, `--root` fell back to the working directory, and `--minimumFailingSeverity` fell back to `error`. `parseArgsAsCheckConfig` hands its input to yargs' `hideBin`, so slicing the node binary and the script path off beforehand ate real flags. Running `astro check` through the Astro CLI was never affected.
- Fixes `astro check --watch` printing a result summary for a check that was cancelled by a newer file change. Those partial counts were announced as a finished run, right after the newer run had cleared the screen.
- Fixes `astro check --watch` ignoring an entire project whose path contains a `node_modules` or `.git` segment. The watcher matched those names against the whole path instead of the path segments below the watched root.
- Fixes `astro check` checking `.astro` files inside nested `node_modules` directories when no `tsconfig.json` or `jsconfig.json` is found. The inferred project's ignore pattern only matched a `node_modules` directory sitting at the root of the workspace, so running the check from the root of a monorepo pulled in the `.astro` files shipped by every workspace's dependencies.
- Corrects the `--help` description of `--preserveWatchOutput`, which described the behaviour of its own negation.

Changesets included: two `@astrojs/check` patches and one `@astrojs/language-server` patch.

## Testing

Tests were added first, in their own commit, and confirmed to fail against the current behaviour before any fix was applied:

- `packages/language-tools/astro-check/test/bin.test.ts` only spawned the binary without any argument, so nothing verified that the flags it is given reach the checker. It now also runs the binary with `--root` (asserting on the directory it reports) and with `--minimumSeverity` (asserting on the severities it prints). The `--root` coverage existed until it was replaced by a `cwd` in #16505.
- `packages/language-tools/astro-check/test/parseArgs.test.ts` fed `parseArgsAsCheckConfig` a `['', '', ...]` placeholder pair, mirroring the implementation rather than pinning the contract. The arguments are now built through an explicit `argv()` helper, and a new case asserts that only the node binary and the script path are skipped, leaving no stray positionals.
- `packages/language-tools/language-server/test/check/check.test.ts` had no coverage of the inferred project path. It now builds a workspace with no tsconfig and a nested `node_modules` directory, and asserts on the resulting root file list.

All `@astrojs/check` tests pass. The two failures in `AstroCheck` (`Can check files and return errors`, `Can return the total amount of errors, warnings and hints`) reproduce on `main` in the same environment and are unrelated to this change.

Two fixes are not covered by a test: the cancelled-summary guard needs a way to drive watch mode and inspect its output, which is the same blocker as the existing `// TODO: Test watch option once we have a way to pass a custom logger`; the watcher's ignore rules are an inline predicate with no seam to test against.

## Docs

No docs changes needed. The CLI reference already documents `--watch`, `--root`, `--minimumFailingSeverity` and `--preserveWatchOutput` with the behaviour these fixes restore, including "Specifies not to clear the output between checks when in watch mode" — it was the in-CLI `--help` string that contradicted it.