### PR TITLE
fix: improve jsdoc for fonts api

### DIFF
--- a/.changeset/strong-shrimps-end.md
+++ b/.changeset/strong-shrimps-end.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves JSDoc for fonts api

--- a/packages/astro/src/assets/fonts/types.ts
+++ b/packages/astro/src/assets/fonts/types.ts
@@ -59,9 +59,9 @@ export interface FontProvider<
 
 export interface FamilyProperties {
 	/**
-	 * @default `"swap"`
-	 *
 	 * Defines [how a font displays](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) based on when it is downloaded and ready for use.
+	 * 
+	 * @default "swap"
 	 */
 	display?: Display | undefined;
 	/**
@@ -132,8 +132,6 @@ export type FontFamily<TFontProvider extends FontProvider = FontProvider> = Fami
 		 */
 		provider: TFontProvider;
 		/**
-		 * @default `[400]`
-		 *
 		 * An array of [font weights](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight). If no value is specified in your configuration, only weight `400` is
 		 * included by default to prevent unnecessary downloads. You will need to include this property to access any other font weights.
 		 *
@@ -142,29 +140,29 @@ export type FontFamily<TFontProvider extends FontProvider = FontProvider> = Fami
 		 * ```js
 		 * weight: "100 900"
 		 * ```
+		 * 
+		 * @default [400]
 		 */
 		weights?: [Weight, ...Array<Weight>] | undefined;
 		/**
-		 * @default `["normal", "italic"]`
-		 *
 		 * An array of [font styles](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style).
+		 * 
+		 * @default ["normal", "italic"]
 		 */
 		styles?: [Style, ...Array<Style>] | undefined;
 		/**
-		 * @default `["latin"]`
-		 *
 		 * Defines a list of [font subsets](https://knaap.dev/posts/font-subsetting/).
+		 * 
+		 * @default ["latin"]
 		 */
 		subsets?: [string, ...Array<string>] | undefined;
 		/**
-		 * @default `["woff2"]`
-		 *
 		 * An array of [font formats](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@font-face/src#font_formats).
+		 * 
+		 * @default ["woff2"]
 		 */
 		formats?: [FontType, ...Array<FontType>] | undefined;
 		/**
-		 * @default `["sans-serif"]`
-		 *
 		 * An array of fonts to use when your chosen font is unavailable, or loading. Fallback fonts will be chosen in the order listed. The first available font will be used:
 		 *
 		 * ```js
@@ -179,12 +177,14 @@ export type FontFamily<TFontProvider extends FontProvider = FontProvider> = Fami
 		 *
 		 * If the last font in the `fallbacks` array is a [generic family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name), Astro will attempt to
 		 * generate [optimized fallbacks](https://developer.chrome.com/blog/font-fallbacks) using font metrics will be generated. To disable this optimization, set `optimizedFallbacks` to false.
+		 * 
+		 * @default ["sans-serif"]
 		 */
 		fallbacks?: Array<string> | undefined;
 		/**
-		 * @default `true`
-		 *
 		 * Whether or not to enable Astro's default optimization when generating fallback fonts. You may disable this default optimization to have full control over how `fallbacks` are generated.
+		 * 
+		 * @default true
 		 */
 		optimizedFallbacks?: boolean | undefined;
 	};


### PR DESCRIPTION
## Changes

Improves jsdoc for fonts api

### Before

<img width="686" height="92" alt="image" src="https://github.com/user-attachments/assets/d7bc726b-6ad0-4277-abe4-2346b97c2347" />

### After

<img width="193" height="81" alt="image" src="https://github.com/user-attachments/assets/b7e83e96-005b-47e0-81b9-efc4e9ca6988" />


## Testing

N/A

## Docs

N/A
