### PR TITLE
Defer content initialization during dev startup

### DIFF
--- a/.changeset/fast-bags-double.md
+++ b/.changeset/fast-bags-double.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves development server startup time for projects using content collections

--- a/.changeset/fast-bags-double.md
+++ b/.changeset/fast-bags-double.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves development server startup time for projects using content collections
+Improves development server startup time for projects using content collections. The experimental JavaScript dev server exposes a `contentReady` promise for consumers that need to wait for initial content synchronization

--- a/.changeset/quick-pandas-dev.md
+++ b/.changeset/quick-pandas-dev.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves dev server startup time. The content config load now starts during server creation instead of blocking it, and the dev server app module graph is compiled lazily on the first request instead of on the critical path. This cuts `astro dev` ready time by roughly a third on projects with a content config.
+Improves dev server startup time. The content config and dev server app module graphs now begin compiling during server creation without blocking the server from listening. Request handling waits for the shared setup result when needed, cutting `astro dev` ready time by roughly a third on projects with a content config.

--- a/.changeset/quick-pandas-dev.md
+++ b/.changeset/quick-pandas-dev.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves dev server startup time. The dev server app and content config module graphs were previously compiled and evaluated on the critical path before the dev server started listening. They are now kicked off early during server creation and awaited lazily on the first request, cutting `astro dev` ready time by roughly a third on projects with a content config.

--- a/.changeset/quick-pandas-dev.md
+++ b/.changeset/quick-pandas-dev.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves dev server startup time. The dev server app and content config module graphs were previously compiled and evaluated on the critical path before the dev server started listening. They are now kicked off early during server creation and awaited lazily on the first request, cutting `astro dev` ready time by roughly a third on projects with a content config.
+Improves dev server startup time. The content config load now starts during server creation instead of blocking it, and the dev server app module graph is compiled lazily on the first request instead of on the critical path. This cuts `astro dev` ready time by roughly a third on projects with a content config.

--- a/packages/astro/src/content/config-prewarm.ts
+++ b/packages/astro/src/content/config-prewarm.ts
@@ -1,0 +1,52 @@
+import type fsMod from 'node:fs';
+import type { RunnableDevEnvironment } from 'vite';
+import type { AstroLogger } from '../core/logger/core.js';
+import type { AstroSettings } from '../types/astro.js';
+import { getContentPaths, reloadContentConfigObserver } from './utils.js';
+
+/**
+ * Starts the content config load as early as possible during dev startup so its
+ * on-demand Vite compilation overlaps other startup work instead of blocking it.
+ *
+ * The types generator (`createContentTypesGenerator#init`) and the dev server
+ * app compile both dedupe on the same in-flight promise, so the config is
+ * compiled and evaluated exactly once per dev server instance.
+ */
+let inFlight: Promise<void> | undefined;
+
+export function getContentConfigLoadPromise(): Promise<void> | undefined {
+	return inFlight;
+}
+
+export function kickOffContentConfigLoad({
+	settings,
+	fs,
+	logger,
+	environment,
+}: {
+	settings: AstroSettings;
+	fs: typeof fsMod;
+	logger: AstroLogger;
+	environment: RunnableDevEnvironment;
+}): Promise<void> {
+	if (inFlight) {
+		return inFlight;
+	}
+	const contentPaths = getContentPaths(
+		settings.config,
+		fs,
+		settings.config.legacy?.collectionsBackwardsCompat,
+	);
+	if (!contentPaths.config.exists) {
+		return Promise.resolve();
+	}
+	inFlight = reloadContentConfigObserver({
+		fs,
+		settings,
+		environment,
+		logger,
+	}).finally(() => {
+		inFlight = undefined;
+	});
+	return inFlight;
+}

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -39,6 +39,7 @@ import {
 	getEntryType,
 	reloadContentConfigObserver,
 } from './utils.js';
+import { getContentConfigLoadPromise } from './config-prewarm.js';
 import { ASTRO_VITE_ENVIRONMENT_NAMES } from '../core/constants.js';
 
 type ChokidarEvent = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
@@ -137,14 +138,26 @@ export async function createContentTypesGenerator({
 			return { shouldGenerateTypes: false };
 		}
 		if (fileType === 'config') {
-			await reloadContentConfigObserver({
-				fs,
-				settings,
-				environment: viteServer.environments[
-					ASTRO_VITE_ENVIRONMENT_NAMES.astro
-				] as RunnableDevEnvironment,
-				logger,
-			});
+			const status = contentConfigObserver.get().status;
+			if (status === 'init') {
+				await reloadContentConfigObserver({
+					fs,
+					settings,
+					environment: viteServer.environments[
+						ASTRO_VITE_ENVIRONMENT_NAMES.astro
+					] as RunnableDevEnvironment,
+					logger,
+				});
+			} else {
+				// The config may already have been loaded by the dev server app
+				// setup, which kicks off the load during server creation. If it
+				// is still in flight, wait for that same load instead of
+				// re-importing (which would compile the config twice).
+				const prewarm = getContentConfigLoadPromise();
+				if (prewarm && status === 'loading') {
+					await prewarm;
+				}
+			}
 			return { shouldGenerateTypes: true };
 		}
 

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -138,8 +138,14 @@ export async function createContentTypesGenerator({
 			return { shouldGenerateTypes: false };
 		}
 		if (fileType === 'config') {
-			const status = contentConfigObserver.get().status;
-			if (status === 'init') {
+			// Dev server creation may already be loading this config. Wait for that
+			// exact load when present; otherwise this path owns the reload. Do not
+			// infer ownership from the global observer status because `astro sync`
+			// can retain a settled status from an earlier invocation in the process.
+			const prewarm = getContentConfigLoadPromise();
+			if (prewarm) {
+				await prewarm;
+			} else {
 				await reloadContentConfigObserver({
 					fs,
 					settings,
@@ -148,15 +154,6 @@ export async function createContentTypesGenerator({
 					] as RunnableDevEnvironment,
 					logger,
 				});
-			} else {
-				// The config may already have been loaded by the dev server app
-				// setup, which kicks off the load during server creation. If it
-				// is still in flight, wait for that same load instead of
-				// re-importing (which would compile the config twice).
-				const prewarm = getContentConfigLoadPromise();
-				if (prewarm && status === 'loading') {
-					await prewarm;
-				}
 			}
 			return { shouldGenerateTypes: true };
 		}

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -57,6 +57,12 @@ export const fetchStateSymbol = Symbol.for('astro.fetchState');
 export const devPrerenderMiddlewareSymbol = Symbol.for('astro.devPrerenderMiddleware');
 
 /**
+ * A promise for background dev server app setup that must settle before Vite's
+ * runnable environments are closed.
+ */
+export const devServerAppReadySymbol = Symbol.for('astro.devServerAppReady');
+
+/**
  * The symbol used as a field on the request object to store a cleanup callback associated with aborting the request when the underlying socket closes.
  */
 export const nodeRequestAbortControllerCleanupSymbol = Symbol.for(

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -62,6 +62,9 @@ export const devPrerenderMiddlewareSymbol = Symbol.for('astro.devPrerenderMiddle
  */
 export const devServerAppReadySymbol = Symbol.for('astro.devServerAppReady');
 
+/** Deferred dev content setup awaited by Astro request handlers and server shutdown. */
+export const devContentReadySymbol = Symbol.for('astro.devContentReady');
+
 /**
  * The symbol used as a field on the request object to store a cleanup callback associated with aborting the request when the underlying socket closes.
  */

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -10,6 +10,7 @@ import {
 } from '../../integrations/hooks.js';
 import type { AstroSettings } from '../../types/astro.js';
 import type { AstroInlineConfig } from '../../types/public/config.js';
+import { devServerAppReadySymbol } from '../constants.js';
 import { createVite } from '../create-vite.js';
 import type { AstroLogger } from '../logger/core.js';
 import { createRoutesList } from '../routing/create-manifest.js';
@@ -152,6 +153,10 @@ export async function createContainer({
 }
 
 async function closeContainer({ viteServer, settings, logger }: Container) {
+	// Background app setup uses the runnable environment's module runner. Let it
+	// settle before Vite disconnects that runner so shutdown cannot strand an
+	// in-flight module import.
+	await (viteServer as any)[devServerAppReadySymbol];
 	await viteServer.close();
 	await runHookServerDone({
 		config: settings.config,

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -10,7 +10,7 @@ import {
 } from '../../integrations/hooks.js';
 import type { AstroSettings } from '../../types/astro.js';
 import type { AstroInlineConfig } from '../../types/public/config.js';
-import { devServerAppReadySymbol } from '../constants.js';
+import { devContentReadySymbol, devServerAppReadySymbol } from '../constants.js';
 import { createVite } from '../create-vite.js';
 import type { AstroLogger } from '../logger/core.js';
 import { createRoutesList } from '../routing/create-manifest.js';
@@ -153,10 +153,13 @@ export async function createContainer({
 }
 
 async function closeContainer({ viteServer, settings, logger }: Container) {
-	// Background app setup uses the runnable environment's module runner. Let it
-	// settle before Vite disconnects that runner so shutdown cannot strand an
-	// in-flight module import.
-	await (viteServer as any)[devServerAppReadySymbol];
+	// Background content setup and dev server app setup use the runnable
+	// environments' module runners. Let both settle before Vite disconnects
+	// those runners so shutdown cannot strand an in-flight module import.
+	await Promise.allSettled([
+		(viteServer as any)[devContentReadySymbol],
+		(viteServer as any)[devServerAppReadySymbol],
+	]);
 	await viteServer.close();
 	await runHookServerDone({
 		config: settings.config,

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -28,6 +28,8 @@ import { piccoloreTextStyler } from '../../cli/infra/piccolore-text-styler.js';
 
 export interface DevServer {
 	address: AddressInfo;
+	/** Resolves when the initial content collections data is ready to serve. */
+	contentReady: Promise<void>;
 	resolvedUrls: vite.ResolvedServerUrls;
 	handle: (req: http.IncomingMessage, res: http.ServerResponse<http.IncomingMessage>) => void;
 	watcher: vite.FSWatcher;
@@ -170,6 +172,7 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 
 	return {
 		address: devServerAddressInfo,
+		contentReady,
 		get resolvedUrls() {
 			return restart.container.viteServer.resolvedUrls || { local: [], network: [] };
 		},

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -12,6 +12,7 @@ import { MutableDataStore } from '../../content/mutable-data-store.js';
 import { globalContentConfigObserver } from '../../content/utils.js';
 import { telemetry } from '../../events/index.js';
 import type { AstroInlineConfig } from '../../types/public/config.js';
+import { devContentReadySymbol } from '../constants.js';
 import * as msg from '../messages/runtime.js';
 import { newVersionAvailable } from '../messages/node.js';
 import { ensureProcessNodeEnv } from '../util.js';
@@ -89,49 +90,61 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 		}
 	}
 
-	let store: MutableDataStore | undefined;
-	try {
-		const chunkSize = getDataStoreChunkSize(restart.container.settings);
-		if (chunkSize !== undefined) {
-			const dataStoreDir = getDataStoreDir(restart.container.settings, true);
-			store = await MutableDataStore.fromDir(dataStoreDir, chunkSize, logger);
-		} else {
-			const dataStoreFile = getDataStoreFile(restart.container.settings, true);
-			store = await MutableDataStore.fromFile(dataStoreFile);
+	// Binding the port does not require content, but Astro handlers must not serve
+	// until the store and generated content modules are ready.
+	const prepareContent = async () => {
+		let store: MutableDataStore | undefined;
+		try {
+			const chunkSize = getDataStoreChunkSize(restart.container.settings);
+			if (chunkSize !== undefined) {
+				const dataStoreDir = getDataStoreDir(restart.container.settings, true);
+				store = await MutableDataStore.fromDir(dataStoreDir, chunkSize, logger);
+			} else {
+				const dataStoreFile = getDataStoreFile(restart.container.settings, true);
+				store = await MutableDataStore.fromFile(dataStoreFile);
+			}
+		} catch (err: any) {
+			logger.error('content', err.message);
 		}
-	} catch (err: any) {
-		logger.error('content', err.message);
-	}
 
-	if (!store) {
-		logger.error('content', 'Failed to create data store');
-	} else {
-		// Invalidate the content virtual modules directly when the store is
-		// written, rather than relying on the file watcher to observe the write.
-		// On Windows the watcher can miss it, leaving dev serving stale content.
-		attachDataStoreInvalidation(store, restart.container.viteServer, restart.container.settings);
-	}
-	await attachContentServerListeners(restart.container);
+		if (!store) {
+			logger.error('content', 'Failed to create data store');
+		} else {
+			// Invalidate the content virtual modules directly when the store is
+			// written, rather than relying on the file watcher to observe the write.
+			// On Windows the watcher can miss it, leaving dev serving stale content.
+			attachDataStoreInvalidation(store, restart.container.viteServer, restart.container.settings);
+		}
+		await attachContentServerListeners(restart.container);
 
-	const config = globalContentConfigObserver.get();
-	if (config.status === 'error') {
-		logger.error('content', config.error.message);
-	}
-	if (config.status === 'loaded' && store) {
-		const contentLayer = globalContentLayer.init({
-			settings: restart.container.settings,
-			logger,
-			watcher: restart.container.viteServer.watcher,
-			store,
-		});
-		contentLayer.watchContentConfig();
-		await contentLayer.sync();
-	} else if (config.status !== 'does-not-exist') {
-		logger.warn('content', 'Content config not loaded');
-	}
+		const config = globalContentConfigObserver.get();
+		if (config.status === 'error') {
+			logger.error('content', config.error.message);
+		}
+		if (config.status === 'loaded' && store) {
+			const contentLayer = globalContentLayer.init({
+				settings: restart.container.settings,
+				logger,
+				watcher: restart.container.viteServer.watcher,
+				store,
+			});
+			contentLayer.watchContentConfig();
+			await contentLayer.sync();
+		} else if (config.status !== 'does-not-exist') {
+			logger.warn('content', 'Content config not loaded');
+		}
+	};
+	let startContent!: () => void;
+	const contentReady = new Promise<void>((resolve, reject) => {
+		startContent = () => void prepareContent().then(resolve, reject);
+	});
+	void contentReady.catch((error) => {
+		logger.error('content', error instanceof Error ? error.message : String(error));
+	});
+	(restart.container.viteServer as any)[devContentReadySymbol] = contentReady;
 
-	// Start listening to the port
 	const devServerAddressInfo = await startContainer(restart.container);
+	startContent();
 
 	restart.bindCLIShortcuts();
 	logger.info(

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -20,6 +20,7 @@ import {
 	warnIfCspResourceFallbackShadowing,
 	warnIfCspWithShiki,
 } from '../messages/runtime.js';
+import { devContentReadySymbol } from '../constants.js';
 import { createRoutesList } from '../routing/create-manifest.js';
 import type { Container } from './container.js';
 import { createContainer } from './container.js';
@@ -206,6 +207,9 @@ export async function createContainerWithAutomaticRestart({
 		return async function (changedFile: string) {
 			if (shouldRestartContainer(restart.container, changedFile)) {
 				logger.info(null, (logMsg + ' Restarting...').trim());
+				// Vite replaces request handler closures during an in-place restart, so
+				// the initial content lifecycle must settle before those handlers serve.
+				await Promise.allSettled([(restart.container.viteServer as any)[devContentReadySymbol]]);
 				const result = await restartContainerInPlace(restart.container);
 				if (result instanceof Error) {
 					resolveRestart(result);

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -76,7 +76,8 @@ export default function createVitePluginAstroServer({
 			// Kick off the content config load and dev server app compile as early
 			// as possible. Neither is needed until the first request, so install the
 			// middleware synchronously and let request handlers await the in-flight
-			// results without blocking server creation.
+			// results without blocking server creation. Serialize the app compile
+			// after the config load so they do not contend for the main thread.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -91,10 +92,10 @@ export default function createVitePluginAstroServer({
 				: Promise.resolve();
 
 			const ssrHandlerPromise = runnableSsrEnvironment
-				? createHandler(runnableSsrEnvironment)
+				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
 				: undefined;
 			const prerenderHandlerPromise = runnablePrerenderEnvironment
-				? createHandler(runnablePrerenderEnvironment)
+				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
 				: undefined;
 
 			// Background setup uses the runnable environments' module runners. Keep

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -6,6 +6,7 @@ import { isRunnableDevEnvironment, type RunnableDevEnvironment } from 'vite';
 import type { RouteInfo, SSRManifest } from '../core/app/types.js';
 import {
 	ASTRO_VITE_ENVIRONMENT_NAMES,
+	devContentReadySymbol,
 	devPrerenderMiddlewareSymbol,
 	devServerAppReadySymbol,
 } from '../core/constants.js';
@@ -196,6 +197,11 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
+								// Wait for the deferred content setup (data store load, types
+								// generation, content layer sync) before serving. Vite static
+								// and internal requests are not gated; only Astro page requests
+								// await readiness.
+								await (viteServer as any)[devContentReadySymbol];
 								const prerenderHandler = await prerenderHandlerPromise!;
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
 								const { routes } = (await prerenderHandler.environment.runner.import(
@@ -235,6 +241,7 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
+						await (viteServer as any)[devContentReadySymbol];
 						const ssrHandler = await ssrHandlerPromise!;
 						localStorage.run(request, () => {
 							ssrHandler.handler(request, response);

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -92,37 +92,39 @@ export default function createVitePluginAstroServer({
 			// so a dev server that is started and stopped without serving any request
 			// never compiles the app at all (and never leaves compilation work
 			// in-flight when the server closes).
-			let ssrHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			let ssrHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
 			const getSsrHandler = () => {
 				if (!ssrHandlerPromise) {
 					if (!runnableSsrEnvironment) {
 						return undefined;
 					}
-					ssrHandlerPromise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
+					const promise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
 					// Compile failures surface here so they are reported, and also as a
 					// rejected lazy await in the request handlers below.
-					ssrHandlerPromise.catch((error) => {
+					promise.catch((error) => {
 						logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
 					});
+					ssrHandlerPromise = promise;
 				}
 				return ssrHandlerPromise;
 			};
 
-			let prerenderHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			let prerenderHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
 			const getPrerenderHandler = () => {
 				if (!prerenderHandlerPromise) {
 					if (!runnablePrerenderEnvironment) {
 						return undefined;
 					}
-					prerenderHandlerPromise = contentConfigLoad.then(() =>
-						createHandler(runnablePrerenderEnvironment),
-					);
-					prerenderHandlerPromise.catch((error) => {
+					const promise = contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment));
+					// Compile failures surface here so they are reported, and also as a
+					// rejected lazy await in the request handlers below.
+					promise.catch((error) => {
 						logger.error(
 							null,
 							`Failed to create the prerender server app: ${error?.message ?? error}`,
 						);
 					});
+					prerenderHandlerPromise = promise;
 				}
 				return prerenderHandlerPromise;
 			};

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -4,7 +4,11 @@ import { IncomingMessage } from 'node:http';
 import type * as vite from 'vite';
 import { isRunnableDevEnvironment, type RunnableDevEnvironment } from 'vite';
 import type { RouteInfo, SSRManifest } from '../core/app/types.js';
-import { ASTRO_VITE_ENVIRONMENT_NAMES, devPrerenderMiddlewareSymbol } from '../core/constants.js';
+import {
+	ASTRO_VITE_ENVIRONMENT_NAMES,
+	devPrerenderMiddlewareSymbol,
+	devServerAppReadySymbol,
+} from '../core/constants.js';
 import { getViteErrorPayload } from '../core/errors/dev/index.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { AstroLogger } from '../core/logger/core.js';
@@ -69,10 +73,14 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			// Kick off the content config load as early as possible. It is awaited by
-			// the types generator before the server finishes starting, so starting it
-			// here overlaps the load with the rest of server creation instead of
-			// blocking on it.
+			// Kick off the content config load and the dev server app compile as
+			// early as possible. Neither is needed until the first request, so
+			// instead of awaiting them here (which blocks server creation on the
+			// on-demand compilation of astro's own module graphs, ~400ms), install
+			// the middleware synchronously and let the request handlers await the
+			// in-flight results lazily. The dev server app compile is serialized
+			// after the content config load so the two don't contend for the main
+			// thread during startup.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -86,48 +94,27 @@ export default function createVitePluginAstroServer({
 					})
 				: Promise.resolve();
 
-			// The dev server app compile is deferred to the first request instead of
-			// being awaited here (which blocks server creation on the on-demand
-			// compilation of astro's own module graphs, ~400ms). It is created lazily
-			// so a dev server that is started and stopped without serving any request
-			// never compiles the app at all (and never leaves compilation work
-			// in-flight when the server closes).
-			let ssrHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
-			const getSsrHandler = () => {
-				if (!ssrHandlerPromise) {
-					if (!runnableSsrEnvironment) {
-						return undefined;
-					}
-					const promise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
-					// Compile failures surface here so they are reported, and also as a
-					// rejected lazy await in the request handlers below.
-					promise.catch((error) => {
-						logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
-					});
-					ssrHandlerPromise = promise;
-				}
-				return ssrHandlerPromise;
-			};
+			const ssrHandlerPromise = runnableSsrEnvironment
+				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
+				: undefined;
+			const prerenderHandlerPromise = runnablePrerenderEnvironment
+				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
+				: undefined;
 
-			let prerenderHandlerPromise: Promise<Awaited<ReturnType<typeof createHandler>>> | undefined;
-			const getPrerenderHandler = () => {
-				if (!prerenderHandlerPromise) {
-					if (!runnablePrerenderEnvironment) {
-						return undefined;
-					}
-					const promise = contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment));
-					// Compile failures surface here so they are reported, and also as a
-					// rejected lazy await in the request handlers below.
-					promise.catch((error) => {
-						logger.error(
-							null,
-							`Failed to create the prerender server app: ${error?.message ?? error}`,
-						);
-					});
-					prerenderHandlerPromise = promise;
-				}
-				return prerenderHandlerPromise;
-			};
+			// App setup uses the runnable environments' module runners. Keep shutdown
+			// from disconnecting those runners while an import is still in flight.
+			(viteServer as any)[devServerAppReadySymbol] = Promise.allSettled(
+				[ssrHandlerPromise, prerenderHandlerPromise].filter(Boolean),
+			).then(() => undefined);
+
+			// Compile failures surface here so startup still reports them, and also
+			// as a rejected lazy await in the request handlers below.
+			ssrHandlerPromise?.catch((error) => {
+				logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
+			});
+			prerenderHandlerPromise?.catch((error) => {
+				logger.error(null, `Failed to create the prerender server app: ${error?.message ?? error}`);
+			});
 			const localStorage = new AsyncLocalStorage();
 
 			async function handleUnhandledRejection(rejection: any) {
@@ -212,7 +199,7 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
-								const prerenderHandler = await getPrerenderHandler()!;
+								const prerenderHandler = await prerenderHandlerPromise!;
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
 								const { routes } = (await prerenderHandler.environment.runner.import(
 									'virtual:astro:routes',
@@ -251,7 +238,7 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
-						const ssrHandler = await getSsrHandler()!;
+						const ssrHandler = await ssrHandlerPromise!;
 						localStorage.run(request, () => {
 							ssrHandler.handler(request, response);
 						});

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -69,14 +69,10 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			// Kick off the content config load and the dev server app compile as
-			// early as possible. Neither is needed until the first request, so
-			// instead of awaiting them here (which blocks server creation on the
-			// on-demand compilation of astro's own module graphs, ~400ms), install
-			// the middleware synchronously and let the request handlers await the
-			// in-flight results lazily. The dev server app compile is serialized
-			// after the content config load so the two don't contend for the main
-			// thread during startup.
+			// Kick off the content config load as early as possible. It is awaited by
+			// the types generator before the server finishes starting, so starting it
+			// here overlaps the load with the rest of server creation instead of
+			// blocking on it.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -90,26 +86,46 @@ export default function createVitePluginAstroServer({
 					})
 				: Promise.resolve();
 
-			const ssrHandlerPromise = runnableSsrEnvironment
-				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
-				: undefined;
-			const prerenderHandlerPromise = runnablePrerenderEnvironment
-				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
-				: undefined;
-			// Compile failures surface here so startup still reports them, and also
-			// as a rejected lazy await in the request handlers below.
-			ssrHandlerPromise?.catch((error) => {
-				logger.error(
-					null,
-					`Failed to create the dev server app: ${error?.message ?? error}`,
-				);
-			});
-			prerenderHandlerPromise?.catch((error) => {
-				logger.error(
-					null,
-					`Failed to create the prerender server app: ${error?.message ?? error}`,
-				);
-			});
+			// The dev server app compile is deferred to the first request instead of
+			// being awaited here (which blocks server creation on the on-demand
+			// compilation of astro's own module graphs, ~400ms). It is created lazily
+			// so a dev server that is started and stopped without serving any request
+			// never compiles the app at all (and never leaves compilation work
+			// in-flight when the server closes).
+			let ssrHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			const getSsrHandler = () => {
+				if (!ssrHandlerPromise) {
+					if (!runnableSsrEnvironment) {
+						return undefined;
+					}
+					ssrHandlerPromise = contentConfigLoad.then(() => createHandler(runnableSsrEnvironment));
+					// Compile failures surface here so they are reported, and also as a
+					// rejected lazy await in the request handlers below.
+					ssrHandlerPromise.catch((error) => {
+						logger.error(null, `Failed to create the dev server app: ${error?.message ?? error}`);
+					});
+				}
+				return ssrHandlerPromise;
+			};
+
+			let prerenderHandlerPromise: Promise<ReturnType<typeof createHandler>> | undefined;
+			const getPrerenderHandler = () => {
+				if (!prerenderHandlerPromise) {
+					if (!runnablePrerenderEnvironment) {
+						return undefined;
+					}
+					prerenderHandlerPromise = contentConfigLoad.then(() =>
+						createHandler(runnablePrerenderEnvironment),
+					);
+					prerenderHandlerPromise.catch((error) => {
+						logger.error(
+							null,
+							`Failed to create the prerender server app: ${error?.message ?? error}`,
+						);
+					});
+				}
+				return prerenderHandlerPromise;
+			};
 			const localStorage = new AsyncLocalStorage();
 
 			async function handleUnhandledRejection(rejection: any) {
@@ -194,7 +210,7 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
-								const prerenderHandler = await prerenderHandlerPromise!;
+								const prerenderHandler = await getPrerenderHandler()!;
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
 								const { routes } = (await prerenderHandler.environment.runner.import(
 									'virtual:astro:routes',
@@ -233,7 +249,7 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
-						const ssrHandler = await ssrHandlerPromise!;
+						const ssrHandler = await getSsrHandler()!;
 						localStorage.run(request, () => {
 							ssrHandler.handler(request, response);
 						});

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import nodeFs from 'node:fs';
 import { IncomingMessage } from 'node:http';
 import type * as vite from 'vite';
 import { isRunnableDevEnvironment, type RunnableDevEnvironment } from 'vite';
@@ -11,6 +12,7 @@ import { createViteLoader } from '../core/module-loader/index.js';
 import { matchAllRoutes } from '../core/routing/match.js';
 import { SERIALIZED_MANIFEST_ID } from '../manifest/serialized.js';
 import type { AstroSettings } from '../types/astro.js';
+import { kickOffContentConfigLoad } from '../content/config-prewarm.js';
 import { ASTRO_DEV_SERVER_APP_ID } from '../vite-plugin-app/index.js';
 import { baseMiddleware } from './base.js';
 import { createController } from './controller.js';
@@ -67,15 +69,50 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			const ssrHandler = runnableSsrEnvironment
-				? await createHandler(runnableSsrEnvironment)
+			// Kick off the content config load and the dev server app compile as
+			// early as possible. Neither is needed until the first request, so
+			// instead of awaiting them here (which blocks server creation on the
+			// on-demand compilation of astro's own module graphs, ~400ms), install
+			// the middleware synchronously and let the request handlers await the
+			// in-flight results lazily. The dev server app compile is serialized
+			// after the content config load so the two don't contend for the main
+			// thread during startup.
+			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
+			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
+				? (astroEnvironment as RunnableDevEnvironment)
 				: undefined;
-			const prerenderHandler = runnablePrerenderEnvironment
-				? await createHandler(runnablePrerenderEnvironment)
+			const contentConfigLoad = runnableAstroEnvironment
+				? kickOffContentConfigLoad({
+						settings,
+						fs: nodeFs,
+						logger,
+						environment: runnableAstroEnvironment,
+					})
+				: Promise.resolve();
+
+			const ssrHandlerPromise = runnableSsrEnvironment
+				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
 				: undefined;
+			const prerenderHandlerPromise = runnablePrerenderEnvironment
+				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
+				: undefined;
+			// Compile failures surface here so startup still reports them, and also
+			// as a rejected lazy await in the request handlers below.
+			ssrHandlerPromise?.catch((error) => {
+				logger.error(
+					null,
+					`Failed to create the dev server app: ${error?.message ?? error}`,
+				);
+			});
+			prerenderHandlerPromise?.catch((error) => {
+				logger.error(
+					null,
+					`Failed to create the prerender server app: ${error?.message ?? error}`,
+				);
+			});
 			const localStorage = new AsyncLocalStorage();
 
-			function handleUnhandledRejection(rejection: any) {
+			async function handleUnhandledRejection(rejection: any) {
 				const error = AstroError.is(rejection)
 					? rejection
 					: new AstroError({
@@ -84,9 +121,11 @@ export default function createVitePluginAstroServer({
 						});
 				const store = localStorage.getStore();
 				const handlers = [];
-				if (ssrHandler) handlers.push(ssrHandler);
-				if (prerenderHandler) handlers.push(prerenderHandler);
+				if (ssrHandlerPromise) handlers.push(await ssrHandlerPromise.catch(() => undefined));
+				if (prerenderHandlerPromise)
+					handlers.push(await prerenderHandlerPromise.catch(() => undefined));
 				for (const currentHandler of handlers) {
+					if (!currentHandler) continue;
 					if (store instanceof IncomingMessage) {
 						setRouteError(currentHandler.controller.state, store.url!, error);
 					}
@@ -104,7 +143,7 @@ export default function createVitePluginAstroServer({
 				}
 			}
 
-			if (ssrHandler || prerenderHandler) {
+			if (runnableSsrEnvironment || runnablePrerenderEnvironment) {
 				process.on('unhandledRejection', handleUnhandledRejection);
 				viteServer.httpServer?.on('close', () => {
 					process.off('unhandledRejection', handleUnhandledRejection);
@@ -137,7 +176,7 @@ export default function createVitePluginAstroServer({
 					handle: secFetchMiddleware(logger, settings.config.security?.allowedDomains),
 				});
 
-				if (prerenderHandler && shouldHandlePrerenderInCore) {
+				if (runnablePrerenderEnvironment && shouldHandlePrerenderInCore) {
 					viteServer.middlewares.use(
 						async function astroDevPrerenderHandler(request, response, next) {
 							if (request.url === undefined || !request.method) {
@@ -155,6 +194,7 @@ export default function createVitePluginAstroServer({
 							}
 
 							try {
+								const prerenderHandler = await prerenderHandlerPromise!;
 								const pathname = decodeURI(new URL(request.url, 'http://localhost').pathname);
 								const { routes } = (await prerenderHandler.environment.runner.import(
 									'virtual:astro:routes',
@@ -184,7 +224,7 @@ export default function createVitePluginAstroServer({
 					);
 				}
 
-				if (ssrHandler) {
+				if (runnableSsrEnvironment) {
 					// Note that this function has a name so other middleware can find it.
 					viteServer.middlewares.use(async function astroDevHandler(request, response) {
 						if (request.url === undefined || !request.method) {
@@ -193,6 +233,7 @@ export default function createVitePluginAstroServer({
 							return;
 						}
 
+						const ssrHandler = await ssrHandlerPromise!;
 						localStorage.run(request, () => {
 							ssrHandler.handler(request, response);
 						});

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -73,14 +73,10 @@ export default function createVitePluginAstroServer({
 				return { controller, handler, loader, manifest, environment };
 			}
 
-			// Kick off the content config load and the dev server app compile as
-			// early as possible. Neither is needed until the first request, so
-			// instead of awaiting them here (which blocks server creation on the
-			// on-demand compilation of astro's own module graphs, ~400ms), install
-			// the middleware synchronously and let the request handlers await the
-			// in-flight results lazily. The dev server app compile is serialized
-			// after the content config load so the two don't contend for the main
-			// thread during startup.
+			// Kick off the content config load and dev server app compile as early
+			// as possible. Neither is needed until the first request, so install the
+			// middleware synchronously and let request handlers await the in-flight
+			// results without blocking server creation.
 			const astroEnvironment = viteServer.environments[ASTRO_VITE_ENVIRONMENT_NAMES.astro];
 			const runnableAstroEnvironment = isRunnableDevEnvironment(astroEnvironment)
 				? (astroEnvironment as RunnableDevEnvironment)
@@ -95,16 +91,16 @@ export default function createVitePluginAstroServer({
 				: Promise.resolve();
 
 			const ssrHandlerPromise = runnableSsrEnvironment
-				? contentConfigLoad.then(() => createHandler(runnableSsrEnvironment))
+				? createHandler(runnableSsrEnvironment)
 				: undefined;
 			const prerenderHandlerPromise = runnablePrerenderEnvironment
-				? contentConfigLoad.then(() => createHandler(runnablePrerenderEnvironment))
+				? createHandler(runnablePrerenderEnvironment)
 				: undefined;
 
-			// App setup uses the runnable environments' module runners. Keep shutdown
-			// from disconnecting those runners while an import is still in flight.
+			// Background setup uses the runnable environments' module runners. Keep
+			// shutdown from disconnecting those runners while an import is in flight.
 			(viteServer as any)[devServerAppReadySymbol] = Promise.allSettled(
-				[ssrHandlerPromise, prerenderHandlerPromise].filter(Boolean),
+				[contentConfigLoad, ssrHandlerPromise, prerenderHandlerPromise].filter(Boolean),
 			).then(() => undefined);
 
 			// Compile failures surface here so startup still reports them, and also

--- a/packages/astro/test/content-frontmatter.test.ts
+++ b/packages/astro/test/content-frontmatter.test.ts
@@ -26,7 +26,7 @@ describe('frontmatter (loadFixture)', () => {
 		fs.writeFileSync(blogPath, originalContent);
 	});
 
-	it('errors in content/ does not crash server', { timeout: 2000 }, async () => {
+	it('errors in content/ does not crash server', { timeout: 5000 }, async () => {
 		// Verify server is alive
 		const res1 = await fixture.fetch('/');
 		assert.equal(res1.status, 200);

--- a/packages/astro/test/dev-content-deferral.test.ts
+++ b/packages/astro/test/dev-content-deferral.test.ts
@@ -1,0 +1,146 @@
+import * as assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, before, beforeEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { type DevServer, type Fixture, loadFixture } from './test-utils.ts';
+
+const fixtureDir = fileURLToPath(new URL('./fixtures/dev-content-deferral/', import.meta.url));
+const astroDir = path.join(fixtureDir, '.astro');
+const markerPath = path.join(fixtureDir, 'server-started.txt');
+const storePath = path.join(astroDir, 'data-store.json');
+const configPath = path.join(fixtureDir, 'astro.config.mjs');
+const originalConfig = fs.readFileSync(configPath, 'utf-8');
+
+function resetFixture() {
+	fs.rmSync(astroDir, { recursive: true, force: true });
+	fs.rmSync(markerPath, { force: true });
+}
+
+let fixture: Fixture;
+
+function startDev() {
+	return fixture.startDevServer({ logLevel: 'silent' });
+}
+
+async function fetchPage(_devServer: DevServer, pathname = '/') {
+	return fixture.fetch(pathname);
+}
+
+async function waitForContent(devServer: DevServer, timeoutMs = 8000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetchPage(devServer);
+			if (res.status === 200 && (await res.text()).includes('Hello world')) {
+				return;
+			}
+		} catch {
+			// An in-place restart briefly closes the HTTP server before binding the same port.
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	throw new Error('Page did not serve synced content within timeout');
+}
+
+async function waitForRestart(devServer: DevServer, previousWatcher: DevServer['watcher']) {
+	const deadline = Date.now() + 8000;
+	while (Date.now() < deadline) {
+		if (devServer.watcher !== previousWatcher) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error('Dev server did not restart within timeout');
+}
+
+describe('dev content deferral', () => {
+	let devServer: DevServer | undefined;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/dev-content-deferral/' });
+	});
+
+	beforeEach(() => {
+		fs.writeFileSync(configPath, originalConfig);
+		resetFixture();
+	});
+
+	afterEach(async () => {
+		await devServer?.stop().catch(() => {});
+		devServer = undefined;
+		fs.writeFileSync(configPath, originalConfig);
+		resetFixture();
+	});
+
+	it('serves fully synced content on the first request after start (fresh store)', async () => {
+		devServer = await startDev();
+		// Content setup runs after the port is listening: the server:start hook
+		// must have run, but the deferred sync must not have written the store yet.
+		assert.equal(
+			fs.existsSync(markerPath),
+			true,
+			'astro:server:start should run before content readiness',
+		);
+		assert.equal(
+			fs.existsSync(storePath),
+			false,
+			'content sync should still be in flight right after dev() resolves',
+		);
+
+		const staticResponse = await fetchPage(devServer, '/static.txt');
+		assert.equal(await staticResponse.text(), 'static content\n');
+		assert.equal(
+			fs.existsSync(storePath),
+			false,
+			'Vite static requests should not wait for content readiness',
+		);
+
+		// The request gate holds until the deferred chain settles, so the first
+		// request must never observe an empty store.
+		const res = await fetchPage(devServer);
+		assert.equal(res.status, 200);
+		const body = await res.text();
+		assert.match(body, /Hello world/);
+		assert.match(body, /Second post/);
+		assert.equal(fs.existsSync(storePath), true, 'sync should have written the store once served');
+	});
+
+	it('stops cleanly when no request was ever made, repeatedly', async () => {
+		for (let i = 0; i < 3; i++) {
+			const server = await startDev();
+			await server.stop();
+		}
+	});
+
+	it('keeps serving correct content across an in-place astro.config restart', async () => {
+		devServer = await startDev();
+		await waitForContent(devServer);
+
+		const previousWatcher = devServer.watcher;
+		fs.writeFileSync(configPath, originalConfig + '\n// restart marker\n');
+
+		await waitForRestart(devServer, previousWatcher);
+		await waitForContent(devServer);
+		const res = await fetchPage(devServer);
+		assert.equal(res.status, 200);
+		assert.match(await res.text(), /Hello world/);
+	});
+
+	it('keeps the server alive when the content config is broken', async () => {
+		resetFixture();
+		const configFile = path.join(fixtureDir, 'src/content.config.ts');
+		const original = fs.readFileSync(configFile, 'utf-8');
+		try {
+			fs.writeFileSync(configFile, 'export const broken = ;');
+			devServer = await startDev();
+			// A broken content config must not hang the request gate: the page is
+			// served (empty store) and the error is logged, matching the behavior
+			// when content setup ran on the ready path.
+			const res = await fetchPage(devServer);
+			assert.equal(res.status, 200);
+		} finally {
+			await devServer?.stop();
+			devServer = undefined;
+			fs.writeFileSync(configFile, original);
+		}
+	});
+});

--- a/packages/astro/test/fixtures/dev-content-deferral/astro.config.mjs
+++ b/packages/astro/test/fixtures/dev-content-deferral/astro.config.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'astro/config';
+
+const markerPath = fileURLToPath(new URL('./server-started.txt', import.meta.url));
+
+export default defineConfig({
+	name: 'content-deferral-test-fixture',
+	integrations: [
+		{
+			name: 'content-deferral-hook-recorder',
+			hooks: {
+				'astro:server:start': () => {
+					fs.writeFileSync(markerPath, Date.now().toString());
+				},
+			},
+		},
+	],
+});

--- a/packages/astro/test/fixtures/dev-content-deferral/package.json
+++ b/packages/astro/test/fixtures/dev-content-deferral/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@astrojs/test-dev-content-deferral",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/dev-content-deferral/public/static.txt
+++ b/packages/astro/test/fixtures/dev-content-deferral/public/static.txt
@@ -1,0 +1,1 @@
+static content

--- a/packages/astro/test/fixtures/dev-content-deferral/src/content.config.ts
+++ b/packages/astro/test/fixtures/dev-content-deferral/src/content.config.ts
@@ -1,0 +1,18 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const posts = defineCollection({
+	loader: glob({ pattern: '*.md', base: './src/content/posts' }),
+	schema: z.object({
+		title: z.string(),
+	}),
+});
+
+const slow = defineCollection({
+	loader: async () => {
+		await new Promise((resolve) => setTimeout(resolve, 250));
+		return [];
+	},
+});
+
+export const collections = { posts, slow };

--- a/packages/astro/test/fixtures/dev-content-deferral/src/content/posts/hello.md
+++ b/packages/astro/test/fixtures/dev-content-deferral/src/content/posts/hello.md
@@ -1,0 +1,4 @@
+---
+title: Hello world
+---
+First post body.

--- a/packages/astro/test/fixtures/dev-content-deferral/src/content/posts/second.md
+++ b/packages/astro/test/fixtures/dev-content-deferral/src/content/posts/second.md
@@ -1,0 +1,4 @@
+---
+title: Second post
+---
+Second post body.

--- a/packages/astro/test/fixtures/dev-content-deferral/src/pages/index.astro
+++ b/packages/astro/test/fixtures/dev-content-deferral/src/pages/index.astro
@@ -1,0 +1,18 @@
+---
+import { getCollection } from 'astro:content';
+
+const posts = await getCollection('posts');
+---
+<html>
+<head>
+	<title>Content deferral fixture</title>
+</head>
+<body>
+	<h1>Posts</h1>
+	<ul>
+		{posts.map((post) => (
+			<li>{post.data.title}</li>
+		))}
+	</ul>
+</body>
+</html>

--- a/packages/integrations/cloudflare/test/content-collections-chunked.test.ts
+++ b/packages/integrations/cloudflare/test/content-collections-chunked.test.ts
@@ -24,6 +24,7 @@ describe('Chunked collection storage', () => {
 	});
 
 	it('loads a multi-chunk entry in workerd development', async () => {
+		await devServer.contentReady;
 		const manifest = JSON.parse(
 			await readFile(new URL('./.astro/data-store/manifest.json', fixture.config.root), 'utf-8'),
 		) as Record<string, string[]>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3291,6 +3291,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/dev-content-deferral:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/dev-render:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Moves development content store loading, type generation, and content synchronization off the server-ready critical path.
- Gates Astro SSR and prerender requests on content readiness while allowing Vite static/internal requests through, and exposes `contentReady` on the experimental JavaScript dev server for consumers that need the initial generated artifacts.
- Settles background content work before restart or shutdown.

## Testing

- Adds a dev content deferral fixture covering fresh-store first requests, ungated static assets, immediate shutdown, config restart, and broken content configuration.
- Updates the Cloudflare chunked-content test to explicitly await content readiness before inspecting its generated manifest.

## Docs

- No docs update needed because the only API addition is on the experimental JavaScript dev server.
