### PR TITLE
Add notFound() and NotFoundError to programmatically trigger 404 responses

### DIFF
--- a/.changeset/blue-views-move.md
+++ b/.changeset/blue-views-move.md
@@ -1,0 +1,33 @@
+---
+'astro': minor
+---
+
+Adds `notFound()` and `NotFoundError` to `astro:navigation` to programmatically trigger 404 responses
+
+This allows `.astro` page components, API endpoints, middleware, and external data-fetching helpers to trigger a 404 response natively by calling `notFound()`, gracefully rendering `404.astro` (with dynamic error props) while suppressing server crash logs.
+
+Because `notFound()` can be called inside helper functions and returns `never`, you can encapsulate 404 checks in data loaders without repeating boilerplate in every `.astro` frontmatter:
+
+```ts
+// src/lib/blog.ts
+import { notFound } from 'astro:navigation';
+
+export async function loadBlog(id: string) {
+  const blog = await fetchBlog(id);
+  if (!blog) {
+    notFound('Blog post not found');
+  }
+  return blog;
+}
+```
+
+```astro
+---
+// src/pages/blog/[id].astro
+import { loadBlog } from '../../lib/blog';
+
+// No need for repetitive `if (!blog) return Astro.redirect('/404')` checks
+const blog = await loadBlog(Astro.params.id);
+---
+<h1>{blog.title}</h1>
+```

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -135,6 +135,10 @@ declare module 'astro:middleware' {
 	export * from 'astro/virtual-modules/middleware.js';
 }
 
+declare module 'astro:navigation' {
+	export * from 'astro/virtual-modules/navigation.js';
+}
+
 declare module 'astro:config/server' {
 	// biome-ignore format: bug
 	type ServerConfigSerialized = import('./dist/types/public/manifest.js').ServerDeserializedManifest;

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -276,6 +276,10 @@ export async function createVite(
 					find: 'astro:middleware',
 					replacement: 'astro/virtual-modules/middleware.js',
 				},
+				{
+					find: 'astro:navigation',
+					replacement: 'astro/virtual-modules/navigation.js',
+				},
 				// TODO: remove in Astro 8
 				{
 					find: 'astro:schema',

--- a/packages/astro/src/core/errors/dev-handler.ts
+++ b/packages/astro/src/core/errors/dev-handler.ts
@@ -87,7 +87,7 @@ export async function renderDevError(
 				);
 			}
 
-			if (error) {
+			if (error && status !== 404) {
 				// Log useful information that the custom 500 page may not display unlike the default error overlay
 				getLogger(manifest).error(
 					'router',

--- a/packages/astro/src/core/middleware/astro-middleware.ts
+++ b/packages/astro/src/core/middleware/astro-middleware.ts
@@ -123,12 +123,15 @@ export async function handleMiddlewareWithErrorFallback(
 		});
 	} catch (err: any) {
 		if (err === nextError) throw err;
-		// User middleware threw: log the stack and render the custom 500
-		// page, the same way `handleRequest` does on the standard path.
-		state.logger.error(null, err.stack || err.message || String(err));
+		const status = err?.name === 'NotFoundError' ? 404 : 500;
+		if (status !== 404) {
+			// User middleware threw: log the stack and render the custom 500
+			// page, the same way `handleRequest` does on the standard path.
+			state.logger.error(null, err.stack || err.message || String(err));
+		}
 		return renderErrorFromState(state, state.request, {
 			...state.renderOptions,
-			status: 500,
+			status,
 			error: err,
 			pathname: state.pathname,
 		});

--- a/packages/astro/src/core/pages/handler.ts
+++ b/packages/astro/src/core/pages/handler.ts
@@ -124,12 +124,15 @@ export async function handlePagesWithErrorFallback(state: FetchState): Promise<R
 	try {
 		return await handlePages(state, ctx);
 	} catch (err: any) {
-		// The header marker can't carry the error object, so render the
-		// 500 page directly to preserve `error` and the logged stack.
-		state.logger.error(null, err.stack || err.message || String(err));
+		const status = err?.name === 'NotFoundError' ? 404 : 500;
+		if (status !== 404) {
+			// The header marker can't carry the error object, so render the
+			// 500 page directly to preserve `error` and the logged stack.
+			state.logger.error(null, err.stack || err.message || String(err));
+		}
 		return renderErrorFromState(state, state.request, {
 			...state.renderOptions,
-			status: 500,
+			status,
 			error: err,
 			pathname: state.pathname,
 		});

--- a/packages/astro/src/core/routing/handler.ts
+++ b/packages/astro/src/core/routing/handler.ts
@@ -165,10 +165,13 @@ async function render(state: FetchState): Promise<Response> {
 			timeStart: state.timeStart,
 		});
 	} catch (err: any) {
-		state.logger.error(null, err.stack || err.message || String(err));
+		const status = err?.name === 'NotFoundError' ? 404 : 500;
+		if (status !== 404) {
+			state.logger.error(null, err.stack || err.message || String(err));
+		}
 		return renderErrorFromState(state, request, {
 			...state.renderOptions,
-			status: 500,
+			status,
 			error: err,
 			pathname: state.pathname,
 		});

--- a/packages/astro/src/navigation/index.ts
+++ b/packages/astro/src/navigation/index.ts
@@ -1,0 +1,16 @@
+export class NotFoundError extends Error {
+	title?: string;
+
+	constructor(message?: string, title?: string) {
+		super(message);
+		this.name = 'NotFoundError';
+		this.title = title;
+	}
+}
+
+/**
+ * Throws a `NotFoundError` to trigger a 404 response in Astro routes, endpoints, or middleware.
+ */
+export function notFound(message?: string, title?: string): never {
+	throw new NotFoundError(message, title);
+}

--- a/packages/astro/src/virtual-modules/navigation.ts
+++ b/packages/astro/src/virtual-modules/navigation.ts
@@ -1,0 +1,1 @@
+export { notFound, NotFoundError } from '../navigation/index.js';

--- a/packages/astro/test/astro-not-found.test.ts
+++ b/packages/astro/test/astro-not-found.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import testAdapter from './test-adapter.ts';
+import { type App, type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+
+describe('notFound() and NotFoundError', () => {
+	let fixture: Fixture;
+	let app: App;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-not-found/',
+			output: 'server',
+			adapter: testAdapter(),
+		});
+		await fixture.build({});
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it('calling notFound() in an .astro component frontmatter renders 404.astro with HTTP status 404', async () => {
+		const logs: unknown[][] = [];
+		const originalError = app.logger.error;
+		app.logger.error = (...args: Parameters<typeof originalError>) => {
+			logs.push(args);
+			return originalError.apply(app.logger, args);
+		};
+
+		try {
+			const request = new Request('http://example.com/page-not-found');
+			const response = await app.render(request);
+
+			assert.equal(response.status, 404);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+			assert.equal($('h1').text(), 'Custom 404 Page');
+			assert.equal(logs.length, 0, 'Should not log server error for notFound()');
+		} finally {
+			app.logger.error = originalError;
+		}
+	});
+
+	it('calling notFound("Item not found", "Custom Title") passes the error object into Astro.props.error', async () => {
+		const request = new Request('http://example.com/page-not-found-custom');
+		const response = await app.render(request);
+
+		assert.equal(response.status, 404);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		assert.equal($('h1').text(), 'Custom 404 Page');
+		assert.equal($('#error-message').text(), 'Item not found');
+		assert.equal($('#error-title').text(), 'Custom Title');
+	});
+
+	it('calling notFound() in an API route endpoint returns a 404 response', async () => {
+		const logs: unknown[][] = [];
+		const originalError = app.logger.error;
+		app.logger.error = (...args: Parameters<typeof originalError>) => {
+			logs.push(args);
+			return originalError.apply(app.logger, args);
+		};
+
+		try {
+			const request = new Request('http://example.com/api/item');
+			const response = await app.render(request);
+
+			assert.equal(response.status, 404);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+			assert.equal($('h1').text(), 'Custom 404 Page');
+			assert.equal($('#error-message').text(), 'API item not found');
+			assert.equal($('#error-title').text(), 'API Error');
+			assert.equal(logs.length, 0, 'Should not log server error for notFound() in endpoint');
+		} finally {
+			app.logger.error = originalError;
+		}
+	});
+
+	it('calling notFound() in middleware renders the 404 page', async () => {
+		const logs: unknown[][] = [];
+		const originalError = app.logger.error;
+		app.logger.error = (...args: Parameters<typeof originalError>) => {
+			logs.push(args);
+			return originalError.apply(app.logger, args);
+		};
+
+		try {
+			const request = new Request('http://example.com/middleware-not-found');
+			const response = await app.render(request);
+
+			assert.equal(response.status, 404);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+			assert.equal($('h1').text(), 'Custom 404 Page');
+			assert.equal($('#error-message').text(), 'Middleware item not found');
+			assert.equal($('#error-title').text(), 'Middleware Title');
+			assert.equal(logs.length, 0, 'Should not log server error for notFound() in middleware');
+		} finally {
+			app.logger.error = originalError;
+		}
+	});
+
+	it('normal uncaught exceptions continue to render 500.astro with HTTP status 500 and output the server stack trace', async () => {
+		const logs: unknown[][] = [];
+		const originalError = app.logger.error;
+		app.logger.error = (...args: Parameters<typeof originalError>) => {
+			logs.push(args);
+			return originalError.apply(app.logger, args);
+		};
+
+		try {
+			const request = new Request('http://example.com/uncaught-error');
+			const response = await app.render(request);
+
+			assert.equal(response.status, 500);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+			assert.equal($('h1').text(), 'Custom 500 Page');
+			assert.equal($('#error-message').text(), 'Server crash failure');
+			assert.ok(logs.length > 0, 'Should log server error for uncaught 500 error');
+			assert.ok(
+				logs.some((l) => JSON.stringify(l).includes('Server crash failure')),
+				'Log should contain the error message and stack trace',
+			);
+		} finally {
+			app.logger.error = originalError;
+		}
+	});
+
+	describe('dev mode', () => {
+		let devFixture: Fixture;
+		let devServer: DevServer;
+
+		before(async () => {
+			devFixture = await loadFixture({
+				root: './fixtures/astro-not-found/',
+			});
+			devServer = await devFixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer?.stop();
+		});
+
+		it('renders 404.astro with status 404 in dev mode', async () => {
+			const res = await devFixture.fetch('/page-not-found-custom');
+			assert.equal(res.status, 404);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('h1').text(), 'Custom 404 Page');
+			assert.equal($('#error-message').text(), 'Item not found');
+			assert.equal($('#error-title').text(), 'Custom Title');
+		});
+
+		it('endpoint returns 404 in dev mode', async () => {
+			const res = await devFixture.fetch('/api/item');
+			assert.equal(res.status, 404);
+		});
+	});
+});

--- a/packages/astro/test/fixtures/astro-not-found/src/middleware.ts
+++ b/packages/astro/test/fixtures/astro-not-found/src/middleware.ts
@@ -1,0 +1,9 @@
+import { notFound } from 'astro:navigation';
+import type { MiddlewareHandler } from 'astro';
+
+export const onRequest: MiddlewareHandler = async (ctx, next) => {
+	if (ctx.url.pathname === '/middleware-not-found') {
+		notFound('Middleware item not found', 'Middleware Title');
+	}
+	return next();
+};

--- a/packages/astro/test/fixtures/astro-not-found/src/pages/404.astro
+++ b/packages/astro/test/fixtures/astro-not-found/src/pages/404.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+	error?: {
+		message?: string;
+		title?: string;
+	};
+}
+const { error } = Astro.props;
+---
+<html>
+<head><title>404</title></head>
+<body>
+	<h1>Custom 404 Page</h1>
+	<p id="error-message">{error?.message ?? 'no-message'}</p>
+	<p id="error-title">{error?.title ?? 'no-title'}</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/astro-not-found/src/pages/500.astro
+++ b/packages/astro/test/fixtures/astro-not-found/src/pages/500.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+	error?: {
+		message?: string;
+	};
+}
+const { error } = Astro.props;
+---
+<html>
+<head><title>500</title></head>
+<body>
+	<h1>Custom 500 Page</h1>
+	<p id="error-message">{error?.message ?? 'no-message'}</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/astro-not-found/src/pages/api/item.ts
+++ b/packages/astro/test/fixtures/astro-not-found/src/pages/api/item.ts
@@ -1,0 +1,6 @@
+import { notFound } from 'astro:navigation';
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = () => {
+	return notFound('API item not found', 'API Error');
+};

--- a/packages/astro/test/fixtures/astro-not-found/src/pages/middleware-not-found.astro
+++ b/packages/astro/test/fixtures/astro-not-found/src/pages/middleware-not-found.astro
@@ -1,0 +1,3 @@
+---
+---
+<div>Middleware not found page</div>

--- a/packages/astro/test/fixtures/astro-not-found/src/pages/page-not-found-custom.astro
+++ b/packages/astro/test/fixtures/astro-not-found/src/pages/page-not-found-custom.astro
@@ -1,0 +1,6 @@
+---
+import { notFound } from 'astro:navigation';
+
+notFound('Item not found', 'Custom Title');
+---
+<div>This will never be rendered</div>

--- a/packages/astro/test/fixtures/astro-not-found/src/pages/page-not-found.astro
+++ b/packages/astro/test/fixtures/astro-not-found/src/pages/page-not-found.astro
@@ -1,0 +1,6 @@
+---
+import { notFound } from 'astro:navigation';
+
+notFound();
+---
+<div>This will never be rendered</div>

--- a/packages/astro/test/fixtures/astro-not-found/src/pages/uncaught-error.astro
+++ b/packages/astro/test/fixtures/astro-not-found/src/pages/uncaught-error.astro
@@ -1,0 +1,4 @@
+---
+throw new Error('Server crash failure');
+---
+<div>This will never be rendered</div>

--- a/packages/astro/test/types/astro-navigation-virtual-module.ts
+++ b/packages/astro/test/types/astro-navigation-virtual-module.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test';
+import { expectTypeOf } from 'expect-type';
+import '../../client.d.ts';
+import { notFound, NotFoundError } from 'astro:navigation';
+
+describe('astro:navigation types', () => {
+	it('notFound types', () => {
+		expectTypeOf(notFound).toBeFunction();
+		expectTypeOf(notFound).returns.toBeNever();
+
+		expectTypeOf(NotFoundError).toBeConstructibleWith('msg', 'title');
+
+		const err = new NotFoundError('Not found', 'Custom');
+		expectTypeOf(err.name).toEqualTypeOf<string>();
+		expectTypeOf(err.message).toEqualTypeOf<string>();
+		expectTypeOf(err.title).toEqualTypeOf<string | undefined>();
+	});
+});


### PR DESCRIPTION
## Changes

- Adds `notFound()` and `NotFoundError` to virtual module `astro:navigation` to programmatically trigger 404 responses.
- Allows external data loaders (e.g. `loadBlog()`), API routes, middleware, and `.astro` components to encapsulate 404 handling without repeating `if (!item) return Astro.redirect('/404')` checks across page frontmatters.
- Intercepts `NotFoundError` in the SSR request pipeline (`core/routing`, `core/pages`, and `core/middleware`) so that calling `notFound()` gracefully renders `404.astro` (with dynamic error props) while suppressing fatal 500 server crash logs.

### Example

```ts
// src/lib/blog.ts
import { notFound } from 'astro:navigation';

export async function loadBlog(id: string) {
  const blog = await fetchBlog(id);
  if (!blog) {
    notFound('Blog post not found'); // Halts execution and triggers 404
  }
  return blog; // TypeScript automatically knows blog is defined!
}

```
```ts
---
// src/pages/blog/[id].astro
import { loadBlog } from '../../lib/blog';

// No need for repetitive `if (!blog) return Astro.redirect('/404')` checks
const blog = await loadBlog(Astro.params.id);
---
<h1>{blog.title}</h1>

```
## Testing

- Added integration tests in `packages/astro/test/astro-not-found.test.ts` covering `.astro` frontmatter, dynamic error props, API routes, middleware, standard 500 error propagation, and dev mode.
- Added compile-time type tests in `packages/astro/test/types/astro-navigation-virtual-module.ts` verifying that `notFound()` returns `never` and `NotFoundError` has the expected prototype and properties.

## Docs

- Docs PR will be opened in `withastro/docs` to document the `astro:navigation` module and `notFound()` helper.
