### PR TITLE
Allow `astro preview --ignore-lock` from AI agent environments

### DIFF
--- a/.changeset/floppy-clowns-cut.md
+++ b/.changeset/floppy-clowns-cut.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro preview --ignore-lock` (and `astro dev --ignore-lock`) being refused when run from an AI agent environment. The flag now starts the server in the foreground instead of erroring, since agent detection only inferred background mode and was never explicitly requested. An explicit `--background` combined with `--ignore-lock` still errors.

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -25,23 +25,18 @@ export function isIgnoreLock(flags: Flags): boolean {
 }
 
 /**
- * `--ignore-lock` skips the lock file entirely, so a background dev server started with it
- * could never be found by `astro dev stop`/`status`/`logs`. Returns an error message if
- * background mode (explicit `--background`, or implied by AI agent detection) is combined
- * with `--ignore-lock`, or `null` if there's no conflict.
+ * Returns an error message when `--ignore-lock` is combined with an explicit `--background`,
+ * or `null` otherwise. A background server started with `--ignore-lock` could never be found
+ * by `astro dev stop`/`status`/`logs` because the flag skips the lock file entirely.
+ * Background implied by AI agent detection never reaches this check: the CLI drops it
+ * whenever `--ignore-lock` is set.
  */
-export function getBackgroundIgnoreLockConflict(
-	flags: Flags,
-	wantsBackground: boolean,
-): string | null {
-	if (!wantsBackground) {
+export function getBackgroundIgnoreLockConflict(flags: Flags): string | null {
+	if (!flags.background) {
 		return null;
 	}
-	const reason = flags.background
-		? '`--background`'
-		: 'an auto-detected AI agent environment, which runs the dev server in the background automatically';
 	return [
-		`\`--ignore-lock\` cannot be used together with ${reason}.`,
+		'`--ignore-lock` cannot be used together with `--background`.',
 		'',
 		'Background dev servers rely on the lock file so `astro dev stop`, `astro dev status`, and `astro dev logs` can find them.',
 		'Run the dev server in the foreground to use --ignore-lock.',
@@ -130,7 +125,10 @@ export async function dev({ flags }: DevOptions) {
 	}
 
 	const ignoreLock = isIgnoreLock(flags);
-	const wantsBackground = !!flags.background || agentDetected;
+	// Agent-inferred background yields to `--ignore-lock`: the flag means a one-off
+	// foreground server that `stop`/`status`/`logs` won't track.
+	// https://github.com/withastro/astro/issues/17903
+	const wantsBackground = !!flags.background || (agentDetected && !ignoreLock);
 
 	const logger = createLoggerFromFlags(flags);
 	const subcommand = flags._[3]?.toString();
@@ -158,8 +156,7 @@ export async function dev({ flags }: DevOptions) {
 
 	// Reject conflicting flag combinations up front, before starting anything.
 	if (ignoreLock) {
-		const conflict =
-			getBackgroundIgnoreLockConflict(flags, wantsBackground) ?? getForceIgnoreLockConflict(flags);
+		const conflict = getBackgroundIgnoreLockConflict(flags) ?? getForceIgnoreLockConflict(flags);
 		if (conflict) {
 			throw new Error(conflict);
 		}

--- a/packages/astro/src/cli/preview/index.ts
+++ b/packages/astro/src/cli/preview/index.ts
@@ -54,7 +54,10 @@ export async function preview({ flags }: PreviewOptions) {
 	}
 
 	const ignoreLock = isIgnoreLock(flags);
-	const wantsBackground = !!flags.background || agentDetected;
+	// Agent-inferred background yields to `--ignore-lock`: the flag means a one-off
+	// foreground server that `stop`/`status`/`logs` won't track.
+	// https://github.com/withastro/astro/issues/17903
+	const wantsBackground = !!flags.background || (agentDetected && !ignoreLock);
 
 	const logger = createLoggerFromFlags(flags);
 	const subcommand = flags._[3]?.toString();
@@ -87,13 +90,10 @@ export async function preview({ flags }: PreviewOptions) {
 		}
 	}
 
-	if (ignoreLock && wantsBackground) {
-		const reason = flags.background
-			? '`--background`'
-			: 'an auto-detected AI agent environment, which runs the preview server in the background automatically';
+	if (ignoreLock && flags.background) {
 		throw new Error(
 			[
-				`\`--ignore-lock\` cannot be used together with ${reason}.`,
+				'`--ignore-lock` cannot be used together with `--background`.',
 				'',
 				'Background preview servers rely on the lock file so `astro preview stop`, `astro preview status`, and `astro preview logs` can find them.',
 				'Run the preview server in the foreground to use --ignore-lock.',

--- a/packages/astro/test/units/dev/ignore-lock-flag.test.ts
+++ b/packages/astro/test/units/dev/ignore-lock-flag.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+	dev,
 	isIgnoreLock,
 	getBackgroundIgnoreLockConflict,
 	getForceIgnoreLockConflict,
@@ -24,26 +25,19 @@ describe('isIgnoreLock', () => {
 
 // #region getBackgroundIgnoreLockConflict
 describe('getBackgroundIgnoreLockConflict', () => {
-	it('returns null when background mode is not requested', () => {
-		assert.equal(getBackgroundIgnoreLockConflict({ _: [], background: false }, false), null);
+	it('returns null when --background is not set', () => {
+		assert.equal(getBackgroundIgnoreLockConflict({ _: [], background: false }), null);
 	});
 
 	it('returns a conflict message when --background is explicit', () => {
-		const message = getBackgroundIgnoreLockConflict({ _: [], background: true }, true);
+		const message = getBackgroundIgnoreLockConflict({ _: [], background: true });
 		assert.notEqual(message, null);
 		assert.match(message!, /`--background`/);
 		assert.match(message!, /cannot be used together/);
 	});
 
-	it('returns a conflict message when background is only implied by agent detection', () => {
-		const message = getBackgroundIgnoreLockConflict({ _: [], background: false }, true);
-		assert.notEqual(message, null);
-		assert.match(message!, /auto-detected AI agent environment/);
-		assert.doesNotMatch(message!, /`--background`/);
-	});
-
 	it('mentions astro dev stop/status/logs', () => {
-		const message = getBackgroundIgnoreLockConflict({ _: [], background: true }, true);
+		const message = getBackgroundIgnoreLockConflict({ _: [], background: true });
 		assert.match(message!, /astro dev stop/);
 		assert.match(message!, /astro dev status/);
 		assert.match(message!, /astro dev logs/);
@@ -70,3 +64,30 @@ describe('getForceIgnoreLockConflict', () => {
 	});
 });
 // #endregion
+
+describe('astro dev --ignore-lock with agent detection', () => {
+	it('starts a foreground server when an AI agent is detected, instead of refusing', async () => {
+		process.env.CLAUDECODE = '1';
+		try {
+			const server = await dev({
+				flags: {
+					_: ['', '', 'dev'],
+					ignoreLock: true,
+					port: 4734,
+					root: './test/fixtures/astro-preview-allowed-hosts/',
+					silent: true,
+				},
+			});
+			assert.ok(server, 'expected the dev server to start in the foreground');
+			try {
+				assert.ok(server.resolvedUrls, 'expected the dev server to expose a URL');
+				const response = await fetch('http://localhost:4734/');
+				assert.equal(response.status, 200);
+			} finally {
+				await server.stop();
+			}
+		} finally {
+			delete process.env.CLAUDECODE;
+		}
+	});
+});

--- a/packages/astro/test/units/preview/ignore-lock-flag.test.ts
+++ b/packages/astro/test/units/preview/ignore-lock-flag.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { loadFixture, type Fixture } from '../../test-utils.ts';
 import { preview } from '../../../dist/cli/preview/index.js';
 
 describe('astro preview --ignore-lock', () => {
@@ -29,5 +30,34 @@ describe('astro preview --ignore-lock', () => {
 				return true;
 			},
 		);
+	});
+
+	it('starts a foreground server when an AI agent is detected, instead of refusing', async () => {
+		const fixture: Fixture = await loadFixture({
+			root: './fixtures/astro-preview-allowed-hosts/',
+		});
+		await fixture.build();
+		process.env.CLAUDECODE = '1';
+		try {
+			const server = await preview({
+				flags: {
+					_: ['', '', 'preview'],
+					ignoreLock: true,
+					port: 4733,
+					root: './test/fixtures/astro-preview-allowed-hosts/',
+					silent: true,
+				},
+			});
+			assert.ok(server, 'expected the preview server to start in the foreground');
+			try {
+				assert.ok(server.urls?.local, 'expected the preview server to expose a URL');
+				const response = await fetch(server.urls.local[0]);
+				assert.equal(response.status, 200);
+			} finally {
+				await server.stop();
+			}
+		} finally {
+			delete process.env.CLAUDECODE;
+		}
 	});
 });


### PR DESCRIPTION
## Changes

- `astro preview --ignore-lock` and `astro dev --ignore-lock` no longer error when an AI agent is detected (e.g. `CLAUDECODE` set in the environment). Agent detection only *infers* background mode, while `--ignore-lock` explicitly asks for a one-off foreground server that `stop`/`status`/`logs` won't track — the flag now wins and the server starts in the foreground. This unblocks Playwright's `webServer` (`npx astro preview --ignore-lock --port <port>`) when run from an agent session.
- Agent-inferred background is dropped whenever `--ignore-lock` is set; an explicit `--background` combined with `--ignore-lock` still errors, unchanged.
- Fixes #17903.

## Testing

- Added unit tests for both `preview` and `dev` that exercise the CLI path with an agent env var set (`CLAUDECODE=1`) plus `--ignore-lock`, asserting a foreground server starts and serves HTTP 200.
- Updated `getBackgroundIgnoreLockConflict` tests for its new single-argument signature; the previous assertion that agent-implied background conflicts was removed, since that combination no longer errors.

## Docs

- No docs update needed: the CLI help text for `--ignore-lock` is unchanged and still accurate.