### PR TITLE
Fix missing whitespace in blog template

### DIFF
--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -20,8 +20,8 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 				website, blog, or portfolio with Astro.
 			</p>
 			<p>
-				This template comes with a few integrations already configured in your
-				<code>astro.config.mjs</code> file. You can customize your setup with
+				This template comes with a few integrations already configured in your{' '}
+				<code>astro.config.mjs</code> file. You can customize your setup with{' '}
 				<a href="https://astro.build/integrations">Astro Integrations</a> to add tools like Tailwind,
 				React, or Vue to your project.
 			</p>
@@ -34,13 +34,13 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 				<li>Customize the blog post page layout in <code>src/layouts/BlogPost.astro</code></li>
 			</ul>
 			<p>
-				Have fun! If you get stuck, remember to
-				<a href="https://docs.astro.build/">read the docs</a>
+				Have fun! If you get stuck, remember to{' '}
+				<a href="https://docs.astro.build/">read the docs</a>{' '}
 				or <a href="https://astro.build/chat">join us on Discord</a> to ask questions.
 			</p>
 			<p>
-				Looking for a blog template with a bit more personality? Check out
-				<a href="https://github.com/Charca/astro-blog-template">astro-blog-template</a>
+				Looking for a blog template with a bit more personality? Check out{' '}
+				<a href="https://github.com/Charca/astro-blog-template">astro-blog-template</a>{' '}
 				by <a href="https://twitter.com/Charca">Maxi Ferreira</a>.
 			</p>
 		</main>


### PR DESCRIPTION
## Changes

I fixed missing whitespace in `src/pages/index.astro` in the blog starter kit. This template wasn't updated since `compressHTML` was set to `jsx`. 

### Before

<img width="903" height="195" alt="image" src="https://github.com/user-attachments/assets/a911ca4f-4e39-494c-ae16-0ef7eb84c9f9" />

### After

<img width="872" height="200" alt="image" src="https://github.com/user-attachments/assets/c94817b2-75aa-40d2-b527-b7c379db4b12" />


## Testing

Verified manually.

## Docs

This issue is [already documented](https://docs.astro.build/en/guides/upgrade-to/v7/#new-default-whitespace-handling-compresshtml-jsx).
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
