### PR TITLE
fix(internal-helpers): detect file extension on bare filenames in hasFileExtension

### DIFF
--- a/.changeset/tidy-parrots-cross.md
+++ b/.changeset/tidy-parrots-cross.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/internal-helpers': patch
+---
+
+Fixes `hasFileExtension` returning `false` for a bare filename with no leading path segment (for example `about.html` or `rss.xml`). The check now anchors the extension match to the start of the string as well as after a slash, so a filename is recognized whether or not it is preceded by a directory segment.

--- a/packages/internal-helpers/src/path.ts
+++ b/packages/internal-helpers/src/path.ts
@@ -284,7 +284,7 @@ export function stripRequestBase(pathname: string, base: string): string {
 	return pathname;
 }
 
-const WITH_FILE_EXT = /\/[^/]+\.\w+$/;
+const WITH_FILE_EXT = /(?:^|\/)[^/]+\.\w+$/;
 
 export function hasFileExtension(path: string) {
 	return WITH_FILE_EXT.test(path);

--- a/packages/internal-helpers/test/path.test.ts
+++ b/packages/internal-helpers/test/path.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+	hasFileExtension,
 	isInternalPath,
 	isParentDirectory,
 	isRemotePath,
@@ -876,5 +877,32 @@ describe('isInternalPath', () => {
 	it('does not flag paths that are only slashes', () => {
 		assert.equal(isInternalPath('//'), false);
 		assert.equal(isInternalPath('///'), false);
+	});
+});
+
+describe('hasFileExtension', () => {
+	it('detects an extension on a path with directory segments', () => {
+		assert.equal(hasFileExtension('/foo/bar.js'), true);
+		assert.equal(hasFileExtension('/a/b/c.png'), true);
+	});
+
+	it('detects an extension on a bare filename without a leading slash', () => {
+		assert.equal(hasFileExtension('about.html'), true);
+		assert.equal(hasFileExtension('rss.xml'), true);
+		assert.equal(hasFileExtension('favicon.ico'), true);
+	});
+
+	it('uses the last dot in a multi-dot filename', () => {
+		assert.equal(hasFileExtension('foo.bar.js'), true);
+	});
+
+	it('returns false for paths without a file extension', () => {
+		assert.equal(hasFileExtension('/blog'), false);
+		assert.equal(hasFileExtension('/blog/'), false);
+		assert.equal(hasFileExtension('index'), false);
+	});
+
+	it('returns false for a trailing dot with no extension', () => {
+		assert.equal(hasFileExtension('file.'), false);
 	});
 });


### PR DESCRIPTION
## Changes

`hasFileExtension` in `@astrojs/internal-helpers` answers "does this path point at a file with an extension?" but its regex required a slash immediately before the filename (`/\/[^/]+\.\w+$/`). Because of the leading slash, a bare filename with no directory segment was never matched:

| input | before | after |
| --- | --- | --- |
| `about.html` | `false` | `true` |
| `rss.xml` | `false` | `true` |
| `favicon.ico` | `false` | `true` |
| `/blog/foo.js` | `true` | `true` |
| `/blog` | `false` | `false` |
| `index` | `false` | `false` |
| `file.` | `false` | `false` |

The fix anchors the match to the start of the string or a slash: `/(?:^|\/)[^/]+\.\w+$/`. This is strictly additive: it only changes results for inputs lacking a leading path segment (incorrect `false` becomes correct `true`). Every path beginning with `/` and every genuinely extension-less input is unchanged.

### Why it matters

`hasFileExtension` decides trailing-slash behavior and static-file handling, including `@astrojs/node` `serve-static.ts` (called on a base-stripped request path that can be a bare filename), and `core/routing/create-manifest.ts` / `params.ts` endpoint trailing-slash decisions. A bare asset filename could previously be misclassified as extension-less.

## Testing

Added a `hasFileExtension` block to `packages/internal-helpers/test/path.test.ts` (the function previously had no tests) covering directory paths, bare filenames, multi-dot names, extension-less paths, and a trailing dot.

Local checks, all green: build, `pnpm test` (70 pass / 0 fail), biome format/lint/check, `tsc -b` typecheck, and `changeset status` (patch bump for `@astrojs/internal-helpers`, cascading to `astro`).

## Docs

No user-facing docs change; internal helper behavior fix. Changeset included (`patch`).