### PR TITLE
Update `@astrojs/partytown` to Partytown 0.14.4

### DIFF
--- a/.changeset/warm-turtles-listen.md
+++ b/.changeset/warm-turtles-listen.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+Updates `@qwik.dev/partytown` from 0.13.2 to 0.14.4, bringing fixes for analytics event forwarding and iframe loading, support for Google Tag Manager's Tag Assistant preview, and automatic execution of scripts added after client-side navigation.

--- a/packages/astro/e2e/view-transitions.test.ts
+++ b/packages/astro/e2e/view-transitions.test.ts
@@ -1184,6 +1184,7 @@ test.describe('View Transitions', () => {
 		const button = page.locator('#react-client-load-navigate-button');
 
 		await expect(button, 'should have content').toHaveText('Navigate to `/two`');
+		await waitForHydrate(page, button);
 
 		await button.click();
 

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -31,7 +31,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@qwik.dev/partytown": "^0.13.2",
+    "@qwik.dev/partytown": "^0.14.4",
     "mrmime": "^2.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6063,8 +6063,8 @@ importers:
   packages/integrations/partytown:
     dependencies:
       '@qwik.dev/partytown':
-        specifier: ^0.13.2
-        version: 0.13.2
+        specifier: ^0.14.4
+        version: 0.14.4
       mrmime:
         specifier: ^2.0.1
         version: 2.0.1
@@ -10263,8 +10263,8 @@ packages:
     resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
     engines: {node: '>=18'}
 
-  '@qwik.dev/partytown@0.13.2':
-    resolution: {integrity: sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==}
+  '@qwik.dev/partytown@0.14.4':
+    resolution: {integrity: sha512-XGBgDuxgG7CsAs4PZ32GUmbD029nAeCR4VGyJRJnNp3r3uVjbZt8Dkxe8cw+f8xY6Dh8VI5cb3ygEZCqSftwtA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -19905,9 +19905,7 @@ snapshots:
 
   '@publint/pack@0.1.4': {}
 
-  '@qwik.dev/partytown@0.13.2':
-    dependencies:
-      dotenv: 16.6.1
+  '@qwik.dev/partytown@0.14.4': {}
 
   '@rolldown/binding-android-arm64@1.2.4':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,7 @@ settings:
 overrides:
   '@types/node@22': ^22.19.0
   modern-tar: '>=0.7.7'
+  docs>@lunariajs/core: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@502ada46073a7f0b003949d78870cefb9290a54f
 
 patchedDependencies:
   '@volar/language-service@2.4.28': 09741a82cb00ac74eaaadd70420ac669b56a8df2b1b926de1cf25500a15a6b5a

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ overrides:
   '@types/node@22': '^22.19.0'
   # Force modern-tar to 0.7.7 which fixes Unicode NFC/NFD path normalization on Linux (issue #17381)
   'modern-tar': '>=0.7.7'
+  'docs>@lunariajs/core': 'https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@502ada46073a7f0b003949d78870cefb9290a54f'
 
 # Wait until three days after release to install new versions of packages
 minimumReleaseAge: 4320


### PR DESCRIPTION
## Changes

Updates the Partytown dependency in `@astrojs/partytown` from **0.13.2 to 0.14.4**, the latest release. Includes the lockfile update and a patch changeset.

This brings in several useful upstream improvements:

- **More reliable analytics events.** Events queued before Partytown starts are forwarded, and events are no longer dropped when the worker's target global is still being initialized. Analytics requests made through `sendBeacon`, including GA4 collection requests, also respect `resolveUrl`. ([0.14.2 release notes](https://github.com/QwikDev/partytown/releases/tag/v0.14.2))
- **Scripts added during navigation run automatically.** Partytown detects scripts added after initialization, such as during client-side route changes, without requiring a manual `ptupdate` event. ([0.14.3 release notes](https://github.com/QwikDev/partytown/releases/tag/v0.14.3))
- **Google Tag Manager preview support.** Tag Assistant can connect when GTM runs in Partytown, making it easier to debug tags. ([0.14.3 release notes](https://github.com/QwikDev/partytown/releases/tag/v0.14.3))
- **Less time blocking the main thread.** Large batches of non-blocking DOM operations periodically yield, helping reduce long tasks. ([0.14.3 release notes](https://github.com/QwikDev/partytown/releases/tag/v0.14.3))
- **Better iframe compatibility.** Cross-origin widgets such as reCAPTCHA can load natively when their content cannot be fetched. The latest patch also fixes iframe service worker behavior when using `loadScriptsOnMainThread`. ([0.14.3](https://github.com/QwikDev/partytown/releases/tag/v0.14.3), [0.14.4 release notes](https://github.com/QwikDev/partytown/releases/tag/v0.14.4))

The docs smoke-test fixture also pins a Lunaria preview that returns HTTP 404. A `docs>@lunariajs/core` override selects the available preview at `502ada46073a7f0b003949d78870cefb9290a54f`. This override only applies to the cloned docs project; it does not change Astro or integration runtime dependencies. It can be removed when the docs repo updates its dependency.

## Testing

- [GitHub CI passed](https://github.com/withastro/astro/actions/runs/34719267870) on `2684a2e`, including Linux and Windows smoke and E2E tests.
- `pnpm install --frozen-lockfile`
- Smoke tests: cloned the same docs revision as CI (`99dba9d`), installed with the override, and ran the full `test:smoke` command with CI's English/Korean configuration. All 44 example build tasks passed, and the docs build generated 1,273 pages.
- `pnpm build` — all 32 build tasks passed, including TypeScript checks.
- `pnpm -C packages/astro exec astro-scripts test 'test/ssr-partytown.test.ts' --strip-types` — both existing SSR tests passed.
- Chrome E2E: the full view-transition and Solid-component suites passed (106 passed, 2 skipped), without retries.
- Firefox E2E: the full view-transition suite passed (92 passed, 2 skipped), without retries.
- `pnpm format`, `pnpm lint:ai`, and `git diff --check` passed. Formatting and lint reported existing warnings and configuration hints.

The existing SSR tests cover script injection and inclusion of Partytown's assets in the SSR manifest. The upstream improvements listed above were not individually browser-tested here.

Also fixes a hydration race exposed by the Linux E2E check: the framework-router test could click React's server-rendered button before its event handler was attached. It now uses the existing `waitForHydrate` helper before clicking. The original test failed in 5 of 10 local runs; with the fix, all 10 passed without retries.

## Docs

Includes a patch changeset describing the upgrade. No integration API or configuration changes are needed; the upstream release notes above describe the included fixes and improvements.
