### PR TITLE
Stop reloading the middleware on hot updates that match no modules

### DIFF
--- a/.changeset/odd-apples-cross.md
+++ b/.changeset/odd-apples-cross.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression in `astro dev` where writes outside the module graph (for example, `@astrojs/cloudflare`'s `.wrangler/state` files) invalidated the middleware on every request, causing repeated SSR reloads. Such writes no longer invalidate the middleware.

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -39,8 +39,16 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 			);
 		},
 		hotUpdate: {
-			handler() {
+			handler(ctx) {
 				if (!isAstroServerEnvironment(this.environment)) return;
+
+				// A change that matched no modules in the graph can't affect the
+				// middleware or anything it imports, so there's nothing to invalidate.
+				// Writes outside the graph (e.g. `@astrojs/cloudflare`'s `.wrangler/state`)
+				// fire a hotUpdate per write and would otherwise reload the middleware
+				// on every request.
+				// https://github.com/withastro/astro/issues/17933
+				if (ctx.modules.length === 0) return;
 
 				const middlewareVirtualMod = this.environment.moduleGraph.getModuleById(
 					MIDDLEWARE_RESOLVED_MODULE_ID,

--- a/packages/astro/test/units/middleware/middleware-hmr.test.ts
+++ b/packages/astro/test/units/middleware/middleware-hmr.test.ts
@@ -72,7 +72,7 @@ describe('middleware HMR hotUpdate handler', () => {
 		const handler = await getHandler();
 		const { environment, invalidated, sent } = fakeEnvironment();
 
-		handler.call(
+		await handler.call(
 			{ environment } as any,
 			{
 				modules: [{ id: '/src/middleware.ts' }],
@@ -87,7 +87,7 @@ describe('middleware HMR hotUpdate handler', () => {
 		const handler = await getHandler();
 		const { environment, invalidated, sent } = fakeEnvironment();
 
-		handler.call(
+		await handler.call(
 			{ environment } as any,
 			{
 				// A change that matched modules in the graph is not filtered: it
@@ -105,7 +105,7 @@ describe('middleware HMR hotUpdate handler', () => {
 		const handler = await getHandler();
 		const { environment, invalidated, sent } = fakeEnvironment();
 
-		handler.call({ environment } as any, { modules: [] } as any);
+		await handler.call({ environment } as any, { modules: [] } as any);
 
 		assert.equal(invalidated.length, 0);
 		assert.equal(sent.length, 0);
@@ -115,7 +115,7 @@ describe('middleware HMR hotUpdate handler', () => {
 		const handler = await getHandler();
 		const { environment, invalidated, sent } = fakeEnvironment('client');
 
-		handler.call(
+		await handler.call(
 			{ environment } as any,
 			{
 				modules: [{ id: '/src/middleware.ts' }],

--- a/packages/astro/test/units/middleware/middleware-hmr.test.ts
+++ b/packages/astro/test/units/middleware/middleware-hmr.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { isMiddlewarePath } from '../../../dist/core/middleware/vite-plugin.js';
+import {
+	isMiddlewarePath,
+	vitePluginMiddleware,
+} from '../../../dist/core/middleware/vite-plugin.js';
+import { createBasicSettings } from '../test-utils.ts';
 
 describe('middleware HMR path matching', () => {
 	it('matches middleware.ts (single-file pattern)', () => {
@@ -33,5 +37,92 @@ describe('middleware HMR path matching', () => {
 
 	it('does not match other unrelated files', () => {
 		assert.ok(!isMiddlewarePath('components/Header.astro'));
+	});
+});
+
+describe('middleware HMR hotUpdate handler', () => {
+	async function getHandler() {
+		const settings = await createBasicSettings();
+		const plugin = vitePluginMiddleware({ settings });
+		const hook = plugin.hotUpdate;
+		const handler = typeof hook === 'function' ? hook : hook?.handler;
+		assert.ok(handler, 'plugin should expose a hotUpdate handler');
+		return handler;
+	}
+
+	function fakeEnvironment(name = 'ssr') {
+		const virtualMod = { id: '\0virtual:astro:middleware' };
+		const invalidated: unknown[] = [];
+		const sent: string[] = [];
+		return {
+			environment: {
+				name,
+				moduleGraph: {
+					getModuleById: () => virtualMod,
+					invalidateModule: (mod: unknown) => invalidated.push(mod),
+				},
+				hot: { send: (event: string) => sent.push(event) },
+			},
+			invalidated,
+			sent,
+		};
+	}
+
+	it('invalidates the middleware when the change matched modules', async () => {
+		const handler = await getHandler();
+		const { environment, invalidated, sent } = fakeEnvironment();
+
+		handler.call(
+			{ environment } as any,
+			{
+				modules: [{ id: '/src/middleware.ts' }],
+			} as any,
+		);
+
+		assert.equal(invalidated.length, 1);
+		assert.deepEqual(sent, ['astro:middleware-updated']);
+	});
+
+	it('invalidates the middleware for unrelated in-graph changes too', async () => {
+		const handler = await getHandler();
+		const { environment, invalidated, sent } = fakeEnvironment();
+
+		handler.call(
+			{ environment } as any,
+			{
+				// A change that matched modules in the graph is not filtered: it
+				// could be a transitive import of the middleware, so the handler
+				// invalidates unless the change matched no modules at all.
+				modules: [{ id: '/src/pages/index.astro' }],
+			} as any,
+		);
+
+		assert.equal(invalidated.length, 1);
+		assert.deepEqual(sent, ['astro:middleware-updated']);
+	});
+
+	it("doesn't invalidate the middleware when the change matched no modules", async () => {
+		const handler = await getHandler();
+		const { environment, invalidated, sent } = fakeEnvironment();
+
+		handler.call({ environment } as any, { modules: [] } as any);
+
+		assert.equal(invalidated.length, 0);
+		assert.equal(sent.length, 0);
+	});
+
+	it('ignores hotUpdates outside server environments', async () => {
+		const handler = await getHandler();
+		const { environment, invalidated, sent } = fakeEnvironment('client');
+
+		handler.call(
+			{ environment } as any,
+			{
+				modules: [{ id: '/src/middleware.ts' }],
+			} as any,
+		);
+
+		assert.equal(invalidated.length, 0);
+		assert.equal(sent.length, 0);
 	});
 });


### PR DESCRIPTION
## Changes

- The middleware `hotUpdate` handler now ignores updates that Vite matched no modules for, instead of invalidating the middleware on every hot update. Writes outside the module graph — e.g. `@astrojs/cloudflare`'s `.wrangler/state` files, which are written on every request — previously forced a middleware reload per write, and an SSR re-bundle on Cloudflare, which could cost ~30s per page load.
- Updates that matched modules (the middleware itself, its transitive imports, or any other module in the graph) still invalidate as before, preserving the middleware HMR behavior added in #17605. Only updates that can't affect the middleware are discarded.

## Testing

- Adds a `middleware HMR hotUpdate handler` unit suite to `test/units/middleware/middleware-hmr.test.ts` with a fake environment covering the handler's branches: invalidates when the update matched modules, invalidates for unrelated in-graph changes, does not invalidate when no modules matched (the regression), and is a no-op outside server environments.
- The no-modules case fails without the guard.

## Docs

- No docs update needed; this restores dev-server behavior that regressed in 7.2.1, with no user-facing API change.

Fixes #17933