### PR TITLE
fix(markdown-satteri): preserve fence languages with raw HTML

### DIFF
--- a/.changeset/bright-apples-talk.md
+++ b/.changeset/bright-apples-talk.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-satteri': patch
+---
+
+Fix syntax highlighting for fenced code blocks when raw HTML is enabled.

--- a/packages/markdown/satteri/src/satteri-processor.ts
+++ b/packages/markdown/satteri/src/satteri-processor.ts
@@ -197,7 +197,13 @@ export function createHighlightPlugin(
 				) as HastNode | undefined;
 				if (!codeChild || codeChild.type !== 'element') return;
 
-				const lang = (codeChild.data as any)?.lang ?? 'plaintext';
+				const languageClass = Array.isArray(codeChild.properties?.className)
+					? codeChild.properties.className.find(
+							(className) => typeof className === 'string' && className.startsWith('language-'),
+						)
+					: undefined;
+				const lang =
+					(codeChild.data as any)?.lang ?? languageClass?.slice('language-'.length) ?? 'plaintext';
 				const meta = (codeChild.data as any)?.meta ?? undefined;
 
 				if (

--- a/packages/markdown/satteri/test/highlight.test.ts
+++ b/packages/markdown/satteri/test/highlight.test.ts
@@ -9,6 +9,16 @@ describe('satteri highlight', () => {
 		assert.match(code, /background-color:/);
 	});
 
+	it('preserves fence languages when raw HTML is enabled', async () => {
+		for (const rawHtml of [false, true]) {
+			const processor = await createSatteriMarkdownProcessor({
+				features: { rawHtml },
+			});
+			const { code } = await processor.render('```ts\nconst x = 1\n```');
+			assert.match(code, /data-language="ts"/);
+		}
+	});
+
 	it('does not highlight math code blocks by default', async () => {
 		const processor = await createSatteriMarkdownProcessor();
 		const { code } = await processor.render('```math\n\\frac{1}{2}\n```');


### PR DESCRIPTION
## Changes

Fix fenced code highlighting when Sätteri's `rawHtml` feature is enabled. The HTML round trip drops internal `data.lang` metadata but preserves the `language-*` code class. Use that class as a fallback while keeping `data.lang` authoritative, so a TypeScript fence is highlighted as TypeScript instead of plaintext.

Includes a patch changeset for `@astrojs/markdown-satteri`.

## Testing

Added a regression test through the real processor with raw HTML both enabled and disabled. The enabled case fails before this fix; all 22 package tests pass afterward. Package build, TypeScript project build, scoped Biome checks, changeset formatting, and `git diff --check` pass.

## Docs

No documentation change needed; this restores the existing fenced-code behavior without changing configuration or APIs.
