### PR TITLE
fix(transitions): snapshot script collection before iterating in runScripts

### DIFF
--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -131,7 +131,7 @@ function runScripts() {
 	// inline module scripts cannot be awaited for with onload.
 	// Thus to be able to wait for the execution of all scripts, we make sure that the last inline module script
 	// is always followed by an external module script
-	for (const script of document.getElementsByTagName('script')) {
+	for (const script of Array.from(document.getElementsByTagName('script'))) {
 		script.dataset.astroExec === undefined &&
 			script.getAttribute('type') === 'module' &&
 			(needsWaitForInlineModuleScript = script.getAttribute('src') === null);
@@ -142,7 +142,7 @@ function runScripts() {
 			`<script type="module" src="data:application/javascript,"/>`,
 		);
 
-	for (const script of document.getElementsByTagName('script')) {
+	for (const script of Array.from(document.getElementsByTagName('script'))) {
 		if (script.dataset.astroExec === '') continue;
 		const type = script.getAttribute('type');
 		if (type && type !== 'module' && type !== 'text/javascript') continue;
@@ -681,7 +681,7 @@ if (inBrowser) {
 			);
 		}
 	}
-	for (const script of document.getElementsByTagName('script')) {
+	for (const script of Array.from(document.getElementsByTagName('script'))) {
 		detectScriptExecuted(script);
 		script.dataset.astroExec = '';
 	}


### PR DESCRIPTION
## Summary

`getElementsByTagName` returns a **live** `HTMLCollection`. When new scripts are appended to the DOM inside the loop body (e.g. the sentinel `data:application/javascript` module), the collection grows mid-iteration and some scripts get skipped entirely — they're never executed.

**Fix:** wrap each `getElementsByTagName` result in `Array.from()` before the loop so the collection is snapshotted to a static array. Every script is visited exactly once regardless of DOM mutations during iteration.