### PR TITLE
Add incremental-build cache reasons, build summaries, and dependency diagnostics

### DIFF
--- a/.changeset/tricky-lions-clap.md
+++ b/.changeset/tricky-lions-clap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds incremental-build cache hit/miss reasons, build summaries, and dependency-change diagnostics.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -666,10 +666,16 @@ async function generatePathWithPrerenderer(
 	const dependencyHash = internals.pageDependencyHashes?.get(route.component) ?? '';
 	const hasServerIsland = internals.serverIslandPageComponents?.has(route.component) ?? false;
 
+	// Only dynamic routes take part in the incremental cache: static pages have
+	// no cacheKey (they always render) and are never reported in the per-path
+	// lines, the summary, or the table.
+	const isDynamicRoute = route.pathname === undefined;
+
 	// Incremental build: decide whether this path can be reused, and why not.
-	const decision = cache
-		? cache.checkPath(route.component, pathname, dependencyHash, cacheKey, hasServerIsland)
-		: null;
+	const decision =
+		cache && isDynamicRoute
+			? cache.checkPath(route.component, pathname, dependencyHash, cacheKey, hasServerIsland)
+			: null;
 	let missReasons: IncrementalPathMissReason[] =
 		decision && !decision.reusable ? decision.reasons : [];
 
@@ -778,17 +784,21 @@ async function generatePathWithPrerenderer(
 		// otherwise be kept (the path is still keyed) and restored on a later skip,
 		// resurrecting output the path no longer emits. Leaving it unrecorded makes
 		// `findOrphanedFiles` prune that copy and forces a re-render next build.
-		reporter?.push({
-			route: route.component,
-			pathname,
-			outputFile: relativeOutFile,
-			result: 'rendered',
-			reasons: missReasons,
-			elapsedMs: performance.now() - timeStart,
-			stored: false,
-			storageNote: 'no-output',
-		});
-		logRenderTime(logger, timeStart, true, missReasons);
+		if (isDynamicRoute) {
+			reporter?.push({
+				route: route.component,
+				pathname,
+				outputFile: relativeOutFile,
+				result: 'rendered',
+				reasons: missReasons,
+				elapsedMs: performance.now() - timeStart,
+				stored: false,
+				storageNote: 'no-output',
+			});
+			logRenderTime(logger, timeStart, true, missReasons);
+		} else {
+			logRenderTime(logger, timeStart, true);
+		}
 		return;
 	}
 
@@ -809,24 +819,28 @@ async function generatePathWithPrerenderer(
 			staticImages,
 			headers,
 		);
-	} else if (cacheKey === undefined) {
+	} else if (cacheKey === undefined && isDynamicRoute) {
 		storageNote = 'no-cache-key';
-	} else if (result.metadata === undefined) {
+	} else if (isDynamicRoute && result.metadata === undefined) {
 		storageNote = 'metadata-unavailable';
 	}
 
-	reporter?.push({
-		route: route.component,
-		pathname,
-		outputFile: relativeOutFile,
-		result: 'rendered',
-		reasons: missReasons,
-		elapsedMs: performance.now() - timeStart,
-		stored: cacheKey !== undefined && result.metadata !== undefined,
-		storageNote,
-	});
-
-	logRenderTime(logger, timeStart, false, missReasons, storageNote);
+	if (isDynamicRoute) {
+		reporter?.push({
+			route: route.component,
+			pathname,
+			outputFile: relativeOutFile,
+			result: 'rendered',
+			reasons: missReasons,
+			elapsedMs: performance.now() - timeStart,
+			stored: cacheKey !== undefined && result.metadata !== undefined,
+			storageNote,
+		});
+		logRenderTime(logger, timeStart, false, missReasons, storageNote);
+	} else {
+		// Static pages render every build; they get a plain duration, no suffix.
+		logRenderTime(logger, timeStart, false);
+	}
 }
 
 function logRenderTime(

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -136,7 +136,6 @@ export async function generatePages(
 			options.force,
 		);
 		reporter = new IncrementalBuildReporter();
-		// Report global cache state before any path decisions are made.
 		logCacheLoadResult(cache.loadResult, logger);
 	}
 
@@ -297,7 +296,7 @@ export async function generatePages(
 				logger.info('build', `Pruned ${pruned} stale file(s) from the incremental cache.`);
 			}
 			cache.writeManifest(options.settings);
-			// Diagnostics are optional provenance; never fail the build over them.
+			// Diagnostics are best-effort; never fail the build over them.
 			try {
 				cache.writeDiagnostics(options.settings);
 			} catch (err) {
@@ -667,8 +666,7 @@ async function generatePathWithPrerenderer(
 	const hasServerIsland = internals.serverIslandPageComponents?.has(route.component) ?? false;
 
 	// Only dynamic routes take part in the incremental cache: static pages have
-	// no cacheKey (they always render) and are never reported in the per-path
-	// lines, the summary, or the table.
+	// no cacheKey (they always render) and are never reported.
 	const isDynamicRoute = route.pathname === undefined;
 
 	// Incremental build: decide whether this path can be reused, and why not.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -38,7 +38,17 @@ import { routeIsRedirect } from '../routing/helpers.js';
 import { getOutputFilename } from '../output-filename.js';
 import { getOutFile, getOutFolder } from './common.js';
 import { createDefaultPrerenderer, type DefaultPrerenderer } from './default-prerenderer.js';
-import { IncrementalBuildCache } from './incremental.js';
+import {
+	createEmptyDiagnosticGraph,
+	IncrementalBuildCache,
+	type IncrementalDiagnosticsFile,
+	type IncrementalPathMissReason,
+} from './incremental.js';
+import {
+	formatMissSuffix,
+	IncrementalBuildReporter,
+	logCacheLoadResult,
+} from './incremental-logging.js';
 import { computeConfigHash } from './config-hash/index.js';
 import { computeLockfileHash } from './lockfile/index.js';
 import { type BuildInternals, hasPrerenderedPages } from './internal.js';
@@ -101,20 +111,33 @@ export async function generatePages(
 
 	// Incremental build support
 	let cache: IncrementalBuildCache | null = null;
+	let reporter: IncrementalBuildReporter | null = null;
 	if (options.settings.config.experimental.incrementalBuild) {
 		const [configHash, lockfileHash, keyDigest] = await Promise.all([
 			computeConfigHash(options.settings.config),
 			computeLockfileHash(fileURLToPath(options.settings.config.root)),
 			options.key.then(hashCryptoKey),
 		]);
+		const diagnostics: IncrementalDiagnosticsFile | null =
+			internals.incrementalDiagnosticsPrerender || internals.incrementalDiagnosticsClient
+				? {
+						version: 1,
+						prerender: internals.incrementalDiagnosticsPrerender ?? createEmptyDiagnosticGraph(),
+						client: internals.incrementalDiagnosticsClient ?? createEmptyDiagnosticGraph(),
+					}
+				: null;
 		cache = IncrementalBuildCache.load(
 			options.settings,
 			configHash,
 			lockfileHash,
 			keyDigest,
 			internals.contentEntryRenderHashes ?? new Map(),
+			diagnostics,
 			options.force,
 		);
+		reporter = new IncrementalBuildReporter();
+		// Report global cache state before any path decisions are made.
+		logCacheLoadResult(cache.loadResult, logger);
 	}
 
 	try {
@@ -203,6 +226,7 @@ export async function generatePages(
 									logger,
 									cache,
 									cacheKey,
+									reporter,
 								),
 							),
 						);
@@ -222,6 +246,7 @@ export async function generatePages(
 						logger,
 						cache,
 						cacheKey,
+						reporter,
 					);
 				}
 			}
@@ -272,6 +297,16 @@ export async function generatePages(
 				logger.info('build', `Pruned ${pruned} stale file(s) from the incremental cache.`);
 			}
 			cache.writeManifest(options.settings);
+			// Diagnostics are optional provenance; never fail the build over them.
+			try {
+				cache.writeDiagnostics(options.settings);
+			} catch (err) {
+				logger.warn(
+					'cache',
+					`Incremental cache dependency diagnostics could not be saved; cache reuse is unaffected. (${err})`,
+				);
+			}
+			reporter?.printSummary(logger);
 		}
 
 		// Must happen before teardown since collectStaticImages fetches from the prerender server
@@ -613,6 +648,7 @@ async function generatePathWithPrerenderer(
 	logger: AstroLogger,
 	cache: IncrementalBuildCache | null,
 	cacheKey: string | undefined,
+	reporter: IncrementalBuildReporter | null,
 ): Promise<void> {
 	const timeStart = performance.now();
 	const { config } = options.settings;
@@ -630,26 +666,29 @@ async function generatePathWithPrerenderer(
 	const dependencyHash = internals.pageDependencyHashes?.get(route.component) ?? '';
 	const hasServerIsland = internals.serverIslandPageComponents?.has(route.component) ?? false;
 
-	// Incremental build: check if we can skip this path
-	if (
-		cacheKey !== undefined &&
-		cache?.canSkip(route.component, pathname, dependencyHash, cacheKey, hasServerIsland)
-	) {
+	// Incremental build: decide whether this path can be reused, and why not.
+	const decision = cache
+		? cache.checkPath(route.component, pathname, dependencyHash, cacheKey, hasServerIsland)
+		: null;
+	let missReasons: IncrementalPathMissReason[] =
+		decision && !decision.reusable ? decision.reasons : [];
+
+	if (decision?.reusable) {
 		const existsInDist = nodeFs.existsSync(outFile);
 		const restored =
-			!existsInDist && (await cache.restoreOutputFile(options.settings, relativeOutFile, outFile));
+			!existsInDist && (await cache!.restoreOutputFile(options.settings, relativeOutFile, outFile));
 
 		if (existsInDist || restored) {
 			// The page is not rendered, so its optimized-image transforms are never
 			// re-registered. Replay them into the global list so the asset pipeline
 			// still emits the images its restored HTML references.
-			const restoredImages = cache.previousStaticImages(route.component, pathname);
+			const restoredImages = cache!.previousStaticImages(route.component, pathname);
 			if (restoredImages) restoreStaticImages(restoredImages);
 
 			// Likewise, the route contributes no response headers when it is not
 			// rendered. Replay them so a `staticHeaders` adapter still writes this
 			// route into its headers file.
-			const restoredHeaders = cache.previousHeaders(route.component, pathname);
+			const restoredHeaders = cache!.previousHeaders(route.component, pathname);
 			if (restoredHeaders && options.settings.adapter?.adapterFeatures?.staticHeaders) {
 				routeToHeaders.set(pathname, {
 					headers: new Headers(restoredHeaders),
@@ -660,13 +699,13 @@ async function generatePathWithPrerenderer(
 			// Record in the new cache so orphan detection knows this path is still alive,
 			// carrying forward the content entries, image transforms, and headers the
 			// path resolved last build.
-			cache.record(
+			cache!.record(
 				route.component,
 				dependencyHash,
 				pathname,
-				cacheKey,
+				cacheKey!,
 				relativeOutFile,
-				cache.previousContentEntryKeys(route.component, pathname),
+				cache!.previousContentEntryKeys(route.component, pathname),
 				restoredImages,
 				restoredHeaders,
 			);
@@ -683,6 +722,16 @@ async function generatePathWithPrerenderer(
 				route.distURL = [outFile];
 			}
 
+			reporter?.push({
+				route: route.component,
+				pathname,
+				outputFile: relativeOutFile,
+				result: restored ? 'restored' : 'cached',
+				reasons: [],
+				elapsedMs: performance.now() - timeStart,
+				stored: true,
+			});
+
 			logger.info(null, `  ${colors.green('├─')} ${colors.dim(filePath)}`, false);
 			logger.info(
 				'SKIP_FORMAT',
@@ -690,6 +739,10 @@ async function generatePathWithPrerenderer(
 			);
 			return;
 		}
+
+		// The metadata said the path is reusable, but neither the current output
+		// nor the persistent cached copy exists, so it must be rendered anyway.
+		missReasons = [{ type: 'cached-output-missing' }];
 	}
 
 	logger.info(null, `  ${colors.blue('├─')} ${colors.dim(filePath)}`, false);
@@ -725,7 +778,17 @@ async function generatePathWithPrerenderer(
 		// otherwise be kept (the path is still keyed) and restored on a later skip,
 		// resurrecting output the path no longer emits. Leaving it unrecorded makes
 		// `findOrphanedFiles` prune that copy and forces a re-render next build.
-		logRenderTime(logger, timeStart, true);
+		reporter?.push({
+			route: route.component,
+			pathname,
+			outputFile: relativeOutFile,
+			result: 'rendered',
+			reasons: missReasons,
+			elapsedMs: performance.now() - timeStart,
+			stored: false,
+			storageNote: 'no-output',
+		});
+		logRenderTime(logger, timeStart, true, missReasons);
 		return;
 	}
 
@@ -733,6 +796,7 @@ async function generatePathWithPrerenderer(
 	await nodeFs.promises.writeFile(result.outFile, result.body);
 
 	// Without a cache key or render metadata, the path cannot be skipped safely.
+	let storageNote: 'no-cache-key' | 'metadata-unavailable' | undefined;
 	if (cache && cacheKey !== undefined && result.metadata !== undefined) {
 		await cache.writeOutputFile(options.settings, relativeOutFile, result.body);
 		cache.record(
@@ -745,19 +809,46 @@ async function generatePathWithPrerenderer(
 			staticImages,
 			headers,
 		);
+	} else if (cacheKey === undefined) {
+		storageNote = 'no-cache-key';
+	} else if (result.metadata === undefined) {
+		storageNote = 'metadata-unavailable';
 	}
 
-	logRenderTime(logger, timeStart, false);
+	reporter?.push({
+		route: route.component,
+		pathname,
+		outputFile: relativeOutFile,
+		result: 'rendered',
+		reasons: missReasons,
+		elapsedMs: performance.now() - timeStart,
+		stored: cacheKey !== undefined && result.metadata !== undefined,
+		storageNote,
+	});
+
+	logRenderTime(logger, timeStart, false, missReasons, storageNote);
 }
 
-function logRenderTime(logger: AstroLogger, timeStart: number, notCreated: boolean) {
+function logRenderTime(
+	logger: AstroLogger,
+	timeStart: number,
+	notCreated: boolean,
+	reasons: IncrementalPathMissReason[] = [],
+	storageNote?: 'no-cache-key' | 'metadata-unavailable' | 'no-output',
+) {
 	const timeEnd = performance.now();
 	const isSlow = timeEnd - timeStart > THRESHOLD_SLOW_RENDER_TIME_MS;
 	const timeIncrease = (isSlow ? colors.red : colors.dim)(`(+${getTimeStat(timeStart, timeEnd)})`);
-	const notCreatedMsg = notCreated
-		? colors.yellow('(file not created, response body was empty)')
-		: '';
-	logger.info('SKIP_FORMAT', ` ${timeIncrease} ${notCreatedMsg}`);
+	const parts = [timeIncrease];
+	const missSuffix = formatMissSuffix(reasons);
+	if (missSuffix) parts.push(missSuffix);
+	if (storageNote === 'metadata-unavailable') {
+		parts.push('(not stored: prerender metadata unavailable)');
+	}
+	if (notCreated) {
+		parts.push(colors.yellow('(file not created, response body was empty)'));
+	}
+	logger.info('SKIP_FORMAT', ` ${parts.join(' ')}`);
 }
 
 function addPageName(pathname: string, opts: StaticBuildOptions): void {

--- a/packages/astro/src/core/build/incremental-logging.ts
+++ b/packages/astro/src/core/build/incremental-logging.ts
@@ -33,7 +33,7 @@ function formatReasonToken(reason: IncrementalPathMissReason): string {
 		case 'no-cache-key':
 			return 'no cacheKey';
 		case 'global-cache':
-			return reason.reasons.map((reason) => GLOBAL_REASON_TOKENS[reason]).join('; ');
+			return reason.reasons.map((loadReason) => GLOBAL_REASON_TOKENS[loadReason]).join('; ');
 		case 'new-route':
 			return 'new route';
 		case 'new-path':
@@ -417,7 +417,7 @@ function compactReasonToken(reason: IncrementalPathMissReason): string {
 		case 'no-cache-key':
 			return 'no cacheKey';
 		case 'global-cache':
-			return reason.reasons.map((reason) => GLOBAL_REASON_TOKENS[reason]).join('; ');
+			return reason.reasons.map((loadReason) => GLOBAL_REASON_TOKENS[loadReason]).join('; ');
 		case 'new-route':
 			return 'new route';
 		case 'new-path':

--- a/packages/astro/src/core/build/incremental-logging.ts
+++ b/packages/astro/src/core/build/incremental-logging.ts
@@ -1,0 +1,443 @@
+import type { AstroLogger } from '../logger/core.js';
+import {
+	INCREMENTAL_CACHE_VERSION,
+	type DependencyChange,
+	type IncrementalCacheLoadReason,
+	type IncrementalCacheLoadResult,
+	type IncrementalPathMissReason,
+} from './incremental.js';
+import { getTimeStat } from './util.js';
+
+/**
+ * The outcome of one path during generation, fed to the reporter as paths
+ * complete so the post-build summary reflects exactly what happened.
+ */
+export interface IncrementalPathOutcome {
+	route: string;
+	pathname: string;
+	outputFile: string;
+	result: 'cached' | 'restored' | 'rendered';
+	reasons: IncrementalPathMissReason[];
+	elapsedMs: number;
+	stored: boolean;
+	storageNote?: 'no-cache-key' | 'metadata-unavailable' | 'no-output';
+}
+
+/**
+ * Format a miss reason as the text after `cache miss:` / `not cacheable:` on a
+ * path line. Content entries are reported as paths (never raw keys), and a
+ * single changed content entry names the entry while several are counted.
+ */
+function formatReasonToken(reason: IncrementalPathMissReason): string {
+	switch (reason.type) {
+		case 'no-cache-key':
+			return 'no cacheKey';
+		case 'global-cache':
+			return reason.reasons.map((reason) => GLOBAL_REASON_TOKENS[reason]).join('; ');
+		case 'new-route':
+			return 'new route';
+		case 'new-path':
+			return 'new path';
+		case 'island-key-changed':
+			return 'server-island encryption key changed';
+		case 'route-dependencies-changed':
+			return 'module dependencies changed';
+		case 'cache-key-changed':
+			return 'cacheKey changed';
+		case 'content-dependencies-changed':
+			return reason.entries.length === 1
+				? `content dependency changed: ${reason.entries[0]}`
+				: `${reason.entries.length} content dependencies changed`;
+		case 'cached-output-missing':
+			return 'cached output missing';
+	}
+}
+
+const GLOBAL_REASON_TOKENS: Record<IncrementalCacheLoadReason, string> = {
+	loaded: 'cache loaded',
+	forced: 'bypassed by --force',
+	missing: 'cache not found',
+	'invalid-manifest': 'cache unavailable',
+	unreadable: 'cache unavailable',
+	'version-changed': 'cache format changed',
+	'config-changed': 'configuration changed',
+	'lockfile-changed': 'dependency lockfile changed',
+};
+
+/**
+ * The parenthetical appended to a rendered path's info line, e.g.
+ * ` (cache miss: module dependencies changed; cacheKey changed)` or
+ * ` (not cacheable: no cacheKey)`. Raw key values are never included.
+ */
+export function formatMissSuffix(reasons: IncrementalPathMissReason[]): string {
+	if (reasons.length === 0) return '';
+	const tokens = reasons.map(formatReasonToken);
+	const verb = reasons.some((reason) => reason.type === 'no-cache-key')
+		? 'not cacheable'
+		: 'cache miss';
+	return `(${verb}: ${tokens.join('; ')})`;
+}
+
+/**
+ * Report the global cache state once, right after the cache is loaded and
+ * before any path decisions are made. Correctness-preserving states (missing
+ * cache, hash mismatches) are info; unusable manifests and unreadable files
+ * are warnings. The manifest path is only mentioned in its cacheDir-relative
+ * form under verbose logging.
+ */
+export function logCacheLoadResult(
+	loadResult: IncrementalCacheLoadResult,
+	logger: AstroLogger,
+): void {
+	for (const reason of loadResult.reasons) {
+		switch (reason) {
+			case 'forced':
+				logger.info('cache', 'Incremental cache bypassed by --force; performing a full build.');
+				break;
+			case 'missing':
+				logger.info('cache', 'Incremental cache not found; performing a full build.');
+				break;
+			case 'invalid-manifest':
+				logger.warn('cache', 'Incremental cache manifest is invalid; performing a full build.');
+				break;
+			case 'unreadable':
+				logger.warn(
+					'cache',
+					`Incremental cache could not be read; performing a full build.${
+						loadResult.errorCode ? ` (${loadResult.errorCode})` : ''
+					}`,
+				);
+				break;
+			case 'version-changed':
+				logger.info(
+					'cache',
+					`Incremental cache invalidated: cache format changed (version ${loadResult.previousVersion} → ${INCREMENTAL_CACHE_VERSION}).`,
+				);
+				break;
+			case 'config-changed':
+				logger.info('cache', 'Incremental cache invalidated: Astro configuration changed.');
+				break;
+			case 'lockfile-changed':
+				logger.info('cache', 'Incremental cache invalidated: dependency lockfile changed.');
+				break;
+			case 'loaded':
+				if (logger.level() === 'debug') {
+					logger.info('cache', 'Incremental cache loaded from incremental-build.json.');
+				}
+				break;
+		}
+	}
+	if (loadResult.islandKeyChanged) {
+		logger.info(
+			'cache',
+			'Incremental cache: server-island encryption key changed; affected pages will be rendered.',
+		);
+	}
+}
+
+const TABLE_ROUTE_HEADER = 'Route';
+const TABLE_RESULT_HEADER = 'Result';
+const TABLE_REASON_HEADER = 'Reason';
+const TABLE_PATHS_HEADER = 'Paths';
+const TABLE_TIME_HEADER = 'Time';
+
+interface GroupedRow {
+	route: string;
+	result: string;
+	reason: string;
+	paths: number;
+	elapsedMs: number;
+}
+
+const RESULT_ORDER = { cached: 0, restored: 1, rendered: 2 } as const;
+
+function formatTime(elapsedMs: number): string {
+	if (elapsedMs < 1) return '<1ms';
+	return getTimeStat(0, elapsedMs);
+}
+
+/**
+ * Collects per-path outcomes during generation and prints the post-build
+ * incremental summary: a one-line reuse count, a grouped route table (or
+ * compact reason totals when the table would be too large), dependency-change
+ * trees, and a warning when keyed renders produced no incremental metadata.
+ */
+export class IncrementalBuildReporter {
+	readonly #outcomes: IncrementalPathOutcome[] = [];
+
+	/** Record a completed path. Synchronous by design: JavaScript mutation is
+	 * not interrupted mid-call, so concurrent path generation cannot interleave. */
+	push(outcome: IncrementalPathOutcome): void {
+		this.#outcomes.push(outcome);
+	}
+
+	printSummary(logger: AstroLogger): void {
+		if (this.#outcomes.length === 0) return;
+		const verbose = logger.level() === 'debug';
+
+		const cached = this.#outcomes.filter((outcome) => outcome.result === 'cached').length;
+		const restored = this.#outcomes.filter((outcome) => outcome.result === 'restored').length;
+		const rendered = this.#outcomes.length - cached - restored;
+		const notStored = this.#outcomes.filter(
+			(outcome) => outcome.result === 'rendered' && !outcome.stored,
+		).length;
+
+		let summary = ` incremental build: ${this.#outcomes.length} paths — ${cached} cached, ${restored} restored, ${rendered} rendered`;
+		if (notStored > 0) summary += ` (${notStored} not stored)`;
+		logger.info('SKIP_FORMAT', summary);
+
+		const grouped = this.#groupRows();
+		if (verbose) {
+			this.#printPathTable(logger, this.#outcomes);
+		} else if (grouped.length <= MAX_GROUPED_ROWS) {
+			this.#printGroupedTable(logger, grouped);
+		} else {
+			this.#printCompactTotals(logger, grouped);
+		}
+
+		this.#printDependencyTrees(logger, verbose);
+
+		const missingMetadata = this.#outcomes.filter(
+			(outcome) => outcome.storageNote === 'metadata-unavailable',
+		).length;
+		if (missingMetadata > 0) {
+			logger.warn(
+				'cache',
+				`Incremental cache could not record ${missingMetadata} rendered path${
+					missingMetadata === 1 ? '' : 's'
+				} because the prerenderer did not return incremental metadata; those paths will render again on the next build.`,
+			);
+		}
+	}
+
+	/** Group outcomes by route, result, and exact reason text, sorted
+	 * deterministically so concurrent completion order never changes the table. */
+	#groupRows(): GroupedRow[] {
+		const groups = new Map<string, GroupedRow>();
+		for (const outcome of this.#outcomes) {
+			const reason =
+				outcome.reasons.length === 0
+					? 'cache hit'
+					: outcome.reasons.map(formatReasonToken).join('; ');
+			const key = `${outcome.route}\u0000${outcome.result}\u0000${reason}`;
+			let row = groups.get(key);
+			if (!row) {
+				row = { route: outcome.route, result: outcome.result, reason, paths: 0, elapsedMs: 0 };
+				groups.set(key, row);
+			}
+			row.paths++;
+			row.elapsedMs += outcome.elapsedMs;
+		}
+		return [...groups.values()].sort((a, b) => {
+			if (a.route !== b.route) return a.route < b.route ? -1 : 1;
+			if (
+				RESULT_ORDER[a.result as keyof typeof RESULT_ORDER] !==
+				RESULT_ORDER[b.result as keyof typeof RESULT_ORDER]
+			) {
+				return RESULT_ORDER[a.result as keyof typeof RESULT_ORDER] <
+					RESULT_ORDER[b.result as keyof typeof RESULT_ORDER]
+					? -1
+					: 1;
+			}
+			return a.reason < b.reason ? -1 : a.reason > b.reason ? 1 : 0;
+		});
+	}
+
+	/** The info-level route table, printed when it has few enough rows. */
+	#printGroupedTable(logger: AstroLogger, rows: GroupedRow[]): void {
+		const routeWidth =
+			Math.max(TABLE_ROUTE_HEADER.length, ...rows.map((row) => row.route.length)) + 10;
+		const resultWidth =
+			Math.max(TABLE_RESULT_HEADER.length, ...rows.map((row) => row.result.length)) + 2;
+		const reasonWidth =
+			Math.max(TABLE_REASON_HEADER.length, ...rows.map((row) => row.reason.length)) + 2;
+		const pathsWidth = Math.max(
+			TABLE_PATHS_HEADER.length,
+			...rows.map((row) => String(row.paths).length),
+		);
+
+		const lines = [
+			` ${TABLE_ROUTE_HEADER.padEnd(routeWidth)}${TABLE_RESULT_HEADER.padEnd(resultWidth)}${TABLE_REASON_HEADER.padEnd(reasonWidth)}${TABLE_PATHS_HEADER.padStart(pathsWidth)}  ${TABLE_TIME_HEADER}`,
+			...rows.map(
+				(row) =>
+					` ${row.route.padEnd(routeWidth)}${row.result.padEnd(resultWidth)}${row.reason.padEnd(reasonWidth)}${String(row.paths).padStart(pathsWidth)}  ${formatTime(row.elapsedMs)}`,
+			),
+		];
+		logger.info('SKIP_FORMAT', `\n${lines.join('\n')}`);
+	}
+
+	/** Compact reason totals instead of the route table when it is too large. */
+	#printCompactTotals(logger: AstroLogger, rows: GroupedRow[]): void {
+		const counts = new Map<string, number>();
+		for (const outcome of this.#outcomes) {
+			for (const reason of outcome.reasons) {
+				const token = compactReasonToken(reason);
+				counts.set(token, (counts.get(token) ?? 0) + 1);
+			}
+		}
+		const totals = [...counts.entries()].sort(
+			(a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0),
+		);
+		logger.info(
+			'SKIP_FORMAT',
+			`\n reasons: ${totals.map(([token, count]) => `${token} ${count}`).join('; ')}\n route table omitted (${rows.length} rows); rerun with --verbose to show all`,
+		);
+	}
+
+	/** The verbose one-row-per-path table. */
+	#printPathTable(logger: AstroLogger, outcomes: IncrementalPathOutcome[]): void {
+		const rows = [...outcomes].sort((a, b) => {
+			const routeCompare = a.route < b.route ? -1 : a.route > b.route ? 1 : 0;
+			if (routeCompare !== 0) return routeCompare;
+			const pathCompare = a.pathname < b.pathname ? -1 : a.pathname > b.pathname ? 1 : 0;
+			if (pathCompare !== 0) return pathCompare;
+			return RESULT_ORDER[a.result] - RESULT_ORDER[b.result];
+		});
+		const routeWidth =
+			Math.max('Route / path'.length, ...rows.map((row) => `${row.route} ${row.pathname}`.length)) +
+			10;
+		const resultWidth =
+			Math.max(TABLE_RESULT_HEADER.length, ...rows.map((row) => row.result.length)) + 2;
+		const reasonWidth =
+			Math.max(
+				TABLE_REASON_HEADER.length,
+				...rows.map(
+					(row) =>
+						(row.reasons.length === 0 ? 'cache hit' : row.reasons.map(formatReasonToken).join('; '))
+							.length,
+				),
+			) + 2;
+
+		const lines = [
+			` ${'Route / path'.padEnd(routeWidth)}${TABLE_RESULT_HEADER.padEnd(resultWidth)}${TABLE_REASON_HEADER.padEnd(reasonWidth)}${TABLE_TIME_HEADER}`,
+			...rows.map((row) => {
+				const reason =
+					row.reasons.length === 0 ? 'cache hit' : row.reasons.map(formatReasonToken).join('; ');
+				return ` ${`${row.route} ${row.pathname}`.padEnd(routeWidth)}${row.result.padEnd(resultWidth)}${reason.padEnd(reasonWidth)}${formatTime(row.elapsedMs)}`;
+			}),
+		];
+		logger.info('SKIP_FORMAT', `\n${lines.join('\n')}`);
+	}
+
+	/** Dependency-change trees, capped at info level and complete under verbose. */
+	#printDependencyTrees(logger: AstroLogger, verbose: boolean): void {
+		interface Tree {
+			route: string;
+			/** Display chains; each starts with a boundary node for content/client changes. */
+			chains: DependencyChange[];
+			unavailable: 'missing-sidecar' | 'unavailable' | null;
+		}
+		const byRoute = new Map<string, Tree>();
+		for (const outcome of this.#outcomes) {
+			for (const reason of outcome.reasons) {
+				if (reason.type === 'route-dependencies-changed') {
+					let tree = byRoute.get(outcome.route);
+					if (!tree) {
+						tree = { route: outcome.route, chains: [], unavailable: null };
+						byRoute.set(outcome.route, tree);
+					}
+					if (reason.changes) tree.chains.push(...reason.changes);
+					tree.unavailable ??= reason.diagnosticsUnavailable ?? null;
+				} else if (reason.type === 'content-dependencies-changed') {
+					let tree = byRoute.get(outcome.route);
+					if (!tree) {
+						tree = { route: outcome.route, chains: [], unavailable: null };
+						byRoute.set(outcome.route, tree);
+					}
+					for (const entryPath of reason.entries) {
+						const entryChains = reason.changes?.[entryPath];
+						if (entryChains && entryChains.length > 0) {
+							tree.chains.push(...entryChains);
+						} else {
+							tree.unavailable ??= reason.diagnosticsUnavailable ?? 'unavailable';
+						}
+					}
+				}
+			}
+		}
+		if (byRoute.size === 0) return;
+
+		const trees = [...byRoute.values()].sort((a, b) =>
+			a.route < b.route ? -1 : a.route > b.route ? 1 : 0,
+		);
+		for (const tree of trees) {
+			tree.chains.sort((a, b) =>
+				a.chain[a.chain.length - 1] < b.chain[b.chain.length - 1]
+					? -1
+					: a.chain[a.chain.length - 1] > b.chain[b.chain.length - 1]
+						? 1
+						: a.chain.join('\u0000') < b.chain.join('\u0000')
+							? -1
+							: 1,
+			);
+		}
+
+		const totalChains = trees.reduce((sum, tree) => sum + tree.chains.length, 0);
+		let printedChains = 0;
+		const lines: string[] = [' dependencies changed'];
+		for (let routeIndex = 0; routeIndex < trees.length; routeIndex++) {
+			const tree = trees[routeIndex];
+			if (!verbose && routeIndex >= MAX_TREE_ROUTES) break;
+			let shown = verbose
+				? tree.chains.length
+				: Math.min(tree.chains.length, MAX_TREE_CHAINS_PER_ROUTE);
+			if (!verbose && printedChains + shown > MAX_TREE_CHAINS) {
+				shown = Math.max(0, MAX_TREE_CHAINS - printedChains);
+			}
+			const showsUnavailable = tree.unavailable !== null && (verbose || shown === 0);
+			if (shown === 0 && !showsUnavailable) continue;
+			lines.push(`  ${tree.route}`);
+			for (let i = 0; i < shown; i++) {
+				const change = tree.chains[i];
+				printedChains++;
+				for (let depth = 0; depth < change.chain.length; depth++) {
+					const status = depth === change.chain.length - 1 ? ` (${change.status})` : '';
+					lines.push(`${' '.repeat(2 + 3 * depth)}└─ ${change.chain[depth]}${status}`);
+				}
+			}
+			if (showsUnavailable) {
+				lines.push(
+					`  └─ dependency details unavailable${
+						tree.unavailable === 'missing-sidecar' ? ' (rerun once to seed diagnostics)' : ''
+					}`,
+				);
+			}
+		}
+		const droppedChains = totalChains - printedChains;
+		if (droppedChains > 0) {
+			lines.push(`… ${droppedChains} more dependency change(s); rerun with --verbose to show all`);
+		}
+		logger.info('SKIP_FORMAT', `\n${lines.join('\n')}`);
+	}
+}
+
+/** Aggregate counts use reason-type-level tokens without per-entry paths. */
+function compactReasonToken(reason: IncrementalPathMissReason): string {
+	switch (reason.type) {
+		case 'no-cache-key':
+			return 'no cacheKey';
+		case 'global-cache':
+			return reason.reasons.map((reason) => GLOBAL_REASON_TOKENS[reason]).join('; ');
+		case 'new-route':
+			return 'new route';
+		case 'new-path':
+			return 'new path';
+		case 'island-key-changed':
+			return 'server-island encryption key changed';
+		case 'route-dependencies-changed':
+			return 'module dependencies changed';
+		case 'cache-key-changed':
+			return 'cacheKey changed';
+		case 'content-dependencies-changed':
+			return reason.entries.length === 1
+				? 'content dependency changed'
+				: 'content dependencies changed';
+		case 'cached-output-missing':
+			return 'cached output missing';
+	}
+}
+
+const MAX_GROUPED_ROWS = 20;
+const MAX_TREE_ROUTES = 5;
+const MAX_TREE_CHAINS_PER_ROUTE = 3;
+const MAX_TREE_CHAINS = 15;

--- a/packages/astro/src/core/build/incremental-logging.ts
+++ b/packages/astro/src/core/build/incremental-logging.ts
@@ -9,8 +9,8 @@ import {
 import { getTimeStat } from './util.js';
 
 /**
- * The outcome of one path during generation, fed to the reporter as paths
- * complete so the post-build summary reflects exactly what happened.
+ * One path's outcome during generation, collected so the post-build summary
+ * reflects exactly what happened.
  */
 export interface IncrementalPathOutcome {
 	route: string;
@@ -158,15 +158,15 @@ function formatTime(elapsedMs: number): string {
 
 /**
  * Collects per-path outcomes during generation and prints the post-build
- * incremental summary: a one-line reuse count, a grouped route table (or
- * compact reason totals when the table would be too large), dependency-change
- * trees, and a warning when keyed renders produced no incremental metadata.
+ * summary: reuse counts, a grouped route table (compact reason totals when the
+ * table would be too large), dependency-change trees, and a warning when keyed
+ * renders produced no incremental metadata.
  */
 export class IncrementalBuildReporter {
 	readonly #outcomes: IncrementalPathOutcome[] = [];
 
-	/** Record a completed path. Synchronous by design: JavaScript mutation is
-	 * not interrupted mid-call, so concurrent path generation cannot interleave. */
+	/** Record a completed path. Pushing synchronously keeps concurrent path
+	 * generation from interleaving the summary. */
 	push(outcome: IncrementalPathOutcome): void {
 		this.#outcomes.push(outcome);
 	}
@@ -325,7 +325,7 @@ export class IncrementalBuildReporter {
 			route: string;
 			/** Display chains; each starts with a boundary node for content/client changes. */
 			chains: DependencyChange[];
-			unavailable: 'missing-sidecar' | 'unavailable' | null;
+			unavailable: 'missing-diagnostics' | 'unavailable' | null;
 		}
 		const byRoute = new Map<string, Tree>();
 		for (const outcome of this.#outcomes) {
@@ -398,7 +398,7 @@ export class IncrementalBuildReporter {
 			if (showsUnavailable) {
 				lines.push(
 					`  └─ dependency details unavailable${
-						tree.unavailable === 'missing-sidecar' ? ' (rerun once to seed diagnostics)' : ''
+						tree.unavailable === 'missing-diagnostics' ? ' (rerun once to seed diagnostics)' : ''
 					}`,
 				);
 			}

--- a/packages/astro/src/core/build/incremental.ts
+++ b/packages/astro/src/core/build/incremental.ts
@@ -110,7 +110,7 @@ export interface IncrementalCacheLoadResult {
 /**
  * A per-module fingerprint plus its direct import edges, captured during the
  * build so a later build can explain which modules changed. Stored in the
- * diagnostics sidecar, never in the correctness-critical manifest.
+ * diagnostics file, not the manifest, so it can never affect reuse decisions.
  */
 export interface DiagnosticModule {
 	/** Hash of the module's own normalized representation plus sorted direct import ids. */
@@ -123,9 +123,8 @@ export interface DiagnosticModule {
  * The diagnostic snapshot of one build environment's module graph: per-module
  * fingerprints and edges, the roots each prerendered route and content entry
  * are seeded from, and the aggregate route hashes. The aggregate hashes are
- * duplicated from the manifest so a sidecar that does not correspond to the
- * previous manifest (e.g. after an interrupted write) can be detected and
- * ignored without affecting reuse decisions.
+ * duplicated from the manifest so a diagnostics file left by an interrupted
+ * write is detected by a hash mismatch and ignored.
  */
 export interface DiagnosticGraph {
 	modules: Record<string, DiagnosticModule>;
@@ -135,9 +134,9 @@ export interface DiagnosticGraph {
 }
 
 /**
- * On-disk shape of the incremental build diagnostics sidecar. It is
- * independently versioned and optional: a missing or mismatched sidecar only
- * suppresses detailed dependency explanations, never invalidates cached HTML.
+ * On-disk shape of the diagnostics file. Versioned separately from the cache
+ * manifest and optional: a missing or outdated file only suppresses detailed
+ * dependency explanations, never invalidates cached HTML.
  */
 export interface IncrementalDiagnosticsFile {
 	version: 1;
@@ -165,10 +164,9 @@ export interface DependencyChange {
 }
 
 /**
- * Why a single path cannot be reused from the previous build. Each reason is
- * independently testable; `checkPath` reports every applicable reason in a
- * stable order so a miss like "module dependencies changed; cacheKey changed"
- * is truthful.
+ * Why a single path cannot be reused from the previous build. `checkPath`
+ * reports every applicable reason, in a stable order, so a miss such as
+ * `module dependencies changed; cacheKey changed` names all of its causes.
  */
 export type IncrementalPathMissReason =
 	| { type: 'no-cache-key' }
@@ -180,14 +178,14 @@ export type IncrementalPathMissReason =
 			type: 'route-dependencies-changed';
 			changes?: DependencyChange[];
 			/** Why no leaf-level explanation is available, when applicable. */
-			diagnosticsUnavailable?: 'missing-sidecar' | 'unavailable';
+			diagnosticsUnavailable?: 'missing-diagnostics' | 'unavailable';
 	  }
 	| { type: 'cache-key-changed' }
 	| {
 			type: 'content-dependencies-changed';
 			entries: string[];
 			changes?: Record<string, DependencyChange[]>;
-			diagnosticsUnavailable?: 'missing-sidecar' | 'unavailable';
+			diagnosticsUnavailable?: 'missing-diagnostics' | 'unavailable';
 	  }
 	| { type: 'cached-output-missing' };
 
@@ -197,11 +195,11 @@ export type IncrementalPathDecision =
 
 type RouteExplanation =
 	| { changes: DependencyChange[] }
-	| { unavailable: 'missing-sidecar' | 'unavailable' };
+	| { unavailable: 'missing-diagnostics' | 'unavailable' };
 
 type EntryExplanation =
 	| { changes: DependencyChange[] }
-	| { unavailable: 'missing-sidecar' | 'unavailable' }
+	| { unavailable: 'missing-diagnostics' | 'unavailable' }
 	| null;
 
 interface GraphDiff {
@@ -400,9 +398,8 @@ function findLeafChains(
 	return chains;
 }
 
-// Bounded so a route whose entire dependency tree changed cannot flood the
-// diagnostics sidecar or the console. Explanations are capped per route; the
-// aggregate reason is still reported for every dropped leaf.
+// Cap explanations per route so a wholesale dependency change cannot flood the
+// console; the aggregate reason still names every dropped leaf.
 const MAX_EXPLAINED_LEAVES = 200;
 
 // Placeholder root used only when a cache was constructed without settings;
@@ -412,10 +409,9 @@ const ROOT_FALLBACK = new URL('file:///');
 /**
  * Tracks which prerendered paths can be reused from a previous build.
  *
- * The invalidation logic (`checkPath`, `record`, `findOrphanedFiles`) is pure
- * and operates on the previous and next manifests held in memory. Disk access
- * is confined to `load` (plus the lazily read diagnostics sidecar) and the
- * output-file methods.
+ * Invalidation is pure over the previous and next manifests held in memory;
+ * disk access is confined to `load` (plus the lazily read diagnostics file)
+ * and the output-file methods.
  */
 export class IncrementalBuildCache {
 	/** Tagged load outcome, used for global invalidation messages. */
@@ -426,7 +422,7 @@ export class IncrementalBuildCache {
 	readonly #createdDirs = new Set<string>();
 	readonly #settings: AstroSettings | undefined;
 	readonly #currentDiagnostics: IncrementalDiagnosticsFile | null;
-	/** Lazy-loaded previous diagnostics sidecar; `undefined` until first read. */
+	/** Previous build's diagnostics file, read lazily; `undefined` until first read. */
 	#previousDiagnostics: IncrementalDiagnosticsFile | null | undefined;
 	#graphDiff: { prerender: GraphDiff; client: GraphDiff } | null = null;
 	#routeChanges = new Map<string, RouteExplanation | null>();
@@ -467,8 +463,8 @@ export class IncrementalBuildCache {
 	 * `contentEntryHashes` is this build's map of content-entry render hashes,
 	 * used to detect when the content a path renders has changed.
 	 *
-	 * `diagnostics` is this build's per-module fingerprint snapshot, written to
-	 * the sidecar so the next build can explain dependency changes.
+	 * `diagnostics` is this build's per-module fingerprint snapshot; the next
+	 * build reads it to explain dependency changes.
 	 *
 	 * `force` ignores any existing manifest so every path is rebuilt, while still
 	 * recording a fresh cache for the next build.
@@ -577,7 +573,7 @@ export class IncrementalBuildCache {
 						{ type: 'content-dependencies-changed' }
 					> = { type: 'content-dependencies-changed', entries: changedEntries };
 					const changes: Record<string, DependencyChange[]> = {};
-					let unavailable: 'missing-sidecar' | 'unavailable' | null = null;
+					let unavailable: 'missing-diagnostics' | 'unavailable' | null = null;
 					for (const entryPath of changedEntries) {
 						const entryExplanation = this.explainContent(entryPath);
 						if (
@@ -688,7 +684,7 @@ export class IncrementalBuildCache {
 	}
 
 	/**
-	 * Write this build's diagnostics sidecar next to the manifest. A failure must
+	 * Write this build's diagnostics file next to the manifest. A failure must
 	 * not fail the build or affect cache reuse; the caller reports it as a warning.
 	 */
 	writeDiagnostics(settings: AstroSettings): void {
@@ -740,11 +736,11 @@ export class IncrementalBuildCache {
 	#explainRoute(routeComponent: string): RouteExplanation | null {
 		const current = this.#currentDiagnostics;
 		const previous = this.#loadPreviousDiagnostics();
-		if (!current || !previous) return { unavailable: 'missing-sidecar' };
+		if (!current || !previous) return { unavailable: 'missing-diagnostics' };
 		const previousRoute = this.#previous?.routes[routeComponent];
 		if (!previousRoute) return null;
-		// A sidecar from a different build (interrupted write) must not be trusted
-		// to explain this route; only the aggregate reason is reported then.
+		// An interrupted write can leave a diagnostics file that does not match
+		// this manifest; only the aggregate reason is reported then.
 		if (previous.prerender.routeDependencyHashes[routeComponent] !== previousRoute.dependencyHash) {
 			return { unavailable: 'unavailable' };
 		}
@@ -839,7 +835,7 @@ export class IncrementalBuildCache {
 	#explainContent(entryPath: string): EntryExplanation {
 		const current = this.#currentDiagnostics;
 		const previous = this.#loadPreviousDiagnostics();
-		if (!current || !previous) return { unavailable: 'missing-sidecar' };
+		if (!current || !previous) return { unavailable: 'missing-diagnostics' };
 		const diffs = this.#loadGraphDiffs(previous);
 		const root = this.#settings?.config.root ?? ROOT_FALLBACK;
 		const currentRoots = current.prerender.contentRoots[entryPath] ?? [];

--- a/packages/astro/src/core/build/incremental.ts
+++ b/packages/astro/src/core/build/incremental.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import type { SerializedStaticImage } from '../../assets/types.js';
 import { rootRelativePath } from '../viteUtils.js';
 import type { AstroSettings } from '../../types/astro.js';
@@ -402,9 +403,10 @@ function findLeafChains(
 // console; the aggregate reason still names every dropped leaf.
 const MAX_EXPLAINED_LEAVES = 200;
 
-// Placeholder root used only when a cache was constructed without settings;
-// production caches always pass the project root.
-const ROOT_FALLBACK = new URL('file:///');
+// Placeholder root used only when a cache is constructed without settings
+// (tests); production caches always pass the project root. `file:///` would be
+// an invalid file URL on Windows, so derive from the working directory instead.
+const ROOT_FALLBACK = pathToFileURL(process.cwd());
 
 /**
  * Tracks which prerendered paths can be reused from a previous build.

--- a/packages/astro/src/core/build/incremental.ts
+++ b/packages/astro/src/core/build/incremental.ts
@@ -1,10 +1,13 @@
 import fs from 'node:fs';
 import type { SerializedStaticImage } from '../../assets/types.js';
+import { rootRelativePath } from '../viteUtils.js';
 import type { AstroSettings } from '../../types/astro.js';
 
 const INCREMENTAL_CACHE_FILE = 'incremental-build.json';
+const INCREMENTAL_DIAGNOSTICS_FILE = 'incremental-build-diagnostics.json';
 const INCREMENTAL_OUTPUT_DIR = 'dist/';
-const CACHE_VERSION = 1;
+export const INCREMENTAL_CACHE_VERSION = 1;
+const DIAGNOSTICS_VERSION = 1;
 
 export interface IncrementalPathEntry {
 	cacheKey: string;
@@ -65,31 +68,238 @@ export interface IncrementalManifest {
 	routes: Record<string, IncrementalRouteEntry>;
 }
 
+/**
+ * Why a previous incremental cache could not be used for this build. `loaded` is
+ * reported only for a valid, usable manifest; every other reason explains why
+ * the previous build's state was discarded or never read.
+ */
+export type IncrementalCacheLoadReason =
+	| 'loaded'
+	| 'forced'
+	| 'missing'
+	| 'invalid-manifest'
+	| 'unreadable'
+	| 'version-changed'
+	| 'config-changed'
+	| 'lockfile-changed';
+
+export interface IncrementalCacheLoadResult {
+	/**
+	 * The previous build's manifest, when it is valid and usable for reuse
+	 * decisions. `null` whenever any load reason other than `loaded` applies.
+	 */
+	previous: IncrementalManifest | null;
+	/**
+	 * All load outcomes that apply. `loaded` is mutually exclusive with the
+	 * other reasons; a parsed manifest may report several of the `*-changed`
+	 * reasons at once (e.g. config and lockfile both changed).
+	 */
+	reasons: IncrementalCacheLoadReason[];
+	/** Parsed manifest version when it differed from the current cache version. */
+	previousVersion?: unknown;
+	/** Stable Node error code (e.g. `EACCES`) when the manifest could not be read. */
+	errorCode?: string;
+	/**
+	 * Whether a valid previous manifest was written with a different
+	 * server-island encryption key digest than this build's. This is not a
+	 * global invalidation: only island routes are affected.
+	 */
+	islandKeyChanged: boolean;
+}
+
+/**
+ * A per-module fingerprint plus its direct import edges, captured during the
+ * build so a later build can explain which modules changed. Stored in the
+ * diagnostics sidecar, never in the correctness-critical manifest.
+ */
+export interface DiagnosticModule {
+	/** Hash of the module's own normalized representation plus sorted direct import ids. */
+	fingerprint: string;
+	importedIds: string[];
+	dynamicallyImportedIds: string[];
+}
+
+/**
+ * The diagnostic snapshot of one build environment's module graph: per-module
+ * fingerprints and edges, the roots each prerendered route and content entry
+ * are seeded from, and the aggregate route hashes. The aggregate hashes are
+ * duplicated from the manifest so a sidecar that does not correspond to the
+ * previous manifest (e.g. after an interrupted write) can be detected and
+ * ignored without affecting reuse decisions.
+ */
+export interface DiagnosticGraph {
+	modules: Record<string, DiagnosticModule>;
+	routeRoots: Record<string, string[]>;
+	contentRoots: Record<string, string[]>;
+	routeDependencyHashes: Record<string, string>;
+}
+
+/**
+ * On-disk shape of the incremental build diagnostics sidecar. It is
+ * independently versioned and optional: a missing or mismatched sidecar only
+ * suppresses detailed dependency explanations, never invalidates cached HTML.
+ */
+export interface IncrementalDiagnosticsFile {
+	version: 1;
+	prerender: DiagnosticGraph;
+	client: DiagnosticGraph;
+}
+
+export function createEmptyDiagnosticGraph(): DiagnosticGraph {
+	return { modules: {}, routeRoots: {}, contentRoots: {}, routeDependencyHashes: {} };
+}
+
+/**
+ * One changed, added, or removed module in a route's dependency graph, with a
+ * deterministic display chain from the route root to the leaf.
+ */
+export interface DependencyChange {
+	status: 'changed' | 'added' | 'removed';
+	/**
+	 * Display nodes from the route root to the changed leaf, sanitized for
+	 * console output (root-relative paths, `virtual:` ids). A client-only or
+	 * hoisted-script change starts with a `client entry: <id>` boundary node; a
+	 * rendered-content change starts with `rendered content: <path>`.
+	 */
+	chain: string[];
+}
+
+/**
+ * Why a single path cannot be reused from the previous build. Each reason is
+ * independently testable; `checkPath` reports every applicable reason in a
+ * stable order so a miss like "module dependencies changed; cacheKey changed"
+ * is truthful.
+ */
+export type IncrementalPathMissReason =
+	| { type: 'no-cache-key' }
+	| { type: 'global-cache'; reasons: IncrementalCacheLoadReason[] }
+	| { type: 'new-route' }
+	| { type: 'new-path' }
+	| { type: 'island-key-changed' }
+	| {
+			type: 'route-dependencies-changed';
+			changes?: DependencyChange[];
+			/** Why no leaf-level explanation is available, when applicable. */
+			diagnosticsUnavailable?: 'missing-sidecar' | 'unavailable';
+	  }
+	| { type: 'cache-key-changed' }
+	| {
+			type: 'content-dependencies-changed';
+			entries: string[];
+			changes?: Record<string, DependencyChange[]>;
+			diagnosticsUnavailable?: 'missing-sidecar' | 'unavailable';
+	  }
+	| { type: 'cached-output-missing' };
+
+export type IncrementalPathDecision =
+	| { reusable: true }
+	| { reusable: false; reasons: IncrementalPathMissReason[] };
+
+type RouteExplanation =
+	| { changes: DependencyChange[] }
+	| { unavailable: 'missing-sidecar' | 'unavailable' };
+
+type EntryExplanation =
+	| { changes: DependencyChange[] }
+	| { unavailable: 'missing-sidecar' | 'unavailable' }
+	| null;
+
+interface GraphDiff {
+	changed: Set<string>;
+	added: Set<string>;
+	removed: Set<string>;
+}
+
 function getManifestFile(settings: AstroSettings): URL {
 	return new URL(INCREMENTAL_CACHE_FILE, settings.config.cacheDir);
+}
+
+function getDiagnosticsFile(settings: AstroSettings): URL {
+	return new URL(INCREMENTAL_DIAGNOSTICS_FILE, settings.config.cacheDir);
 }
 
 function getCachedOutputFile(settings: AstroSettings, outputFile: string): URL {
 	return new URL(outputFile, new URL(INCREMENTAL_OUTPUT_DIR, settings.config.cacheDir));
 }
 
-function readManifest(
+/**
+ * Read the previous manifest and classify why it cannot be used, if at all.
+ * All applicable version/config/lockfile mismatches of a parsed manifest are
+ * collected before the manifest is discarded, so simultaneous changes produce
+ * multiple reasons. `--force` short-circuits before any disk access.
+ */
+function readLoadResult(
 	settings: AstroSettings,
 	expectedConfigHash: string,
 	expectedLockfileHash: string,
-): IncrementalManifest | null {
+	keyDigest: string,
+): IncrementalCacheLoadResult {
 	try {
 		const raw = fs.readFileSync(getManifestFile(settings), 'utf-8');
-		const data = JSON.parse(raw) as IncrementalManifest;
-		if (data.version !== CACHE_VERSION) {
-			return null;
+		let data: IncrementalManifest;
+		try {
+			data = JSON.parse(raw) as IncrementalManifest;
+		} catch {
+			return { previous: null, reasons: ['invalid-manifest'], islandKeyChanged: false };
 		}
-		// Output-affecting config changed since the cache was written, discard it.
-		if (data.configHash !== expectedConfigHash) {
-			return null;
+		if (
+			typeof data !== 'object' ||
+			data === null ||
+			typeof data.version !== 'number' ||
+			typeof data.configHash !== 'string' ||
+			typeof data.lockfileHash !== 'string' ||
+			typeof data.keyDigest !== 'string' ||
+			typeof data.routes !== 'object' ||
+			data.routes === null
+		) {
+			return { previous: null, reasons: ['invalid-manifest'], islandKeyChanged: false };
 		}
-		// Dependencies changed since the cache was written, discard it.
-		if (data.lockfileHash !== expectedLockfileHash) {
+		const reasons: IncrementalCacheLoadReason[] = [];
+		if (data.version !== INCREMENTAL_CACHE_VERSION) reasons.push('version-changed');
+		if (data.configHash !== expectedConfigHash) reasons.push('config-changed');
+		if (data.lockfileHash !== expectedLockfileHash) reasons.push('lockfile-changed');
+		if (reasons.length > 0) {
+			return {
+				previous: null,
+				reasons,
+				previousVersion: data.version !== INCREMENTAL_CACHE_VERSION ? data.version : undefined,
+				islandKeyChanged: false,
+			};
+		}
+		return { previous: data, reasons: ['loaded'], islandKeyChanged: data.keyDigest !== keyDigest };
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException)?.code;
+		if (code === 'ENOENT') return { previous: null, reasons: ['missing'], islandKeyChanged: false };
+		return { previous: null, reasons: ['unreadable'], errorCode: code, islandKeyChanged: false };
+	}
+}
+
+function isValidDiagnosticGraph(graph: unknown): graph is DiagnosticGraph {
+	if (typeof graph !== 'object' || graph === null) return false;
+	const candidate = graph as DiagnosticGraph;
+	return (
+		typeof candidate.modules === 'object' &&
+		candidate.modules !== null &&
+		typeof candidate.routeRoots === 'object' &&
+		candidate.routeRoots !== null &&
+		typeof candidate.contentRoots === 'object' &&
+		candidate.contentRoots !== null &&
+		typeof candidate.routeDependencyHashes === 'object' &&
+		candidate.routeDependencyHashes !== null
+	);
+}
+
+function readDiagnostics(settings: AstroSettings): IncrementalDiagnosticsFile | null {
+	try {
+		const raw = fs.readFileSync(getDiagnosticsFile(settings), 'utf-8');
+		const data = JSON.parse(raw) as IncrementalDiagnosticsFile;
+		if (
+			typeof data !== 'object' ||
+			data === null ||
+			data.version !== DIAGNOSTICS_VERSION ||
+			!isValidDiagnosticGraph(data.prerender) ||
+			!isValidDiagnosticGraph(data.client)
+		) {
 			return null;
 		}
 		return data;
@@ -98,29 +308,155 @@ function readManifest(
 	}
 }
 
+function diffGraphs(current: DiagnosticGraph, previous: DiagnosticGraph): GraphDiff {
+	const changed = new Set<string>();
+	const added = new Set<string>();
+	for (const [id, module] of Object.entries(current.modules)) {
+		const previousModule = previous.modules[id];
+		if (!previousModule) added.add(id);
+		else if (previousModule.fingerprint !== module.fingerprint) changed.add(id);
+	}
+	const removed = new Set<string>();
+	for (const id of Object.keys(previous.modules)) {
+		if (!(id in current.modules)) removed.add(id);
+	}
+	return { changed, added, removed };
+}
+
+/**
+ * Turn a raw module id into something printable: root-relative project paths,
+ * `node_modules/...` under the project root, and `virtual:` ids. The project's
+ * absolute root is never printed.
+ */
+function sanitizeModuleId(id: string, root: URL): string {
+	if (id.startsWith('\0')) return 'virtual:' + id.slice(1);
+	if (id.startsWith('/@fs/')) return sanitizeModuleId(id.slice('/@fs'.length), root);
+	return rootRelativePath(root, id, false);
+}
+
+/**
+ * Breadth-first search from a route's root modules to every changed/added leaf
+ * in `leaves`, returning one shortest deterministic chain per leaf. Roots are
+ * visited in sorted order and neighbors in sorted order, so output is stable
+ * across concurrent builds.
+ *
+ * `displayRoot` maps a root module id to its display node (e.g. a
+ * `client entry:` or `rendered content:` boundary), or `null` to drop the root
+ * from the chain (the prerender route root is the route itself and is printed
+ * by the caller).
+ */
+function findLeafChains(
+	roots: string[],
+	graph: DiagnosticGraph,
+	leaves: ReadonlySet<string>,
+	status: 'changed' | 'added' | 'removed',
+	displayRoot: (id: string) => string | null,
+	root: URL,
+): DependencyChange[] {
+	if (roots.length === 0 || leaves.size === 0) return [];
+	const parents = new Map<string, string | null>();
+	const queue: string[] = [];
+	const seen = new Set<string>();
+	for (const rootId of [...roots].sort()) {
+		parents.set(rootId, null);
+		seen.add(rootId);
+		queue.push(rootId);
+	}
+	const chains: DependencyChange[] = [];
+	let head = 0;
+	while (head < queue.length) {
+		const id = queue[head++];
+		if (leaves.has(id)) {
+			const chain: string[] = [];
+			let current: string | undefined = id;
+			while (current !== undefined) {
+				chain.push(current);
+				const parent = parents.get(current);
+				if (parent === undefined || parent === null) break;
+				current = parent;
+			}
+			chain.reverse();
+			let displayed = chain.map((nodeId) => sanitizeModuleId(nodeId, root));
+			const rootDisplay = displayRoot(chain[0]);
+			if (rootDisplay === null) {
+				displayed = displayed.slice(1);
+			} else {
+				displayed[0] = rootDisplay;
+			}
+			chains.push({ status, chain: displayed });
+			if (chains.length >= MAX_EXPLAINED_LEAVES) break;
+		}
+		const module = graph.modules[id];
+		if (!module) continue;
+		const neighbors = [...module.importedIds, ...module.dynamicallyImportedIds].sort();
+		for (const neighbor of neighbors) {
+			if (!seen.has(neighbor) && graph.modules[neighbor] !== undefined) {
+				seen.add(neighbor);
+				parents.set(neighbor, id);
+				queue.push(neighbor);
+			}
+		}
+	}
+	return chains;
+}
+
+// Bounded so a route whose entire dependency tree changed cannot flood the
+// diagnostics sidecar or the console. Explanations are capped per route; the
+// aggregate reason is still reported for every dropped leaf.
+const MAX_EXPLAINED_LEAVES = 200;
+
+// Placeholder root used only when a cache was constructed without settings;
+// production caches always pass the project root.
+const ROOT_FALLBACK = new URL('file:///');
+
 /**
  * Tracks which prerendered paths can be reused from a previous build.
  *
- * The invalidation logic (`canSkip`, `record`, `findOrphanedFiles`) is pure and
- * operates on the previous and next manifests held in memory. Disk access is
- * confined to `load` and the output-file methods.
+ * The invalidation logic (`checkPath`, `record`, `findOrphanedFiles`) is pure
+ * and operates on the previous and next manifests held in memory. Disk access
+ * is confined to `load` (plus the lazily read diagnostics sidecar) and the
+ * output-file methods.
  */
 export class IncrementalBuildCache {
+	/** Tagged load outcome, used for global invalidation messages. */
+	readonly loadResult: IncrementalCacheLoadResult;
 	readonly #previous: IncrementalManifest | null;
 	readonly #next: IncrementalManifest;
 	readonly #contentEntryHashes: Map<string, string>;
 	readonly #createdDirs = new Set<string>();
+	readonly #settings: AstroSettings | undefined;
+	readonly #currentDiagnostics: IncrementalDiagnosticsFile | null;
+	/** Lazy-loaded previous diagnostics sidecar; `undefined` until first read. */
+	#previousDiagnostics: IncrementalDiagnosticsFile | null | undefined;
+	#graphDiff: { prerender: GraphDiff; client: GraphDiff } | null = null;
+	#routeChanges = new Map<string, RouteExplanation | null>();
+	#contentChanges = new Map<string, EntryExplanation>();
 
 	constructor(
 		configHash: string,
 		lockfileHash: string,
 		keyDigest: string,
 		contentEntryHashes = new Map<string, string>(),
-		previous: IncrementalManifest | null = null,
+		loadResult: IncrementalCacheLoadResult = {
+			previous: null,
+			reasons: ['missing'],
+			islandKeyChanged: false,
+		},
+		currentDiagnostics: IncrementalDiagnosticsFile | null = null,
+		settings: AstroSettings | undefined = undefined,
 	) {
-		this.#previous = previous;
+		this.loadResult = loadResult;
+		this.#previous = loadResult.previous;
 		this.#contentEntryHashes = contentEntryHashes;
-		this.#next = { version: CACHE_VERSION, configHash, lockfileHash, keyDigest, routes: {} };
+		this.#currentDiagnostics = currentDiagnostics;
+		this.#settings = settings;
+		this.#next = {
+			version: INCREMENTAL_CACHE_VERSION,
+			configHash,
+			lockfileHash,
+			keyDigest,
+			routes: {},
+		};
 	}
 
 	/**
@@ -131,6 +467,9 @@ export class IncrementalBuildCache {
 	 * `contentEntryHashes` is this build's map of content-entry render hashes,
 	 * used to detect when the content a path renders has changed.
 	 *
+	 * `diagnostics` is this build's per-module fingerprint snapshot, written to
+	 * the sidecar so the next build can explain dependency changes.
+	 *
 	 * `force` ignores any existing manifest so every path is rebuilt, while still
 	 * recording a fresh cache for the next build.
 	 */
@@ -140,22 +479,33 @@ export class IncrementalBuildCache {
 		lockfileHash: string,
 		keyDigest: string,
 		contentEntryHashes = new Map<string, string>(),
+		diagnostics: IncrementalDiagnosticsFile | null = null,
 		force = false,
 	): IncrementalBuildCache {
+		const loadResult = force
+			? {
+					previous: null,
+					reasons: ['forced'] as IncrementalCacheLoadReason[],
+					islandKeyChanged: false,
+				}
+			: readLoadResult(settings, configHash, lockfileHash, keyDigest);
 		return new IncrementalBuildCache(
 			configHash,
 			lockfileHash,
 			keyDigest,
 			contentEntryHashes,
-			force ? null : readManifest(settings, configHash, lockfileHash),
+			loadResult,
+			diagnostics,
+			settings,
 		);
 	}
 
 	/**
-	 * Determine if a path can be reused from the previous build. A path is
-	 * skippable when:
+	 * Determine if a path can be reused from the previous build, and why not if
+	 * it cannot. A path is reusable only when every independently testable input
+	 * matches the previous build:
 	 * 1. It returned a cacheKey in this build.
-	 * 2. The previous cache has an entry for the route.
+	 * 2. The previous cache is valid and has an entry for the route.
 	 * 3. The route's dependency hash matches the previous build (template code is identical).
 	 * 4. The previous cache has an entry for this exact path.
 	 * 5. The path's cacheKey matches the previous build (user data is identical).
@@ -163,33 +513,92 @@ export class IncrementalBuildCache {
 	 *    render hash (imported components inside that content are unchanged).
 	 * 7. If the path renders a server island, the encryption key is unchanged, so
 	 *    the ciphertext baked into the restored HTML is still decryptable.
+	 *
+	 * All applicable miss reasons are returned in a stable order: global cache
+	 * state, island key, module dependencies, path existence, cacheKey, content
+	 * dependencies. `cached output missing` is deliberately not produced here —
+	 * only the caller knows whether current output exists or was restored.
 	 */
-	canSkip(
+	checkPath(
 		routeComponent: string,
 		pathname: string,
 		dependencyHash: string,
-		cacheKey: string,
+		cacheKey: string | undefined,
 		hasServerIsland = false,
-	): boolean {
-		const routeEntry = this.#previous?.routes[routeComponent];
-		if (!routeEntry) return false;
-
-		if (hasServerIsland && this.#previous?.keyDigest !== this.#next.keyDigest) return false;
-
-		if (routeEntry.dependencyHash !== dependencyHash) return false;
-
-		const pathEntry = routeEntry.paths[pathname];
-		if (!pathEntry) return false;
-
-		if (pathEntry.cacheKey !== cacheKey) return false;
-
-		if (pathEntry.contentHashes) {
-			for (const [entryPath, previousHash] of Object.entries(pathEntry.contentHashes)) {
-				if (this.#contentEntryHashes.get(entryPath) !== previousHash) return false;
-			}
+	): IncrementalPathDecision {
+		if (cacheKey === undefined) {
+			return { reusable: false, reasons: [{ type: 'no-cache-key' }] };
+		}
+		const loadReasons = this.loadResult.reasons.filter((reason) => reason !== 'loaded');
+		if (loadReasons.length > 0) {
+			return { reusable: false, reasons: [{ type: 'global-cache', reasons: loadReasons }] };
 		}
 
-		return true;
+		const routeEntry = this.#previous?.routes[routeComponent];
+		if (!routeEntry) {
+			return { reusable: false, reasons: [{ type: 'new-route' }] };
+		}
+
+		const reasons: IncrementalPathMissReason[] = [];
+		if (hasServerIsland && this.#previous?.keyDigest !== this.#next.keyDigest) {
+			reasons.push({ type: 'island-key-changed' });
+		}
+		if (routeEntry.dependencyHash !== dependencyHash) {
+			const explanation = this.explainRoute(routeComponent);
+			const reason: Extract<IncrementalPathMissReason, { type: 'route-dependencies-changed' }> = {
+				type: 'route-dependencies-changed',
+			};
+			if (explanation && 'changes' in explanation) {
+				if (explanation.changes.length > 0) reason.changes = explanation.changes;
+				else reason.diagnosticsUnavailable = 'unavailable';
+			} else {
+				reason.diagnosticsUnavailable =
+					explanation && 'unavailable' in explanation ? explanation.unavailable : 'unavailable';
+			}
+			reasons.push(reason);
+		}
+
+		const pathEntry = routeEntry.paths[pathname];
+		if (!pathEntry) {
+			reasons.push({ type: 'new-path' });
+		} else {
+			if (pathEntry.cacheKey !== cacheKey) {
+				reasons.push({ type: 'cache-key-changed' });
+			}
+			if (pathEntry.contentHashes) {
+				const changedEntries: string[] = [];
+				for (const [entryPath, previousHash] of Object.entries(pathEntry.contentHashes)) {
+					if (this.#contentEntryHashes.get(entryPath) !== previousHash)
+						changedEntries.push(entryPath);
+				}
+				if (changedEntries.length > 0) {
+					const reason: Extract<
+						IncrementalPathMissReason,
+						{ type: 'content-dependencies-changed' }
+					> = { type: 'content-dependencies-changed', entries: changedEntries };
+					const changes: Record<string, DependencyChange[]> = {};
+					let unavailable: 'missing-sidecar' | 'unavailable' | null = null;
+					for (const entryPath of changedEntries) {
+						const entryExplanation = this.explainContent(entryPath);
+						if (
+							entryExplanation &&
+							'changes' in entryExplanation &&
+							entryExplanation.changes.length > 0
+						) {
+							changes[entryPath] = entryExplanation.changes;
+						} else if (entryExplanation && 'unavailable' in entryExplanation) {
+							unavailable ??= entryExplanation.unavailable;
+						} else {
+							unavailable ??= 'unavailable';
+						}
+					}
+					if (Object.keys(changes).length > 0) reason.changes = changes;
+					if (unavailable) reason.diagnosticsUnavailable = unavailable;
+					reasons.push(reason);
+				}
+			}
+		}
+		return reasons.length > 0 ? { reusable: false, reasons } : { reusable: true };
 	}
 
 	/**
@@ -278,6 +687,17 @@ export class IncrementalBuildCache {
 		fs.writeFileSync(manifestFile, JSON.stringify(this.#next, null, '\t'));
 	}
 
+	/**
+	 * Write this build's diagnostics sidecar next to the manifest. A failure must
+	 * not fail the build or affect cache reuse; the caller reports it as a warning.
+	 */
+	writeDiagnostics(settings: AstroSettings): void {
+		if (!this.#currentDiagnostics) return;
+		const diagnosticsFile = getDiagnosticsFile(settings);
+		fs.mkdirSync(new URL('./', diagnosticsFile), { recursive: true });
+		fs.writeFileSync(diagnosticsFile, JSON.stringify(this.#currentDiagnostics));
+	}
+
 	async restoreOutputFile(
 		settings: AstroSettings,
 		outputFile: string,
@@ -303,6 +723,178 @@ export class IncrementalBuildCache {
 
 	async deleteOutputFile(settings: AstroSettings, outputFile: string): Promise<void> {
 		await fs.promises.rm(getCachedOutputFile(settings, outputFile), { force: true });
+	}
+
+	/**
+	 * Explain a route's dependency change with leaf-level chains, memoized per
+	 * route. `null` means the previous manifest had no such route or no previous
+	 * manifest exists.
+	 */
+	explainRoute(routeComponent: string): RouteExplanation | null {
+		if (this.#routeChanges.has(routeComponent)) return this.#routeChanges.get(routeComponent)!;
+		const explanation = this.#explainRoute(routeComponent);
+		this.#routeChanges.set(routeComponent, explanation);
+		return explanation;
+	}
+
+	#explainRoute(routeComponent: string): RouteExplanation | null {
+		const current = this.#currentDiagnostics;
+		const previous = this.#loadPreviousDiagnostics();
+		if (!current || !previous) return { unavailable: 'missing-sidecar' };
+		const previousRoute = this.#previous?.routes[routeComponent];
+		if (!previousRoute) return null;
+		// A sidecar from a different build (interrupted write) must not be trusted
+		// to explain this route; only the aggregate reason is reported then.
+		if (previous.prerender.routeDependencyHashes[routeComponent] !== previousRoute.dependencyHash) {
+			return { unavailable: 'unavailable' };
+		}
+
+		const diffs = this.#loadGraphDiffs(previous);
+		const root = this.#settings?.config.root ?? ROOT_FALLBACK;
+		const changes: DependencyChange[] = [];
+
+		const prerenderRoots = current.prerender.routeRoots[routeComponent] ?? [];
+		changes.push(
+			...findLeafChains(
+				prerenderRoots,
+				current.prerender,
+				diffs.prerender.changed,
+				'changed',
+				() => null,
+				root,
+			),
+			...findLeafChains(
+				prerenderRoots,
+				current.prerender,
+				diffs.prerender.added,
+				'added',
+				() => null,
+				root,
+			),
+		);
+		const previousPrerenderRoots = previous.prerender.routeRoots[routeComponent] ?? [];
+		changes.push(
+			...findLeafChains(
+				previousPrerenderRoots,
+				previous.prerender,
+				diffs.prerender.removed,
+				'removed',
+				() => null,
+				root,
+			),
+		);
+
+		const clientRoots = current.client.routeRoots[routeComponent] ?? [];
+		const previousClientRoots = previous.client.routeRoots[routeComponent] ?? [];
+		if (diffs.client.changed.size > 0) {
+			changes.push(
+				...findLeafChains(
+					clientRoots,
+					current.client,
+					diffs.client.changed,
+					'changed',
+					(id) => `client entry: ${sanitizeModuleId(id, root)}`,
+					root,
+				),
+			);
+		}
+		if (diffs.client.added.size > 0) {
+			changes.push(
+				...findLeafChains(
+					clientRoots,
+					current.client,
+					diffs.client.added,
+					'added',
+					(id) => `client entry: ${sanitizeModuleId(id, root)}`,
+					root,
+				),
+			);
+		}
+		const removedClientLeaves = diffs.client.removed;
+		if (removedClientLeaves.size > 0) {
+			changes.push(
+				...findLeafChains(
+					previousClientRoots,
+					previous.client,
+					removedClientLeaves,
+					'removed',
+					(id) => `client entry: ${sanitizeModuleId(id, root)}`,
+					root,
+				),
+			);
+		}
+
+		if (changes.length === 0) return { unavailable: 'unavailable' };
+		return { changes };
+	}
+
+	/** Explain a changed content entry's render-graph change, memoized per entry. */
+	explainContent(entryPath: string): EntryExplanation {
+		if (this.#contentChanges.has(entryPath)) return this.#contentChanges.get(entryPath)!;
+		const explanation = this.#explainContent(entryPath);
+		this.#contentChanges.set(entryPath, explanation);
+		return explanation;
+	}
+
+	#explainContent(entryPath: string): EntryExplanation {
+		const current = this.#currentDiagnostics;
+		const previous = this.#loadPreviousDiagnostics();
+		if (!current || !previous) return { unavailable: 'missing-sidecar' };
+		const diffs = this.#loadGraphDiffs(previous);
+		const root = this.#settings?.config.root ?? ROOT_FALLBACK;
+		const currentRoots = current.prerender.contentRoots[entryPath] ?? [];
+		const previousRoots = previous.prerender.contentRoots[entryPath] ?? [];
+		const changes: DependencyChange[] = [];
+		changes.push(
+			...findLeafChains(
+				currentRoots,
+				current.prerender,
+				diffs.prerender.changed,
+				'changed',
+				() => `rendered content: ${entryPath}`,
+				root,
+			),
+			...findLeafChains(
+				currentRoots,
+				current.prerender,
+				diffs.prerender.added,
+				'added',
+				() => `rendered content: ${entryPath}`,
+				root,
+			),
+		);
+		changes.push(
+			...findLeafChains(
+				previousRoots,
+				previous.prerender,
+				diffs.prerender.removed,
+				'removed',
+				() => `rendered content: ${entryPath}`,
+				root,
+			),
+		);
+		return changes.length > 0 ? { changes } : { unavailable: 'unavailable' };
+	}
+
+	#loadPreviousDiagnostics(): IncrementalDiagnosticsFile | null {
+		if (this.#previousDiagnostics !== undefined) return this.#previousDiagnostics;
+		if (!this.#settings) return null;
+		this.#previousDiagnostics = readDiagnostics(this.#settings);
+		return this.#previousDiagnostics;
+	}
+
+	#loadGraphDiffs(previous: IncrementalDiagnosticsFile): {
+		prerender: GraphDiff;
+		client: GraphDiff;
+	} {
+		if (!this.#graphDiff) {
+			const current = this.#currentDiagnostics!;
+			this.#graphDiff = {
+				prerender: diffGraphs(current.prerender, previous.prerender),
+				client: diffGraphs(current.client, previous.client),
+			};
+		}
+		return this.#graphDiff;
 	}
 
 	async #ensureDir(dir: URL): Promise<void> {

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -2,6 +2,7 @@ import type { SSRResult } from '../../types/public/internal.js';
 import type { AstroEnvironmentNames } from '../constants.js';
 import { prependForwardSlash, removeFileExtension } from '../path.js';
 import { viteID } from '../util.js';
+import type { DiagnosticGraph } from './incremental.js';
 import type { PageBuildData, StylesheetAsset, ViteID } from './types.js';
 
 export interface BuildInternals {
@@ -163,6 +164,20 @@ export interface BuildInternals {
 	 * cache only reuses them while the encryption key is unchanged.
 	 */
 	serverIslandPageComponents?: Set<string>;
+
+	/**
+	 * Per-module fingerprints and import edges of the prerender build's module
+	 * graph, collected by the incremental plugin. Written to the diagnostics
+	 * sidecar so the next build can explain why a route's dependency hash
+	 * changed. Diagnostics never affect reuse decisions.
+	 */
+	incrementalDiagnosticsPrerender?: DiagnosticGraph;
+
+	/**
+	 * Per-module fingerprints and import edges of the client build's module
+	 * graph, plus the client-only/hoisted-script entrypoints each route consumes.
+	 */
+	incrementalDiagnosticsClient?: DiagnosticGraph;
 }
 
 /**

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -167,9 +167,9 @@ export interface BuildInternals {
 
 	/**
 	 * Per-module fingerprints and import edges of the prerender build's module
-	 * graph, collected by the incremental plugin. Written to the diagnostics
-	 * sidecar so the next build can explain why a route's dependency hash
-	 * changed. Diagnostics never affect reuse decisions.
+	 * graph, collected by the incremental plugin. Written to the diagnostics file
+	 * so the next build can explain why a route's dependency hash changed; never
+	 * affects reuse decisions.
 	 */
 	incrementalDiagnosticsPrerender?: DiagnosticGraph;
 

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -396,10 +396,10 @@ function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInte
 	}
 
 	if (rootsByComponent.size > 0) {
-		const graph = createEmptyDiagnosticGraph();
-		graph.modules = diagnostics.modules;
-		graph.routeRoots = Object.fromEntries(rootsByComponent);
-		internals.incrementalDiagnosticsClient = graph;
+		const clientGraph = createEmptyDiagnosticGraph();
+		clientGraph.modules = diagnostics.modules;
+		clientGraph.routeRoots = Object.fromEntries(rootsByComponent);
+		internals.incrementalDiagnosticsClient = clientGraph;
 	}
 }
 

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -132,10 +132,9 @@ function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
 }
 
 /**
- * Fingerprint one module for the diagnostics sidecar: its normalized own
- * representation plus its sorted direct static/dynamic import ids. This detects
- * transformed-code changes, added/removed imports, and resolution changes
- * without storing source code.
+ * Fingerprint one module for the diagnostics: its normalized own representation
+ * plus its sorted direct static and dynamic import ids. Detects
+ * transformed-code, import, and resolution changes without storing source code.
  */
 function fingerprintModule(graph: ModuleGraph, id: string): string {
 	const hasher = crypto.createHash('sha256');
@@ -279,8 +278,8 @@ function createTransitiveGraphCache(graph: HashableModuleGraph): TransitiveGraph
 		}
 	}
 
-	// Per-module fingerprints and edges for the diagnostics sidecar, mirroring
-	// the same non-excluded module set and edge filtering as the hash graph.
+	// Diagnostics cover the same modules and edges as the hash graph, so a hash
+	// change is always explainable.
 	const diagnosticModules: Record<string, DiagnosticModule> = {};
 	for (const id of modules.keys()) {
 		const info = modules.get(id);
@@ -350,12 +349,11 @@ function collectClientEntrypointHashes(
 /**
  * `client:only` components and hoisted `<script>` tags are not part of the
  * prerender module graph, so the per-route hash cannot see their transitive
- * dependencies. Each is a client-build entrypoint whose bundle, and everything it
- * imports, is emitted with a content-hashed URL (or inlined) into the page markup,
- * so a change anywhere in that graph must re-render the page. During the client
- * build we hash each entrypoint's transitive graph and fold it into the dependency
- * hash of every route that uses it, and record the entrypoint ids as the route's
- * client-graph roots for the diagnostics sidecar.
+ * dependencies. Each is a client-build entrypoint whose bundle (a content-hashed
+ * URL, or inline) is baked into the page markup, so a change anywhere in that
+ * graph must re-render the page. Fold each entrypoint's transitive hash into
+ * the dependency hash of every route that uses it, and record the entrypoint
+ * ids as the route's client-graph roots in the diagnostics.
  */
 function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInternals): void {
 	const baseHashes = internals.pageDependencyHashes;
@@ -388,8 +386,8 @@ function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInte
 		}
 		const finalHash = hasher.digest('hex');
 		baseHashes.set(component, finalHash);
-		// Keep the sidecar's aggregate hash aligned with the manifest so a later
-		// build can trust the diagnostics for this route.
+		// Store the same aggregate hash the manifest will, so a later build can
+		// trust these diagnostics for the route.
 		if (internals.incrementalDiagnosticsPrerender) {
 			internals.incrementalDiagnosticsPrerender.routeDependencyHashes[component] = finalHash;
 		}
@@ -408,12 +406,12 @@ function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInte
  * root-relative `filePath` (matching what the content runtime reports at render
  * time). A content entry's render module (compiled MD/MDX) and the components it
  * imports are reachable only through the `content-data`-pruned bridges, so the
- * per-route hash never sees them. Seeding the traversal at each render module
- * captures them per entry, giving precise invalidation without pulling one
- * entry's graph into another route's hash.
+ * per-route hash never sees them. Hashing each render module's graph per entry
+ * keeps invalidation precise without pulling one entry's graph into another
+ * route's hash.
  *
- * `contentRoots` records each entry's render module id for the diagnostics
- * sidecar, so a later build can explain content-render-graph changes.
+ * `contentRoots` records each entry's render module id for the diagnostics,
+ * so a later build can explain content-render-graph changes.
  */
 function collectContentEntryHashes(
 	graph: HashableModuleGraph,
@@ -500,7 +498,7 @@ export function pluginIncremental(internals: BuildInternals, root: URL): VitePlu
 			);
 			internals.serverIslandPageComponents = serverIslandComponents;
 
-			// Snapshot the prerender graph for the diagnostics sidecar.
+			// Snapshot the prerender graph for the diagnostics.
 			const diagnostics = createEmptyDiagnosticGraph();
 			diagnostics.modules = transitiveGraph.diagnostics.modules;
 			diagnostics.routeRoots = Object.fromEntries(rootsByComponent);

--- a/packages/astro/src/core/build/plugins/plugin-incremental.ts
+++ b/packages/astro/src/core/build/plugins/plugin-incremental.ts
@@ -8,6 +8,11 @@ import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../../constants.js';
 import { removeQueryString } from '../../path.js';
 import { CSS_LANGS_RE, rootRelativePath } from '../../viteUtils.js';
 import { moduleIsTopLevelPage } from '../graph.js';
+import {
+	createEmptyDiagnosticGraph,
+	type DiagnosticGraph,
+	type DiagnosticModule,
+} from '../incremental.js';
 import { isContentDataIncrementalModule } from '../incremental-metadata.js';
 import type { BuildInternals } from '../internal.js';
 import { getPageDataByViteID } from '../internal.js';
@@ -32,6 +37,7 @@ interface HashableModuleGraph extends ModuleGraph {
 interface TransitiveGraphCache {
 	hashes: Map<string, string>;
 	serverIslandModules: Set<string>;
+	diagnostics: DiagnosticGraph;
 }
 
 /** Each placeholder pattern paired with the token that has to be present for it to match. */
@@ -79,37 +85,72 @@ function resolveAssetPlaceholders(graph: ModuleGraph, code: string): string {
 }
 
 /**
+ * The normalized representation of one module that the aggregate and per-module
+ * hashers share: transformed code with emitted-asset handles resolved to their
+ * stable file names, or the source file for extracted CSS. Empty for modules
+ * with neither code nor a readable CSS source.
+ */
+function getModuleRepresentation(graph: ModuleGraph, id: string): string {
+	const code = graph.getModuleInfo(id)?.code;
+	if (code != null && code.length > 0) {
+		return resolveAssetPlaceholders(graph, code);
+	}
+	if (CSS_LANGS_RE.test(id)) {
+		// Vite extracts CSS into separate assets, so the module's `code` in the
+		// prerender bundle is empty. Read the source file so that stylesheet
+		// changes are reflected in the dependency hash (#17704).
+		try {
+			return nodeFs.readFileSync(removeQueryString(id), 'utf-8');
+		} catch {
+			// Virtual CSS or unreadable file — skip. The worst case is a
+			// cache miss (re-render), never a stale hit.
+		}
+	}
+	return '';
+}
+
+/**
  * Hash a sorted set of module ids together with each module's compiled output.
  * Hashing the transformed `code` from the bundle (rather than the source file on
  * disk) reflects what actually ships and covers virtual modules, which have no
  * file on disk but still carry generated code. Emitted-asset placeholders in
  * that code are resolved to their file names first, since the handles
  * themselves are not stable between builds.
- *
- * CSS modules are a special case: Vite extracts their content during the
- * prerender build, leaving `code` as an empty string. For those modules, the
- * source file is read from disk so that CSS edits invalidate the hash.
  */
 function hashModules(graph: ModuleGraph, sortedIds: string[]): string {
 	const hasher = crypto.createHash('sha256');
 	for (const id of sortedIds) {
 		hasher.update(id);
 		hasher.update('\n');
-		const code = graph.getModuleInfo(id)?.code;
-		if (code != null && code.length > 0) {
-			hasher.update(resolveAssetPlaceholders(graph, code));
-		} else if (CSS_LANGS_RE.test(id)) {
-			// Vite extracts CSS into separate assets, so the module's `code` in the
-			// prerender bundle is empty. Read the source file so that stylesheet
-			// changes are reflected in the dependency hash (#17704).
-			try {
-				hasher.update(nodeFs.readFileSync(removeQueryString(id), 'utf-8'));
-			} catch {
-				// Virtual CSS or unreadable file — skip. The worst case is a
-				// cache miss (re-render), never a stale hit.
-			}
+		const representation = getModuleRepresentation(graph, id);
+		if (representation.length > 0) {
+			hasher.update(representation);
 		}
 		hasher.update('\n');
+	}
+	return hasher.digest('hex');
+}
+
+/**
+ * Fingerprint one module for the diagnostics sidecar: its normalized own
+ * representation plus its sorted direct static/dynamic import ids. This detects
+ * transformed-code changes, added/removed imports, and resolution changes
+ * without storing source code.
+ */
+function fingerprintModule(graph: ModuleGraph, id: string): string {
+	const hasher = crypto.createHash('sha256');
+	const representation = getModuleRepresentation(graph, id);
+	if (representation.length > 0) {
+		hasher.update(representation);
+	}
+	const info = graph.getModuleInfo(id);
+	const importedIds = [
+		...(info?.importedIds ?? []),
+		...(info?.dynamicallyImportedIds ?? []),
+	].sort();
+	for (const importedId of importedIds) {
+		hasher.update('\n');
+		hasher.update(importedId);
 	}
 	return hasher.digest('hex');
 }
@@ -238,6 +279,18 @@ function createTransitiveGraphCache(graph: HashableModuleGraph): TransitiveGraph
 		}
 	}
 
+	// Per-module fingerprints and edges for the diagnostics sidecar, mirroring
+	// the same non-excluded module set and edge filtering as the hash graph.
+	const diagnosticModules: Record<string, DiagnosticModule> = {};
+	for (const id of modules.keys()) {
+		const info = modules.get(id);
+		diagnosticModules[id] = {
+			fingerprint: fingerprintModule(graph, id),
+			importedIds: [...(info?.importedIds ?? [])].sort(),
+			dynamicallyImportedIds: [...(info?.dynamicallyImportedIds ?? [])].sort(),
+		};
+	}
+
 	return {
 		hashes: new Map(
 			[...componentByModule].map(([id, componentIndex]) => [
@@ -250,18 +303,26 @@ function createTransitiveGraphCache(graph: HashableModuleGraph): TransitiveGraph
 				.filter(([, componentIndex]) => componentHasServerIsland.get(componentIndex))
 				.map(([id]) => id),
 		),
+		diagnostics: {
+			modules: diagnosticModules,
+			routeRoots: {},
+			contentRoots: {},
+			routeDependencyHashes: {},
+		},
 	};
 }
 
 /**
  * Hash the transitive graph of each client entrypoint and accumulate the result
- * against every page that uses it, keyed by page component.
+ * against every page that uses it, keyed by page component. The entrypoint ids
+ * are also recorded as the route's client-graph roots for diagnostics.
  */
 function collectClientEntrypointHashes(
 	transitiveHashes: Map<string, string>,
 	entrypointIds: Iterable<string>,
 	pagesByEntrypoint: Map<string, Set<PageBuildData>>,
 	hashesByComponent: Map<string, string[]>,
+	rootsByComponent: Map<string, string[]>,
 ): void {
 	for (const entrypointId of entrypointIds) {
 		const pages = pagesByEntrypoint.get(entrypointId);
@@ -276,6 +337,12 @@ function collectClientEntrypointHashes(
 				hashesByComponent.set(pageData.component, list);
 			}
 			list.push(hash);
+			let roots = rootsByComponent.get(pageData.component);
+			if (!roots) {
+				roots = [];
+				rootsByComponent.set(pageData.component, roots);
+			}
+			roots.push(entrypointId);
 		}
 	}
 }
@@ -287,25 +354,29 @@ function collectClientEntrypointHashes(
  * imports, is emitted with a content-hashed URL (or inlined) into the page markup,
  * so a change anywhere in that graph must re-render the page. During the client
  * build we hash each entrypoint's transitive graph and fold it into the dependency
- * hash of every route that uses it.
+ * hash of every route that uses it, and record the entrypoint ids as the route's
+ * client-graph roots for the diagnostics sidecar.
  */
 function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInternals): void {
 	const baseHashes = internals.pageDependencyHashes;
 	if (!baseHashes) return;
 
-	const { hashes: transitiveHashes } = createTransitiveGraphCache(graph);
+	const { hashes: transitiveHashes, diagnostics } = createTransitiveGraphCache(graph);
 	const hashesByComponent = new Map<string, string[]>();
+	const rootsByComponent = new Map<string, string[]>();
 	collectClientEntrypointHashes(
 		transitiveHashes,
 		internals.discoveredClientOnlyComponents.keys(),
 		internals.pagesByClientOnly,
 		hashesByComponent,
+		rootsByComponent,
 	);
 	collectClientEntrypointHashes(
 		transitiveHashes,
 		internals.discoveredScripts,
 		internals.pagesByScriptId,
 		hashesByComponent,
+		rootsByComponent,
 	);
 
 	for (const [component, clientHashes] of hashesByComponent) {
@@ -315,7 +386,20 @@ function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInte
 			hasher.update('\n');
 			hasher.update(hash);
 		}
-		baseHashes.set(component, hasher.digest('hex'));
+		const finalHash = hasher.digest('hex');
+		baseHashes.set(component, finalHash);
+		// Keep the sidecar's aggregate hash aligned with the manifest so a later
+		// build can trust the diagnostics for this route.
+		if (internals.incrementalDiagnosticsPrerender) {
+			internals.incrementalDiagnosticsPrerender.routeDependencyHashes[component] = finalHash;
+		}
+	}
+
+	if (rootsByComponent.size > 0) {
+		const graph = createEmptyDiagnosticGraph();
+		graph.modules = diagnostics.modules;
+		graph.routeRoots = Object.fromEntries(rootsByComponent);
+		internals.incrementalDiagnosticsClient = graph;
 	}
 }
 
@@ -327,11 +411,15 @@ function foldClientDependencies(graph: HashableModuleGraph, internals: BuildInte
  * per-route hash never sees them. Seeding the traversal at each render module
  * captures them per entry, giving precise invalidation without pulling one
  * entry's graph into another route's hash.
+ *
+ * `contentRoots` records each entry's render module id for the diagnostics
+ * sidecar, so a later build can explain content-render-graph changes.
  */
 function collectContentEntryHashes(
 	graph: HashableModuleGraph,
 	root: URL,
 	transitiveHashes: Map<string, string>,
+	contentRoots: Record<string, string[]>,
 ): Map<string, string> {
 	const entryHashes = new Map<string, string>();
 	for (const id of graph.getModuleIds()) {
@@ -340,7 +428,10 @@ function collectContentEntryHashes(
 		const renderModuleId = removeQueryString(id);
 		const key = rootRelativePath(root, renderModuleId, false);
 		const hash = transitiveHashes.get(renderModuleId);
-		if (hash) entryHashes.set(key, hash);
+		if (hash) {
+			entryHashes.set(key, hash);
+			contentRoots[key] = [renderModuleId];
+		}
 	}
 	return entryHashes;
 }
@@ -374,6 +465,7 @@ export function pluginIncremental(internals: BuildInternals, root: URL): VitePlu
 			const transitiveGraph = createTransitiveGraphCache(this);
 			const hashes = new Map<string, string>();
 			const serverIslandComponents = new Set<string>();
+			const rootsByComponent = new Map<string, string[]>();
 			for (const id of this.getModuleIds()) {
 				const info = this.getModuleInfo(id);
 				if (!info) continue;
@@ -390,15 +482,31 @@ export function pluginIncremental(internals: BuildInternals, root: URL): VitePlu
 				if (transitiveGraph.serverIslandModules.has(info.id)) {
 					serverIslandComponents.add(pageData.component);
 				}
+				let roots = rootsByComponent.get(pageData.component);
+				if (!roots) {
+					roots = [];
+					rootsByComponent.set(pageData.component, roots);
+				}
+				roots.push(info.id);
 			}
 
 			internals.pageDependencyHashes = hashes;
+			const contentRoots: Record<string, string[]> = {};
 			internals.contentEntryRenderHashes = collectContentEntryHashes(
 				this,
 				root,
 				transitiveGraph.hashes,
+				contentRoots,
 			);
 			internals.serverIslandPageComponents = serverIslandComponents;
+
+			// Snapshot the prerender graph for the diagnostics sidecar.
+			const diagnostics = createEmptyDiagnosticGraph();
+			diagnostics.modules = transitiveGraph.diagnostics.modules;
+			diagnostics.routeRoots = Object.fromEntries(rootsByComponent);
+			diagnostics.contentRoots = contentRoots;
+			diagnostics.routeDependencyHashes = Object.fromEntries(hashes);
+			internals.incrementalDiagnosticsPrerender = diagnostics;
 		},
 	};
 }

--- a/packages/astro/test/fixtures/incremental-build-logging/astro.config.mjs
+++ b/packages/astro/test/fixtures/incremental-build-logging/astro.config.mjs
@@ -1,0 +1,6 @@
+import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	integrations: [mdx()],
+});

--- a/packages/astro/test/fixtures/incremental-build-logging/package.json
+++ b/packages/astro/test/fixtures/incremental-build-logging/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/incremental-build-logging",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/mdx": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/incremental-build-logging/src/components/Callout.astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/components/Callout.astro
@@ -1,0 +1,1 @@
+<p class="callout" data-version="v1">Callout v1</p>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/components/Island.astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/components/Island.astro
@@ -1,0 +1,1 @@
+<h2 id="island">I'm an island</h2>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/components/Sidebar.astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/components/Sidebar.astro
@@ -1,0 +1,6 @@
+---
+import { items } from './sidebar_data.ts';
+---
+<nav class="sidebar" data-version="v1">
+	{items.map((item) => <a href={`/${item.toLowerCase()}`}>{item}</a>)}
+</nav>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/components/sidebar_data.ts
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/components/sidebar_data.ts
@@ -1,0 +1,1 @@
+export const items = ['Home', 'About', 'Contact'];

--- a/packages/astro/test/fixtures/incremental-build-logging/src/content.config.ts
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/content.config.ts
@@ -1,0 +1,12 @@
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
+
+const docs = defineCollection({
+	loader: glob({ pattern: '**/*.mdx', base: './src/content/docs' }),
+	schema: z.object({
+		title: z.string(),
+	}),
+});
+
+export const collections = { docs };

--- a/packages/astro/test/fixtures/incremental-build-logging/src/content/docs/one.mdx
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/content/docs/one.mdx
@@ -1,0 +1,9 @@
+---
+title: One
+---
+
+import Callout from '../../components/Callout.astro';
+
+<Callout />
+
+Alpha content.

--- a/packages/astro/test/fixtures/incremental-build-logging/src/content/docs/two.mdx
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/content/docs/two.mdx
@@ -1,0 +1,5 @@
+---
+title: Two
+---
+
+Beta content.

--- a/packages/astro/test/fixtures/incremental-build-logging/src/data/blog-data.json
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/data/blog-data.json
@@ -1,0 +1,8 @@
+{
+	"posts": [
+		{ "slug": "post-1", "title": "Post 1", "digest": "v1" },
+		{ "slug": "post-2", "title": "Post 2", "digest": "v1" },
+		{ "slug": "post-3", "title": "Post 3", "digest": "v1" },
+		{ "slug": "post-4", "title": "Post 4", "digest": "v1" }
+	]
+}

--- a/packages/astro/test/fixtures/incremental-build-logging/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/layouts/Layout.astro
@@ -1,0 +1,13 @@
+---
+const { title } = Astro.props;
+---
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>{title}</title>
+</head>
+<body>
+	<slot />
+</body>
+</html>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/pages/blog/[slug].astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/pages/blog/[slug].astro
@@ -1,0 +1,18 @@
+---
+import data from '../../data/blog-data.json';
+import Layout from '../../layouts/Layout.astro';
+
+export async function getStaticPaths() {
+	return data.posts.map((post) => ({
+		params: { slug: post.slug },
+		props: { title: post.title },
+		cacheKey: post.digest,
+	}));
+}
+
+const { title } = Astro.props;
+---
+<Layout title={title}>
+	<h1>{title}</h1>
+	<p>Slug: {Astro.params.slug}</p>
+</Layout>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/pages/docs/[...slug].astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/pages/docs/[...slug].astro
@@ -1,0 +1,20 @@
+---
+import { getCollection, render } from 'astro:content';
+import Layout from '../../layouts/Layout.astro';
+
+export async function getStaticPaths() {
+	const entries = await getCollection('docs');
+	return entries.map((entry) => ({
+		params: { slug: entry.id },
+		props: { entry },
+		cacheKey: String(entry.digest),
+	}));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+<Layout title={entry.data.title}>
+	<h1>{entry.data.title}</h1>
+	<Content />
+</Layout>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/pages/index.astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/pages/index.astro
@@ -1,0 +1,6 @@
+<html>
+<body>
+	<h1>Home</h1>
+	<p>Static page without a cacheKey.</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/pages/island/[slug].astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/pages/island/[slug].astro
@@ -1,0 +1,18 @@
+---
+import Island from '../../components/Island.astro';
+
+export async function getStaticPaths() {
+	return [{ params: { slug: 'a' }, props: { title: 'Island A' }, cacheKey: 'v1' }];
+}
+
+const { title } = Astro.props;
+---
+<html lang="en">
+<head>
+	<title>{title}</title>
+</head>
+<body>
+	<h1>{title}</h1>
+	<Island server:defer />
+</body>
+</html>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/pages/plain/[slug].astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/pages/plain/[slug].astro
@@ -1,0 +1,15 @@
+---
+export async function getStaticPaths() {
+	return [{ params: { slug: 'a' }, props: { title: 'Plain A' }, cacheKey: 'v1' }];
+}
+
+const { title } = Astro.props;
+---
+<html lang="en">
+<head>
+	<title>{title}</title>
+</head>
+<body>
+	<h1>{title}</h1>
+</body>
+</html>

--- a/packages/astro/test/fixtures/incremental-build-logging/src/pages/sidebar/[slug].astro
+++ b/packages/astro/test/fixtures/incremental-build-logging/src/pages/sidebar/[slug].astro
@@ -1,0 +1,18 @@
+---
+import Sidebar from '../../components/Sidebar.astro';
+
+export async function getStaticPaths() {
+	return [
+		{ params: { slug: 'a' }, props: {}, cacheKey: 'v1' },
+		{ params: { slug: 'b' }, props: {}, cacheKey: 'v1' },
+	];
+}
+---
+<html>
+<head>
+	<title>Sidebar page</title>
+</head>
+<body>
+	<Sidebar />
+</body>
+</html>

--- a/packages/astro/test/incremental-build-logging.test.ts
+++ b/packages/astro/test/incremental-build-logging.test.ts
@@ -36,9 +36,8 @@ describe('experimental.incrementalBuild logging output', () => {
 	let fixture: Fixture;
 
 	async function build(extraInlineConfig: Record<string, any> = {}): Promise<string> {
-		// A fresh array per build: stale loggers from earlier builds keep writing
-		// into their own closure, so captured output is never polluted by a
-		// previous build's late messages (e.g. prerenderer teardown).
+		// A fresh capture array per build, so an earlier build's late log
+		// messages (e.g. prerenderer teardown) cannot leak into this build's text.
 		const capture: AstroLoggerMessage[] = [];
 		const logger = new AstroLogger({
 			destination: { write: (event) => capture.push(event) },

--- a/packages/astro/test/incremental-build-logging.test.ts
+++ b/packages/astro/test/incremental-build-logging.test.ts
@@ -15,8 +15,9 @@ const cacheFile = new URL('incremental-build.json', cacheDir);
 const FIXED_KEY = 'eKBaVEuI7YjfanEXHuJe/pwZKKt3LkAHeMxvTU7aR0M=';
 const ROTATED_KEY = '7L9SkkvbK2nwAuX3pzmGk2ffANCIbINvjcjkkS9IB2E=';
 
-// Total paths: blog x4, sidebar x2, docs x2, index x1, plain x1, island x1.
-const TOTAL_PATHS = 11;
+// Dynamic paths only: blog x4, sidebar x2, docs x2, plain x1, island x1. The
+// static index page renders every build and is not part of incremental logging.
+const TOTAL_PATHS = 10;
 
 // Built from String.fromCharCode so the literal never contains a control
 // character (eslint no-control-regex); `\[\d+m` matches ANSI SGR sequences.
@@ -73,10 +74,11 @@ describe('experimental.incrementalBuild logging output', () => {
 	it('cold build: prints the global missing-cache line, no-key suffix, and summary', async () => {
 		const text = await build();
 		assert.ok(text.includes('Incremental cache not found; performing a full build.'));
-		assert.ok(text.includes('(not cacheable: no cacheKey)'), `missing no-key suffix in:\n${text}`);
+		// Static pages are not incremental paths, so no `no cacheKey` note appears.
+		assert.ok(!text.includes('no cacheKey'), `static page should not be logged:\n${text}`);
 		assert.ok(
 			text.includes(
-				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 0 restored, ${TOTAL_PATHS} rendered (1 not stored)`,
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 0 restored, ${TOTAL_PATHS} rendered`,
 			),
 			`missing summary in:\n${text}`,
 		);
@@ -91,7 +93,7 @@ describe('experimental.incrementalBuild logging output', () => {
 		assert.ok(!text.includes('(cache miss:'), `no misses expected:\n${text}`);
 		assert.ok(
 			text.includes(
-				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 10 restored, 1 rendered (1 not stored)`,
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, ${TOTAL_PATHS} restored, 0 rendered`,
 			),
 		);
 	});
@@ -113,7 +115,7 @@ describe('experimental.incrementalBuild logging output', () => {
 			);
 			assert.ok(
 				text.includes(
-					` incremental build: ${TOTAL_PATHS} paths — 0 cached, 9 restored, 2 rendered (1 not stored)`,
+					` incremental build: ${TOTAL_PATHS} paths — 0 cached, 9 restored, 1 rendered`,
 				),
 			);
 		});
@@ -143,7 +145,7 @@ describe('experimental.incrementalBuild logging output', () => {
 			);
 			assert.ok(
 				text.includes(
-					` incremental build: ${TOTAL_PATHS} paths — 0 cached, 5 restored, 6 rendered (1 not stored)`,
+					` incremental build: ${TOTAL_PATHS} paths — 0 cached, 5 restored, 5 rendered`,
 				),
 			);
 		});
@@ -229,7 +231,7 @@ describe('experimental.incrementalBuild logging output', () => {
 		);
 		assert.ok(
 			text.includes(
-				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 0 restored, ${TOTAL_PATHS} rendered (1 not stored)`,
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 0 restored, ${TOTAL_PATHS} rendered`,
 			),
 		);
 	});
@@ -314,7 +316,7 @@ describe('experimental.incrementalBuild logging output', () => {
 		);
 		assert.ok(
 			text.includes(
-				` incremental build: ${TOTAL_PATHS} paths — 0 cached, ${TOTAL_PATHS - 1} restored, 1 rendered (1 not stored)`,
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, ${TOTAL_PATHS} restored, 0 rendered`,
 			),
 		);
 	});

--- a/packages/astro/test/incremental-build-logging.test.ts
+++ b/packages/astro/test/incremental-build-logging.test.ts
@@ -1,0 +1,367 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { after, before, describe, it } from 'node:test';
+import { AstroLogger, type AstroLoggerMessage } from '../dist/core/logger/core.js';
+import { type Fixture, loadFixture } from './test-utils.ts';
+import createTestPrerenderer from './test-prerenderer.ts';
+import testAdapter from './test-adapter.ts';
+
+const root = new URL('./fixtures/incremental-build-logging/', import.meta.url);
+const cacheDir = new URL('node_modules/.astro/', root);
+const cacheFile = new URL('incremental-build.json', cacheDir);
+
+// Two valid 32-byte base64 keys so the server-island encryption key can be
+// rotated between builds without minting a fresh key every build.
+const FIXED_KEY = 'eKBaVEuI7YjfanEXHuJe/pwZKKt3LkAHeMxvTU7aR0M=';
+const ROTATED_KEY = '7L9SkkvbK2nwAuX3pzmGk2ffANCIbINvjcjkkS9IB2E=';
+
+// Total paths: blog x4, sidebar x2, docs x2, index x1, plain x1, island x1.
+const TOTAL_PATHS = 11;
+
+function stripAnsi(text: string): string {
+	return text.replace(/\u001B\[\d+m/g, '');
+}
+
+/** Replace volatile durations so exact summary lines stay stable. */
+function normalizeTime(text: string): string {
+	return text.replace(/\+\d+(?:\.\d+)?m?s/g, '+<time>').replace(/<1ms/g, '<time>');
+}
+
+describe('experimental.incrementalBuild logging output', () => {
+	let fixture: Fixture;
+
+	async function build(extraInlineConfig: Record<string, any> = {}): Promise<string> {
+		// A fresh array per build: stale loggers from earlier builds keep writing
+		// into their own closure, so captured output is never polluted by a
+		// previous build's late messages (e.g. prerenderer teardown).
+		const capture: AstroLoggerMessage[] = [];
+		const logger = new AstroLogger({
+			destination: { write: (event) => capture.push(event) },
+			level: (extraInlineConfig._logger as AstroLogger | undefined)?.level() ?? 'info',
+		});
+		// @ts-expect-error: `_logger` is an internal API
+		await fixture.build({ ...extraInlineConfig, _logger: logger });
+		return stripAnsi(normalizeTime(capture.map((log) => log.message).join('\n')));
+	}
+
+	before(async () => {
+		fs.rmSync(new URL('dist/', root), { recursive: true, force: true });
+		fs.rmSync(cacheDir, { recursive: true, force: true });
+		process.env.ASTRO_KEY = FIXED_KEY;
+		fixture = await loadFixture({
+			root,
+			output: 'static',
+			build: { concurrency: 4 },
+			experimental: {
+				incrementalBuild: true,
+			},
+			adapter: testAdapter(),
+		});
+	});
+
+	after(() => {
+		delete process.env.ASTRO_KEY;
+		fs.rmSync(new URL('dist/', root), { recursive: true, force: true });
+		fs.rmSync(cacheDir, { recursive: true, force: true });
+		fs.rmSync(new URL('pnpm-lock.yaml', root), { force: true });
+	});
+
+	it('cold build: prints the global missing-cache line, no-key suffix, and summary', async () => {
+		const text = await build();
+		assert.ok(text.includes('Incremental cache not found; performing a full build.'));
+		assert.ok(text.includes('(not cacheable: no cacheKey)'), `missing no-key suffix in:\n${text}`);
+		assert.ok(
+			text.includes(
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 0 restored, ${TOTAL_PATHS} rendered (1 not stored)`,
+			),
+			`missing summary in:\n${text}`,
+		);
+		// The grouped table is printed for small builds.
+		assert.ok(text.includes('Result    Reason'), `missing table in:\n${text}`);
+		assert.ok(text.includes('src/pages/blog/[slug].astro'), `missing blog row in:\n${text}`);
+	});
+
+	it('unchanged build: restores every keyed path and reports the hit counts', async () => {
+		const text = await build();
+		assert.ok(text.includes('(restored)'), `unchanged keyed paths should restore:\n${text}`);
+		assert.ok(!text.includes('(cache miss:'), `no misses expected:\n${text}`);
+		assert.ok(
+			text.includes(
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 10 restored, 1 rendered (1 not stored)`,
+			),
+		);
+	});
+
+	describe('changed content dependency (Callout in MDX render graph)', () => {
+		const callout = new URL('src/components/Callout.astro', root);
+		let original: string;
+
+		before(async () => {
+			original = fs.readFileSync(callout, 'utf-8');
+			fs.writeFileSync(callout, original.replace('Callout v1', 'Callout v2'));
+		});
+
+		it('reports the changed content entry by path', async () => {
+			const text = await build();
+			assert.ok(
+				text.includes('(cache miss: content dependency changed: src/content/docs/one.mdx)'),
+				`missing content reason in:\n${text}`,
+			);
+			assert.ok(
+				text.includes(
+					` incremental build: ${TOTAL_PATHS} paths — 0 cached, 9 restored, 2 rendered (1 not stored)`,
+				),
+			);
+		});
+
+		after(() => {
+			fs.writeFileSync(callout, original);
+		});
+	});
+
+	describe('changed cacheKey (data module)', () => {
+		const blogData = new URL('src/data/blog-data.json', root);
+		let original: string;
+
+		before(async () => {
+			original = fs.readFileSync(blogData, 'utf-8');
+			fs.writeFileSync(
+				blogData,
+				original.replace('"Post 2", "digest": "v1"', '"Post 2", "digest": "v2"'),
+			);
+		});
+
+		it('renders the changed path with the dual module+key reason suffix', async () => {
+			const text = await build();
+			assert.ok(
+				text.includes('(cache miss: module dependencies changed; cacheKey changed)'),
+				`missing reason in:\n${text}`,
+			);
+			assert.ok(
+				text.includes(
+					` incremental build: ${TOTAL_PATHS} paths — 0 cached, 5 restored, 6 rendered (1 not stored)`,
+				),
+			);
+		});
+
+		after(() => {
+			fs.writeFileSync(blogData, original);
+		});
+	});
+
+	describe('changed module dependency (Sidebar graph)', () => {
+		const dataFile = new URL('src/components/sidebar_data.ts', root);
+		let original: string;
+
+		before(async () => {
+			original = fs.readFileSync(dataFile, 'utf-8');
+			fs.writeFileSync(dataFile, original.replace("'Contact'", "'Contact', 'Blog'"));
+		});
+
+		it('reports module dependencies changed with a dependency tree', async () => {
+			const text = await build();
+			assert.ok(
+				text.includes('(cache miss: module dependencies changed)'),
+				`missing reason in:\n${text}`,
+			);
+			assert.ok(text.includes(' dependencies changed'), `missing tree header in:\n${text}`);
+			assert.ok(text.includes('  src/pages/sidebar/[slug].astro'), `missing route in:\n${text}`);
+			assert.ok(
+				text.includes('  └─ src/components/Sidebar.astro'),
+				`missing chain node in:\n${text}`,
+			);
+			assert.ok(
+				text.includes('     └─ src/components/sidebar_data.ts (changed)'),
+				`missing changed leaf in:\n${text}`,
+			);
+		});
+
+		after(() => {
+			fs.writeFileSync(dataFile, original);
+		});
+	});
+
+	it('rotated server-island key: re-renders the island page with the exact reason', async () => {
+		process.env.ASTRO_KEY = ROTATED_KEY;
+		try {
+			const text = await build();
+			assert.ok(
+				text.includes(
+					'Incremental cache: server-island encryption key changed; affected pages will be rendered.',
+				),
+				`missing global island line in:\n${text}`,
+			);
+			assert.ok(
+				text.includes('(cache miss: server-island encryption key changed)'),
+				`missing island reason in:\n${text}`,
+			);
+		} finally {
+			process.env.ASTRO_KEY = FIXED_KEY;
+		}
+	});
+
+	it('deleted persistent output: re-renders with cached output missing', async () => {
+		// The static adapter writes prerendered output under `client/`. Remove both
+		// the rendered file and the cache's copy, so the restore fails and the
+		// path is reported as `cached output missing`.
+		fs.rmSync(new URL('dist/client/blog/post-1/index.html', root), { force: true });
+		fs.rmSync(new URL('dist/client/blog/post-1/index.html', cacheDir), { force: true });
+		const text = await build();
+		assert.ok(
+			text.includes('(cache miss: cached output missing)'),
+			`missing cached-output-missing reason in:\n${text}`,
+		);
+	});
+
+	it('force build: bypasses the cache with the exact reason', async () => {
+		const text = await build({ force: true });
+		assert.ok(
+			text.includes('Incremental cache bypassed by --force; performing a full build.'),
+			`missing force line in:\n${text}`,
+		);
+		assert.ok(
+			text.includes('(cache miss: bypassed by --force)'),
+			`missing force reason in:\n${text}`,
+		);
+		assert.ok(
+			text.includes(
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, 0 restored, ${TOTAL_PATHS} rendered (1 not stored)`,
+			),
+		);
+	});
+
+	describe('lockfile change', () => {
+		const lockfile = new URL('pnpm-lock.yaml', root);
+		let original: string | null;
+
+		before(async () => {
+			// The fixture has no lockfile, so the previous builds hashed the
+			// workspace root's. Creating one at the fixture root changes the set of
+			// lockfiles found and therefore the lockfile hash.
+			original = fs.existsSync(lockfile) ? fs.readFileSync(lockfile, 'utf-8') : null;
+			fs.writeFileSync(lockfile, 'lockfileVersion: "9.0"\n');
+		});
+
+		it('invalidates the cache with the exact global line and reason', async () => {
+			const text = await build();
+			assert.ok(
+				text.includes('Incremental cache invalidated: dependency lockfile changed.'),
+				`missing lockfile line in:\n${text}`,
+			);
+			assert.ok(
+				text.includes('(cache miss: dependency lockfile changed)'),
+				`missing lockfile reason in:\n${text}`,
+			);
+		});
+
+		after(() => {
+			if (original === null) fs.rmSync(lockfile, { force: true });
+			else fs.writeFileSync(lockfile, original);
+		});
+	});
+
+	it('config override: invalidates the cache with the exact global line', async () => {
+		const text = await build({ compressHTML: true });
+		assert.ok(
+			text.includes('Incremental cache invalidated: Astro configuration changed.'),
+			`missing config line in:\n${text}`,
+		);
+		assert.ok(
+			text.includes('(cache miss: configuration changed; dependency lockfile changed)'),
+			`missing config reason in:\n${text}`,
+		);
+	});
+
+	it('malformed manifest: warns and falls back to a full build', async () => {
+		fs.writeFileSync(cacheFile, 'not json {');
+		const text = await build();
+		assert.ok(
+			text.includes('Incremental cache manifest is invalid; performing a full build.'),
+			`missing invalid-manifest warn in:\n${text}`,
+		);
+		assert.ok(text.includes('(cache miss: cache unavailable)'), `missing reason in:\n${text}`);
+	});
+
+	it('downgraded cache version: reports the version change', async () => {
+		const manifest = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+		manifest.version = 0;
+		fs.writeFileSync(cacheFile, JSON.stringify(manifest));
+		const text = await build();
+		assert.ok(
+			text.includes('Incremental cache invalidated: cache format changed (version 0 → 1).'),
+			`missing version line in:\n${text}`,
+		);
+		assert.ok(
+			text.includes('(cache miss: cache format changed)'),
+			`missing version reason in:\n${text}`,
+		);
+	});
+
+	it('verbose build: prints one row per path', async () => {
+		const debugLogger = new AstroLogger({
+			destination: { write: () => {} },
+			level: 'debug',
+		});
+		const text = await build({ _logger: debugLogger });
+		assert.ok(text.includes('Route / path'), `missing verbose header in:\n${text}`);
+		assert.ok(
+			text.includes('src/pages/blog/[slug].astro /blog/post-1'),
+			`missing verbose row in:\n${text}`,
+		);
+		assert.ok(
+			text.includes(
+				` incremental build: ${TOTAL_PATHS} paths — 0 cached, ${TOTAL_PATHS - 1} restored, 1 rendered (1 not stored)`,
+			),
+		);
+	});
+});
+
+describe('experimental.incrementalBuild logging with a metadata-less prerenderer', () => {
+	const untrackedCacheDir = new URL('node_modules/.astro-untracked/', root);
+	let fixture: Fixture;
+	let text = '';
+
+	before(async () => {
+		fs.rmSync(new URL('dist/logging-untracked/', root), { recursive: true, force: true });
+		fs.rmSync(untrackedCacheDir, { recursive: true, force: true });
+		const testPrerenderer = createTestPrerenderer();
+		const logs: AstroLoggerMessage[] = [];
+		const logger = new AstroLogger({
+			destination: { write: (event) => logs.push(event) },
+			level: 'info',
+		});
+		fixture = await loadFixture({
+			root,
+			outDir: './dist/logging-untracked/',
+			cacheDir: './node_modules/.astro-untracked/',
+			integrations: [testPrerenderer.integration],
+			experimental: {
+				incrementalBuild: true,
+			},
+			// The fixture contains a server-island page, which requires an adapter.
+			adapter: testAdapter(),
+			// @ts-expect-error: `_logger` is an internal API
+			_logger: logger,
+		});
+		await fixture.build();
+		text = stripAnsi(normalizeTime(logs.map((log) => log.message).join('\n')));
+	});
+
+	after(() => {
+		fs.rmSync(new URL('dist/logging-untracked/', root), { recursive: true, force: true });
+		fs.rmSync(untrackedCacheDir, { recursive: true, force: true });
+	});
+
+	it('flags keyed renders that produced no metadata', () => {
+		assert.ok(
+			text.includes('(not stored: prerender metadata unavailable)'),
+			`missing storage note in:\n${text}`,
+		);
+		assert.ok(
+			text.includes(
+				'Incremental cache could not record 10 rendered paths because the prerenderer did not return incremental metadata; those paths will render again on the next build.',
+			),
+			`missing metadata warning in:\n${text}`,
+		);
+	});
+});

--- a/packages/astro/test/incremental-build-logging.test.ts
+++ b/packages/astro/test/incremental-build-logging.test.ts
@@ -18,8 +18,12 @@ const ROTATED_KEY = '7L9SkkvbK2nwAuX3pzmGk2ffANCIbINvjcjkkS9IB2E=';
 // Total paths: blog x4, sidebar x2, docs x2, index x1, plain x1, island x1.
 const TOTAL_PATHS = 11;
 
+// Built from String.fromCharCode so the literal never contains a control
+// character (eslint no-control-regex); `\[\d+m` matches ANSI SGR sequences.
+const ansiEscapePattern = new RegExp(`${String.fromCharCode(27)}\\[\\d+m`, 'g');
+
 function stripAnsi(text: string): string {
-	return text.replace(/\u001B\[\d+m/g, '');
+	return text.replace(ansiEscapePattern, '');
 }
 
 /** Replace volatile durations so exact summary lines stay stable. */

--- a/packages/astro/test/units/build/incremental-cache.test.ts
+++ b/packages/astro/test/units/build/incremental-cache.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { slash } from '../../../dist/core/path.js';
 import { after, describe, it } from 'node:test';
 import {
 	IncrementalBuildCache,
@@ -17,7 +18,14 @@ import type { AstroSettings } from '../../../dist/types/astro.js';
 
 const ROUTE = 'src/pages/[slug].astro';
 const HASH = 'deadbeef';
-const ROOT = new URL('file:///project/');
+// A real absolute file URL so `rootRelativePath` path math works on every OS;
+// the directory itself never needs to exist.
+const ROOT = new URL('./project/', import.meta.url);
+
+/** Absolute forward-slash module id under the fake project root. */
+function projectFile(path: string): string {
+	return slash(fileURLToPath(new URL(path, ROOT)));
+}
 
 function settings(cacheDir: URL): AstroSettings {
 	return { config: { cacheDir, root: ROOT } } as unknown as AstroSettings;
@@ -438,10 +446,10 @@ describe('IncrementalBuildCache', () => {
 			return { cache, temp };
 		}
 
-		const PAGE = '/project/src/pages/page.astro';
-		const SIDEBAR = '/project/src/components/Sidebar.astro';
-		const SIDEBAR_DATA = '/project/src/data/sidebar_data.ts';
-		const OTHER = '/project/src/components/Other.astro';
+		const PAGE = projectFile('src/pages/page.astro');
+		const SIDEBAR = projectFile('src/components/Sidebar.astro');
+		const SIDEBAR_DATA = projectFile('src/data/sidebar_data.ts');
+		const OTHER = projectFile('src/components/Other.astro');
 
 		it('explains a changed leaf with a deterministic chain', () => {
 			const previous = graph(
@@ -542,8 +550,8 @@ describe('IncrementalBuildCache', () => {
 		});
 
 		it('terminates on cycles and explains each changed leaf once', () => {
-			const A = '/project/src/components/A.astro';
-			const B = '/project/src/components/B.astro';
+			const A = projectFile('src/components/A.astro');
+			const B = projectFile('src/components/B.astro');
 			const previous = graph(
 				{
 					[PAGE]: { fingerprint: 'page', importedIds: [A] },
@@ -571,8 +579,8 @@ describe('IncrementalBuildCache', () => {
 		});
 
 		it('explains a content entry change through the rendered-content boundary', () => {
-			const ENTRY = '/project/src/content/docs/a.mdx';
-			const CALLOUT = '/project/src/components/Callout.astro';
+			const ENTRY = projectFile('src/content/docs/a.mdx');
+			const CALLOUT = projectFile('src/components/Callout.astro');
 			const previous = graph(
 				{
 					[ENTRY]: { fingerprint: 'entry1', importedIds: [CALLOUT] },

--- a/packages/astro/test/units/build/incremental-cache.test.ts
+++ b/packages/astro/test/units/build/incremental-cache.test.ts
@@ -417,9 +417,9 @@ describe('IncrementalBuildCache', () => {
 			previousGraph: DiagnosticGraph,
 			currentGraph: DiagnosticGraph,
 			{
-				sidecar = previousGraph,
+				diagnostics = previousGraph,
 				previousManifestHash = HASH,
-			}: { sidecar?: DiagnosticGraph; previousManifestHash?: string } = {},
+			}: { diagnostics?: DiagnosticGraph; previousManifestHash?: string } = {},
 		): { cache: IncrementalBuildCache; temp: { cleanup: () => void } } {
 			const temp = tmpCacheDir();
 			const manifest = previousManifest(
@@ -429,7 +429,7 @@ describe('IncrementalBuildCache', () => {
 			writeFileSync(new URL('incremental-build.json', temp.dir), JSON.stringify(manifest));
 			writeFileSync(
 				new URL('incremental-build-diagnostics.json', temp.dir),
-				JSON.stringify({ version: 1, prerender: sidecar, client: emptyGraph() }),
+				JSON.stringify({ version: 1, prerender: diagnostics, client: emptyGraph() }),
 			);
 			const cache = loadedCache(manifest, {
 				currentDiagnostics: { version: 1, prerender: currentGraph, client: emptyGraph() },
@@ -604,7 +604,7 @@ describe('IncrementalBuildCache', () => {
 			temp.cleanup();
 		});
 
-		it('ignores a sidecar that does not match the manifest route hash', () => {
+		it('ignores a diagnostics file that does not match the manifest route hash', () => {
 			const current = graph(
 				{
 					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
@@ -613,7 +613,7 @@ describe('IncrementalBuildCache', () => {
 				},
 				{ routeRoots: { [ROUTE]: [PAGE] } },
 			);
-			const staleSidecar = graph(
+			const staleDiagnostics = graph(
 				{
 					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
 					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
@@ -621,8 +621,8 @@ describe('IncrementalBuildCache', () => {
 				},
 				{ routeRoots: { [ROUTE]: [PAGE] }, routeDependencyHashes: { [ROUTE]: 'stale-hash' } },
 			);
-			const { cache, temp } = diagnosticsCache(staleSidecar, current, {
-				sidecar: staleSidecar,
+			const { cache, temp } = diagnosticsCache(staleDiagnostics, current, {
+				diagnostics: staleDiagnostics,
 				previousManifestHash: HASH,
 			});
 			const decision = cache.checkPath(ROUTE, '/a', 'changed-hash', 'k1');
@@ -635,7 +635,7 @@ describe('IncrementalBuildCache', () => {
 			temp.cleanup();
 		});
 
-		it('reports missing-sidecar when no previous diagnostics exist', () => {
+		it('reports missing-diagnostics when no previous diagnostics exist', () => {
 			const temp = tmpCacheDir();
 			const manifest = previousManifest({
 				'/a': { cacheKey: 'k1', outputFile: 'a/index.html' },
@@ -662,7 +662,7 @@ describe('IncrementalBuildCache', () => {
 			const reason = decision.reasons.find((r) => r.type === 'route-dependencies-changed');
 			assert.ok(reason && reason.type === 'route-dependencies-changed');
 			assert.equal(reason.changes, undefined);
-			assert.equal(reason.diagnosticsUnavailable, 'missing-sidecar');
+			assert.equal(reason.diagnosticsUnavailable, 'missing-diagnostics');
 			temp.cleanup();
 		});
 	});

--- a/packages/astro/test/units/build/incremental-cache.test.ts
+++ b/packages/astro/test/units/build/incremental-cache.test.ts
@@ -1,9 +1,36 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
-import { IncrementalBuildCache } from '../../../dist/core/build/incremental.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { after, describe, it } from 'node:test';
+import {
+	IncrementalBuildCache,
+	type DiagnosticGraph,
+	type IncrementalCacheLoadReason,
+	type IncrementalCacheLoadResult,
+	type IncrementalDiagnosticsFile,
+	type IncrementalManifest,
+	type IncrementalPathMissReason,
+} from '../../../dist/core/build/incremental.js';
+import type { AstroSettings } from '../../../dist/types/astro.js';
 
 const ROUTE = 'src/pages/[slug].astro';
 const HASH = 'deadbeef';
+const ROOT = new URL('file:///project/');
+
+function settings(cacheDir: URL): AstroSettings {
+	return { config: { cacheDir, root: ROOT } } as unknown as AstroSettings;
+}
+
+function tmpCacheDir(): { dir: URL; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), 'astro-incremental-'));
+	const cacheDir = new URL(pathToFileURL(dir).href + '/');
+	return {
+		dir: cacheDir,
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
 
 function previousManifest(
 	paths: Record<
@@ -11,7 +38,7 @@ function previousManifest(
 		{ cacheKey: string; outputFile: string; contentHashes?: Record<string, string> }
 	>,
 	{ dependencyHash = HASH, route = ROUTE, keyDigest = 'key' } = {},
-) {
+): IncrementalManifest {
 	return {
 		version: 1,
 		configHash: 'cfg',
@@ -21,99 +48,635 @@ function previousManifest(
 	};
 }
 
+function loadedCache(
+	previous: IncrementalManifest | null,
+	{
+		reasons = previous
+			? (['loaded'] as IncrementalCacheLoadReason[])
+			: (['missing'] as IncrementalCacheLoadReason[]),
+		contentHashes = new Map<string, string>(),
+		currentDiagnostics = null,
+		settingsOverride,
+		islandKeyChanged = false,
+	}: {
+		reasons?: IncrementalCacheLoadReason[];
+		contentHashes?: Map<string, string>;
+		currentDiagnostics?: IncrementalDiagnosticsFile | null;
+		settingsOverride?: AstroSettings;
+		islandKeyChanged?: boolean;
+	} = {},
+): IncrementalBuildCache {
+	const loadResult: IncrementalCacheLoadResult = {
+		previous,
+		reasons,
+		islandKeyChanged,
+	};
+	return new IncrementalBuildCache(
+		'cfg',
+		'lock',
+		'key',
+		contentHashes,
+		loadResult,
+		currentDiagnostics,
+		settingsOverride,
+	);
+}
+
+function graph(
+	modules: Record<
+		string,
+		{ fingerprint: string; importedIds?: string[]; dynamicallyImportedIds?: string[] }
+	>,
+	opts: {
+		routeRoots?: Record<string, string[]>;
+		contentRoots?: Record<string, string[]>;
+		routeDependencyHashes?: Record<string, string>;
+	} = {},
+): DiagnosticGraph {
+	return {
+		modules: Object.fromEntries(
+			Object.entries(modules).map(([id, module]) => [
+				id,
+				{
+					fingerprint: module.fingerprint,
+					importedIds: [...(module.importedIds ?? [])].sort(),
+					dynamicallyImportedIds: [...(module.dynamicallyImportedIds ?? [])].sort(),
+				},
+			]),
+		),
+		routeRoots: opts.routeRoots ?? {},
+		contentRoots: opts.contentRoots ?? {},
+		routeDependencyHashes: opts.routeDependencyHashes ?? {},
+	};
+}
+
+const emptyGraph = () => graph({});
+
+function missReasons(
+	cache: IncrementalBuildCache,
+	pathname: string,
+	cacheKey?: string,
+	hasServerIsland = false,
+): IncrementalPathMissReason[] {
+	const decision = cache.checkPath(ROUTE, pathname, HASH, cacheKey, hasServerIsland);
+	assert.equal(decision.reusable, false);
+	return decision.reusable ? [] : decision.reasons;
+}
+
 describe('IncrementalBuildCache', () => {
-	describe('canSkip', () => {
-		const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
+	describe('load result classification', () => {
+		const temp = tmpCacheDir();
+		after(() => temp.cleanup());
 
-		it('does not skip when there is no previous build', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), null);
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k1'), false);
+		function load(force = false) {
+			return IncrementalBuildCache.load(
+				settings(temp.dir),
+				'cfg',
+				'lock',
+				'key',
+				new Map(),
+				null,
+				force,
+			).loadResult;
+		}
+
+		it('reports a missing manifest (ENOENT)', () => {
+			assert.deepEqual(load(), { previous: null, reasons: ['missing'], islandKeyChanged: false });
 		});
 
-		it('does not skip when the route is absent from the previous build', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
-			assert.equal(cache.canSkip('src/pages/other.astro', '/a', HASH, 'k1'), false);
+		it('reports malformed JSON as an invalid manifest', () => {
+			writeFileSync(new URL('incremental-build.json', temp.dir), 'not json {');
+			assert.deepEqual(load(), {
+				previous: null,
+				reasons: ['invalid-manifest'],
+				islandKeyChanged: false,
+			});
 		});
 
-		it('does not skip when the dependency hash changed', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
-			assert.equal(cache.canSkip(ROUTE, '/a', 'changed', 'k1'), false);
+		it('reports a manifest with an invalid top-level shape as invalid', () => {
+			writeFileSync(new URL('incremental-build.json', temp.dir), JSON.stringify({ version: 1 }));
+			assert.deepEqual(load(), {
+				previous: null,
+				reasons: ['invalid-manifest'],
+				islandKeyChanged: false,
+			});
 		});
 
-		it('does not skip when the path is absent', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
-			assert.equal(cache.canSkip(ROUTE, '/missing', HASH, 'k1'), false);
+		it('reports an unreadable manifest with its error code', () => {
+			// A directory at the manifest path makes readFileSync throw (EISDIR).
+			rmSync(new URL('incremental-build.json', temp.dir), { force: true });
+			mkdirSync(new URL('incremental-build.json', temp.dir));
+			const result = load();
+			assert.deepEqual(result.reasons, ['unreadable']);
+			assert.equal(result.errorCode, 'EISDIR');
+			rmSync(new URL('incremental-build.json', temp.dir), { recursive: true, force: true });
 		});
 
-		it('does not skip when the cacheKey changed', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k2'), false);
+		it('reports a cache-format version mismatch', () => {
+			const manifest = previousManifest({});
+			manifest.version = 0;
+			writeFileSync(new URL('incremental-build.json', temp.dir), JSON.stringify(manifest));
+			const result = load();
+			assert.deepEqual(result.reasons, ['version-changed']);
+			assert.equal(result.previousVersion, 0);
 		});
 
-		it('skips when the dependency hash and cacheKey match', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k1'), true);
+		it('reports a config hash mismatch', () => {
+			writeFileSync(
+				new URL('incremental-build.json', temp.dir),
+				JSON.stringify(previousManifest({})),
+			);
+			const result = IncrementalBuildCache.load(
+				settings(temp.dir),
+				'changed-config',
+				'lock',
+				'key',
+			).loadResult;
+			assert.deepEqual(result.reasons, ['config-changed']);
 		});
 
-		it('does not skip when a rendered content entry hash changed', () => {
-			const previousWithContent = previousManifest({
+		it('reports a lockfile hash mismatch', () => {
+			writeFileSync(
+				new URL('incremental-build.json', temp.dir),
+				JSON.stringify(previousManifest({})),
+			);
+			const result = IncrementalBuildCache.load(
+				settings(temp.dir),
+				'cfg',
+				'changed-lockfile',
+				'key',
+			).loadResult;
+			assert.deepEqual(result.reasons, ['lockfile-changed']);
+		});
+
+		it('reports simultaneous config and lockfile mismatches in stable order', () => {
+			writeFileSync(
+				new URL('incremental-build.json', temp.dir),
+				JSON.stringify(previousManifest({})),
+			);
+			const result = IncrementalBuildCache.load(
+				settings(temp.dir),
+				'changed-config',
+				'changed-lockfile',
+				'key',
+			).loadResult;
+			assert.deepEqual(result.reasons, ['config-changed', 'lockfile-changed']);
+		});
+
+		it('force takes precedence over a valid manifest', () => {
+			writeFileSync(
+				new URL('incremental-build.json', temp.dir),
+				JSON.stringify(previousManifest({})),
+			);
+			const result = load(true);
+			assert.deepEqual(result.reasons, ['forced']);
+			assert.equal(result.previous, null);
+		});
+
+		it('loads a valid manifest and reports a server-island key mismatch separately', () => {
+			writeFileSync(
+				new URL('incremental-build.json', temp.dir),
+				JSON.stringify(previousManifest({}, { keyDigest: 'old-key' })),
+			);
+			const result = load();
+			assert.deepEqual(result.reasons, ['loaded']);
+			assert.notEqual(result.previous, null);
+			assert.equal(result.islandKeyChanged, true);
+		});
+
+		it('loads a valid manifest with a matching island key', () => {
+			writeFileSync(
+				new URL('incremental-build.json', temp.dir),
+				JSON.stringify(previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } })),
+			);
+			const result = load();
+			assert.deepEqual(result.reasons, ['loaded']);
+			assert.equal(result.islandKeyChanged, false);
+			assert.equal(result.previous?.routes[ROUTE]?.paths['/a']?.cacheKey, 'k1');
+		});
+	});
+
+	describe('checkPath', () => {
+		it('reports no cacheKey', () => {
+			const cache = loadedCache(null);
+			assert.deepEqual(missReasons(cache, '/a'), [{ type: 'no-cache-key' }]);
+		});
+
+		it('reports a forced build', () => {
+			const cache = loadedCache(null, { reasons: ['forced'] });
+			assert.deepEqual(missReasons(cache, '/a', 'k1'), [
+				{ type: 'global-cache', reasons: ['forced'] },
+			]);
+		});
+
+		it('reports a missing cache', () => {
+			const cache = loadedCache(null);
+			assert.deepEqual(missReasons(cache, '/a', 'k1'), [
+				{ type: 'global-cache', reasons: ['missing'] },
+			]);
+		});
+
+		it('reports an invalid manifest', () => {
+			const cache = loadedCache(null, { reasons: ['invalid-manifest'] });
+			assert.deepEqual(missReasons(cache, '/a', 'k1'), [
+				{ type: 'global-cache', reasons: ['invalid-manifest'] },
+			]);
+		});
+
+		it('reports simultaneous global mismatches', () => {
+			const cache = loadedCache(null, { reasons: ['config-changed', 'lockfile-changed'] });
+			assert.deepEqual(missReasons(cache, '/a', 'k1'), [
+				{ type: 'global-cache', reasons: ['config-changed', 'lockfile-changed'] },
+			]);
+		});
+
+		it('reports a new route', () => {
+			const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
+			const cache = loadedCache(previous);
+			const decision = cache.checkPath('src/pages/other.astro', '/a', HASH, 'k1');
+			assert.deepEqual(decision, { reusable: false, reasons: [{ type: 'new-route' }] });
+		});
+
+		it('reports changed module dependencies', () => {
+			const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
+			const cache = loadedCache(previous);
+			const decision = cache.checkPath(ROUTE, '/a', 'changed', 'k1');
+			assert.equal(decision.reusable, false);
+			assert.ok(
+				decision.reusable === false && decision.reasons[0].type === 'route-dependencies-changed',
+			);
+		});
+
+		it('reports a new path', () => {
+			const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
+			const cache = loadedCache(previous);
+			assert.deepEqual(missReasons(cache, '/missing', 'k1'), [{ type: 'new-path' }]);
+		});
+
+		it('reports a changed cacheKey', () => {
+			const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
+			const cache = loadedCache(previous);
+			assert.deepEqual(missReasons(cache, '/a', 'k2'), [{ type: 'cache-key-changed' }]);
+		});
+
+		it('reports a single changed content entry', () => {
+			const previous = previousManifest({
 				'/a': {
 					cacheKey: 'k1',
 					outputFile: 'a/index.html',
 					contentHashes: { 'src/content/docs/a.mdx': 'h1' },
 				},
 			});
-			const cache = new IncrementalBuildCache(
-				'cfg',
-				'lock',
-				'key',
-				new Map([['src/content/docs/a.mdx', 'h2']]),
-				previousWithContent,
-			);
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k1'), false);
+			const cache = loadedCache(previous, {
+				contentHashes: new Map([['src/content/docs/a.mdx', 'h2']]),
+			});
+			const reasons = missReasons(cache, '/a', 'k1');
+			assert.equal(reasons.length, 1);
+			assert.equal(reasons[0].type, 'content-dependencies-changed');
+			if (reasons[0].type === 'content-dependencies-changed') {
+				assert.deepEqual(reasons[0].entries, ['src/content/docs/a.mdx']);
+			}
 		});
 
-		it('skips when rendered content entry hashes are unchanged', () => {
-			const previousWithContent = previousManifest({
+		it('reports multiple changed content entries', () => {
+			const previous = previousManifest({
 				'/a': {
 					cacheKey: 'k1',
 					outputFile: 'a/index.html',
-					contentHashes: { 'src/content/docs/a.mdx': 'h1' },
+					contentHashes: { 'src/content/docs/a.mdx': 'h1', 'src/content/docs/b.mdx': 'h2' },
 				},
 			});
-			const cache = new IncrementalBuildCache(
-				'cfg',
-				'lock',
-				'key',
-				new Map([['src/content/docs/a.mdx', 'h1']]),
-				previousWithContent,
+			const cache = loadedCache(previous, {
+				contentHashes: new Map([
+					['src/content/docs/a.mdx', 'h2'],
+					['src/content/docs/b.mdx', 'h3'],
+				]),
+			});
+			const reasons = missReasons(cache, '/a', 'k1');
+			assert.equal(reasons.length, 1);
+			if (reasons[0].type === 'content-dependencies-changed') {
+				assert.deepEqual(reasons[0].entries, ['src/content/docs/a.mdx', 'src/content/docs/b.mdx']);
+			}
+		});
+
+		it('reports every independent reason in stable order', () => {
+			const previous = previousManifest(
+				{
+					'/a': {
+						cacheKey: 'k1',
+						outputFile: 'a/index.html',
+						contentHashes: { 'src/content/docs/a.mdx': 'h1' },
+					},
+				},
+				{ keyDigest: 'old-key' },
 			);
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k1'), true);
+			const cache = loadedCache(previous, {
+				contentHashes: new Map([['src/content/docs/a.mdx', 'h2']]),
+				islandKeyChanged: true,
+			});
+			const decision = cache.checkPath(ROUTE, '/a', 'changed', 'k2', true);
+			assert.equal(decision.reusable, false);
+			if (decision.reusable) return;
+			assert.deepEqual(
+				decision.reasons.map((reason) => reason.type),
+				[
+					'island-key-changed',
+					'route-dependencies-changed',
+					'cache-key-changed',
+					'content-dependencies-changed',
+				],
+			);
 		});
 
 		it('skips a server-island page when the key digest is unchanged', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k1', true), true);
+			const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
+			const cache = loadedCache(previous);
+			assert.deepEqual(cache.checkPath(ROUTE, '/a', HASH, 'k1', true), { reusable: true });
 		});
 
 		it('does not skip a server-island page when the key digest changed', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'newkey', new Map(), previous);
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k1', true), false);
+			const previous = previousManifest(
+				{ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } },
+				{ keyDigest: 'old-key' },
+			);
+			const cache = loadedCache(previous, { islandKeyChanged: true });
+			assert.deepEqual(missReasons(cache, '/a', 'k1', true), [{ type: 'island-key-changed' }]);
 			// A page without an island is unaffected by the key change.
-			assert.equal(cache.canSkip(ROUTE, '/a', HASH, 'k1', false), true);
+			assert.deepEqual(cache.checkPath(ROUTE, '/a', HASH, 'k1', false), { reusable: true });
+		});
+
+		it('is reusable when every input matches', () => {
+			const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
+			const cache = loadedCache(previous);
+			assert.deepEqual(cache.checkPath(ROUTE, '/a', HASH, 'k1'), { reusable: true });
+		});
+	});
+
+	describe('dependency explanations', () => {
+		function diagnosticsCache(
+			previousGraph: DiagnosticGraph,
+			currentGraph: DiagnosticGraph,
+			{
+				sidecar = previousGraph,
+				previousManifestHash = HASH,
+			}: { sidecar?: DiagnosticGraph; previousManifestHash?: string } = {},
+		): { cache: IncrementalBuildCache; temp: { cleanup: () => void } } {
+			const temp = tmpCacheDir();
+			const manifest = previousManifest(
+				{ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } },
+				{ dependencyHash: previousManifestHash },
+			);
+			writeFileSync(new URL('incremental-build.json', temp.dir), JSON.stringify(manifest));
+			writeFileSync(
+				new URL('incremental-build-diagnostics.json', temp.dir),
+				JSON.stringify({ version: 1, prerender: sidecar, client: emptyGraph() }),
+			);
+			const cache = loadedCache(manifest, {
+				currentDiagnostics: { version: 1, prerender: currentGraph, client: emptyGraph() },
+				settingsOverride: settings(temp.dir),
+			});
+			return { cache, temp };
+		}
+
+		const PAGE = '/project/src/pages/page.astro';
+		const SIDEBAR = '/project/src/components/Sidebar.astro';
+		const SIDEBAR_DATA = '/project/src/data/sidebar_data.ts';
+		const OTHER = '/project/src/components/Other.astro';
+
+		it('explains a changed leaf with a deterministic chain', () => {
+			const previous = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+					[SIDEBAR_DATA]: { fingerprint: 'v1' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] }, routeDependencyHashes: { [ROUTE]: HASH } },
+			);
+			const current = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+					[SIDEBAR_DATA]: { fingerprint: 'v2' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] } },
+			);
+			const { cache, temp } = diagnosticsCache(previous, current);
+			const decision = cache.checkPath(ROUTE, '/a', 'changed-hash', 'k1');
+			assert.equal(decision.reusable, false);
+			if (decision.reusable) return;
+			const reason = decision.reasons.find((r) => r.type === 'route-dependencies-changed');
+			assert.ok(reason && reason.type === 'route-dependencies-changed' && reason.changes);
+			assert.deepEqual(reason.changes, [
+				{
+					status: 'changed',
+					chain: ['src/components/Sidebar.astro', 'src/data/sidebar_data.ts'],
+				},
+			]);
+			temp.cleanup();
+		});
+
+		it('reports added and removed leaves', () => {
+			const previous = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+					[SIDEBAR_DATA]: { fingerprint: 'v1' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] }, routeDependencyHashes: { [ROUTE]: HASH } },
+			);
+			const current = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [OTHER] },
+					[OTHER]: { fingerprint: 'other' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] } },
+			);
+			const { cache, temp } = diagnosticsCache(previous, current);
+			const explanation = cache.explainRoute(ROUTE);
+			assert.ok(explanation && 'changes' in explanation);
+			if (explanation && 'changes' in explanation) {
+				assert.deepEqual(
+					explanation.changes.map((change) => [change.status, change.chain.at(-1)]),
+					[
+						['added', 'src/components/Other.astro'],
+						['removed', 'src/data/sidebar_data.ts'],
+					],
+				);
+			}
+			temp.cleanup();
+		});
+
+		it('finds the shortest chain when a module has multiple importers', () => {
+			const previous = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR, OTHER] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+					[OTHER]: { fingerprint: 'other', importedIds: [SIDEBAR_DATA] },
+					[SIDEBAR_DATA]: { fingerprint: 'v1' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] }, routeDependencyHashes: { [ROUTE]: HASH } },
+			);
+			const current = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR, OTHER] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+					[OTHER]: { fingerprint: 'other', importedIds: [SIDEBAR_DATA] },
+					[SIDEBAR_DATA]: { fingerprint: 'v2' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] } },
+			);
+			const { cache, temp } = diagnosticsCache(previous, current);
+			const explanation = cache.explainRoute(ROUTE);
+			assert.ok(explanation && 'changes' in explanation);
+			if (explanation && 'changes' in explanation) {
+				assert.equal(explanation.changes.length, 1);
+				// SIDEBAR_DATA is reachable directly from OTHER, so the chain is
+				// PAGE → OTHER → SIDEBAR_DATA and skips the longer SIDEBAR path.
+				assert.deepEqual(explanation.changes[0].chain, [
+					'src/components/Other.astro',
+					'src/data/sidebar_data.ts',
+				]);
+			}
+			temp.cleanup();
+		});
+
+		it('terminates on cycles and explains each changed leaf once', () => {
+			const A = '/project/src/components/A.astro';
+			const B = '/project/src/components/B.astro';
+			const previous = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [A] },
+					[A]: { fingerprint: 'a1', importedIds: [B] },
+					[B]: { fingerprint: 'b1', importedIds: [A] },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] }, routeDependencyHashes: { [ROUTE]: HASH } },
+			);
+			const current = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [A] },
+					[A]: { fingerprint: 'a1', importedIds: [B] },
+					[B]: { fingerprint: 'b2', importedIds: [A] },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] } },
+			);
+			const { cache, temp } = diagnosticsCache(previous, current);
+			const explanation = cache.explainRoute(ROUTE);
+			assert.ok(explanation && 'changes' in explanation);
+			if (explanation && 'changes' in explanation) {
+				assert.equal(explanation.changes.length, 1);
+				assert.equal(explanation.changes[0].chain.at(-1), 'src/components/B.astro');
+			}
+			temp.cleanup();
+		});
+
+		it('explains a content entry change through the rendered-content boundary', () => {
+			const ENTRY = '/project/src/content/docs/a.mdx';
+			const CALLOUT = '/project/src/components/Callout.astro';
+			const previous = graph(
+				{
+					[ENTRY]: { fingerprint: 'entry1', importedIds: [CALLOUT] },
+					[CALLOUT]: { fingerprint: 'callout1' },
+				},
+				{
+					contentRoots: { 'src/content/docs/a.mdx': [ENTRY] },
+					routeDependencyHashes: { [ROUTE]: HASH },
+				},
+			);
+			const current = graph(
+				{
+					[ENTRY]: { fingerprint: 'entry1', importedIds: [CALLOUT] },
+					[CALLOUT]: { fingerprint: 'callout2' },
+				},
+				{ contentRoots: { 'src/content/docs/a.mdx': [ENTRY] } },
+			);
+			const { cache, temp } = diagnosticsCache(previous, current);
+			const explanation = cache.explainContent('src/content/docs/a.mdx');
+			assert.ok(explanation && 'changes' in explanation);
+			if (explanation && 'changes' in explanation) {
+				assert.deepEqual(explanation.changes, [
+					{
+						status: 'changed',
+						chain: ['rendered content: src/content/docs/a.mdx', 'src/components/Callout.astro'],
+					},
+				]);
+			}
+			temp.cleanup();
+		});
+
+		it('ignores a sidecar that does not match the manifest route hash', () => {
+			const current = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+					[SIDEBAR_DATA]: { fingerprint: 'v2' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] } },
+			);
+			const staleSidecar = graph(
+				{
+					[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
+					[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+					[SIDEBAR_DATA]: { fingerprint: 'v1' },
+				},
+				{ routeRoots: { [ROUTE]: [PAGE] }, routeDependencyHashes: { [ROUTE]: 'stale-hash' } },
+			);
+			const { cache, temp } = diagnosticsCache(staleSidecar, current, {
+				sidecar: staleSidecar,
+				previousManifestHash: HASH,
+			});
+			const decision = cache.checkPath(ROUTE, '/a', 'changed-hash', 'k1');
+			assert.equal(decision.reusable, false);
+			if (decision.reusable) return;
+			const reason = decision.reasons.find((r) => r.type === 'route-dependencies-changed');
+			assert.ok(reason && reason.type === 'route-dependencies-changed');
+			assert.equal(reason.changes, undefined);
+			assert.equal(reason.diagnosticsUnavailable, 'unavailable');
+			temp.cleanup();
+		});
+
+		it('reports missing-sidecar when no previous diagnostics exist', () => {
+			const temp = tmpCacheDir();
+			const manifest = previousManifest({
+				'/a': { cacheKey: 'k1', outputFile: 'a/index.html' },
+			});
+			writeFileSync(new URL('incremental-build.json', temp.dir), JSON.stringify(manifest));
+			const cache = loadedCache(manifest, {
+				currentDiagnostics: {
+					version: 1,
+					prerender: graph(
+						{
+							[PAGE]: { fingerprint: 'page', importedIds: [SIDEBAR] },
+							[SIDEBAR]: { fingerprint: 'sidebar', importedIds: [SIDEBAR_DATA] },
+							[SIDEBAR_DATA]: { fingerprint: 'v2' },
+						},
+						{ routeRoots: { [ROUTE]: [PAGE] } },
+					),
+					client: emptyGraph(),
+				},
+				settingsOverride: settings(temp.dir),
+			});
+			const decision = cache.checkPath(ROUTE, '/a', 'changed-hash', 'k1');
+			assert.equal(decision.reusable, false);
+			if (decision.reusable) return;
+			const reason = decision.reasons.find((r) => r.type === 'route-dependencies-changed');
+			assert.ok(reason && reason.type === 'route-dependencies-changed');
+			assert.equal(reason.changes, undefined);
+			assert.equal(reason.diagnosticsUnavailable, 'missing-sidecar');
+			temp.cleanup();
 		});
 	});
 
 	describe('findOrphanedFiles', () => {
 		it('is empty when there is no previous build', () => {
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), null);
+			const cache = loadedCache(null);
 			cache.record(ROUTE, HASH, '/a', 'k1', 'a/index.html');
 			assert.deepEqual(cache.findOrphanedFiles(), []);
 		});
 
 		it('does not orphan a path re-recorded in this build', () => {
 			const previous = previousManifest({ '/a': { cacheKey: 'k1', outputFile: 'a/index.html' } });
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
+			const cache = loadedCache(previous);
 			cache.record(ROUTE, HASH, '/a', 'k1', 'a/index.html');
 			assert.deepEqual(cache.findOrphanedFiles(), []);
 		});
@@ -123,7 +686,7 @@ describe('IncrementalBuildCache', () => {
 				'/a': { cacheKey: 'k1', outputFile: 'a/index.html' },
 				'/b': { cacheKey: 'k2', outputFile: 'b/index.html' },
 			});
-			const cache = new IncrementalBuildCache('cfg', 'lock', 'key', new Map(), previous);
+			const cache = loadedCache(previous);
 			cache.record(ROUTE, HASH, '/a', 'k1', 'a/index.html');
 			assert.deepEqual(cache.findOrphanedFiles(), ['b/index.html']);
 		});

--- a/packages/astro/test/units/build/incremental-logging.test.ts
+++ b/packages/astro/test/units/build/incremental-logging.test.ts
@@ -1,0 +1,508 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { AstroLogger, type AstroLoggerMessage } from '../../../dist/core/logger/core.js';
+import {
+	formatMissSuffix,
+	IncrementalBuildReporter,
+	logCacheLoadResult,
+	type IncrementalPathOutcome,
+} from '../../../dist/core/build/incremental-logging.js';
+import type {
+	IncrementalCacheLoadResult,
+	IncrementalPathMissReason,
+} from '../../../dist/core/build/incremental.js';
+
+function captureLogger(level: 'info' | 'debug' = 'info'): {
+	logger: AstroLogger;
+	logs: AstroLoggerMessage[];
+} {
+	const logs: AstroLoggerMessage[] = [];
+	const logger = new AstroLogger({
+		destination: {
+			write(event) {
+				logs.push(event);
+			},
+		},
+		level,
+	});
+	return { logger, logs };
+}
+
+function outcome(
+	route: string,
+	pathname: string,
+	result: IncrementalPathOutcome['result'],
+	reasons: IncrementalPathMissReason[] = [],
+	{
+		elapsedMs = 0,
+		stored = true,
+		storageNote,
+	}: {
+		elapsedMs?: number;
+		stored?: boolean;
+		storageNote?: IncrementalPathOutcome['storageNote'];
+	} = {},
+): IncrementalPathOutcome {
+	return {
+		route,
+		pathname,
+		outputFile: `${pathname}/index.html`,
+		result,
+		reasons,
+		elapsedMs,
+		stored,
+		storageNote,
+	};
+}
+
+/** Replace volatile duration strings so exact snapshots stay stable. */
+function normalizeTime(text: string): string {
+	return text.replace(/<1ms|\d+(?:\.\d+)?m?s/g, '<time>');
+}
+
+describe('logCacheLoadResult', () => {
+	it('prints the exact global messages for every load reason', () => {
+		const { logger, logs } = captureLogger();
+		const loadResult: IncrementalCacheLoadResult = {
+			previous: null,
+			reasons: [
+				'forced',
+				'missing',
+				'invalid-manifest',
+				'unreadable',
+				'version-changed',
+				'config-changed',
+				'lockfile-changed',
+			],
+			previousVersion: 0,
+			errorCode: 'EACCES',
+			islandKeyChanged: true,
+		};
+		logCacheLoadResult(loadResult, logger);
+		const messages = logs.map((log) => log.message);
+		assert.ok(messages.includes('Incremental cache bypassed by --force; performing a full build.'));
+		assert.ok(messages.includes('Incremental cache not found; performing a full build.'));
+		assert.ok(messages.includes('Incremental cache manifest is invalid; performing a full build.'));
+		assert.ok(
+			messages.includes('Incremental cache could not be read; performing a full build. (EACCES)'),
+		);
+		assert.ok(
+			messages.includes('Incremental cache invalidated: cache format changed (version 0 → 1).'),
+		);
+		assert.ok(messages.includes('Incremental cache invalidated: Astro configuration changed.'));
+		assert.ok(messages.includes('Incremental cache invalidated: dependency lockfile changed.'));
+		assert.ok(
+			messages.includes(
+				'Incremental cache: server-island encryption key changed; affected pages will be rendered.',
+			),
+		);
+		// Invalid-manifest and unreadable are warnings; everything else is info.
+		assert.deepEqual(
+			logs.filter((log) => log.level === 'warn').map((log) => log.message),
+			[
+				'Incremental cache manifest is invalid; performing a full build.',
+				'Incremental cache could not be read; performing a full build. (EACCES)',
+			],
+		);
+	});
+
+	it('omits the error code when none is available', () => {
+		const { logger, logs } = captureLogger();
+		logCacheLoadResult(
+			{ previous: null, reasons: ['unreadable'], islandKeyChanged: false },
+			logger,
+		);
+		assert.ok(
+			logs.some(
+				(log) => log.message === 'Incremental cache could not be read; performing a full build.',
+			),
+		);
+	});
+
+	it('is silent about a loaded cache at info level but reports it under verbose', () => {
+		const infoLogs = captureLogger();
+		logCacheLoadResult(
+			{ previous: {}, reasons: ['loaded'], islandKeyChanged: false } as IncrementalCacheLoadResult,
+			infoLogs.logger,
+		);
+		assert.ok(!infoLogs.logs.some((log) => log.message.includes('loaded from')));
+
+		const verboseLogs = captureLogger('debug');
+		logCacheLoadResult(
+			{ previous: {}, reasons: ['loaded'], islandKeyChanged: false } as IncrementalCacheLoadResult,
+			verboseLogs.logger,
+		);
+		assert.ok(
+			verboseLogs.logs.some(
+				(log) => log.message === 'Incremental cache loaded from incremental-build.json.',
+			),
+		);
+	});
+});
+
+describe('formatMissSuffix', () => {
+	it('formats every miss reason exactly', () => {
+		const cases: Array<[IncrementalPathMissReason[], string]> = [
+			[[{ type: 'no-cache-key' }], '(not cacheable: no cacheKey)'],
+			[[{ type: 'global-cache', reasons: ['forced'] }], '(cache miss: bypassed by --force)'],
+			[[{ type: 'global-cache', reasons: ['missing'] }], '(cache miss: cache not found)'],
+			[
+				[{ type: 'global-cache', reasons: ['invalid-manifest'] }],
+				'(cache miss: cache unavailable)',
+			],
+			[[{ type: 'global-cache', reasons: ['unreadable'] }], '(cache miss: cache unavailable)'],
+			[
+				[{ type: 'global-cache', reasons: ['version-changed'] }],
+				'(cache miss: cache format changed)',
+			],
+			[
+				[{ type: 'global-cache', reasons: ['config-changed'] }],
+				'(cache miss: configuration changed)',
+			],
+			[
+				[{ type: 'global-cache', reasons: ['lockfile-changed'] }],
+				'(cache miss: dependency lockfile changed)',
+			],
+			[
+				[{ type: 'global-cache', reasons: ['config-changed', 'lockfile-changed'] }],
+				'(cache miss: configuration changed; dependency lockfile changed)',
+			],
+			[[{ type: 'new-route' }], '(cache miss: new route)'],
+			[[{ type: 'new-path' }], '(cache miss: new path)'],
+			[[{ type: 'island-key-changed' }], '(cache miss: server-island encryption key changed)'],
+			[[{ type: 'route-dependencies-changed' }], '(cache miss: module dependencies changed)'],
+			[[{ type: 'cache-key-changed' }], '(cache miss: cacheKey changed)'],
+			[
+				[{ type: 'content-dependencies-changed', entries: ['src/content/docs/one.mdx'] }],
+				'(cache miss: content dependency changed: src/content/docs/one.mdx)',
+			],
+			[
+				[
+					{
+						type: 'content-dependencies-changed',
+						entries: ['src/content/docs/one.mdx', 'src/content/docs/two.mdx'],
+					},
+				],
+				'(cache miss: 2 content dependencies changed)',
+			],
+			[[{ type: 'cached-output-missing' }], '(cache miss: cached output missing)'],
+		];
+		for (const [reasons, expected] of cases) {
+			assert.equal(formatMissSuffix(reasons), expected);
+		}
+	});
+
+	it('lists multiple reasons in the given order', () => {
+		assert.equal(
+			formatMissSuffix([{ type: 'route-dependencies-changed' }, { type: 'cache-key-changed' }]),
+			'(cache miss: module dependencies changed; cacheKey changed)',
+		);
+	});
+
+	it('never discloses raw cacheKey values', () => {
+		// A key can be a token, user data, or a large serialized object; only the
+		// fact that it changed is reported.
+		assert.equal(
+			formatMissSuffix([{ type: 'cache-key-changed' }]),
+			'(cache miss: cacheKey changed)',
+		);
+		assert.ok(!formatMissSuffix([{ type: 'cache-key-changed' }]).includes('secret-token'));
+	});
+
+	it('returns nothing when there are no reasons', () => {
+		assert.equal(formatMissSuffix([]), '');
+	});
+});
+
+describe('IncrementalBuildReporter', () => {
+	const BLOG = 'src/pages/blog/[slug].astro';
+	const ABOUT = 'src/pages/about.astro';
+
+	function print(
+		level: 'info' | 'debug',
+		outcomes: IncrementalPathOutcome[],
+	): { logs: AstroLoggerMessage[]; text: string } {
+		const { logger, logs } = captureLogger(level);
+		const reporter = new IncrementalBuildReporter();
+		for (const item of outcomes) reporter.push(item);
+		reporter.printSummary(logger);
+		return { logs, text: logs.map((log) => log.message).join('\n') };
+	}
+
+	it('prints nothing when no paths were processed', () => {
+		const { logs } = print('info', []);
+		assert.equal(logs.length, 0);
+	});
+
+	it('prints the one-line summary with hit/miss counts', () => {
+		const { text } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'cached', [], { elapsedMs: 1 }),
+			outcome(BLOG, '/blog/post-1', 'restored', [], { elapsedMs: 2 }),
+			outcome(BLOG, '/blog/post-2', 'rendered', [{ type: 'cache-key-changed' }], { elapsedMs: 5 }),
+			outcome(ABOUT, '/about', 'rendered', [{ type: 'no-cache-key' }], {
+				stored: false,
+				elapsedMs: 3,
+			}),
+		]);
+		assert.ok(
+			text.includes(
+				' incremental build: 4 paths — 1 cached, 1 restored, 2 rendered (1 not stored)',
+			),
+		);
+	});
+
+	it('omits the not-stored count when everything was stored', () => {
+		const { text } = print('info', [outcome(BLOG, '/blog/post-1', 'cached', [])]);
+		assert.ok(text.includes(' incremental build: 1 paths — 1 cached, 0 restored, 0 rendered'));
+		assert.ok(!text.includes('not stored'));
+	});
+
+	it('prints the grouped route table with deterministic sorting', () => {
+		const { text } = print('info', [
+			outcome(BLOG, '/blog/post-3', 'rendered', [{ type: 'cache-key-changed' }], { elapsedMs: 31 }),
+			outcome(BLOG, '/blog/post-2', 'rendered', [{ type: 'cache-key-changed' }], { elapsedMs: 30 }),
+			outcome(BLOG, '/blog/post-1', 'cached', [], { elapsedMs: 9 }),
+			outcome(ABOUT, '/about', 'rendered', [{ type: 'no-cache-key' }], {
+				stored: false,
+				elapsedMs: 3,
+			}),
+		]);
+		const normalized = normalizeTime(text);
+		assert.ok(
+			normalized.includes(
+				' Route                                Result    Reason            Paths  Time',
+			),
+			`missing header in:\n${normalized}`,
+		);
+		// Rows are sorted by route, then cached < restored < rendered.
+		const aboutIndex = normalized.indexOf('src/pages/about.astro');
+		const cachedIndex = normalized.indexOf('src/pages/blog/[slug].astro          cached');
+		assert.ok(aboutIndex < cachedIndex, 'about sorts before blog');
+		assert.ok(
+			normalized.includes(
+				'src/pages/blog/[slug].astro          cached    cache hit             1  <time>',
+			),
+		);
+		assert.ok(
+			normalized.includes(
+				'src/pages/blog/[slug].astro          rendered  cacheKey changed      2  <time>',
+			),
+		);
+		assert.ok(
+			normalized.includes(
+				'src/pages/about.astro                rendered  no cacheKey           1  <time>',
+			),
+		);
+	});
+
+	it('aggregates path counts and time per group', () => {
+		const { text } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'restored', [], { elapsedMs: 4 }),
+			outcome(BLOG, '/blog/post-2', 'restored', [], { elapsedMs: 5 }),
+		]);
+		const normalized = normalizeTime(text);
+		assert.ok(
+			normalized.includes(
+				'src/pages/blog/[slug].astro          restored  cache hit      2  <time>',
+			),
+		);
+	});
+
+	it('switches to compact totals beyond 20 grouped rows', () => {
+		const outcomes = Array.from({ length: 21 }, (_, i) =>
+			outcome(`src/pages/route-${i}.astro`, `/page-${i}`, 'rendered', [{ type: 'new-path' }], {
+				stored: false,
+			}),
+		);
+		const { text } = print('info', outcomes);
+		assert.ok(!text.includes('Route                                  Result'));
+		assert.ok(text.includes(' reasons: new path 21'));
+		assert.ok(text.includes(' route table omitted (21 rows); rerun with --verbose to show all'));
+	});
+
+	it('prints the full table at exactly 20 grouped rows', () => {
+		const outcomes = Array.from({ length: 20 }, (_, i) =>
+			outcome(`src/pages/route-${i}.astro`, `/page-${i}`, 'rendered', [{ type: 'new-path' }], {
+				stored: false,
+			}),
+		);
+		const { text } = print('info', outcomes);
+		for (let i = 0; i < 20; i++) {
+			assert.ok(
+				text.includes(`src/pages/route-${i}.astro`),
+				`route-${i} should be in the table:\n${text}`,
+			);
+		}
+		assert.ok(!text.includes('route table omitted'));
+	});
+
+	it('aggregates compact totals by reason across paths', () => {
+		// More than 20 grouped rows forces the compact totals view.
+		const outcomes = [
+			...Array.from({ length: 11 }, (_, i) =>
+				outcome(`src/pages/deps-${i}.astro`, `/deps-${i}`, 'rendered', [
+					{ type: 'route-dependencies-changed' },
+				]),
+			),
+			...Array.from({ length: 6 }, (_, i) =>
+				outcome(`src/pages/keys-${i}.astro`, `/keys-${i}`, 'rendered', [
+					{ type: 'cache-key-changed' },
+				]),
+			),
+			...Array.from({ length: 5 }, (_, i) =>
+				outcome(
+					`src/pages/nokey-${i}.astro`,
+					`/nokey-${i}`,
+					'rendered',
+					[{ type: 'no-cache-key' }],
+					{
+						stored: false,
+					},
+				),
+			),
+		];
+		const { text } = print('info', outcomes);
+		assert.ok(
+			text.includes(' reasons: module dependencies changed 11; cacheKey changed 6; no cacheKey 5'),
+		);
+	});
+
+	it('prints one row per path under verbose logging', () => {
+		const { text } = print('debug', [
+			outcome(BLOG, '/blog/post-1', 'cached', [], { elapsedMs: 1 }),
+			outcome(BLOG, '/blog/post-2', 'rendered', [{ type: 'cache-key-changed' }], { elapsedMs: 12 }),
+		]);
+		const normalized = normalizeTime(text);
+		assert.ok(
+			normalized.includes(
+				' Route / path                                      Result    Reason            Time',
+			),
+			`missing verbose header in:\n${normalized}`,
+		);
+		assert.ok(
+			normalized.includes(
+				'src/pages/blog/[slug].astro /blog/post-1          cached    cache hit         <time>',
+			),
+		);
+		assert.ok(
+			normalized.includes(
+				'src/pages/blog/[slug].astro /blog/post-2          rendered  cacheKey changed  <time>',
+			),
+		);
+	});
+
+	it('prints dependency-change trees with status labels', () => {
+		const { text } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'rendered', [
+				{
+					type: 'route-dependencies-changed',
+					changes: [
+						{
+							status: 'changed',
+							chain: ['src/components/Sidebar.astro', 'src/data/sidebar_data.ts'],
+						},
+					],
+				},
+			]),
+		]);
+		assert.ok(text.includes(' dependencies changed'), `missing trees in:\n${text}`);
+		assert.ok(text.includes(`  ${BLOG}`));
+		assert.ok(text.includes('  └─ src/components/Sidebar.astro'));
+		assert.ok(text.includes('     └─ src/data/sidebar_data.ts (changed)'));
+	});
+
+	it('prints the rerun hint when the sidecar was missing', () => {
+		const { text } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'rendered', [
+				{ type: 'route-dependencies-changed', diagnosticsUnavailable: 'missing-sidecar' },
+			]),
+		]);
+		assert.ok(text.includes('└─ dependency details unavailable (rerun once to seed diagnostics)'));
+	});
+
+	it('prints plain unavailable without the rerun hint', () => {
+		const { text } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'rendered', [
+				{ type: 'route-dependencies-changed', diagnosticsUnavailable: 'unavailable' },
+			]),
+		]);
+		assert.ok(text.includes('  └─ dependency details unavailable'));
+		assert.ok(!text.includes('rerun once to seed diagnostics'));
+	});
+
+	it('caps trees at info level and reports the remainder', () => {
+		const chains = Array.from({ length: 6 }, (_, i) => ({
+			status: 'changed' as const,
+			chain: [`src/components/C${i}.astro`, `src/data/data_${i}.ts`],
+		}));
+		const { text } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'rendered', [
+				{ type: 'route-dependencies-changed', changes: chains },
+			]),
+		]);
+		// 6 chains on one route: capped to 3 per route, 15 total.
+		const leafLines = text.split('\n').filter((line) => line.includes(' (changed)'));
+		assert.equal(leafLines.length, 3);
+		assert.ok(text.includes('… 3 more dependency change(s); rerun with --verbose to show all'));
+	});
+
+	it('shows all trees under verbose logging', () => {
+		const chains = Array.from({ length: 6 }, (_, i) => ({
+			status: 'changed' as const,
+			chain: [`src/components/C${i}.astro`, `src/data/data_${i}.ts`],
+		}));
+		const { text } = print('debug', [
+			outcome(BLOG, '/blog/post-1', 'rendered', [
+				{ type: 'route-dependencies-changed', changes: chains },
+			]),
+		]);
+		const leafLines = text.split('\n').filter((line) => line.includes(' (changed)'));
+		assert.equal(leafLines.length, 6);
+		assert.ok(!text.includes('more dependency change(s)'));
+	});
+
+	it('prints a singular metadata warning for one path', () => {
+		const { logs } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'rendered', [{ type: 'cache-key-changed' }], {
+				stored: false,
+				storageNote: 'metadata-unavailable',
+			}),
+		]);
+		assert.ok(
+			logs.some(
+				(log) =>
+					log.level === 'warn' &&
+					log.message ===
+						'Incremental cache could not record 1 rendered path because the prerenderer did not return incremental metadata; those paths will render again on the next build.',
+			),
+		);
+	});
+
+	it('prints a plural metadata warning for several paths', () => {
+		const { logs } = print('info', [
+			outcome(BLOG, '/blog/post-1', 'rendered', [], {
+				stored: false,
+				storageNote: 'metadata-unavailable',
+			}),
+			outcome(BLOG, '/blog/post-2', 'rendered', [], {
+				stored: false,
+				storageNote: 'metadata-unavailable',
+			}),
+		]);
+		assert.ok(
+			logs.some(
+				(log) =>
+					log.level === 'warn' &&
+					log.message ===
+						'Incremental cache could not record 2 rendered paths because the prerenderer did not return incremental metadata; those paths will render again on the next build.',
+			),
+		);
+	});
+
+	it('does not warn for no-key renders', () => {
+		const { logs } = print('info', [
+			outcome(ABOUT, '/about', 'rendered', [{ type: 'no-cache-key' }], { stored: false }),
+		]);
+		assert.ok(!logs.some((log) => log.level === 'warn'));
+	});
+});

--- a/packages/astro/test/units/build/incremental-logging.test.ts
+++ b/packages/astro/test/units/build/incremental-logging.test.ts
@@ -411,10 +411,10 @@ describe('IncrementalBuildReporter', () => {
 		assert.ok(text.includes('     └─ src/data/sidebar_data.ts (changed)'));
 	});
 
-	it('prints the rerun hint when the sidecar was missing', () => {
+	it('prints the rerun hint when the diagnostics were missing', () => {
 		const { text } = print('info', [
 			outcome(BLOG, '/blog/post-1', 'rendered', [
-				{ type: 'route-dependencies-changed', diagnosticsUnavailable: 'missing-sidecar' },
+				{ type: 'route-dependencies-changed', diagnosticsUnavailable: 'missing-diagnostics' },
 			]),
 		]);
 		assert.ok(text.includes('└─ dependency details unavailable (rerun once to seed diagnostics)'));

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -313,8 +313,8 @@ describe('pluginIncremental', () => {
 			assert.ok(client, 'client diagnostics should be recorded');
 			assert.deepEqual(client.routeRoots[COMPONENT], [entryId]);
 			assert.ok(client.modules[entryId], 'client module should be fingerprinted');
-			// The final aggregate hash is folded back into the prerender sidecar so
-			// the next build can trust the diagnostics for this route.
+			// The final aggregate hash is folded back into the prerender diagnostics
+			// so the next build can trust them for this route.
 			assert.notEqual(
 				internals.incrementalDiagnosticsPrerender.routeDependencyHashes[COMPONENT],
 				'base',

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -18,14 +18,19 @@ const HANDLE_TWO = 'WPGYjwIlzWVNM1bYhOc83w';
 
 function moduleInfo(
 	id: string,
-	{ code = '', importedIds = [] as string[], importers = [] as string[] } = {},
+	{
+		code = '',
+		importedIds = [] as string[],
+		importers = [] as string[],
+		dynamicallyImportedIds = [] as string[],
+	} = {},
 ) {
 	return {
 		id,
 		code,
 		importedIds,
 		importers,
-		dynamicallyImportedIds: [],
+		dynamicallyImportedIds,
 		dynamicImporters: [] as string[],
 		meta: {},
 	};
@@ -77,6 +82,50 @@ function dependencyHash(
 	const plugin = pluginIncremental(internals, ROOT) as any;
 	plugin.generateBundle.call(pluginContext(codeByModule, fileNames, importedIds));
 	return internals.pageDependencyHashes.get(COMPONENT);
+}
+
+function diagnosticsGraph(
+	codeByModule: Record<string, string>,
+	fileNames: Record<string, string>,
+	importedIds: string[],
+	dynamicallyImportedIds: string[] = [],
+	moduleImports: Record<string, { importedIds?: string[]; dynamicallyImportedIds?: string[] }> = {},
+) {
+	const internals = { pagesByViteID: new Map([[PAGE_ID, { component: COMPONENT }]]) } as any;
+	const plugin = pluginIncremental(internals, ROOT) as any;
+	const modules = new Map([
+		[
+			PAGE_ID,
+			moduleInfo(PAGE_ID, {
+				code: 'export default page',
+				importedIds,
+				dynamicallyImportedIds,
+				importers: [VIRTUAL_PAGE_RESOLVED_MODULE_ID],
+			}),
+		],
+		...[...importedIds, ...dynamicallyImportedIds].map((id) => {
+			const overrides = moduleImports[id] ?? {};
+			return [
+				id,
+				moduleInfo(id, {
+					code: codeByModule[id],
+					importedIds: overrides.importedIds ?? [],
+					dynamicallyImportedIds: overrides.dynamicallyImportedIds ?? [],
+				}),
+			] as const;
+		}),
+	]);
+	plugin.generateBundle.call({
+		environment: { name: 'prerender' },
+		getModuleIds: () => modules.keys(),
+		getModuleInfo: (id: string) => modules.get(id) ?? null,
+		getFileName: (handle: string) => {
+			const fileName = fileNames[handle];
+			if (!fileName) throw new Error(`Unknown reference id ${handle}`);
+			return fileName;
+		},
+	});
+	return internals.incrementalDiagnosticsPrerender as Record<string, any>;
 }
 
 describe('pluginIncremental', () => {
@@ -150,6 +199,126 @@ describe('pluginIncremental', () => {
 
 				assert.equal(first, second);
 			});
+		});
+	});
+
+	describe('diagnostics graph', () => {
+		const MODULE = '/project/src/utils/format.ts';
+
+		it('records the page root and module fingerprints', () => {
+			const diagnostics = diagnosticsGraph({ [MODULE]: 'export const fmt = 1;' }, {}, [MODULE]);
+			assert.deepEqual(diagnostics.routeRoots[COMPONENT], [PAGE_ID]);
+			assert.match(diagnostics.modules[PAGE_ID].fingerprint, /^[0-9a-f]{64}$/);
+			assert.match(diagnostics.modules[MODULE].fingerprint, /^[0-9a-f]{64}$/);
+		});
+
+		it('keeps fingerprints stable across unstable asset handles', () => {
+			const first = diagnosticsGraph(
+				{ [RED]: imageCode(HANDLE_ONE), [BLUE]: imageCode(HANDLE_TWO) },
+				{ [HANDLE_ONE]: '_astro/red.aaaa.png', [HANDLE_TWO]: '_astro/blue.bbbb.png' },
+				[RED, BLUE],
+			);
+			const second = diagnosticsGraph(
+				{ [RED]: imageCode(HANDLE_TWO), [BLUE]: imageCode(HANDLE_ONE) },
+				{ [HANDLE_TWO]: '_astro/red.aaaa.png', [HANDLE_ONE]: '_astro/blue.bbbb.png' },
+				[RED, BLUE],
+			);
+			assert.equal(first.modules[RED].fingerprint, second.modules[RED].fingerprint);
+			assert.equal(first.modules[BLUE].fingerprint, second.modules[BLUE].fingerprint);
+		});
+
+		it('changes a fingerprint when the module code changes', () => {
+			const first = diagnosticsGraph({ [MODULE]: 'export const a = 1;' }, {}, [MODULE]);
+			const second = diagnosticsGraph({ [MODULE]: 'export const a = 2;' }, {}, [MODULE]);
+			assert.notEqual(first.modules[MODULE].fingerprint, second.modules[MODULE].fingerprint);
+		});
+
+		it('changes a fingerprint when an import edge changes', () => {
+			const OTHER = '/project/src/utils/other.ts';
+			const EXTRA = '/project/src/utils/extra.ts';
+			const first = diagnosticsGraph(
+				{ [MODULE]: 'x', [OTHER]: 'y', [EXTRA]: 'z' },
+				{},
+				[MODULE],
+				[],
+				{ [MODULE]: { importedIds: [OTHER] } },
+			);
+			const second = diagnosticsGraph(
+				{ [MODULE]: 'x', [OTHER]: 'y', [EXTRA]: 'z' },
+				{},
+				[MODULE],
+				[],
+				{ [MODULE]: { importedIds: [OTHER, EXTRA] } },
+			);
+			assert.notEqual(first.modules[MODULE].fingerprint, second.modules[MODULE].fingerprint);
+		});
+
+		it('captures static and dynamic import edges', () => {
+			const STATIC = '/project/src/static.ts';
+			const DYNAMIC = '/project/src/dynamic.ts';
+			const diagnostics = diagnosticsGraph(
+				{ [STATIC]: 's', [DYNAMIC]: 'd' },
+				{},
+				[STATIC],
+				[DYNAMIC],
+			);
+			assert.deepEqual(diagnostics.modules[PAGE_ID].importedIds, [STATIC]);
+			assert.deepEqual(diagnostics.modules[PAGE_ID].dynamicallyImportedIds, [DYNAMIC]);
+		});
+
+		it('records content render roots for propagated asset modules', () => {
+			const RENDER = '/project/src/content/docs/a.mdx';
+			const PROPAGATED = `${RENDER}?astroPropagatedAssets`;
+			const diagnostics = diagnosticsGraph(
+				{ [RENDER]: 'export default {};', [PROPAGATED]: 'import x from "./a.mdx";' },
+				{},
+				[RENDER, PROPAGATED],
+			);
+			assert.deepEqual(diagnostics.contentRoots['src/content/docs/a.mdx'], [RENDER]);
+		});
+
+		it('records client entrypoint roots for consuming routes', () => {
+			const internals = {
+				pagesByViteID: new Map([[PAGE_ID, { component: COMPONENT }]]),
+				pageDependencyHashes: new Map([[COMPONENT, 'base']]),
+				discoveredClientOnlyComponents: new Map([
+					['/@fs/project/src/components/Search.tsx', ['default']],
+				]),
+				pagesByClientOnly: new Map([
+					['/@fs/project/src/components/Search.tsx', new Set([{ component: COMPONENT }])],
+				]),
+				discoveredScripts: new Set(),
+				pagesByScriptId: new Map(),
+				incrementalDiagnosticsPrerender: {
+					modules: {},
+					routeRoots: {},
+					contentRoots: {},
+					routeDependencyHashes: { [COMPONENT]: 'base' },
+				},
+			} as any;
+			const plugin = pluginIncremental(internals, ROOT) as any;
+			const entryId = '/@fs/project/src/components/Search.tsx';
+			const modules = new Map([
+				[entryId, moduleInfo(entryId, { code: 'export default () => null;' })],
+			]);
+			plugin.generateBundle.call({
+				environment: { name: 'client' },
+				getModuleIds: () => modules.keys(),
+				getModuleInfo: (id: string) => modules.get(id) ?? null,
+				getFileName: (handle: string) => {
+					throw new Error(`Unknown reference id ${handle}`);
+				},
+			});
+			const client = internals.incrementalDiagnosticsClient;
+			assert.ok(client, 'client diagnostics should be recorded');
+			assert.deepEqual(client.routeRoots[COMPONENT], [entryId]);
+			assert.ok(client.modules[entryId], 'client module should be fingerprinted');
+			// The final aggregate hash is folded back into the prerender sidecar so
+			// the next build can trust the diagnostics for this route.
+			assert.notEqual(
+				internals.incrementalDiagnosticsPrerender.routeDependencyHashes[COMPONENT],
+				'base',
+			);
 		});
 	});
 });

--- a/packages/astro/test/units/build/plugin-incremental.test.ts
+++ b/packages/astro/test/units/build/plugin-incremental.test.ts
@@ -3,15 +3,26 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { slash } from '../../../dist/core/path.js';
 import { pluginIncremental } from '../../../dist/core/build/plugins/plugin-incremental.js';
 import { VIRTUAL_PAGE_RESOLVED_MODULE_ID } from '../../../dist/vite-plugin-pages/const.js';
 
-const ROOT = new URL('file:///project/');
-const PAGE_ID = '/project/src/pages/[slug].astro';
+// A real absolute file URL so `rootRelativePath` path math works on every OS;
+// the directory itself never needs to exist.
+const ROOT = new URL('./project/', import.meta.url);
+const PROJECT_PATH = slash(fileURLToPath(ROOT));
+
+/** Absolute forward-slash module id under the fake project root. */
+function projectFile(path: string): string {
+	return PROJECT_PATH + path;
+}
+
+const PAGE_ID = projectFile('src/pages/[slug].astro');
 const COMPONENT = 'src/pages/[slug].astro';
-const RED = '/project/src/assets/red.png';
-const BLUE = '/project/src/assets/blue.png';
-const VIDEO = '/project/src/assets/clip.mp4';
+const RED = projectFile('src/assets/red.png');
+const BLUE = projectFile('src/assets/blue.png');
+const VIDEO = projectFile('src/assets/clip.mp4');
 
 const HANDLE_ONE = 'VRAku6fjghkApIISiBWPzg';
 const HANDLE_TWO = 'WPGYjwIlzWVNM1bYhOc83w';
@@ -203,7 +214,7 @@ describe('pluginIncremental', () => {
 	});
 
 	describe('diagnostics graph', () => {
-		const MODULE = '/project/src/utils/format.ts';
+		const MODULE = projectFile('src/utils/format.ts');
 
 		it('records the page root and module fingerprints', () => {
 			const diagnostics = diagnosticsGraph({ [MODULE]: 'export const fmt = 1;' }, {}, [MODULE]);
@@ -234,8 +245,8 @@ describe('pluginIncremental', () => {
 		});
 
 		it('changes a fingerprint when an import edge changes', () => {
-			const OTHER = '/project/src/utils/other.ts';
-			const EXTRA = '/project/src/utils/extra.ts';
+			const OTHER = projectFile('src/utils/other.ts');
+			const EXTRA = projectFile('src/utils/extra.ts');
 			const first = diagnosticsGraph(
 				{ [MODULE]: 'x', [OTHER]: 'y', [EXTRA]: 'z' },
 				{},
@@ -254,8 +265,8 @@ describe('pluginIncremental', () => {
 		});
 
 		it('captures static and dynamic import edges', () => {
-			const STATIC = '/project/src/static.ts';
-			const DYNAMIC = '/project/src/dynamic.ts';
+			const STATIC = projectFile('src/static.ts');
+			const DYNAMIC = projectFile('src/dynamic.ts');
 			const diagnostics = diagnosticsGraph(
 				{ [STATIC]: 's', [DYNAMIC]: 'd' },
 				{},
@@ -267,7 +278,7 @@ describe('pluginIncremental', () => {
 		});
 
 		it('records content render roots for propagated asset modules', () => {
-			const RENDER = '/project/src/content/docs/a.mdx';
+			const RENDER = projectFile('src/content/docs/a.mdx');
 			const PROPAGATED = `${RENDER}?astroPropagatedAssets`;
 			const diagnostics = diagnosticsGraph(
 				{ [RENDER]: 'export default {};', [PROPAGATED]: 'import x from "./a.mdx";' },
@@ -282,10 +293,13 @@ describe('pluginIncremental', () => {
 				pagesByViteID: new Map([[PAGE_ID, { component: COMPONENT }]]),
 				pageDependencyHashes: new Map([[COMPONENT, 'base']]),
 				discoveredClientOnlyComponents: new Map([
-					['/@fs/project/src/components/Search.tsx', ['default']],
+					['/@fs/' + PROJECT_PATH + 'src/components/Search.tsx', ['default']],
 				]),
 				pagesByClientOnly: new Map([
-					['/@fs/project/src/components/Search.tsx', new Set([{ component: COMPONENT }])],
+					[
+						'/@fs/' + PROJECT_PATH + 'src/components/Search.tsx',
+						new Set([{ component: COMPONENT }]),
+					],
 				]),
 				discoveredScripts: new Set(),
 				pagesByScriptId: new Map(),
@@ -297,7 +311,7 @@ describe('pluginIncremental', () => {
 				},
 			} as any;
 			const plugin = pluginIncremental(internals, ROOT) as any;
-			const entryId = '/@fs/project/src/components/Search.tsx';
+			const entryId = '/@fs/' + PROJECT_PATH + 'src/components/Search.tsx';
 			const modules = new Map([
 				[entryId, moduleInfo(entryId, { code: 'export default () => null;' })],
 			]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3579,6 +3579,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/incremental-build-logging:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: workspace:*
+        version: link:../../../../integrations/mdx
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/incremental-build-no-output:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Adds user-visible output for `experimental.incrementalBuild`.
  - global invalidation reasons (missing/invalid manifest, cache version, config, lockfile, usage of `--force`)
  - per-path miss reasons (`module dependencies changed`, `cacheKey changed`, `content dependency changed`, new path, `cached output missing`, server-island key)
  - post-render summary
- Only dynamic routes, since those are the only ones we currently support with incremental builds.
- Writes an optional diagnostics file next to the manifest that records which modules changed.

Example output when a shared component changes:

```text
prerendering static routes
  ├─ /blog/post-1/index.html
 (restored)
  ├─ /blog/post-2/index.html
 (restored)
  ├─ /sidebar/a/index.html
 (+5ms) (cache miss: module dependencies changed)
  ├─ /sidebar/b/index.html
 (+2ms) (cache miss: module dependencies changed)
  ├─ /index.html
 (+1ms)
 incremental build: 10 paths — 0 cached, 8 restored, 2 rendered

 Route                                   Result    Reason                       Paths  Time
 src/pages/blog/[slug].astro             restored  cache hit                        4  16ms
 src/pages/docs/[...slug].astro          restored  cache hit                        2  2ms
 src/pages/island/[slug].astro           restored  cache hit                        1  2ms
 src/pages/plain/[slug].astro            restored  cache hit                        1  1ms
 src/pages/sidebar/[slug].astro          rendered  module dependencies changed      2  7ms

 dependencies changed
  src/pages/sidebar/[slug].astro
  └─ src/components/Sidebar.astro
     └─ src/components/sidebar_data.ts (changed)
```

A cold build prints `Incremental cache not found; performing a full build.` and `(cache miss: cache not found)` per dynamic path; a no-change build prints `(restored)` per keyed path.

## Testing

- New integration suite `incremental-build-logging.test.ts`
- Unit tests

## Docs

- Not yet, probably should be.