### PR TITLE
Prune stale entries when a glob() collection becomes empty

### DIFF
--- a/.changeset/two-experts-flash.md
+++ b/.changeset/two-experts-flash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the `glob()` content loader kept stale entries in the data store after the last file in a collection was deleted. Empty collections are now pruned correctly, and the file watcher is registered in dev so the first file added to an empty collection is picked up without a restart.

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -292,7 +292,6 @@ export function glob(globOptions: GlobOptions & { [secretLegacyFlag]?: boolean }
 				logger.warn(
 					`No files found matching "${globOptions.pattern}" in directory "${relativePath}"`,
 				);
-				return;
 			}
 
 			function configForFile(file: string) {

--- a/packages/astro/test/units/content-layer/glob-loader.test.ts
+++ b/packages/astro/test/units/content-layer/glob-loader.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -511,6 +511,44 @@ describe('Glob Loader', () => {
 		await contentLayer.sync();
 
 		assert.ok(warnings.some((w) => w.includes('No files found matching')));
+	});
+
+	it('prunes stale entries when the last file in a collection is deleted', async () => {
+		const tempDir = createTempDir();
+		const contentDir = join(fileURLToPath(tempDir), 'src', 'content', 'posts');
+		mkdirSync(contentDir, { recursive: true });
+		writeFileSync(join(contentDir, 'post.md'), '---\ntitle: Post MD\n---\nContent MD');
+
+		const store = new MutableDataStore();
+		const settings = createMinimalSettings(tempDir, {
+			contentEntryTypes: [createMarkdownEntryType()],
+		});
+		const logger = new AstroLogger({
+			destination: { write: () => true },
+			level: 'silent',
+		});
+
+		const collections = {
+			posts: defineCollection({
+				loader: glob({ pattern: '*.md', base: 'src/content/posts' }),
+			}),
+		};
+
+		const contentLayer = new ContentLayer({
+			settings,
+			logger,
+			store,
+			contentConfigObserver: createTestConfigObserver(collections),
+		});
+
+		await contentLayer.sync();
+		assert.equal(store.values('posts').length, 1);
+
+		// Delete the only file, leaving the (still existing) directory in place
+		rmSync(join(contentDir, 'post.md'));
+
+		await contentLayer.sync();
+		assert.equal(store.values('posts').length, 0);
 	});
 
 	it('throws on duplicate IDs when prerenderConflictBehavior is error', async () => {


### PR DESCRIPTION
## Changes

- Stops the `glob()` content loader from returning early when an existing directory matches no files, so the stale-entry pruning pass and the dev file watcher still run. Previously, deleting the last entry of a collection left it in the data store and re-rendered it on every incremental build; an emptied collection also never registered its watcher in dev.
- Keeps the existing `No files found matching...` warning; only the early exit is removed.

## Testing

- Adds a unit test to `glob-loader.test.ts` covering the prune-on-empty behavior: sync with one entry, delete the last file (the directory stays), sync again, assert the store is empty. Fails without the change and passes with it.

## Docs

- No docs update needed; this matches the documented expectation that a collection reflects the files on disk.

Fixes https://github.com/withastro/astro/issues/17919