### PR TITLE
fix(node): keep the full query string on trailing slash redirects

### DIFF
--- a/.changeset/brave-doors-keep.md
+++ b/.changeset/brave-doors-keep.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes a bug where the trailing slash redirect dropped part of the query string when it contained a second `?`, for example `?redirect=/page?id=1`.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -57,7 +57,10 @@ export function createStaticHandler(
 				fullUrl = fullUrl.slice(0, req.url.indexOf('#'));
 			}
 
-			const [urlPath, urlQuery] = fullUrl.split('?');
+			// Only split on the first `?` so a query string that itself contains `?` is kept intact.
+			const queryIndex = fullUrl.indexOf('?');
+			const urlPath = queryIndex === -1 ? fullUrl : fullUrl.slice(0, queryIndex);
+			const urlQuery = queryIndex === -1 ? undefined : fullUrl.slice(queryIndex + 1);
 			let fsPath = app.removeBase(urlPath);
 			try {
 				fsPath = decodeURI(fsPath);

--- a/packages/integrations/node/test/trailing-slash.test.ts
+++ b/packages/integrations/node/test/trailing-slash.test.ts
@@ -88,6 +88,17 @@ describe('Trailing slash', () => {
 				assert.equal(res.headers.get('location'), '/some-base/one/?foo=bar');
 			});
 
+			it('Keeps a query string that contains a second `?` on redirect', async () => {
+				const res = await fetch(
+					`http://${server.host}:${server.port}/some-base/one?redirect=/x?y=1&z=2`,
+					{
+						redirect: 'manual',
+					},
+				);
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/some-base/one/?redirect=/x?y=1&z=2');
+			});
+
 			it('Can render prerendered route with query params', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/?foo=bar`);
 				const html = await res.text();
@@ -162,6 +173,14 @@ describe('Trailing slash', () => {
 				});
 				assert.equal(res.status, 301);
 				assert.equal(res.headers.get('location'), '/one/?foo=bar');
+			});
+
+			it('Keeps a query string that contains a second `?` on redirect', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one?redirect=/x?y=1&z=2`, {
+					redirect: 'manual',
+				});
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/one/?redirect=/x?y=1&z=2');
 			});
 
 			it('Can render prerendered route with query params', async () => {
@@ -296,6 +315,18 @@ describe('Trailing slash', () => {
 				assert.equal(res.headers.get('location'), '/some-base/one?foo=bar');
 			});
 
+			it('Keeps a query string that contains a second `?` on redirect', async () => {
+				const res = await fetch(
+					`http://${server.host}:${server.port}/some-base/one/?redirect=/x?y=1&z=2`,
+					{
+						redirect: 'manual',
+					},
+				);
+
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/some-base/one?redirect=/x?y=1&z=2');
+			});
+
 			it('Can render prerendered route with query params', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one?foo=bar`);
 				const html = await res.text();
@@ -352,6 +383,15 @@ describe('Trailing slash', () => {
 
 				assert.equal(res.status, 301);
 				assert.equal(res.headers.get('location'), '/one?foo=bar');
+			});
+
+			it('Keeps a query string that contains a second `?` on redirect', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one/?redirect=/x?y=1&z=2`, {
+					redirect: 'manual',
+				});
+
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/one?redirect=/x?y=1&z=2');
 			});
 
 			it('Can render prerendered route and query params', async () => {


### PR DESCRIPTION
Fixes #17962

## Changes

`@astrojs/node`'s static handler splits the request URL with `fullUrl.split('?')` and keeps only the first two parts, so a query string that itself contains a `?` is cut off when the trailing-slash redirect rebuilds the `Location` header.

- `GET /one/?redirect=/x?y=1&z=2` with `trailingSlash: 'never'` → `301 Location: /one?redirect=/x` (expected `/one?redirect=/x?y=1&z=2`)
- `GET /one?redirect=/x?y=1&z=2` with `trailingSlash: 'always'` → `301 Location: /one/?redirect=/x`

This affects any return URL, OAuth `state`, or search URL carried in the query. The fix splits on the first `?` only, which is what RFC 3986 allows inside the query component.

Changeset: `'@astrojs/node': patch`.

## Testing

Added `Keeps a query string that contains a second `?` on redirect` to all four existing redirect suites in `test/trailing-slash.test.ts` (`always`/`never`, with and without `base`). All four fail before the change:

```
actual:   '/one?redirect=/x'
expected: '/one?redirect=/x?y=1&z=2'
```

and pass after it (38/38 in the file).

## Docs

No docs change: this restores the documented behavior of the trailing-slash redirect, which is only meant to normalize the slash.
