### PR TITLE
Fix release retries skipping VS Code/OpenVSX publishing and release announcements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,20 @@ jobs:
           # Use OIDC for npm authentication instead of NPM_TOKEN
           NPM_TOKEN: '' # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
 
-      - name: Check if astro-vscode was published
+      # On a re-run after npm already received the versions, changesets publishes nothing new
+      # and `publishedPackages` is empty. The git tag created by the first attempt persists
+      # and points at this release commit, so it identifies astro-vscode as part of this
+      # release with marketplace publication still pending.
+      - name: Check if astro-vscode needs marketplace publishing
         id: vscode-published
-        if: steps.changesets.outputs.published == 'true'
         run: |
-          if echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null; then
+          VERSION=$(git show HEAD:packages/language-tools/vscode/package.json | jq -r .version)
+          TAG_SHA=$(git ls-remote --tags origin "astro-vscode@${VERSION}^{}" | awk '{print $1}')
+          if [ -z "$TAG_SHA" ]; then
+            TAG_SHA=$(git ls-remote --tags origin "astro-vscode@${VERSION}" | awk '{print $1}')
+          fi
+          if echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null \
+             || { [ -n "$TAG_SHA" ] && [ "$TAG_SHA" = "$(git rev-parse HEAD)" ]; }; then
             echo "published=true" >> $GITHUB_OUTPUT
           else
             echo "published=false" >> $GITHUB_OUTPUT
@@ -87,13 +96,13 @@ jobs:
         if: steps.vscode-published.outputs.published == 'true'
         working-directory: ./packages/language-tools/vscode
         run: |
-          npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
+          npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --skip-duplicate --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
 
       - name: Publish to OpenVSX
         if: steps.vscode-published.outputs.published == 'true'
         working-directory: ./packages/language-tools/vscode
         run: |
-          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
+          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --skip-duplicate --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
           
       - name: Restore root package.json and node_modules
         if: steps.vscode-published.outputs.published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
             PAYLOAD='${{ steps.changesets.outputs.publishedPackages }}'
             HAS_RELEASE=true
           elif git log -1 --format=%s HEAD | grep -q '^\[ci\] release'; then
+            # Nothing was published, so this is a re-run (or the same commit on another branch):
+            # npm already has these versions, so rebuild the released-package list from the
+            # version bumps in the release commit.
             while read -r f; do
               case "$f" in
                 *"/test/"*|*"/fixtures/"*|*"/node_modules/"*) continue ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,39 +66,43 @@ jobs:
       # On a re-run after npm already received the versions, changesets publishes nothing new
       # and its `published`/`publishedPackages` outputs are empty, so any downstream work gated
       # on them would be skipped while the run turns green. The version bumps for this release
-      # live in the release commit itself, so the cohort is reconstructed from the commit diff:
-      # it is available on every attempt and does not depend on tags or on what npm received
-      # this run.
+      # live in the release commit itself, so the cohort is rebuilt from the commit diff on
+      # retries. Only the squash-merged "[ci] release" version PR commit bumps package versions;
+      # fixture edits, manual version changes, merges, and reverts must not look like releases.
       - name: Detect release cohort
         id: release
         run: |
+          HAS_RELEASE=false
+          HAS_VSCODE=false
           COHORT=""
-          while read -r f; do
-            V_OLD=$(git show "$(git rev-parse HEAD^):$f" 2>/dev/null | jq -r .version 2>/dev/null || true)
-            V_NEW=$(git show "HEAD:$f" | jq -r .version 2>/dev/null || true)
-            PRIVATE=$(git show "HEAD:$f" | jq -r .private 2>/dev/null || true)
-            if [ -n "$V_NEW" ] && [ "$V_NEW" != "null" ] && [ "$V_OLD" != "$V_NEW" ] && [ "$PRIVATE" != "true" ]; then
-              COHORT="$COHORT{\"name\":\"$(git show "HEAD:$f" | jq -r .name)\",\"version\":\"$V_NEW\"},"
-            fi
-          done < <(git diff --name-only "$(git rev-parse HEAD^)" HEAD -- packages | grep -E '(^|/)package\.json$' | sort -u)
-          COHORT="[${COHORT%,}]"
-          if echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null \
-             || echo "$COHORT" | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null; then
-            HAS_VSCODE=true
-          else
-            HAS_VSCODE=false
-          fi
-          # On the first attempt `publishedPackages` is the ground truth for the announcement;
-          # on a retry it is empty, so the reconstructed cohort is used instead.
           if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
             PAYLOAD='${{ steps.changesets.outputs.publishedPackages }}'
             HAS_RELEASE=true
-          elif [ "$COHORT" != "[]" ]; then
-            PAYLOAD="$COHORT"
-            HAS_RELEASE=true
+          elif git log -1 --format=%s HEAD | grep -q '^\[ci\] release'; then
+            while read -r f; do
+              case "$f" in
+                *"/test/"*|*"/fixtures/"*|*"/node_modules/"*) continue ;;
+              esac
+              V_OLD=$(git show "$(git rev-parse HEAD^):$f" 2>/dev/null | jq -r .version 2>/dev/null || true)
+              V_NEW=$(git show "HEAD:$f" | jq -r .version 2>/dev/null || true)
+              PRIVATE=$(git show "HEAD:$f" | jq -r .private 2>/dev/null || true)
+              if [ -n "$V_NEW" ] && [ "$V_NEW" != "null" ] && [ "$V_OLD" != "$V_NEW" ] && [ "$PRIVATE" != "true" ]; then
+                COHORT="$COHORT{\"name\":\"$(git show "HEAD:$f" | jq -r .name)\",\"version\":\"$V_NEW\"},"
+              fi
+            done < <(git diff --name-only "$(git rev-parse HEAD^)" HEAD -- packages | grep -E '(^|/)package\.json$' | sort -u)
+            COHORT="[${COHORT%,}]"
+            if [ "$COHORT" != "[]" ]; then
+              PAYLOAD="$COHORT"
+              HAS_RELEASE=true
+            else
+              PAYLOAD=""
+            fi
           else
             PAYLOAD=""
-            HAS_RELEASE=false
+          fi
+          if echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null 2>&1 \
+             || { [ -n "$COHORT" ] && echo "$COHORT" | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null 2>&1; }; then
+            HAS_VSCODE=true
           fi
           echo "has_vscode=$HAS_VSCODE" >> "$GITHUB_OUTPUT"
           echo "has_release=$HAS_RELEASE" >> "$GITHUB_OUTPUT"
@@ -136,14 +140,29 @@ jobs:
           mv ./package.temp.json ./package.json
           pnpm install --frozen-lockfile
           
+      # Fail closed: an unverifiable marker read fails the run rather than risking a duplicate
+      # announcement; a clean "no such ref" (ls-remote exit 2) is the expected case.
       - name: Check if this release was already announced
         id: announced
         if: steps.release.outputs.has_release == 'true'
         run: |
-          if git ls-remote origin "refs/release-announced/${GITHUB_SHA}" 2>/dev/null | grep -q .; then
-            echo "already_announced=true" >> "$GITHUB_OUTPUT"
-          else
+          rc=2
+          for attempt in 1 2; do
+            set +e
+            git ls-remote --exit-code origin "refs/release-announced/${GITHUB_SHA}" >/dev/null 2>&1
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              echo "already_announced=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            [ "$rc" -eq 2 ] && break
+          done
+          if [ "$rc" -eq 2 ]; then
             echo "already_announced=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not verify the announcement marker (git ls-remote exit $rc)"
+            exit 1
           fi
 
       - name: Generate Announcement
@@ -168,9 +187,40 @@ jobs:
         run: |
           git push origin HEAD:refs/release-announced/${GITHUB_SHA}
 
-      - name: Dispatch post-release event
+      # The dispatch gets its own marker: re-running a completed release must not dispatch again
+      # (the consumer fails on "Already up to date"), while a failed dispatch must still be
+      # retried without re-announcing.
+      - name: Check if this release was already dispatched
+        id: dispatched
         if: steps.release.outputs.has_release == 'true' && github.ref_name == 'main'
+        run: |
+          rc=2
+          for attempt in 1 2; do
+            set +e
+            git ls-remote --exit-code origin "refs/release-dispatched/${GITHUB_SHA}" >/dev/null 2>&1
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              echo "already_dispatched=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            [ "$rc" -eq 2 ] && break
+          done
+          if [ "$rc" -eq 2 ]; then
+            echo "already_dispatched=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not verify the dispatch marker (git ls-remote exit $rc)"
+            exit 1
+          fi
+
+      - name: Dispatch post-release event
+        if: steps.dispatched.outputs.already_dispatched == 'false'
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           event-type: release-published
+
+      - name: Mark release as dispatched
+        if: steps.dispatched.outputs.already_dispatched == 'false'
+        run: |
+          git push origin HEAD:refs/release-dispatched/${GITHUB_SHA}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The release cohort is derived from the diff against the parent commit, so the
+          # default depth-1 checkout (no parent) is not enough.
+          fetch-depth: 2
 
       - name: Setup PNPM
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -60,26 +64,48 @@ jobs:
           NPM_TOKEN: '' # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
 
       # On a re-run after npm already received the versions, changesets publishes nothing new
-      # and `publishedPackages` is empty. The git tag created by the first attempt persists
-      # and points at this release commit, so it identifies astro-vscode as part of this
-      # release with marketplace publication still pending.
-      - name: Check if astro-vscode needs marketplace publishing
-        id: vscode-published
+      # and its `published`/`publishedPackages` outputs are empty, so any downstream work gated
+      # on them would be skipped while the run turns green. The version bumps for this release
+      # live in the release commit itself, so the cohort is reconstructed from the commit diff:
+      # it is available on every attempt and does not depend on tags or on what npm received
+      # this run.
+      - name: Detect release cohort
+        id: release
         run: |
-          VERSION=$(git show HEAD:packages/language-tools/vscode/package.json | jq -r .version)
-          TAG_SHA=$(git ls-remote --tags origin "astro-vscode@${VERSION}^{}" | awk '{print $1}')
-          if [ -z "$TAG_SHA" ]; then
-            TAG_SHA=$(git ls-remote --tags origin "astro-vscode@${VERSION}" | awk '{print $1}')
-          fi
+          COHORT=""
+          while read -r f; do
+            V_OLD=$(git show "$(git rev-parse HEAD^):$f" 2>/dev/null | jq -r .version 2>/dev/null || true)
+            V_NEW=$(git show "HEAD:$f" | jq -r .version 2>/dev/null || true)
+            PRIVATE=$(git show "HEAD:$f" | jq -r .private 2>/dev/null || true)
+            if [ -n "$V_NEW" ] && [ "$V_NEW" != "null" ] && [ "$V_OLD" != "$V_NEW" ] && [ "$PRIVATE" != "true" ]; then
+              COHORT="$COHORT{\"name\":\"$(git show "HEAD:$f" | jq -r .name)\",\"version\":\"$V_NEW\"},"
+            fi
+          done < <(git diff --name-only "$(git rev-parse HEAD^)" HEAD -- packages | grep -E '(^|/)package\.json$' | sort -u)
+          COHORT="[${COHORT%,}]"
           if echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null \
-             || { [ -n "$TAG_SHA" ] && [ "$TAG_SHA" = "$(git rev-parse HEAD)" ]; }; then
-            echo "published=true" >> $GITHUB_OUTPUT
+             || echo "$COHORT" | jq -e '.[] | select(.name == "astro-vscode")' > /dev/null; then
+            HAS_VSCODE=true
           else
-            echo "published=false" >> $GITHUB_OUTPUT
+            HAS_VSCODE=false
           fi
+          # On the first attempt `publishedPackages` is the ground truth for the announcement;
+          # on a retry it is empty, so the reconstructed cohort is used instead.
+          if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
+            PAYLOAD='${{ steps.changesets.outputs.publishedPackages }}'
+            HAS_RELEASE=true
+          elif [ "$COHORT" != "[]" ]; then
+            PAYLOAD="$COHORT"
+            HAS_RELEASE=true
+          else
+            PAYLOAD=""
+            HAS_RELEASE=false
+          fi
+          echo "has_vscode=$HAS_VSCODE" >> "$GITHUB_OUTPUT"
+          echo "has_release=$HAS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "cohort=$PAYLOAD" >> "$GITHUB_OUTPUT"
 
       - name: Prepare vscode folder
-        if: steps.vscode-published.outputs.published == 'true'
+        if: steps.release.outputs.has_vscode == 'true'
         working-directory: ./packages/language-tools/vscode
         run: |
           npm run build:grammar
@@ -93,40 +119,57 @@ jobs:
           mv ./astro-ts-plugin-bundle ./node_modules/astro-ts-plugin-bundle
 
       - name: Publish to VSCode Marketplace
-        if: steps.vscode-published.outputs.published == 'true'
+        if: steps.release.outputs.has_vscode == 'true'
         working-directory: ./packages/language-tools/vscode
         run: |
           npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --skip-duplicate --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
 
       - name: Publish to OpenVSX
-        if: steps.vscode-published.outputs.published == 'true'
+        if: steps.release.outputs.has_vscode == 'true'
         working-directory: ./packages/language-tools/vscode
         run: |
           npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --skip-duplicate --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
           
       - name: Restore root package.json and node_modules
-        if: steps.vscode-published.outputs.published == 'true'
+        if: steps.release.outputs.has_vscode == 'true'
         run: |
           mv ./package.temp.json ./package.json
           pnpm install --frozen-lockfile
           
+      - name: Check if this release was already announced
+        id: announced
+        if: steps.release.outputs.has_release == 'true'
+        run: |
+          if git ls-remote origin "refs/release-announced/${GITHUB_SHA}" 2>/dev/null | grep -q .; then
+            echo "already_announced=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_announced=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate Announcement
         id: message
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.announced.outputs.already_announced == 'false'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        run: node .github/scripts/announce.mjs '${{ steps.changesets.outputs.publishedPackages }}'
+        run: node .github/scripts/announce.mjs '${{ steps.release.outputs.cohort }}'
 
       - name: Send message on Discord
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.announced.outputs.already_announced == 'false'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # 0.4.0
         with:
           args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"
 
+      # Record the announcement before the dispatch so a failed dispatch can be retried without
+      # re-announcing. Re-running the same release commit then skips the announcement entirely.
+      - name: Mark release as announced
+        if: steps.announced.outputs.already_announced == 'false'
+        run: |
+          git push origin HEAD:refs/release-announced/${GITHUB_SHA}
+
       - name: Dispatch post-release event
-        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'
+        if: steps.release.outputs.has_release == 'true' && github.ref_name == 'main'
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,17 +82,29 @@ jobs:
             # Nothing was published, so this is a re-run (or the same commit on another branch):
             # npm already has these versions, so rebuild the released-package list from the
             # version bumps in the release commit.
+            # Feed the loop the list of package.json files changed between the parent commit
+            # and this one (a release commit only changes the files it bumps).
             while read -r f; do
+              # Skip fixture/test packages: their package.json files change with tests, not releases.
               case "$f" in
                 *"/test/"*|*"/fixtures/"*|*"/node_modules/"*) continue ;;
               esac
+              # Version of this package at the parent commit. Empty when the file is new there;
+              # the `|| true` keeps a missing file or unparsable JSON from failing the step
+              # (the job runs with `set -e`).
               V_OLD=$(git show "$(git rev-parse HEAD^):$f" 2>/dev/null | jq -r .version 2>/dev/null || true)
+              # Same read at this commit.
               V_NEW=$(git show "HEAD:$f" | jq -r .version 2>/dev/null || true)
+              # `private: true` packages are never published to npm, so they are not releases.
               PRIVATE=$(git show "HEAD:$f" | jq -r .private 2>/dev/null || true)
+              # Released means: has a version, and that version differs from the parent commit.
               if [ -n "$V_NEW" ] && [ "$V_NEW" != "null" ] && [ "$V_OLD" != "$V_NEW" ] && [ "$PRIVATE" != "true" ]; then
+                # Append one {"name":"...","version":"..."} entry; the trailing comma is
+                # stripped below.
                 COHORT="$COHORT{\"name\":\"$(git show "HEAD:$f" | jq -r .name)\",\"version\":\"$V_NEW\"},"
               fi
             done < <(git diff --name-only "$(git rev-parse HEAD^)" HEAD -- packages | grep -E '(^|/)package\.json$' | sort -u)
+            # Wrap the accumulated entries in a JSON array; ${COHORT%,} drops the trailing comma.
             COHORT="[${COHORT%,}]"
             if [ "$COHORT" != "[]" ]; then
               PAYLOAD="$COHORT"


### PR DESCRIPTION
Fixes #17956

## Changes

- A retried release still publishes to the VS Code Marketplace and OpenVSX and announces on Discord, even when npm already has the versions. The workflow figures out what was released from the version bumps in the release commit, so a retry announces the same full release as the first attempt.
- Each release is announced and dispatched (`release-published`) at most once: after the announcement goes out the workflow pushes a ref to the repo (`refs/release-announced/<sha>`, same for the dispatch), and a re-run of the same release commit skips both. A dispatch that failed is still retried.
- Re-running a finished release is a no-op for the marketplace steps (`--skip-duplicate`).
- Only actual `[ci] release` commits trigger this path, so regular commits, reverts, and branch merges are unaffected.

## Testing

- N/A

## Docs

- N/A