### PR TITLE
Astro.currentLocale ignores a URL segment that differs only in case or separator

### DIFF
--- a/.changeset/shiny-donkeys-marry.md
+++ b/.changeset/shiny-donkeys-marry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `Astro.currentLocale` returning the default locale for a URL segment that differs from the configured locale only in letter case or in `-` vs `_`

--- a/packages/astro/src/i18n/utils.ts
+++ b/packages/astro/src/i18n/utils.ts
@@ -157,8 +157,6 @@ export function computeCurrentLocale(
 	for (const segment of pathname.split('/').map(normalizeThePath)) {
 		for (const locale of locales) {
 			if (typeof locale === 'string') {
-				// we skip ta locale that isn't present in the current segment
-				if (!segment.includes(locale)) continue;
 				if (normalizeTheLocale(locale) === normalizeTheLocale(segment)) {
 					return locale;
 				}

--- a/packages/astro/test/units/i18n/i18n-utils.test.ts
+++ b/packages/astro/test/units/i18n/i18n-utils.test.ts
@@ -13,6 +13,7 @@ import {
 	toCodes,
 	toPaths,
 } from '../../../dist/i18n/index.js';
+import { pathHasLocale } from '../../../dist/i18n/path.js';
 
 describe('computeCurrentLocale', () => {
 	const stringLocales = ['en', 'fr', 'es'];
@@ -39,6 +40,25 @@ describe('computeCurrentLocale', () => {
 
 	it('handles case-insensitive locale matching', () => {
 		assert.equal(computeCurrentLocale('/EN/about', stringLocales, 'en'), 'en');
+	});
+
+	// 'en' above is also the default locale, so that assertion holds whether the
+	// segment matched or the lookup fell through. These use a non-default locale
+	// so only a real match can satisfy them.
+	it('matches a non-default locale whose segment differs in case', () => {
+		assert.equal(computeCurrentLocale('/FR/about', stringLocales, 'en'), 'fr');
+	});
+
+	it('matches a locale whose segment differs in separator', () => {
+		const locales = ['en_US', 'fr'];
+		assert.equal(computeCurrentLocale('/en-us/about', locales, 'fr'), 'en_US');
+		assert.equal(computeCurrentLocale('/EN_us/about', ['en-US', 'fr'], 'fr'), 'en-US');
+	});
+
+	it('agrees with pathHasLocale', () => {
+		// The two answer the same question and must not disagree.
+		assert.equal(pathHasLocale('/FR/about', stringLocales), true);
+		assert.equal(computeCurrentLocale('/FR/about', stringLocales, 'en'), 'fr');
 	});
 
 	it('handles object locales with path', () => {


### PR DESCRIPTION
## Changes

`computeCurrentLocale` pre-filters candidate locales with a case- and separator-**sensitive** `includes`, then compares them with a case- and separator-**insensitive** equality:

```ts
// we skip ta locale that isn't present in the current segment
if (!segment.includes(locale)) continue;
if (normalizeTheLocale(locale) === normalizeTheLocale(segment)) {
	return locale;
}
```

`normalizeTheLocale` lowercases and maps `_` to `-`, so the filter rejects exactly the segments the comparison exists to accept. The loop then falls through to the default-locale branch at the bottom.

| URL | locales | `Astro.currentLocale` today | expected |
|---|---|---|---|
| `/FR/about` | `['en', 'fr', 'es']`, default `en` | `'en'` | `'fr'` |
| `/en-us/about` | `['en_US', 'fr']`, default `fr` | `'fr'` | `'en_US'` |
| `/EN_us/about` | `['en-US', 'fr']`, default `fr` | `'fr'` | `'en-US'` |

This is a silent wrong answer from a documented public API: user code that picks translations or sets `lang`/`dir` from `Astro.currentLocale` renders the default language on a page that is unambiguously in another one.

`pathHasLocale`, in the same module, already answers the same question with the normalized comparison and no pre-filter, so the two disagree today:

```
/FR/about   ->  pathHasLocale = true   but   currentLocale = 'en'
```

Removing the filter makes them agree. It was only ever an optimisation; the normalized comparison below it is the real check.

## Why this was not caught

The existing case-insensitivity test uses the default locale as the case-varied one:

```ts
it('handles case-insensitive locale matching', () => {
	assert.equal(computeCurrentLocale('/EN/about', stringLocales, 'en'), 'en');
});
```

`'en'` is both the expected locale and the default, so the assertion holds whether the segment matched or the lookup fell through to the default. It passes on both the current code and the fix. The three tests added here use a non-default locale, so only a real match satisfies them.

## Testing

- Added three cases to `computeCurrentLocale` in `packages/astro/test/units/i18n/i18n-utils.test.ts`: differing case, differing separator (both directions), and agreement with `pathHasLocale`.
- Ran: `node --test test/units/i18n/i18n-utils.test.ts` → **37 passing**.
- Ran: every `test/units/i18n/*.test.ts`. The set of failing files is identical to an unmodified tree here, so this introduces no regressions; the change adds 3 passing tests and repairs none of the pre-existing failures.
- Checked: reverting only `utils.ts` fails all three new tests, while the existing case-insensitivity test keeps passing — which is the point above.

## Docs

No docs change. This restores the documented behaviour of `Astro.currentLocale` rather than altering it.