### PR TITLE
Organize imports across Astro frontmatter and scripts

### DIFF
--- a/.changeset/perky-clowns-pay.md
+++ b/.changeset/perky-clowns-pay.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fixes organize imports across frontmatter and multiple script tags

--- a/packages/language-tools/language-server/test/typescript/organize-imports.test.ts
+++ b/packages/language-tools/language-server/test/typescript/organize-imports.test.ts
@@ -130,4 +130,50 @@ describe('TypeScript - Organize & Sort Imports', () => {
 
 		assert.ok(returnedText.some((text) => text.includes('helperOne, helperTwo')));
 	});
+
+	it('organizes imports in every TypeScript region for full-document actions', async () => {
+		const document = await languageServer.openFakeDocument(
+			`---
+import { serverTwo, serverOne } from './server';
+
+serverOne();
+serverTwo();
+---
+
+<script>
+	import { clientTwo, clientOne } from './client';
+
+	clientOne();
+	clientTwo();
+</script>
+
+<script>
+	import { otherTwo, otherOne } from './other';
+
+	otherOne();
+	otherTwo();
+</script>
+`,
+			'astro',
+		);
+		const organizeActions = await languageServer.handle.sendCodeActionsRequest(
+			document.uri,
+			Range.create(0, 0, document.lineCount - 1, 0),
+			{
+				diagnostics: [],
+				only: ['source.organizeImports'],
+				triggerKind: 2,
+			},
+		);
+		const organizeEdits = await Promise.all(
+			(organizeActions as CodeAction[]).map((action) =>
+				languageServer.handle.sendCodeActionResolveRequest(action),
+			),
+		);
+		const returnedText = getTextEdits(organizeEdits).map((edit) => edit.newText);
+
+		assert.ok(returnedText.some((text) => text.includes('serverOne, serverTwo')));
+		assert.ok(returnedText.some((text) => text.includes('clientOne, clientTwo')));
+		assert.ok(returnedText.some((text) => text.includes('otherOne, otherTwo')));
+	});
 });

--- a/patches/@volar__language-service@2.4.28.patch
+++ b/patches/@volar__language-service@2.4.28.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/utils/dedupe.js b/lib/utils/dedupe.js
+--- a/lib/utils/dedupe.js
++++ b/lib/utils/dedupe.js
+@@ -39,6 +39,7 @@ function createLocationSet() {
+ function withCodeAction(items) {
+     return dedupe(items, item => [
+         item.title,
++        JSON.stringify(item.data),
+     ].join(':'));
+ }
+ function withTextEdits(items) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,7 @@ overrides:
   modern-tar: '>=0.7.7'
 
 patchedDependencies:
+  '@volar/language-service@2.4.28': 09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a
   '@volar/typescript@2.4.28': 08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad
 
 importers:
@@ -6783,7 +6784,7 @@ importers:
         version: 2.4.28
       '@volar/language-service':
         specifier: ~2.4.28
-        version: 2.4.28
+        version: 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
       muggle-string:
         specifier: ^0.4.1
         version: 0.4.1
@@ -20718,7 +20719,7 @@ snapshots:
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
       '@volar/typescript': 2.4.28(patch_hash=08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad)
       typesafe-path: 0.2.2
       typescript: 6.0.3
@@ -20732,7 +20733,7 @@ snapshots:
   '@volar/language-server@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
       '@volar/typescript': 2.4.28(patch_hash=08646e153f568c63dc1e7a3dae0333806b3d8395c5ffbad47fa695f7c26bacad)
       path-browserify: 1.0.1
       request-light: 0.7.0
@@ -20741,7 +20742,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  '@volar/language-service@2.4.28':
+  '@volar/language-service@2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)':
     dependencies:
       '@volar/language-core': 2.4.28
       vscode-languageserver-protocol: 3.17.5
@@ -26981,7 +26982,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
 
   volar-service-emmet@0.0.71(@volar/language-service@2.4.28):
     dependencies:
@@ -26990,7 +26991,7 @@ snapshots:
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
 
   volar-service-html@0.0.71(@volar/language-service@2.4.28):
     dependencies:
@@ -26998,20 +26999,20 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
 
   volar-service-prettier@0.0.71(@volar/language-service@2.4.28)(prettier@3.9.0):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
       prettier: 3.9.0
 
   volar-service-typescript-twoslash-queries@0.0.71(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
 
   volar-service-typescript@0.0.71(@volar/language-service@2.4.28):
     dependencies:
@@ -27022,14 +27023,14 @@ snapshots:
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
 
   volar-service-yaml@0.0.71(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
       yaml-language-server: 1.23.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(patch_hash=09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a)
 
   vscode-css-languageservice@6.3.9:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,4 +113,5 @@ allowBuilds:
   workerd: false
 
 patchedDependencies:
+  '@volar/language-service@2.4.28': patches/@volar__language-service@2.4.28.patch
   '@volar/typescript@2.4.28': patches/@volar__typescript@2.4.28.patch


### PR DESCRIPTION
## Changes

- Organizes imports across Astro frontmatter and every processed `<script>` block.
- Keeps Volar code actions with distinct resolution targets instead of deduplicating by title alone. Fixes #17909.

<img width="1205" height="750" alt="organize-imports-fixed" src="https://github.com/user-attachments/assets/05f5beec-daee-4315-aa35-742f10418bb6" />


## Testing

- Adds full-document organize-import coverage for frontmatter and two script blocks.

## Docs

- No docs update needed; this restores expected editor behavior.
