### PR TITLE
fix(errors): add a message to the redirect error and a hint to the rewrite error

### DIFF
--- a/.changeset/quiet-owls-explain.md
+++ b/.changeset/quiet-owls-explain.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds a message to the `RedirectWithNoLocation` error and hints to the `RewriteWithBodyUsed` and `ResponseSentError` errors to explain how to fix them.
+Adds a message to the `RedirectWithNoLocation` error and a hint to the `RewriteWithBodyUsed` error to explain how to fix them.

--- a/.changeset/quiet-owls-explain.md
+++ b/.changeset/quiet-owls-explain.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds hints to the middleware, endpoint, redirect, rewrite, and response errors to explain how to fix them.
+Adds a message to the `RedirectWithNoLocation` error and hints to the `RewriteWithBodyUsed` and `ResponseSentError` errors to explain how to fix them.

--- a/.changeset/quiet-owls-explain.md
+++ b/.changeset/quiet-owls-explain.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds a message to the `RedirectWithNoLocation` error and a hint to the `RewriteWithBodyUsed` error to explain how to fix them.
+Improves the diagnostics of some Astro errors.

--- a/.changeset/quiet-owls-explain.md
+++ b/.changeset/quiet-owls-explain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds hints to the middleware, endpoint, redirect, rewrite, and response errors to explain how to fix them.

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -834,6 +834,7 @@ export const ResponseSentError = {
 	name: 'ResponseSentError',
 	title: 'Unable to set response.',
 	message: 'The response has already been sent to the browser and cannot be altered.',
+	hint: 'When HTML streaming is enabled, set cookies, headers, and the status code, or call `Astro.redirect()`, in the page frontmatter or in middleware before any HTML is rendered, not inside a child component. See https://docs.astro.build/en/guides/on-demand-rendering/#html-streaming for more information.',
 } satisfies ErrorData;
 
 /**
@@ -855,6 +856,7 @@ export const MiddlewareNoDataOrNextCalled = {
 	title: "The middleware didn't return a `Response`.",
 	message:
 		'Make sure your middleware returns a `Response` object, either directly or by returning the `Response` from calling the `next` function.',
+	hint: 'This usually happens when a code path in your middleware neither calls `next()` nor returns a `Response`, for example a condition that only returns in one branch. See https://docs.astro.build/en/guides/middleware/ for more information.',
 } satisfies ErrorData;
 
 /**
@@ -874,6 +876,7 @@ export const MiddlewareNotAResponse = {
 	name: 'MiddlewareNotAResponse',
 	title: 'The middleware returned something that is not a `Response` object.',
 	message: 'Any data returned from middleware must be a valid `Response` object.',
+	hint: 'To share data with your pages and endpoints, store it in `context.locals` instead of returning it. See https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals for more information.',
 } satisfies ErrorData;
 
 /**
@@ -898,6 +901,7 @@ export const EndpointDidNotReturnAResponse = {
 	title: 'The endpoint did not return a `Response`.',
 	message:
 		'An endpoint must return either a `Response`, or a `Promise` that resolves with a `Response`.',
+	hint: 'Wrap plain values in a `Response`, for example with `Response.json()` or `new Response()`. See https://docs.astro.build/en/guides/endpoints/#server-endpoints-api-routes for more information.',
 } satisfies ErrorData;
 
 /**
@@ -1040,6 +1044,7 @@ export const AstroGlobNoMatch = {
 export const RedirectWithNoLocation = {
 	name: 'RedirectWithNoLocation',
 	title: 'A redirect must be given a location with the `Location` header.',
+	hint: 'Use `Astro.redirect()` to create redirects, or add a `Location` header to the returned `Response`. See https://docs.astro.build/en/reference/api-reference/#redirect for more information.',
 } satisfies ErrorData;
 
 /**
@@ -1398,6 +1403,7 @@ export const RewriteWithBodyUsed = {
 	title: 'Cannot use `Astro.rewrite()` after the request body has been read.',
 	message:
 		'`Astro.rewrite()` cannot be used if the request body has already been read. If you need to read the body, first clone the request.',
+	hint: 'Read the body from a clone, for example `await Astro.request.clone().formData()`, and then call `Astro.rewrite()`. See https://docs.astro.build/en/reference/api-reference/#rewrite for more information.',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -834,7 +834,7 @@ export const ResponseSentError = {
 	name: 'ResponseSentError',
 	title: 'Unable to set response.',
 	message: 'The response has already been sent to the browser and cannot be altered.',
-	hint: 'When HTML streaming is enabled, set cookies, headers, and the status code, or call `Astro.redirect()`, in the page frontmatter or in middleware before any HTML is rendered, not inside a child component. See https://docs.astro.build/en/guides/on-demand-rendering/#html-streaming for more information.',
+	hint: 'Set cookies, headers, and the status code, or redirect, before the page starts rendering: in the frontmatter of the page or in middleware, not inside a child component.',
 } satisfies ErrorData;
 
 /**
@@ -856,7 +856,6 @@ export const MiddlewareNoDataOrNextCalled = {
 	title: "The middleware didn't return a `Response`.",
 	message:
 		'Make sure your middleware returns a `Response` object, either directly or by returning the `Response` from calling the `next` function.',
-	hint: 'This usually happens when a code path in your middleware neither calls `next()` nor returns a `Response`, for example a condition that only returns in one branch. See https://docs.astro.build/en/guides/middleware/ for more information.',
 } satisfies ErrorData;
 
 /**
@@ -876,7 +875,6 @@ export const MiddlewareNotAResponse = {
 	name: 'MiddlewareNotAResponse',
 	title: 'The middleware returned something that is not a `Response` object.',
 	message: 'Any data returned from middleware must be a valid `Response` object.',
-	hint: 'To share data with your pages and endpoints, store it in `context.locals` instead of returning it. See https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals for more information.',
 } satisfies ErrorData;
 
 /**
@@ -901,7 +899,6 @@ export const EndpointDidNotReturnAResponse = {
 	title: 'The endpoint did not return a `Response`.',
 	message:
 		'An endpoint must return either a `Response`, or a `Promise` that resolves with a `Response`.',
-	hint: 'Wrap plain values in a `Response`, for example with `Response.json()` or `new Response()`. See https://docs.astro.build/en/guides/endpoints/#server-endpoints-api-routes for more information.',
 } satisfies ErrorData;
 
 /**
@@ -1044,7 +1041,8 @@ export const AstroGlobNoMatch = {
 export const RedirectWithNoLocation = {
 	name: 'RedirectWithNoLocation',
 	title: 'A redirect must be given a location with the `Location` header.',
-	hint: 'Use `Astro.redirect()` to create redirects, or add a `Location` header to the returned `Response`. See https://docs.astro.build/en/reference/api-reference/#redirect for more information.',
+	message:
+		'The redirect `Response` has no `Location` header. Use `Astro.redirect()` to create redirects, or add a `Location` header to the `Response`.',
 } satisfies ErrorData;
 
 /**
@@ -1403,7 +1401,7 @@ export const RewriteWithBodyUsed = {
 	title: 'Cannot use `Astro.rewrite()` after the request body has been read.',
 	message:
 		'`Astro.rewrite()` cannot be used if the request body has already been read. If you need to read the body, first clone the request.',
-	hint: 'Read the body from a clone, for example `await Astro.request.clone().formData()`, and then call `Astro.rewrite()`. See https://docs.astro.build/en/reference/api-reference/#rewrite for more information.',
+	hint: 'Read the body from `Astro.request.clone()` instead of `Astro.request`, so the original request can still be rewritten.',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -834,7 +834,6 @@ export const ResponseSentError = {
 	name: 'ResponseSentError',
 	title: 'Unable to set response.',
 	message: 'The response has already been sent to the browser and cannot be altered.',
-	hint: 'Set cookies, headers, and the status code, or redirect, before the page starts rendering: in the frontmatter of the page or in middleware, not inside a child component.',
 } satisfies ErrorData;
 
 /**


### PR DESCRIPTION
## Changes

Revised after review (thanks @ematipico). Two changes remain:

- `RedirectWithNoLocation`: this entry only had a `title`; adds a `message` that says what happened and how to fix it (`Astro.redirect()` or a `Location` header).
- `RewriteWithBodyUsed`: adds a hint that names the mechanism, read the body from `Astro.request.clone()` so the original request can still be rewritten, without assuming a body format.

No `name` or `title` was changed. Changeset: `'astro': patch`.

## Testing

Text-only change, so no new tests. Locally: `pnpm -C packages/astro build`, then `packages/astro/test/units/errors/` passes, and the CLI error formatter renders the new text. Biome and ESLint are clean on the changed file.

## Docs

The error reference at docs.astro.build is generated from `errors-data.ts`, so the new text will appear there on the next docs build; no docs PR needed.