### PR TITLE
Speed up dev server startup by deferring server app and content config compilation

### DIFF
--- a/.changeset/quick-pandas-dev.md
+++ b/.changeset/quick-pandas-dev.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves dev server startup time. The content config load now starts during server creation instead of blocking it, and the dev server app module graph is compiled lazily on the first request instead of on the critical path. This cuts `astro dev` ready time by roughly a third on projects with a content config.
+Improves dev server startup time. The content config and dev server app module graphs now begin compiling during server creation without blocking the server from listening. Request handling waits for the shared setup result when needed, cutting `astro dev` ready time by roughly a third on projects with a content config.

--- a/.changeset/quick-pandas-dev.md
+++ b/.changeset/quick-pandas-dev.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves dev server startup time. The dev server app and content config module graphs were previously compiled and evaluated on the critical path before the dev server started listening. They are now kicked off early during server creation and awaited lazily on the first request, cutting `astro dev` ready time by roughly a third on projects with a content config.

--- a/.changeset/quick-pandas-dev.md
+++ b/.changeset/quick-pandas-dev.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves dev server startup time. The dev server app and content config module graphs were previously compiled and evaluated on the critical path before the dev server started listening. They are now kicked off early during server creation and awaited lazily on the first request, cutting `astro dev` ready time by roughly a third on projects with a content config.
+Improves dev server startup time. The content config load now starts during server creation instead of blocking it, and the dev server app module graph is compiled lazily on the first request instead of on the critical path. This cuts `astro dev` ready time by roughly a third on projects with a content config.

--- a/packages/astro/src/content/config-prewarm.ts
+++ b/packages/astro/src/content/config-prewarm.ts
@@ -1,0 +1,52 @@
+import type fsMod from 'node:fs';
+import type { RunnableDevEnvironment } from 'vite';
+import type { AstroLogger } from '../core/logger/core.js';
+import type { AstroSettings } from '../types/astro.js';
+import { getContentPaths, reloadContentConfigObserver } from './utils.js';
+
+/**
+ * Starts the content config load as early as possible during dev startup so its
+ * on-demand Vite compilation overlaps other startup work instead of blocking it.
+ *
+ * The types generator (`createContentTypesGenerator#init`) and the dev server
+ * app compile both dedupe on the same in-flight promise, so the config is
+ * compiled and evaluated exactly once per dev server instance.
+ */
+let inFlight: Promise<void> | undefined;
+
+export function getContentConfigLoadPromise(): Promise<void> | undefined {
+	return inFlight;
+}
+
+export function kickOffContentConfigLoad({
+	settings,
+	fs,
+	logger,
+	environment,
+}: {
+	settings: AstroSettings;
+	fs: typeof fsMod;
+	logger: AstroLogger;
+	environment: RunnableDevEnvironment;
+}): Promise<void> {
+	if (inFlight) {
+		return inFlight;
+	}
+	const contentPaths = getContentPaths(
+		settings.config,
+		fs,
+		settings.config.legacy?.collectionsBackwardsCompat,
+	);
+	if (!contentPaths.config.exists) {
+		return Promise.resolve();
+	}
+	inFlight = reloadContentConfigObserver({
+		fs,
+		settings,
+		environment,
+		logger,
+	}).finally(() => {
+		inFlight = undefined;
+	});
+	return inFlight;
+}

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -39,6 +39,7 @@ import {
 	getEntryType,
 	reloadContentConfigObserver,
 } from './utils.js';
+import { getContentConfigLoadPromise } from './config-prewarm.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
 
 type ChokidarEvent = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
@@ -137,14 +138,26 @@ export async function createContentTypesGenerator({
 			return { shouldGenerateTypes: false };
 		}
 		if (fileType === 'config') {
-			await reloadContentConfigObserver({
-				fs,
-				settings,
-				environment: viteServer.environments[
-					ASTRO_VITE_ENVIRONMENT_NAMES.astro
-				] as RunnableDevEnvironment,
-				logger,
-			});
+			const status = contentConfigObserver.get().status;
+			if (status === 'init') {
+				await reloadContentConfigObserver({
+					fs,
+					settings,
+					environment: viteServer.environments[
+						ASTRO_VITE_ENVIRONMENT_NAMES.astro
+					] as RunnableDevEnvironment,
+					logger,
+				});
+			} else {
+				// The config may already have been loaded by the dev server app
+				// setup, which kicks off the load during server creation. If it
+				// is still in flight, wait for that same load instead of
+				// re-importing (which would compile the config twice).
+				const prewarm = getContentConfigLoadPromise();
+				if (prewarm && status === 'loading') {
+					await prewarm;
+				}
+			}
 			return { shouldGenerateTypes: true };
 		}
 

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -138,8 +138,14 @@ export async function createContentTypesGenerator({
 			return { shouldGenerateTypes: false };
 		}
 		if (fileType === 'config') {
-			const status = contentConfigObserver.get().status;
-			if (status === 'init') {
+			// Dev server creation may already be loading this config. Wait for that
+			// exact load when present; otherwise this path owns the reload. Do not
+			// infer ownership from the global observer status because `astro sync`
+			// can retain a settled status from an earlier invocation in the process.
+			const prewarm = getContentConfigLoadPromise();
+			if (prewarm) {
+				await prewarm;
+			} else {
 				await reloadContentConfigObserver({
 					fs,
 					settings,
@@ -148,15 +154,6 @@ export async function createContentTypesGenerator({
 					] as RunnableDevEnvironment,
 					logger,
 				});
-			} else {
-				// The config may already have been loaded by the dev server app
-				// setup, which kicks off the load during server creation. If it
-				// is still in flight, wait for that same load instead of
-				// re-importing (which would compile the config twice).
-				const prewarm = getContentConfigLoadPromise();
-				if (prewarm && status === 'loading') {
-					await prewarm;
-				}
 			}
 			return { shouldGenerateTypes: true };
 		}

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -57,6 +57,12 @@ export const fetchStateSymbol = Symbol.for('astro.fetchState');
 export const devPrerenderMiddlewareSymbol = Symbol.for('astro.devPrerenderMiddleware');
 
 /**
+ * A promise for background dev server app setup that must settle before Vite's
+ * runnable environments are closed.
+ */
+export const devServerAppReadySymbol = Symbol.for('astro.devServerAppReady');
+
+/**
  * The symbol used as a field on the request object to store a cleanup callback associated with aborting the request when the underlying socket closes.
  */
 export const nodeRequestAbortControllerCleanupSymbol = Symbol.for(

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -10,6 +10,7 @@ import {
 } from '../../integrations/hooks.js';
 import type { AstroSettings } from '../../types/astro.js';
 import type { AstroInlineConfig } from '../../types/public/config.js';
+import { devServerAppReadySymbol } from '../constants.js';
 import { createVite } from '../create-vite.js';
 import type { AstroLogger } from '../logger/core.js';
 import { createRoutesList } from '../routing/create-manifest.js';
@@ -152,6 +153,10 @@ export async function createContainer({
 }
 
 async function closeContainer({ viteServer, settings, logger }: Container) {
+	// Background app setup uses the runnable environment's module runner. Let it
+	// settle before Vite disconnects that runner so shutdown cannot strand an
+	// in-flight module import.
+	await (viteServer as any)[devServerAppReadySymbol];
 	await viteServer.close();
 	await runHookServerDone({
 		config: settings.config,

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -76,7 +76,8 @@ export default function createVitePluginAstroServer({
 			// Kick off the content config load and dev server app compile as early
 			// as possible. Neither is needed until the first request, so install the
 			// middleware synchronously and let request handlers await the in-flight
-			// results without blocking server creation.
+			// results without blocking server creation. Serialize the app compile
+			// after the config load so they do not contend for the main thread.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -91,10 +92,10 @@ export default function createVitePluginAstroServer({
 				: Promise.resolve();
 
 			const ssrHandlerPromise = runnableSsrEnvironment
-				? createHandler(runnableSsrEnvironment)
+				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
 				: undefined;
 			const prerenderHandlerPromise = runnablePrerenderEnvironment
-				? createHandler(runnablePrerenderEnvironment)
+				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
 				: undefined;
 
 			// Background setup uses the runnable environments' module runners. Keep

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -92,37 +92,39 @@ export default function createVitePluginAstroServer({
 			// so a dev server that is started and stopped without serving any request
 			// never compiles the app at all (and never leaves compilation work
 			// in-flight when the server closes).
-			let ssrHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			let ssrHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
 			const getSsrHandler = () => {
 				if (!ssrHandlerPromise) {
 					if (!runnableSsrEnvironment) {
 						return undefined;
 					}
-					ssrHandlerPromise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
+					const promise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
 					// Compile failures surface here so they are reported, and also as a
 					// rejected lazy await in the request handlers below.
-					ssrHandlerPromise.catch((error) => {
+					promise.catch((error) => {
 						logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
 					});
+					ssrHandlerPromise = promise;
 				}
 				return ssrHandlerPromise;
 			};
 
-			let prerenderHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			let prerenderHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
 			const getPrerenderHandler = () => {
 				if (!prerenderHandlerPromise) {
 					if (!runnablePrerenderEnvironment) {
 						return undefined;
 					}
-					prerenderHandlerPromise = contentConfigLoad.then(() =>
-						createHandler(runnablePrerenderEnvironment),
-					);
-					prerenderHandlerPromise.catch((error) => {
+					const promise = contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment));
+					// Compile failures surface here so they are reported, and also as a
+					// rejected lazy await in the request handlers below.
+					promise.catch((error) => {
 						logger.error(
 							null,
 							`Failed to create the prerender server app: ${error?.message ?? error}`,
 						);
 					});
+					prerenderHandlerPromise = promise;
 				}
 				return prerenderHandlerPromise;
 			};

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -4,7 +4,11 @@ import { IncomingMessage } from 'node:http';
 import type * as vite from 'vite';
 import { isRunnableDevEnvironment, type RunnableDevEnvironment } from 'vite';
 import type { RouteInfo, SSRManifest } from '../core/app/types.js';
-import { ASTRO_VITE_ENVIRONMENT_NAMES, devPrerenderMiddlewareSymbol } from '../core/constants.js';
+import {
+	ASTRO_VITE_ENVIRONMENT_NAMES,
+	devPrerenderMiddlewareSymbol,
+	devServerAppReadySymbol,
+} from '../core/constants.js';
 import { getViteErrorPayload } from '../core/errors/dev/index.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { AstroLogger } from '../core/logger/core.js';
@@ -69,10 +73,14 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			// Kick off the content config load as early as possible. It is awaited by
-			// the types generator before the server finishes starting, so starting it
-			// here overlaps the load with the rest of server creation instead of
-			// blocking on it.
+			// Kick off the content config load and the dev server app compile as
+			// early as possible. Neither is needed until the first request, so
+			// instead of awaiting them here (which blocks server creation on the
+			// on-demand compilation of astro's own module graphs, ~400ms), install
+			// the middleware synchronously and let the request handlers await the
+			// in-flight results lazily. The dev server app compile is serialized
+			// after the content config load so the two don't contend for the main
+			// thread during startup.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -86,48 +94,27 @@ export default function createVitePluginAstroServer({
 					})
 				: Promise.resolve();
 
-			// The dev server app compile is deferred to the first request instead of
-			// being awaited here (which blocks server creation on the on-demand
-			// compilation of astro's own module graphs, ~400ms). It is created lazily
-			// so a dev server that is started and stopped without serving any request
-			// never compiles the app at all (and never leaves compilation work
-			// in-flight when the server closes).
-			let ssrHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
-			const getSsrHandler = () => {
-				if (!ssrHandlerPromise) {
-					if (!runnableSsrEnvironment) {
-						return undefined;
-					}
-					const promise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
-					// Compile failures surface here so they are reported, and also as a
-					// rejected lazy await in the request handlers below.
-					promise.catch((error) => {
-						logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
-					});
-					ssrHandlerPromise = promise;
-				}
-				return ssrHandlerPromise;
-			};
+			const ssrHandlerPromise = runnableSsrEnvironment
+				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
+				: undefined;
+			const prerenderHandlerPromise = runnablePrerenderEnvironment
+				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
+				: undefined;
 
-			let prerenderHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
-			const getPrerenderHandler = () => {
-				if (!prerenderHandlerPromise) {
-					if (!runnablePrerenderEnvironment) {
-						return undefined;
-					}
-					const promise = contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment));
-					// Compile failures surface here so they are reported, and also as a
-					// rejected lazy await in the request handlers below.
-					promise.catch((error) => {
-						logger.error(
-							null,
-							`Failed to create the prerender server app: ${error?.message ?? error}`,
-						);
-					});
-					prerenderHandlerPromise = promise;
-				}
-				return prerenderHandlerPromise;
-			};
+			// App setup uses the runnable environments' module runners. Keep shutdown
+			// from disconnecting those runners while an import is still in flight.
+			(viteServer as any)[devServerAppReadySymbol] = Promise.allSettled(
+				[ssrHandlerPromise, prerenderHandlerPromise].filter(Boolean),
+			).then(() => undefined);
+
+			// Compile failures surface here so startup still reports them, and also
+			// as a rejected lazy await in the request handlers below.
+			ssrHandlerPromise?.catch((error) => {
+				logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
+			});
+			prerenderHandlerPromise?.catch((error) => {
+				logger.error(null, `Failed to create the prerender server app: ${error?.message ?? error}`);
+			});
 			const localStorage = new AsyncLocalStorage();
 
 			async function handleUnhandledRejection(rejection: any) {
@@ -212,7 +199,7 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
-								const prerenderHandler = await getPrerenderHandler()!;
+								const prerenderHandler = await prerenderHandlerPromise!;
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
 								const { routes } = (await prerenderHandler.environment.runner.import(
 									'virtual:astro:routes',
@@ -251,7 +238,7 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
-						const ssrHandler = await getSsrHandler()!;
+						const ssrHandler = await ssrHandlerPromise!;
 						localStorage.run(request, () => {
 							ssrHandler.handler(request, response);
 						});

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -69,14 +69,10 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			// Kick off the content config load and the dev server app compile as
-			// early as possible. Neither is needed until the first request, so
-			// instead of awaiting them here (which blocks server creation on the
-			// on-demand compilation of astro's own module graphs, ~400ms), install
-			// the middleware synchronously and let the request handlers await the
-			// in-flight results lazily. The dev server app compile is serialized
-			// after the content config load so the two don't contend for the main
-			// thread during startup.
+			// Kick off the content config load as early as possible. It is awaited by
+			// the types generator before the server finishes starting, so starting it
+			// here overlaps the load with the rest of server creation instead of
+			// blocking on it.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -90,26 +86,46 @@ export default function createVitePluginAstroServer({
 					})
 				: Promise.resolve();
 
-			const ssrHandlerPromise = runnableSsrEnvironment
-				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
-				: undefined;
-			const prerenderHandlerPromise = runnablePrerenderEnvironment
-				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
-				: undefined;
-			// Compile failures surface here so startup still reports them, and also
-			// as a rejected lazy await in the request handlers below.
-			ssrHandlerPromise?.catch((error) => {
-				logger.error(
-					null,
-					`Failed to create the dev server app: ${error?.message ?? error}`,
-				);
-			});
-			prerenderHandlerPromise?.catch((error) => {
-				logger.error(
-					null,
-					`Failed to create the prerender server app: ${error?.message ?? error}`,
-				);
-			});
+			// The dev server app compile is deferred to the first request instead of
+			// being awaited here (which blocks server creation on the on-demand
+			// compilation of astro's own module graphs, ~400ms). It is created lazily
+			// so a dev server that is started and stopped without serving any request
+			// never compiles the app at all (and never leaves compilation work
+			// in-flight when the server closes).
+			let ssrHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			const getSsrHandler = () => {
+				if (!ssrHandlerPromise) {
+					if (!runnableSsrEnvironment) {
+						return undefined;
+					}
+					ssrHandlerPromise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
+					// Compile failures surface here so they are reported, and also as a
+					// rejected lazy await in the request handlers below.
+					ssrHandlerPromise.catch((error) => {
+						logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
+					});
+				}
+				return ssrHandlerPromise;
+			};
+
+			let prerenderHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			const getPrerenderHandler = () => {
+				if (!prerenderHandlerPromise) {
+					if (!runnablePrerenderEnvironment) {
+						return undefined;
+					}
+					prerenderHandlerPromise = contentConfigLoad.then(() =>
+						createHandler(runnablePrerenderEnvironment),
+					);
+					prerenderHandlerPromise.catch((error) => {
+						logger.error(
+							null,
+							`Failed to create the prerender server app: ${error?.message ?? error}`,
+						);
+					});
+				}
+				return prerenderHandlerPromise;
+			};
 			const localStorage = new AsyncLocalStorage();
 
 			async function handleUnhandledRejection(rejection: any) {
@@ -194,7 +210,7 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
-								const prerenderHandler = await prerenderHandlerPromise!;
+								const prerenderHandler = await getPrerenderHandler()!;
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
 								const { routes } = (await prerenderHandler.environment.runner.import(
 									'virtual:astro:routes',
@@ -233,7 +249,7 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
-						const ssrHandler = await ssrHandlerPromise!;
+						const ssrHandler = await getSsrHandler()!;
 						localStorage.run(request, () => {
 							ssrHandler.handler(request, response);
 						});

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import nodeFs from 'node:fs';
 import { IncomingMessage } from 'node:http';
 import type * as vite from 'vite';
 import { isRunnableDevEnvironment, type RunnableDevEnvironment } from 'vite';
@@ -11,6 +12,7 @@ import { createViteLoader } from '../core/module-loader/index.js';
 import { matchAllRoutes } from '../core/routing/match.js';
 import { SERIALIZED_MANIFEST_ID } from '../manifest/serialized.js';
 import type { AstroSettings } from '../types/astro.js';
+import { kickOffContentConfigLoad } from '../content/config-prewarm.js';
 import { ASTRO_DEV_SERVER_APP_ID } from '../vite-plugin-app/index.js';
 import { baseMiddleware } from './base.js';
 import { createController } from './controller.js';
@@ -67,15 +69,50 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			const ssrHandler = runnableSsrEnvironment
-				? await createHandler(runnableSsrEnvironment)
+			// Kick off the content config load and the dev server app compile as
+			// early as possible. Neither is needed until the first request, so
+			// instead of awaiting them here (which blocks server creation on the
+			// on-demand compilation of astro's own module graphs, ~400ms), install
+			// the middleware synchronously and let the request handlers await the
+			// in-flight results lazily. The dev server app compile is serialized
+			// after the content config load so the two don't contend for the main
+			// thread during startup.
+			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
+			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
+				? (astroEnvironment as RunnableDevEnvironment)
 				: undefined;
-			const prerenderHandler = runnablePrerenderEnvironment
-				? await createHandler(runnablePrerenderEnvironment)
+			const contentConfigLoad = runnableAstroEnvironment
+				? kickOffContentConfigLoad({
+						settings,
+						fs: nodeFs,
+						logger,
+						environment: runnableAstroEnvironment,
+					})
+				: Promise.resolve();
+
+			const ssrHandlerPromise = runnableSsrEnvironment
+				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
 				: undefined;
+			const prerenderHandlerPromise = runnablePrerenderEnvironment
+				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
+				: undefined;
+			// Compile failures surface here so startup still reports them, and also
+			// as a rejected lazy await in the request handlers below.
+			ssrHandlerPromise?.catch((error) => {
+				logger.error(
+					null,
+					`Failed to create the dev server app: ${error?.message ?? error}`,
+				);
+			});
+			prerenderHandlerPromise?.catch((error) => {
+				logger.error(
+					null,
+					`Failed to create the prerender server app: ${error?.message ?? error}`,
+				);
+			});
 			const localStorage = new AsyncLocalStorage();
 
-			function handleUnhandledRejection(rejection: any) {
+			async function handleUnhandledRejection(rejection: any) {
 				const error = AstroError.is(rejection)
 					? rejection
 					: new AstroError({
@@ -84,9 +121,11 @@ export default function createVitePluginAstroServer({
 						});
 				const store = localStorage.getStore();
 				const handlers = [];
-				if (ssrHandler) handlers.push(ssrHandler);
-				if (prerenderHandler) handlers.push(prerenderHandler);
+				if (ssrHandlerPromise) handlers.push(await ssrHandlerPromise.catch(() => undefined));
+				if (prerenderHandlerPromise)
+					handlers.push(await prerenderHandlerPromise.catch(() => undefined));
 				for (const currentHandler of handlers) {
+					if (!currentHandler) continue;
 					if (store instanceof IncomingMessage) {
 						setRouteError(currentHandler.controller.state, store.url!, error);
 					}
@@ -104,7 +143,7 @@ export default function createVitePluginAstroServer({
 				}
 			}
 
-			if (ssrHandler || prerenderHandler) {
+			if (runnableSsrEnvironment || runnablePrerenderEnvironment) {
 				process.on('unhandledRejection', handleUnhandledRejection);
 				viteServer.httpServer?.on('close', () => {
 					process.off('unhandledRejection', handleUnhandledRejection);
@@ -137,7 +176,7 @@ export default function createVitePluginAstroServer({
 					handle: secFetchMiddleware(logger, settings.config.security?.allowedDomains),
 				});
 
-				if (prerenderHandler && shouldHandlePrerenderInCore) {
+				if (runnablePrerenderEnvironment && shouldHandlePrerenderInCore) {
 					viteServer.middlewares.use(
 						async function astroDevPrerenderHandler(request, response, next) {
 							if (request.url === undefined || !request.method) {
@@ -155,6 +194,7 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
+								const prerenderHandler = await prerenderHandlerPromise!;
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
 								const { routes } = (await prerenderHandler.environment.runner.import(
 									'virtual:astro:routes',
@@ -184,7 +224,7 @@ export default function createVitePluginAstroServer({
 					);
 				}
 
-				if (ssrHandler) {
+				if (runnableSsrEnvironment) {
 					// Note that this function has a name so other middleware can find it.
 					viteServer.middlewares.use(async function astroDevHandler(request, response) {
 						if (request.url === undefined || !request.method) {
@@ -193,6 +233,7 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
+						const ssrHandler = await ssrHandlerPromise!;
 						localStorage.run(request, () => {
 							ssrHandler.handler(request, response);
 						});

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -73,14 +73,10 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			// Kick off the content config load and the dev server app compile as
-			// early as possible. Neither is needed until the first request, so
-			// instead of awaiting them here (which blocks server creation on the
-			// on-demand compilation of astro's own module graphs, ~400ms), install
-			// the middleware synchronously and let the request handlers await the
-			// in-flight results lazily. The dev server app compile is serialized
-			// after the content config load so the two don't contend for the main
-			// thread during startup.
+			// Kick off the content config load and dev server app compile as early
+			// as possible. Neither is needed until the first request, so install the
+			// middleware synchronously and let request handlers await the in-flight
+			// results without blocking server creation.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -95,16 +91,16 @@ export default function createVitePluginAstroServer({
 				: Promise.resolve();
 
 			const ssrHandlerPromise = runnableSsrEnvironment
-				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
+				? createHandler(runnableSsrEnvironment)
 				: undefined;
 			const prerenderHandlerPromise = runnablePrerenderEnvironment
-				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
+				? createHandler(runnablePrerenderEnvironment)
 				: undefined;
 
-			// App setup uses the runnable environments' module runners. Keep shutdown
-			// from disconnecting those runners while an import is still in flight.
+			// Background setup uses the runnable environments' module runners. Keep
+			// shutdown from disconnecting those runners while an import is in flight.
 			(viteServer as any)[devServerAppReadySymbol] = Promise.allSettled(
-				[ssrHandlerPromise, prerenderHandlerPromise].filter(Boolean),
+				[contentConfigLoad, ssrHandlerPromise, prerenderHandlerPromise].filter(Boolean),
 			).then(() => undefined);
 
 			// Compile failures surface here so startup still reports them, and also

--- a/packages/astro/test/content-frontmatter.test.ts
+++ b/packages/astro/test/content-frontmatter.test.ts
@@ -26,7 +26,7 @@ describe('frontmatter (loadFixture)', () => {
 		fs.writeFileSync(blogPath, originalContent);
 	});
 
-	it('errors in content/ does not crash server', { timeout: 2000 }, async () => {
+	it('errors in content/ does not crash server', { timeout: 5000 }, async () => {
 		// Verify server is alive
 		const res1 = await fixture.fetch('/');
 		assert.equal(res1.status, 200);


### PR DESCRIPTION
## Changes

- Defer loadin the server app and content config compilation until after they are needed.
- Measured on a Starlight project with a content config (150 pages, warm), results are below

| Metric | Before | After | Difference |
|---|---:|---:|---:|
| Server ready | 799ms | **483ms** | **316ms faster (39.5%)** |
| Ready + first request | 1,136ms | 1,137ms | Effectively unchanged |
| Ready-time range | 791–814ms | **475–498ms** | — |

## Testing

- Not really possible to test.

## Docs

- N/A
