### PR TITLE
Fix flaky Cloudflare e2e tests by pre-bundling Preact in the fixture

### DIFF
--- a/packages/astro/e2e/cloudflare.test.ts
+++ b/packages/astro/e2e/cloudflare.test.ts
@@ -132,11 +132,14 @@ function sharedTests(testRunner: AstroTest, infoLogs: LogEntry[] | null = null) 
 		// Test for https://github.com/vitejs/vite/issues/20867
 		// When using a linked package with client:only, the first page load can trigger
 		// Vite's dep optimizer mid-request, causing client scripts to fail with 504.
-		// The fix sets `ignoreOutdatedRequests: true` on the client environment.
+		// The fix sets `ignoreOutdatedRequests: true` on the client environment, which
+		// holds the request until re-optimization finishes. That wait can exceed the
+		// default assertion timeout on slow CI runners, so the first hydration check
+		// gets a generous timeout.
 		testRunner('linked package with client:only hydrates', async ({ page, astro }) => {
 			await page.goto(astro.resolveUrl('/linked-package'));
 			const button = page.locator('#counter');
-			await expect(button).toBeVisible();
+			await expect(button).toBeVisible({ timeout: 30_000 });
 			await expect(button).toContainText('Count: 0');
 			await button.click();
 			await expect(button).toContainText('Count: 1');

--- a/packages/astro/e2e/fixtures/cloudflare/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/cloudflare/astro.config.mjs
@@ -21,6 +21,13 @@ export default defineConfig({
 				'@images': fileURLToPath(new URL('./images', import.meta.url)),
 			},
 		},
+		optimizeDeps: {
+			// Pre-bundle the Preact SSR renderer so the dev server's dep optimizer
+			// doesn't discover it in a second pass, which deletes the pre-bundled
+			// worker entrypoint that workerd still references and crashes the dev
+			// server. See https://github.com/withastro/astro/issues/16248.
+			include: ['preact', 'preact-render-to-string'],
+		},
 	},
 	i18n: {
 		defaultLocale: "en",


### PR DESCRIPTION
## Changes

- Pre-bundles the Preact SSR renderer (`preact`, `preact-render-to-string`) in the cloudflare e2e fixture's dev config. Without it, the dev-server dep optimizer discovered these in a second pass and deleted the pre-bundled worker entrypoint that workerd still referenced, crashing the dev server with a "The file does not exist" error and destabilizing the whole Cloudflare Development test block on slow CI runners.
- Waits up to 30s (instead of the default 6s) for the client-only island to hydrate in the `linked package with client:only hydrates` test. The first load of `/linked-package` intentionally triggers a mid-request re-optimization, which can exceed the default assertion timeout on slow CI runners.

## Testing

- Reproduced the crash locally with a cold `.vite` cache (dev server logs `dependencies optimized: preact-render-to-string, preact` followed by the missing `deps_ssr/handler-*.js` error); with the fixture entries, startup is clean and `/` and `/linked-package` serve 200.
- The `linked package with client:only hydrates` test still exercises the client-side late discovery it guards (vitejs/vite#20867), so its regression coverage is unchanged.

## Docs

- No docs update needed; test fixture and e2e test changes only.
