### PR TITLE
fix(transitions): route ClientRouter through the Navigation API when available

### DIFF
--- a/.changeset/sharp-words-share.md
+++ b/.changeset/sharp-words-share.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves `ClientRouter` navigation and scroll restoration in browsers that support the Navigation API

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -5,6 +5,7 @@ import Layout from '../components/Layout.astro';
 	<p id="one">Page 1</p>
 	<a id="click-one" href="#test">test</a>
 	<a id="click-two" href="/two">go to 2</a>
+	<a id="click-two-bottom" href="/two#bottom">go to 2 bottom</a>
 	<a id="click-three" href="/three">go to 3</a>
 	<a id="click-seven" href="/seven">go to 7</a>
 	<a id="click-eight" href="/eight">go to 8</a>

--- a/packages/astro/e2e/navigation-api-interop.test.ts
+++ b/packages/astro/e2e/navigation-api-interop.test.ts
@@ -1,0 +1,107 @@
+import { expect } from '@playwright/test';
+import { type DevServer, testFactory, warmupDevServer } from './test-utils.ts';
+
+const test = testFactory(import.meta.url, { root: './fixtures/view-transitions/' });
+
+let devServer: DevServer;
+
+test.beforeAll(async ({ astro, browser }) => {
+	devServer = await astro.startDevServer();
+	await warmupDevServer(browser, astro.resolveUrl('/one'));
+});
+
+test.afterAll(async () => {
+	await devServer.stop();
+});
+
+async function installExternalRouter(page: import('@playwright/test').Page) {
+	await page.evaluate(() => {
+		const navigation = (window as Window & { navigation: any }).navigation;
+		navigation.addEventListener('navigate', (event: any) => {
+			if (event.info?.externalRouter === true || event.navigationType === 'traverse') {
+				event.intercept({ handler: async () => {} });
+			}
+		});
+	});
+}
+
+async function expectNavigationApi(page: import('@playwright/test').Page) {
+	const supported = await page.evaluate(
+		() =>
+			typeof (window as Window & { navigation?: unknown }).navigation === 'object' &&
+			typeof (window as Window & { NavigationPrecommitController?: unknown })
+				.NavigationPrecommitController === 'function',
+	);
+	if (!supported) test.skip();
+}
+
+async function startPreparationCounter(page: import('@playwright/test').Page) {
+	await page.evaluate(() => {
+		(window as Window & { astroPreparations?: number }).astroPreparations = 0;
+		document.addEventListener('astro:before-preparation', () => {
+			(window as Window & { astroPreparations?: number }).astroPreparations!++;
+		});
+	});
+}
+
+async function expectNoAstroPreparation(page: import('@playwright/test').Page) {
+	expect(
+		await page.evaluate(
+			() => (window as Window & { astroPreparations?: number }).astroPreparations,
+		),
+	).toBe(0);
+}
+
+test('does not claim pushed entries owned by another Navigation API router', async ({
+	page,
+	astro,
+}) => {
+	await page.goto(astro.resolveUrl('/one'));
+	await expectNavigationApi(page);
+	await installExternalRouter(page);
+
+	await page.evaluate(async () => {
+		const navigation = (window as Window & { navigation: any }).navigation;
+		await navigation.navigate('/one?external-router=1', {
+			info: { externalRouter: true },
+		}).finished;
+	});
+	await expect(page).toHaveURL(/\/one\?external-router=1$/);
+
+	await startPreparationCounter(page);
+	await page.evaluate(async () => {
+		const navigation = (window as Window & { navigation: any }).navigation;
+		await navigation.back().finished;
+	});
+	await expect(page).toHaveURL(/\/one$/);
+	await expectNoAstroPreparation(page);
+});
+
+test('does not claim replaced entries owned by another Navigation API router', async ({
+	page,
+	astro,
+}) => {
+	await page.goto(astro.resolveUrl('/one'));
+	await expectNavigationApi(page);
+
+	await page.click('#click-two');
+	await expect(page.locator('#two')).toHaveText('Page 2');
+	await installExternalRouter(page);
+
+	await page.evaluate(async () => {
+		const navigation = (window as Window & { navigation: any }).navigation;
+		await navigation.navigate('/two?external-router=replace', {
+			history: 'replace',
+			info: { externalRouter: true },
+		}).finished;
+	});
+	await expect(page).toHaveURL(/\/two\?external-router=replace$/);
+
+	await startPreparationCounter(page);
+	await page.evaluate(async () => {
+		const navigation = (window as Window & { navigation: any }).navigation;
+		await navigation.back().finished;
+	});
+	await expect(page).toHaveURL(/\/one$/);
+	await expectNoAstroPreparation(page);
+});

--- a/packages/astro/e2e/view-transitions.test.ts
+++ b/packages/astro/e2e/view-transitions.test.ts
@@ -4,11 +4,52 @@ import { type DevServer, testFactory, waitForHydrate, warmupDevServer } from './
 declare global {
 	interface Window {
 		preloads: string[];
+		transitionEvents?: {
+			direction?: string;
+			name: string;
+			navigationType?: string;
+			scrollY: number;
+		}[];
 		clientSideRouterForTestsParkedHere?: (
 			url: string,
-			options?: { history?: 'auto' | 'replace' | 'push' },
-		) => void;
+			options?: { history?: 'auto' | 'replace' | 'push'; state?: any },
+		) => Promise<void>;
 	}
+}
+
+async function collectTransitionEvents(page: Page) {
+	await page.evaluate(() => {
+		window.transitionEvents = [];
+		for (const name of [
+			'astro:before-preparation',
+			'astro:after-preparation',
+			'astro:before-swap',
+			'astro:after-swap',
+			'astro:page-load',
+		]) {
+			document.addEventListener(name, (event) => {
+				const transitionEvent = event as Event & {
+					direction?: string;
+					navigationType?: string;
+				};
+				window.transitionEvents!.push({
+					name,
+					direction: transitionEvent.direction,
+					navigationType: transitionEvent.navigationType,
+					scrollY: window.scrollY,
+				});
+			});
+		}
+	});
+}
+
+function hasNavigationApi(page: Page) {
+	return page.evaluate(
+		() =>
+			typeof (window as Window & { navigation?: unknown }).navigation === 'object' &&
+			typeof (window as Window & { NavigationPrecommitController?: unknown })
+				.NavigationPrecommitController === 'function',
+	);
 }
 
 const test = testFactory(import.meta.url, { root: './fixtures/view-transitions/' });
@@ -294,6 +335,10 @@ test.describe('View Transitions', () => {
 			return document.getAnimations();
 		});
 		expect(animations.length).toEqual(1);
+		// Finish the setup animation before checking whether swap() causes a new render.
+		await page.evaluate(async () => {
+			await Promise.allSettled(document.getAnimations().map((animation) => animation.finished));
+		});
 
 		// go to page 2
 		await page.click('#totwo');
@@ -332,6 +377,22 @@ test.describe('View Transitions', () => {
 		await page.click('#click-self');
 		await expect(p, 'should have content').toHaveText('Page 1');
 		await expectLoads(1);
+	});
+
+	test('push navigation starts the destination at the top', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/long-page'));
+		await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+		expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+		await page.click('#click-one');
+		await expect(page.locator('#one')).toHaveText('Page 1');
+		expect(await page.evaluate(() => window.scrollY)).toBe(0);
+	});
+
+	test('cross-route fragments scroll after the destination swaps', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/one'));
+		await page.click('#click-two-bottom');
+		await expect(page.locator('#bottom')).toBeInViewport();
 	});
 
 	test('Scroll position restored on back button', async ({ page, astro }) => {
@@ -445,6 +506,264 @@ test.describe('View Transitions', () => {
 		await page.goForward();
 		locator = page.locator('#click-one-again');
 		await expect(locator).toBeInViewport();
+	});
+
+	test('reports push, back, and forward directions', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/one'));
+		await collectTransitionEvents(page);
+
+		await page.click('#click-two');
+		await expect(page.locator('#two')).toHaveText('Page 2');
+		await page.goBack();
+		await expect(page.locator('#one')).toHaveText('Page 1');
+		await page.goForward();
+		await expect(page.locator('#two')).toHaveText('Page 2');
+
+		const events = await page.evaluate(() => window.transitionEvents);
+		expect(
+			events
+				?.filter((event) => event.name === 'astro:before-preparation')
+				.map((event) => [event.direction, event.navigationType]),
+		).toEqual([
+			['forward', 'push'],
+			['back', 'traverse'],
+			['forward', 'traverse'],
+		]);
+	});
+
+	test('runs lifecycle events once and in order for one click', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/one'));
+		await collectTransitionEvents(page);
+
+		await page.click('#click-two');
+		await expect(page.locator('#two')).toHaveText('Page 2');
+		await expect.poll(() => page.evaluate(() => window.transitionEvents?.length)).toBe(5);
+
+		const events = await page.evaluate(() => window.transitionEvents);
+		expect(events?.map((event) => event.name)).toEqual([
+			'astro:before-preparation',
+			'astro:after-preparation',
+			'astro:before-swap',
+			'astro:after-swap',
+			'astro:page-load',
+		]);
+		expect(events?.filter((event) => event.name === 'astro:before-preparation')).toHaveLength(1);
+	});
+
+	test('Navigation API preserves navigate state and await completion', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/six'));
+		await expect(page.locator('#one')).toHaveText('Page 1');
+		if (!(await hasNavigationApi(page))) test.skip();
+
+		const result = await page.evaluate(async () => {
+			let swapped = false;
+			document.addEventListener('astro:after-swap', () => (swapped = true), { once: true });
+			await window.clientSideRouterForTestsParkedHere!('/two', { state: { answer: 42 } });
+			const navigation = (
+				window as Window & {
+					navigation: { currentEntry: { getState: () => unknown } };
+				}
+			).navigation;
+			return {
+				swapped,
+				pathname: location.pathname,
+				navigationState: navigation.currentEntry.getState(),
+				historyState: history.state,
+			};
+		});
+
+		expect(result).toEqual({
+			swapped: true,
+			pathname: '/two',
+			navigationState: { answer: 42 },
+			historyState: { answer: 42 },
+		});
+	});
+
+	test('Navigation API runs custom preparation loaders before committing', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/one'));
+		if (!(await hasNavigationApi(page))) test.skip();
+		const requests: string[] = [];
+		page.on('request', (request) => {
+			if (new URL(request.url()).pathname === '/three') requests.push(request.url());
+		});
+		await page.evaluate(() => {
+			document.addEventListener(
+				'astro:before-preparation',
+				(event) => {
+					const transitionEvent = event as Event & {
+						loader: () => Promise<void>;
+						newDocument: Document;
+					};
+					transitionEvent.loader = async () => {
+						const nextDocument = document.implementation.createHTMLDocument('Custom');
+						const meta = nextDocument.createElement('meta');
+						meta.setAttribute('name', 'astro-view-transitions-enabled');
+						nextDocument.head.append(meta);
+						nextDocument.body.innerHTML = '<p id="custom-loader-result">custom</p>';
+						transitionEvent.newDocument = nextDocument;
+					};
+				},
+				{ once: true },
+			);
+		});
+
+		await page.click('#click-three');
+		await expect(page.locator('#custom-loader-result')).toHaveText('custom');
+		expect(requests).toEqual([]);
+		await expect(page).toHaveURL(/\/three$/);
+	});
+
+	test('ClientRouter does not claim external Navigation API navigations with info', async ({
+		page,
+		astro,
+	}) => {
+		const expectLoads = collectLoads(page);
+		await page.goto(astro.resolveUrl('/one'));
+		await expectLoads(1);
+		if (!(await hasNavigationApi(page))) test.skip();
+		await page.evaluate((url) => {
+			(
+				window as Window & {
+					navigation: { navigate: (url: string, options?: { info?: unknown }) => unknown };
+				}
+			).navigation.navigate(url, { info: { external: true } });
+		}, astro.resolveUrl('/two'));
+		await expect(page.locator('#two')).toHaveText('Page 2');
+		await expectLoads(2);
+	});
+
+	test('ClientRouter does not intercept cross-document traversals', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/three'));
+		await page.goto(astro.resolveUrl('/one'));
+		if (!(await hasNavigationApi(page))) test.skip();
+		await page.evaluate(() => {
+			localStorage.removeItem('astro-cross-document-traverse-intercepted');
+			document.addEventListener('astro:before-preparation', () => {
+				localStorage.setItem('astro-cross-document-traverse-intercepted', 'true');
+			});
+		});
+		await page.goBack();
+		await expect(page.locator('#three')).toHaveText('Page 3');
+		expect(
+			await page.evaluate(() => localStorage.getItem('astro-cross-document-traverse-intercepted')),
+		).toBeNull();
+	});
+
+	test('falls back to History API when Navigation precommit is unavailable', async ({
+		page,
+		astro,
+	}) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(window, 'NavigationPrecommitController', {
+				configurable: true,
+				value: undefined,
+			});
+		});
+		await page.goto(astro.resolveUrl('/one'));
+		expect(await page.evaluate(() => history.state?.index)).toBe(0);
+		await page.click('#click-two');
+		await expect(page.locator('#two')).toHaveText('Page 2');
+		expect(await page.evaluate(() => history.state?.index)).toBe(1);
+	});
+
+	test('Navigation API push and replace navigation use the native history entries', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/one'));
+		if (!(await hasNavigationApi(page))) test.skip();
+
+		const firstIndex = await page.evaluate(
+			() =>
+				(window as Window & { navigation: { currentEntry: { index: number } } }).navigation
+					.currentEntry.index,
+		);
+		await page.click('#click-two');
+		await expect(page.locator('#two')).toHaveText('Page 2');
+		expect(
+			await page.evaluate(
+				() =>
+					(window as Window & { navigation: { currentEntry: { index: number } } }).navigation
+						.currentEntry.index,
+			),
+		).toBeGreaterThan(firstIndex);
+
+		await page.click('#click-longpage');
+		await expect(page.locator('#longpage')).toBeVisible();
+		await page.goBack();
+		await expect(page.locator('#one')).toHaveText('Page 1');
+	});
+
+	test('Navigation API restores Astro-managed traversal scroll positions and applies fragments before after-swap', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/long-page'));
+		if (!(await hasNavigationApi(page))) test.skip();
+
+		await page.evaluate(() => {
+			window.scrollTo(0, document.documentElement.scrollHeight);
+			window.dispatchEvent(new Event('scroll'));
+		});
+		const scrollPosition = await page.evaluate(() => window.scrollY);
+		await page.evaluate(() => document.querySelector<HTMLElement>('#click-one')!.click());
+		await expect(page.locator('#one')).toHaveText('Page 1');
+		await page.goBack();
+		await expect(page.locator('#longpage')).toBeVisible();
+		expect(await page.evaluate(() => window.scrollY)).toBe(scrollPosition);
+
+		await page.click('#click-one');
+		await expect(page.locator('#one')).toHaveText('Page 1');
+		await collectTransitionEvents(page);
+		await page.click('#click-two-bottom');
+		await expect(page.locator('#bottom')).toBeInViewport();
+		const afterSwapScroll = await page.evaluate(() =>
+			window.transitionEvents?.find((event) => event.name === 'astro:after-swap'),
+		);
+		expect(afterSwapScroll?.scrollY).toBeGreaterThan(0);
+	});
+
+	test('Navigation API reports traversal direction and handles superseded navigation once', async ({
+		page,
+		astro,
+	}) => {
+		await page.goto(astro.resolveUrl('/one'));
+		if (!(await hasNavigationApi(page))) test.skip();
+		await collectTransitionEvents(page);
+
+		await page.click('#click-two');
+		await expect(page.locator('#two')).toHaveText('Page 2');
+		await page.goBack();
+		await expect(page.locator('#one')).toHaveText('Page 1');
+		const directions = await page.evaluate(() =>
+			window.transitionEvents
+				?.filter((event) => event.name === 'astro:before-preparation')
+				.map((event) => event.direction),
+		);
+		expect(directions).toEqual(['forward', 'back']);
+
+		await page.goto(astro.resolveUrl('/abort'));
+		await expect(page.locator('#one')).toHaveText('Page 1');
+	});
+
+	test('uses the History API fallback when Navigation API is unavailable', async ({
+		page,
+		astro,
+	}) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(window, 'navigation', { configurable: true, value: undefined });
+		});
+		await page.goto(astro.resolveUrl('/one'));
+		await expect(page.locator('#one')).toHaveText('Page 1');
+		expect(await page.evaluate(() => history.state?.index)).toBe(0);
+
+		await page.click('#click-two');
+		await expect(page.locator('#two')).toHaveText('Page 2');
+		expect(await page.evaluate(() => history.state?.index)).toBe(1);
 	});
 
 	test('View Transitions Rule', async ({ page, astro }) => {
@@ -1010,6 +1329,7 @@ test.describe('View Transitions', () => {
 		await page.click('#click-redirect-two');
 		p = page.locator('#two');
 		await expect(p, 'should have content').toHaveText('Page 2');
+		await expect(page).toHaveURL(/\/two$/);
 
 		// go back
 		await page.goBack();
@@ -1033,6 +1353,7 @@ test.describe('View Transitions', () => {
 		await page.click('#click-redirect-two-hash');
 		p = page.locator('#two');
 		await expect(p, 'should have content').toHaveText('Page 2');
+		await expect(page).toHaveURL(/\/two#bottom$/);
 
 		const Y = await page.evaluate(() => window.scrollY);
 		expect(Y, 'The target is further down the page').toBeGreaterThan(0);
@@ -1161,7 +1482,7 @@ test.describe('View Transitions', () => {
 		await page.evaluate(() => {
 			// get the router from its fixture park position
 			const navigate = window.clientSideRouterForTestsParkedHere!;
-			navigate('/three');
+			void navigate('/three');
 		});
 		p = page.locator('#three');
 		await expect(p, 'should have content').toHaveText('Page 3');
@@ -1184,7 +1505,10 @@ test.describe('View Transitions', () => {
 		const button = page.locator('#react-client-load-navigate-button');
 
 		await expect(button, 'should have content').toHaveText('Navigate to `/two`');
-
+		await expect(
+			page.locator('astro-island:not([ssr]) #react-client-load-navigate-button'),
+			'should be hydrated',
+		).toHaveCount(1);
 		await button.click();
 
 		const p = page.locator('#two');
@@ -1240,14 +1564,14 @@ test.describe('View Transitions', () => {
 
 		// goto #2
 		await page.evaluate(() => {
-			window.clientSideRouterForTestsParkedHere!('/two', { history: 'auto' });
+			void window.clientSideRouterForTestsParkedHere!('/two', { history: 'auto' });
 		});
 		p = page.locator('#two');
 		await expect(p, 'should have content').toHaveText('Page 2');
 
 		// replace with long page
 		await page.evaluate(() => {
-			window.clientSideRouterForTestsParkedHere!('/long-page', { history: 'replace' });
+			void window.clientSideRouterForTestsParkedHere!('/long-page', { history: 'replace' });
 		});
 		let article = page.locator('#longpage');
 		await expect(article, 'should have script content').toBeVisible();
@@ -1291,6 +1615,7 @@ test.describe('View Transitions', () => {
 		await page.click('#submit');
 		const span = page.locator('#contact-name');
 		await expect(span, 'should have content').toHaveText('Testing');
+		await expect(page).toHaveURL(/\/form-response\?name=Testing$/);
 		// There should be only 1 page load. No additional loads for the form submission
 		await expectLoads(1);
 	});
@@ -1319,6 +1644,7 @@ test.describe('View Transitions', () => {
 		await page.click('#submit');
 		const span = page.locator('#contact-name');
 		await expect(span, 'should have content').toHaveText('Testing');
+		await expect(page).toHaveURL(/\/form-response\?name=Testing$/);
 		// There should be only 1 page load. No additional loads for the form submission
 		await expectLoads(1);
 	});

--- a/packages/astro/src/transitions/events.ts
+++ b/packages/astro/src/transitions/events.ts
@@ -136,6 +136,7 @@ export async function doPreparation(
 	signal: AbortSignal,
 	formData: FormData | undefined,
 	defaultLoader: (event: TransitionBeforePreparationEvent) => Promise<void>,
+	shouldSaveScroll = true,
 ) {
 	const event = new TransitionBeforePreparationEvent(
 		from,
@@ -153,7 +154,7 @@ export async function doPreparation(
 		await event.loader();
 		if (!event.defaultPrevented) {
 			triggerEvent('astro:after-preparation');
-			if (event.navigationType !== 'traverse') {
+			if (shouldSaveScroll && event.navigationType !== 'traverse') {
 				// save the current scroll position before we change the DOM and transition to the new page
 				updateScrollPosition({ scrollX, scrollY });
 			}

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -3,7 +3,7 @@ import type { TransitionBeforePreparationEvent } from './events.js';
 
 import { doPreparation, doSwap, onPageLoad, triggerEvent, updateScrollPosition } from './events.js';
 import { detectScriptExecuted } from './swap-functions.js';
-import type { Direction, Fallback, Options } from './types.js';
+import type { Direction, Fallback, NavigationTypeString, Options } from './types.js';
 
 type State = {
 	index: number;
@@ -11,6 +11,62 @@ type State = {
 	scrollY: number;
 };
 type Navigation = { controller: AbortController };
+type FetchedHTML = { html: string; redirected?: string; mediaType: DOMParserSupportedType };
+type NavigationHistoryEntry = {
+	id: string;
+	addEventListener: (type: 'dispose', listener: () => void, options?: { once?: boolean }) => void;
+	getState: () => unknown;
+	index: number;
+	key: string;
+	sameDocument: boolean;
+	url: string;
+};
+type NavigationResult = { committed: Promise<unknown>; finished: Promise<unknown> };
+type NavigationPrecommitController = {
+	redirect: (
+		url: string,
+		options?: { history?: Options['history']; info?: unknown; state?: unknown },
+	) => void;
+};
+type NavigationApi = {
+	addEventListener: {
+		(type: 'navigate', listener: (event: NavigateEvent) => void): void;
+		(
+			type: 'currententrychange',
+			listener: (event: NavigationCurrentEntryChangeEvent) => void,
+		): void;
+	};
+	currentEntry: NavigationHistoryEntry | null;
+	navigate: (
+		url: string,
+		options?: { history?: Options['history']; info?: unknown; state?: unknown },
+	) => NavigationResult;
+	updateCurrentEntry: (options: { state: unknown }) => void;
+};
+type NavigateEvent = {
+	canIntercept: boolean;
+	cancelable: boolean;
+	destination: { id: string; index: number; key: string; sameDocument: boolean; url: string };
+	formData?: FormData;
+	hasUAVisualTransition?: boolean;
+	hashChange: boolean;
+	info?: unknown;
+	navigationType: 'push' | 'replace' | 'reload' | 'traverse';
+	signal: AbortSignal;
+	sourceElement?: Element;
+	intercept: (options: {
+		focusReset: 'manual';
+		handler: () => Promise<void>;
+		precommitHandler?: (controller: NavigationPrecommitController) => Promise<void>;
+		scroll: 'manual';
+	}) => void;
+	scroll: () => void;
+};
+type NavigationCurrentEntryChangeEvent = {
+	from: NavigationHistoryEntry;
+	navigationType: NavigateEvent['navigationType'] | null;
+};
+type AstroNavigationRequest = { intercepted: boolean; options: Options };
 type Transition = {
 	// The view transitions object (API and simulation)
 	viewTransition?: ViewTransition;
@@ -21,8 +77,17 @@ type Transition = {
 };
 
 const inBrowser = import.meta.env.SSR === false;
+const rawNavigationApi = inBrowser
+	? (window as Window & { navigation?: NavigationApi }).navigation
+	: undefined;
+const supportsNavigationPrecommit =
+	inBrowser &&
+	typeof (window as Window & { NavigationPrecommitController?: unknown })
+		.NavigationPrecommitController === 'function';
+const navigationApi = supportsNavigationPrecommit ? rawNavigationApi : undefined;
 
 export const supportsViewTransitions = inBrowser && !!document.startViewTransition;
+export const supportsNavigationApi = !!navigationApi;
 
 export const transitionEnabledOnThisPage = () =>
 	inBrowser && !!document.querySelector('[name="astro-view-transitions-enabled"]');
@@ -68,8 +133,13 @@ let parser: DOMParser;
 // you can figure it using an index. On pushState the index is incremented so you
 // can use that to determine popstate if going forward or back.
 let currentHistoryIndex = 0;
+let bypassNavigationApi = false;
+const navigationScrollPositions = new Map<string, { scrollX: number; scrollY: number }>();
+const navigationEntries = new Map<string, NavigationHistoryEntry>();
+let pendingManagedHashEntry = false;
+const astroNavigationRequests = new WeakMap<object, AstroNavigationRequest>();
 
-if (inBrowser) {
+if (inBrowser && !supportsNavigationApi) {
 	if (history.state) {
 		// Here we reloaded a page with history state
 		// (e.g. history navigation from non-transition page or browser reload)
@@ -83,11 +153,41 @@ if (inBrowser) {
 	}
 }
 
+function trackNavigationEntry(entry = navigationApi?.currentEntry) {
+	if (!entry || navigationEntries.get(entry.id) === entry) return;
+	navigationEntries.set(entry.id, entry);
+	entry.addEventListener(
+		'dispose',
+		() => {
+			if (navigationEntries.get(entry.id) !== entry) return;
+			navigationEntries.delete(entry.id);
+			navigationScrollPositions.delete(entry.key);
+		},
+		{ once: true },
+	);
+}
+
+function saveNavigationScrollPosition() {
+	const entry = navigationApi?.currentEntry;
+	if (entry && navigationEntries.has(entry.id)) {
+		navigationScrollPositions.set(entry.key, { scrollX, scrollY });
+	}
+}
+
+function onNavigationCurrentEntryChange(event: NavigationCurrentEntryChangeEvent) {
+	const currentEntry = navigationApi?.currentEntry;
+	if (
+		pendingManagedHashEntry &&
+		currentEntry?.sameDocument &&
+		navigationEntries.has(event.from.id)
+	) {
+		trackNavigationEntry(currentEntry);
+	}
+	pendingManagedHashEntry = false;
+}
+
 // returns the contents of the page or null if the router can't deal with it.
-async function fetchHTML(
-	href: string,
-	init?: RequestInit,
-): Promise<null | { html: string; redirected?: string; mediaType: DOMParserSupportedType }> {
+async function fetchHTML(href: string, init?: RequestInit): Promise<null | FetchedHTML> {
 	try {
 		// Apply adapter-specific headers for internal fetches
 		const headers = new Headers(init?.headers);
@@ -271,6 +371,7 @@ async function updateDOM(
 	currentTransition: Transition,
 	historyState?: State,
 	fallback?: Fallback,
+	navigationEvent?: NavigateEvent,
 ) {
 	async function animate(phase: string) {
 		function isInfinite(animation: Animation) {
@@ -312,7 +413,28 @@ async function updateDOM(
 		currentTransition.viewTransition!,
 		animateFallbackOld,
 	);
-	moveToLocation(swapEvent.to, swapEvent.from, options, pageTitleForBrowserHistory, historyState);
+	if (navigationEvent) {
+		originalLocation = swapEvent.to;
+		if (navigationEvent.navigationType === 'traverse') {
+			const scrollPosition = navigationScrollPositions.get(navigationEvent.destination.key);
+			if (scrollPosition) {
+				scrollTo(scrollPosition.scrollX, scrollPosition.scrollY);
+			} else {
+				navigationEvent.scroll();
+			}
+		} else {
+			// Navigation API state and classic history.state are separate. Keep the public
+			// navigate({ state }) behavior visible through both APIs.
+			if (options.state !== undefined) {
+				history.replaceState(options.state, '');
+				navigationApi?.updateCurrentEntry({ state: options.state });
+			}
+			trackNavigationEntry();
+			navigationEvent.scroll();
+		}
+	} else {
+		moveToLocation(swapEvent.to, swapEvent.from, options, pageTitleForBrowserHistory, historyState);
+	}
 	triggerEvent('astro:after-swap');
 
 	// Resolve the finished promise of the simulation's ViewTransition.
@@ -332,6 +454,83 @@ function abortAndRecreateMostRecentNavigation(): Navigation {
 	});
 }
 
+async function defaultLoader(preparationEvent: TransitionBeforePreparationEvent, from: URL) {
+	const href = preparationEvent.to.href;
+	const init: RequestInit = { signal: preparationEvent.signal };
+	if (preparationEvent.formData) {
+		init.method = 'POST';
+		const form =
+			preparationEvent.sourceElement instanceof HTMLFormElement
+				? preparationEvent.sourceElement
+				: preparationEvent.sourceElement instanceof HTMLElement &&
+						'form' in preparationEvent.sourceElement
+					? (preparationEvent.sourceElement.form as HTMLFormElement)
+					: preparationEvent.sourceElement?.closest('form');
+		// Form elements without enctype explicitly set default to application/x-www-form-urlencoded.
+		// In order to maintain compatibility with Astro 4.x, we need to check the value of enctype
+		// on the attributes property rather than accessing .enctype directly. Astro 5.x may
+		// introduce defaulting to application/x-www-form-urlencoded as a breaking change, and then
+		// we can access .enctype directly.
+		//
+		// Note: getNamedItem can return null in real life, even if TypeScript doesn't think so, hence
+		// the ?.
+		init.body =
+			from !== undefined &&
+			Reflect.get(HTMLFormElement.prototype, 'attributes', form).getNamedItem('enctype')?.value ===
+				'application/x-www-form-urlencoded'
+				? new URLSearchParams(preparationEvent.formData as any)
+				: preparationEvent.formData;
+	}
+	const response = await fetchHTML(href, init);
+	// If there is a problem fetching the new page, just do an MPA navigation to it.
+	if (response === null) {
+		preparationEvent.preventDefault();
+		return;
+	}
+	// if there was a redirection, show the final URL in the browser's address bar
+	if (response.redirected) {
+		const redirectedTo = new URL(response.redirected);
+		// but do not redirect cross origin
+		if (redirectedTo.origin !== preparationEvent.to.origin) {
+			preparationEvent.preventDefault();
+			return;
+		}
+		// preserve fragment
+		const fragment = preparationEvent.to.hash;
+		preparationEvent.to = redirectedTo;
+		preparationEvent.to.hash = fragment;
+	}
+
+	parser ??= new DOMParser();
+
+	preparationEvent.newDocument = parser.parseFromString(response.html, response.mediaType);
+	// The next line might look like a hack,
+	// but it is actually necessary as noscript elements
+	// and their contents are returned as markup by the parser,
+	// see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
+	preparationEvent.newDocument.querySelectorAll('noscript').forEach((el) => el.remove());
+
+	// If ClientRouter is not enabled on the incoming page, do a full page load to it.
+	// Unless this was a form submission, in which case we do not want to trigger another mutation.
+	if (
+		!preparationEvent.newDocument.querySelector('[name="astro-view-transitions-enabled"]') &&
+		!preparationEvent.formData
+	) {
+		preparationEvent.preventDefault();
+		return;
+	}
+
+	const links = preloadStyleLinks(preparationEvent.newDocument);
+	links.length && !preparationEvent.signal.aborted && (await Promise.all(links));
+
+	if (import.meta.env.DEV && !preparationEvent.signal.aborted)
+		await prepareForClientOnlyComponents(
+			preparationEvent.newDocument,
+			preparationEvent.to,
+			preparationEvent.signal,
+		);
+}
+
 async function transition(
 	direction: Direction,
 	from: URL,
@@ -339,6 +538,9 @@ async function transition(
 	options: Options,
 	historyState?: State,
 	hasUAVisualTransition = false,
+	navigationTypeOverride?: NavigationTypeString,
+	navigationEvent?: NavigateEvent,
+	preparedEvent?: TransitionBeforePreparationEvent,
 ) {
 	// The most recent navigation always has precedence
 	// Yes, there can be several navigation instances as the user can click links
@@ -347,24 +549,26 @@ async function transition(
 	// Invariant: all but the most recent navigation are already aborted.
 
 	const currentNavigation = abortAndRecreateMostRecentNavigation();
+	navigationEvent?.signal.addEventListener('abort', () => currentNavigation.controller.abort(), {
+		once: true,
+	});
 
 	// not ours
 	if (!transitionEnabledOnThisPage() || location.origin !== to.origin) {
 		if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+		if (navigationEvent) bypassNavigationApi = true;
 		location.href = to.href;
 		return;
 	}
 
-	const navigationType = historyState
-		? 'traverse'
-		: options.history === 'replace'
-			? 'replace'
-			: 'push';
+	const navigationType =
+		navigationTypeOverride ??
+		(historyState ? 'traverse' : options.history === 'replace' ? 'replace' : 'push');
 
-	if (navigationType !== 'traverse') {
+	if (!navigationEvent && navigationType !== 'traverse') {
 		updateScrollPosition({ scrollX, scrollY });
 	}
-	if (samePage(from, to) && !options.formData) {
+	if (!navigationEvent && samePage(from, to) && !options.formData) {
 		if ((direction !== 'back' && to.hash) || (direction === 'back' && from.hash)) {
 			moveToLocation(to, from, options, document.title, historyState);
 			if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
@@ -372,103 +576,31 @@ async function transition(
 		}
 	}
 
-	const prepEvent = await doPreparation(
-		from,
-		to,
-		direction,
-		navigationType,
-		options.sourceElement,
-		options.info,
-		currentNavigation!.controller.signal,
-		options.formData,
-		defaultLoader,
-	);
+	const prepEvent =
+		preparedEvent ??
+		(await doPreparation(
+			from,
+			to,
+			direction,
+			navigationType,
+			options.sourceElement,
+			options.info,
+			currentNavigation!.controller.signal,
+			options.formData,
+			(event) => defaultLoader(event, from),
+			!navigationEvent,
+		));
 	if (prepEvent.defaultPrevented || prepEvent.signal.aborted) {
 		if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
 		if (!prepEvent.signal.aborted) {
 			// not aborted -> delegate to browser
+			if (navigationEvent) bypassNavigationApi = true;
 			location.href = to.href;
 		}
 		// and / or exit
 		return;
 	}
 
-	async function defaultLoader(preparationEvent: TransitionBeforePreparationEvent) {
-		const href = preparationEvent.to.href;
-		const init: RequestInit = { signal: preparationEvent.signal };
-		if (preparationEvent.formData) {
-			init.method = 'POST';
-			const form =
-				preparationEvent.sourceElement instanceof HTMLFormElement
-					? preparationEvent.sourceElement
-					: preparationEvent.sourceElement instanceof HTMLElement &&
-							'form' in preparationEvent.sourceElement
-						? (preparationEvent.sourceElement.form as HTMLFormElement)
-						: preparationEvent.sourceElement?.closest('form');
-			// Form elements without enctype explicitly set default to application/x-www-form-urlencoded.
-			// In order to maintain compatibility with Astro 4.x, we need to check the value of enctype
-			// on the attributes property rather than accessing .enctype directly. Astro 5.x may
-			// introduce defaulting to application/x-www-form-urlencoded as a breaking change, and then
-			// we can access .enctype directly.
-			//
-			// Note: getNamedItem can return null in real life, even if TypeScript doesn't think so, hence
-			// the ?.
-			init.body =
-				from !== undefined &&
-				Reflect.get(HTMLFormElement.prototype, 'attributes', form).getNamedItem('enctype')
-					?.value === 'application/x-www-form-urlencoded'
-					? new URLSearchParams(preparationEvent.formData as any)
-					: preparationEvent.formData;
-		}
-		const response = await fetchHTML(href, init);
-		// If there is a problem fetching the new page, just do an MPA navigation to it.
-		if (response === null) {
-			preparationEvent.preventDefault();
-			return;
-		}
-		// if there was a redirection, show the final URL in the browser's address bar
-		if (response.redirected) {
-			const redirectedTo = new URL(response.redirected);
-			// but do not redirect cross origin
-			if (redirectedTo.origin !== preparationEvent.to.origin) {
-				preparationEvent.preventDefault();
-				return;
-			}
-			// preserve fragment
-			const fragment = preparationEvent.to.hash;
-			preparationEvent.to = redirectedTo;
-			preparationEvent.to.hash = fragment;
-		}
-
-		parser ??= new DOMParser();
-
-		preparationEvent.newDocument = parser.parseFromString(response.html, response.mediaType);
-		// The next line might look like a hack,
-		// but it is actually necessary as noscript elements
-		// and their contents are returned as markup by the parser,
-		// see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
-		preparationEvent.newDocument.querySelectorAll('noscript').forEach((el) => el.remove());
-
-		// If ClientRouter is not enabled on the incoming page, do a full page load to it.
-		// Unless this was a form submission, in which case we do not want to trigger another mutation.
-		if (
-			!preparationEvent.newDocument.querySelector('[name="astro-view-transitions-enabled"]') &&
-			!preparationEvent.formData
-		) {
-			preparationEvent.preventDefault();
-			return;
-		}
-
-		const links = preloadStyleLinks(preparationEvent.newDocument);
-		links.length && !preparationEvent.signal.aborted && (await Promise.all(links));
-
-		if (import.meta.env.DEV && !preparationEvent.signal.aborted)
-			await prepareForClientOnlyComponents(
-				preparationEvent.newDocument,
-				preparationEvent.to,
-				preparationEvent.signal,
-			);
-	}
 	async function abortAndRecreateMostRecentTransition(): Promise<Transition> {
 		if (mostRecentTransition) {
 			if (mostRecentTransition.viewTransition) {
@@ -503,7 +635,15 @@ async function transition(
 		// This automatically cancels any previous transition
 		// We also already took care that the earlier update callback got through
 		currentTransition.viewTransition = document.startViewTransition(
-			async () => await updateDOM(prepEvent, options, currentTransition, historyState),
+			async () =>
+				await updateDOM(
+					prepEvent,
+					options,
+					currentTransition,
+					historyState,
+					undefined,
+					navigationEvent,
+				),
 		);
 	} else {
 		// Simulation mode requires a bit more manual work.
@@ -519,6 +659,7 @@ async function transition(
 				currentTransition,
 				historyState,
 				hasUAVisualTransition ? 'swap' : getFallback(),
+				navigationEvent,
 			);
 			return undefined;
 		})();
@@ -594,10 +735,147 @@ export async function navigate(href: string, options?: Options) {
 		}
 		return;
 	}
+	if (navigationApi) {
+		const to = new URL(href, location.href);
+		const request: AstroNavigationRequest = { intercepted: false, options: options ?? {} };
+		const info = {};
+		astroNavigationRequests.set(info, request);
+		const result = navigationApi.navigate(to.href, {
+			history: request.options.history ?? 'auto',
+			info,
+			state: request.options.state,
+		});
+		// The navigate event is dispatched synchronously. If Astro did not intercept it,
+		// the browser owns the navigation and cross-document promises may never settle.
+		if (!request.intercepted) return;
+		try {
+			await result.finished;
+		} catch (error) {
+			// Superseded navigations and navigations delegated back to the browser abort the
+			// intercepted navigation. The History API implementation did not surface that abort.
+			if (error instanceof DOMException && error.name === 'AbortError') return;
+			throw error;
+		}
+		return;
+	}
 	await transition('forward', originalLocation, new URL(href, location.href), options ?? {});
 }
 
+function onNavigate(event: NavigateEvent) {
+	if (bypassNavigationApi) {
+		bypassNavigationApi = false;
+		return;
+	}
+	if (!transitionEnabledOnThisPage()) return;
+
+	const navigationType = event.navigationType;
+	const request =
+		typeof event.info === 'object' && event.info !== null
+			? astroNavigationRequests.get(event.info)
+			: undefined;
+	const isAstroNavigation = request !== undefined;
+	const options = request?.options ?? {};
+	const formData = event.formData ?? options.formData;
+	const currentEntry = navigationApi?.currentEntry;
+	const from = new URL(currentEntry?.url ?? location.href);
+	const to = new URL(event.destination.url);
+	const direction: Direction =
+		navigationType === 'traverse' && event.destination.index < (currentEntry?.index ?? 0)
+			? 'back'
+			: 'forward';
+	const browserHandlesHashChange =
+		!formData &&
+		event.hashChange &&
+		((direction !== 'back' && !!to.hash) || (direction === 'back' && !!from.hash));
+	const needsPrecommit = navigationType === 'push' || navigationType === 'replace';
+	const managedTraverse =
+		navigationType !== 'traverse' ||
+		(!!currentEntry &&
+			navigationEntries.has(currentEntry.id) &&
+			navigationEntries.has(event.destination.id));
+
+	pendingManagedHashEntry =
+		browserHandlesHashChange &&
+		isAstroNavigation &&
+		!!currentEntry &&
+		navigationEntries.has(currentEntry.id);
+	saveNavigationScrollPosition();
+
+	if (
+		(needsPrecommit && !isAstroNavigation) ||
+		(needsPrecommit && !event.cancelable) ||
+		(navigationType === 'traverse' && (!event.destination.sameDocument || !managedTraverse)) ||
+		!event.canIntercept ||
+		browserHandlesHashChange ||
+		location.origin !== to.origin ||
+		navigationType === 'reload'
+	) {
+		return;
+	}
+
+	let preparedEvent: TransitionBeforePreparationEvent | undefined;
+	event.intercept({
+		focusReset: 'manual',
+		precommitHandler: needsPrecommit
+			? async (controller) => {
+					preparedEvent = await doPreparation(
+						from,
+						to,
+						direction,
+						navigationType,
+						options.sourceElement ?? event.sourceElement,
+						options.info,
+						event.signal,
+						formData,
+						(preparationEvent) => defaultLoader(preparationEvent, from),
+						false,
+					);
+					if (event.signal.aborted) {
+						throw event.signal.reason ?? new DOMException('Navigation aborted', 'AbortError');
+					}
+					if (preparedEvent.defaultPrevented) {
+						bypassNavigationApi = true;
+						location.href = to.href;
+						throw new DOMException('Delegating navigation to the browser', 'AbortError');
+					}
+					if (preparedEvent.to.origin !== location.origin) {
+						bypassNavigationApi = true;
+						location.href = preparedEvent.to.href;
+						throw new DOMException('Delegating navigation to the browser', 'AbortError');
+					}
+					if (preparedEvent.to.href !== to.href) {
+						controller.redirect(preparedEvent.to.href, {
+							history: options.history ?? 'auto',
+							info: event.info,
+							state: options.state,
+						});
+					}
+				}
+			: undefined,
+		scroll: 'manual',
+		handler: async () => {
+			await transition(
+				direction,
+				from,
+				preparedEvent?.to ?? new URL(event.destination.url),
+				{
+					...options,
+					sourceElement: options.sourceElement ?? event.sourceElement,
+					formData,
+				},
+				undefined,
+				event.hasUAVisualTransition ?? false,
+				navigationType,
+				event,
+				preparedEvent,
+			);
+		},
+	});
+	if (request) request.intercepted = true;
+}
+
 function onPopState(ev: PopStateEvent) {
+	if (supportsNavigationApi) return;
 	if (!transitionEnabledOnThisPage() && ev.state) {
 		// The current page doesn't have View Transitions enabled
 		// but the page we navigate to does (because it set the state).
@@ -642,12 +920,18 @@ const onScrollEnd = () => {
 if (inBrowser) {
 	if (supportsViewTransitions || getFallback() !== 'none') {
 		originalLocation = new URL(location.href);
-		addEventListener('popstate', onPopState);
+		if (navigationApi) {
+			if (transitionEnabledOnThisPage()) trackNavigationEntry();
+			navigationApi.addEventListener('navigate', onNavigate);
+			navigationApi.addEventListener('currententrychange', onNavigationCurrentEntryChange);
+		} else {
+			addEventListener('popstate', onPopState);
+		}
 		addEventListener('load', onPageLoad);
 		// There's not a good way to record scroll position before a history back
 		// navigation, so we will record it when the user has stopped scrolling.
-		if ('onscrollend' in window) addEventListener('scrollend', onScrollEnd);
-		else {
+		if (!navigationApi && 'onscrollend' in window) addEventListener('scrollend', onScrollEnd);
+		else if (!navigationApi) {
 			// Keep track of state between intervals
 			let intervalId: number | undefined, lastY: number, lastX: number, lastIndex: State['index'];
 			const scrollInterval = () => {


### PR DESCRIPTION
## Changes

* Use the Navigation API for `ClientRouter` when the browser supports the required precommit APIs.
* Keep the existing History API implementation as a fallback.
* Run Astro preparation in `NavigateEvent.intercept()` precommit so redirects, custom loaders, cancellation, and lifecycle events resolve before commit.
* Preserve `navigate()` state/completion behavior, traversal direction, fragment navigation, and Astro-managed scroll restoration.
* Avoid intercepting same-document history entries owned by another Navigation API router.
* Includes a patch changeset.

Related: #8231, #16058, #16025, #17020, withastro/roadmap#770

This was originally motivated by a first-scroll-not-hiding-the-address-bar issue observed on Android Chrome after `ClientRouter` navigation.

## Testing

* Added E2E coverage for Navigation API navigation, traversal, redirects, forms, state, custom loaders, cross-document navigation, fallback behavior, and external-router interoperability.
* Full Chrome View Transitions suite passes.
* Firefox fallback E2E suite passes.
* Astro unit/integration/type tests pass.
* Biome/typechecking pass.
* Repeated swap and framework-router stress tests pass.

## Docs

No docs changes. This changes the internal `ClientRouter` implementation without adding or changing a public API.
