### PR TITLE
refactor: remove the unused pageInput set from viteBuild

### DIFF
--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -13,7 +13,6 @@ import { SERIALIZED_MANIFEST_RESOLVED_ID } from '../../manifest/serialized.js';
 import { getPrerenderOutputDirectory, getServerOutputDirectory } from '../../prerender/utils.js';
 import type { RouteData } from '../../types/public/internal.js';
 import { PAGE_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
-import { routeIsRedirect } from '../routing/helpers.js';
 
 import { generatePages } from './generate.js';
 import { trackPageData } from './internal.js';
@@ -86,10 +85,6 @@ function extractRelevantChunks(
 export async function viteBuild(opts: StaticBuildOptions) {
 	const { allPages, settings } = opts;
 
-	// The pages to be built for rendering purposes.
-	// (comment above may be outdated ?)
-	const pageInput = new Set<string>();
-
 	// Build internals needed by the CSS plugin
 	const internals = createBuildInternals();
 
@@ -99,10 +94,6 @@ export async function viteBuild(opts: StaticBuildOptions) {
 
 		// Track the page data in internals
 		trackPageData(internals, pageData.component, pageData, astroModuleId, astroModuleURL);
-
-		if (!routeIsRedirect(pageData.route)) {
-			pageInput.add(astroModuleId);
-		}
 	}
 
 	// Empty out the dist folder, if needed. Vite has a config for doing this


### PR DESCRIPTION
### What

`viteBuild` in `packages/astro/src/core/build/static-build.ts` builds a
`pageInput` set of module ids and never reads it.

Its consumer used to be `ssrBuild(opts, internals, pageInput, container)`, which
was removed with the Environment API in #14306. The producer stayed behind —
together with a comment that already suspected itself:

```ts
// The pages to be built for rendering purposes.
// (comment above may be outdated ?)
const pageInput = new Set<string>();
```

`pageInput` has no other reference anywhere in `packages/astro/src`.

### Changes

- Remove the `pageInput` set.
- Remove the `if (!routeIsRedirect(pageData.route))` guard, whose only body was
  the single `pageInput.add(...)`.
- Remove the `routeIsRedirect` import, unused after that.

9 deletions in one file, no behaviour change.

### Checks

`tsc --noEmit -p packages/astro/tsconfig.json` reports 0 errors with the change,
and 0 on the same tree without it — identical to the baseline.

No changeset: nothing observable changes for users, matching how internal-only
changes land here (e.g. #17430, #16734).

### Use of AI

An automated check flagged the collection as written-but-never-read; I traced the
consumer's removal to #14306, confirmed there are no other readers, and wrote and
verified the change myself.