### PR TITLE
fix: normalize visited module IDs in dev graph traversal

### DIFF
--- a/.changeset/quiet-graphs-recur.md
+++ b/.changeset/quiet-graphs-recur.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes repeated traversal of wrapped module IDs in the development server's module graph crawler.

--- a/packages/astro/src/vite-plugin-astro-server/vite.ts
+++ b/packages/astro/src/vite-plugin-astro-server/vite.ts
@@ -106,7 +106,7 @@ export async function* crawlGraph(
 	// scan imported modules for CSS imports & add them to our collection.
 	// Then, crawl that file to follow and scan all deep imports as well.
 	for (const importedModule of importedModules) {
-		if (!importedModule.id || scanned.has(importedModule.id)) {
+		if (!importedModule.id || scanned.has(unwrapId(importedModule.id))) {
 			continue;
 		}
 

--- a/packages/astro/test/units/vite-plugin-astro-server/vite.test.ts
+++ b/packages/astro/test/units/vite-plugin-astro-server/vite.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { EnvironmentModuleNode, RunnableDevEnvironment } from 'vite';
+import { crawlGraph } from '../../../dist/vite-plugin-astro-server/vite.js';
+
+function createEnvironment(imports: Record<string, string[]>): RunnableDevEnvironment {
+	const modules = new Map<string, EnvironmentModuleNode>();
+	for (const id of Object.keys(imports)) {
+		modules.set(id, {
+			id,
+			importedModules: new Set(),
+			importers: new Set(),
+		} as EnvironmentModuleNode);
+	}
+	for (const [id, dependencies] of Object.entries(imports)) {
+		const parent = modules.get(id)!;
+		for (const dependency of dependencies) {
+			const child = modules.get(dependency)!;
+			parent.importedModules.add(child);
+			child.importers.add(parent);
+		}
+	}
+	return {
+		moduleGraph: {
+			getModuleById: (id: string) => modules.get(id),
+			getModulesByFile: (id: string) => new Set([modules.get(id)!]),
+		},
+	} as RunnableDevEnvironment;
+}
+
+describe('crawlGraph', () => {
+	for (const backEdge of ['\0virtual:shared', '/@id/__x00__virtual:shared']) {
+		it(`terminates a cycle through ${JSON.stringify(backEdge)}`, async () => {
+			const environment = createEnvironment({
+				'/entry.js': ['\0virtual:shared'],
+				[backEdge]: [],
+				'\0virtual:shared': [backEdge],
+			});
+			const graph = crawlGraph(environment, '/entry.js', true);
+			try {
+				assert.equal((await graph.next()).value?.id, '\0virtual:shared');
+				assert.deepEqual(await graph.next(), { value: undefined, done: true });
+			} finally {
+				await graph.return();
+			}
+		});
+	}
+
+	it('visits a shared dependency once across wrapped and unwrapped imports', async () => {
+		const environment = createEnvironment({
+			'/entry.js': ['/first.js', '/second.js'],
+			'/first.js': ['\0virtual:shared'],
+			'/second.js': ['/@id/__x00__virtual:shared'],
+			'\0virtual:shared': [],
+			'/@id/__x00__virtual:shared': [],
+		});
+		const ids = [];
+		for await (const module of crawlGraph(environment, '/entry.js', false)) {
+			ids.push(module.id);
+		}
+		assert.deepEqual(ids, ['/first.js', '\0virtual:shared', '/second.js']);
+	});
+
+	it('preserves an unseen wrapped import and crawls its unwrapped module', async () => {
+		const environment = createEnvironment({
+			'/entry.js': ['/@id/__x00__virtual:shared'],
+			'/@id/__x00__virtual:shared': [],
+			'\0virtual:shared': ['/style.css'],
+			'/style.css': [],
+		});
+		const ids = [];
+		for await (const module of crawlGraph(environment, '/entry.js', false)) {
+			ids.push(module.id);
+		}
+		assert.deepEqual(ids, ['/@id/__x00__virtual:shared', '/style.css']);
+	});
+});


### PR DESCRIPTION
## Changes

Fixes #17934.

`crawlGraph()` records unwrapped module IDs in its visited set but checks recursive imports using their original IDs. A wrapped reference to an already visited module can therefore bypass deduplication and, for a normalized cycle, recurse back into the same module indefinitely.

Normalize the visited-set lookup with the existing `unwrapId()` helper. Keep the yielded module and its ID unchanged. Includes an `astro` patch changeset.

The [standalone reproduction](https://github.com/rwv/astro/tree/41ebe0e) runs against published Astro 7.3.1. It deliberately models the mixed-ID module graph; it is **not** an application-level reproduction of a confirmed Vue regression. Ordinary Vite resolution may normalize these IDs before the crawler sees them. See the issue for the downstream patch's history and the limits of the reproduction.

## Testing

- Added four bounded unit tests covering wrapped and unwrapped cycles, shared-dependency deduplication, and preserving an unseen wrapped ID while traversing its unwrapped module. The two regression cases fail before the fix; all four pass afterward.
- Verified the standalone reproduction fails on unpatched npm `astro@7.3.1` and passes with the same one-line fix.
- `pnpm build:ci` — passed (27 tasks).
- `pnpm exec turbo run build --filter=@astrojs/check...` — passed (14 tasks, including the Astro package build, TypeScript build, and component diagnostics).
- `pnpm format` — passed.
- `pnpm lint:ai` — passed (one existing Biome warning in a language-server fixture).
- `pnpm -C packages/astro exec astro-scripts test 'test/units/vite-plugin-astro-server/*.test.ts' --strip-types` — 11 passed.
- `pnpm -C packages/astro exec astro-scripts test 'test/{vite-virtual-modules,0-css,css-dynamic-import-dev,css-order,partials-css-boundary}.test.ts' --strip-types` — 46 passed, 1 skipped.
- `pnpm exec tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck --ignoreConfig packages/astro/test/units/vite-plugin-astro-server/vite.test.ts` — passed.

## Docs

No public API or configuration changes. The patch changeset describes the internal development-server fix.
